### PR TITLE
Fix 'user cannot patch resource "events" in API group'

### DIFF
--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -522,6 +522,7 @@ rules:
   - list
   - create
   - update
+  - patch
   - delete
 - apiGroups:
   - apps.foundationdb.org

--- a/config/samples/deployment/rbac_role.yaml
+++ b/config/samples/deployment/rbac_role.yaml
@@ -17,6 +17,7 @@ rules:
   - list
   - create
   - update
+  - patch
   - delete
 - apiGroups:
   - apps.foundationdb.org


### PR DESCRIPTION
Hi!

I just started playing with the operator, and found a minor issue on the `deployment.yaml`:

```bash
kubectl version                                   
# Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.4", GitCommit:"224be7bdce5a9dd0c2fd0d46b83865648e2fe0ba", GitTreeState:"clean", BuildDate:"2019-12-16T16:34:49Z", GoVersion:"go1.12.14", Compiler:"gc", Platform:"linux/amd64"}
# Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.4", GitCommit:"224be7bdce5a9dd0c2fd0d46b83865648e2fe0ba", GitTreeState:"clean", BuildDate:"2019-12-11T12:37:43Z", GoVersion:"go1.12.12", Compiler:"gc", Platform:"linux/amd64"}

kubectl apply -f config/samples/deployment.yaml
kubectl apply -f config/samples/cluster_local.yaml

kubectl logs fdb-kubernetes-operator-controller-manager-0 --container=manager
# (...) 'events "sample-cluster.15e88c105ec0aa7f" is forbidden: User "system:serviceaccount:default:default" cannot patch resource "events" in API group "" in the namespace "default"' (will not retry!)
# Full log: E0110 14:14:52.992094       1 event.go:203] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"sample-cluster.15e88c105ec0aa7f", GenerateName:"", Namespace:"default", SelfLink:"", UID:"", ResourceVersion:"8623571656", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, InvolvedObject:v1.ObjectReference{Kind:"FoundationDBCluster", Namespace:"default", Name:"sample-cluster", UID:"8e1d9897-4d4d-4aa5-b0a6-db328a9961bf", APIVersion:"apps.foundationdb.org/v1beta1", ResourceVersion:"8623571659", FieldPath:""}, Reason:"ChangingCoordinators", Message:"Choosing initial coordinators", Source:v1.EventSource{Component:"foundationdbcluster-controller", Host:""}, FirstTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63714262471, loc:(*time.Location)(0x2131e00)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xbf7e3f973ae3d166, ext:74571172311, loc:(*time.Location)(0x2131e00)}}, Count:23, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events "sample-cluster.15e88c105ec0aa7f" is forbidden: User "system:serviceaccount:default:default" cannot patch resource "events" in API group "" in the namespace "default"' (will not retry!)
```

