### PR TITLE
Support locality_data_hall

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -129,6 +129,9 @@ type FoundationDBClusterSpec struct {
 	// DataCenter defines the data center where these processes are running.
 	DataCenter string `json:"dataCenter,omitempty"`
 
+	// DataHall defines the data hall where these processes are running.
+	DataHall string `json:"dataHall,omitempty"`
+
 	// AutomationOptions defines customization for enabling or disabling certain
 	// operations in the operator.
 	AutomationOptions FoundationDBClusterAutomationOptions `json:"automationOptions,omitempty"`

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -1165,6 +1165,10 @@ spec:
               description: DataCenter defines the data center where these processes
                 are running.
               type: string
+            dataHall:
+              description: DataHall defines the data hall where these processes are
+                running.
+              type: string
             databaseConfiguration:
               description: DatabaseConfiguration defines the database configuration.
               properties:

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -515,6 +515,10 @@ func getStartCommandLines(cluster *fdbtypes.FoundationDBCluster, processClass st
 		confLines = append(confLines, fmt.Sprintf("locality_dcid = %s", cluster.Spec.DataCenter))
 	}
 
+	if cluster.Spec.DataHall != "" {
+		confLines = append(confLines, fmt.Sprintf("locality_data_hall = %s", cluster.Spec.DataHall))
+	}
+
 	if cluster.Spec.MainContainer.PeerVerificationRules != "" {
 		confLines = append(confLines, fmt.Sprintf("tls_verify_peers = %s", cluster.Spec.MainContainer.PeerVerificationRules))
 	}


### PR DESCRIPTION
This allows setting `locality_data_hall` in the fdbmonitor config. Which is needed by the `three_data_hall` redundancy mode.