### PR TITLE
Move the removal of pods in a shrink to the end of the reconciliation workflow.

### DIFF
--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -80,7 +80,8 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 			instanceIDs[class] = make(map[int]bool)
 		}
 
-		if instance.Pod != nil && instance.Pod.DeletionTimestamp != nil {
+		_, pendingRemoval := cluster.Spec.PendingRemovals[instance.Metadata.Name]
+		if instance.Pod != nil && instance.Pod.DeletionTimestamp != nil && !pendingRemoval {
 			return false, ReconciliationNotReadyError{message: "Cluster has pod that is pending deletion", retryable: true}
 		}
 

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -107,10 +107,10 @@ func (r *FoundationDBClusterReconciler) Reconcile(request ctrl.Request) (ctrl.Re
 		ChooseRemovals{},
 		ExcludeInstances{},
 		ChangeCoordinators{},
-		RemovePods{},
-		IncludeInstances{},
 		BounceProcesses{},
 		UpdatePods{},
+		RemovePods{},
+		IncludeInstances{},
 		UpdateStatus{UpdateGenerations: true},
 	}
 

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -45,7 +45,9 @@ func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 		if instance.Pod == nil {
 			continue
 		}
-		if instance.Pod.DeletionTimestamp != nil {
+		_, pendingRemoval := cluster.Spec.PendingRemovals[instance.Metadata.Name]
+
+		if instance.Pod.DeletionTimestamp != nil && !pendingRemoval {
 			return false, ReconciliationNotReadyError{message: "Cluster has pod that is pending deletion", retryable: true}
 		}
 

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -103,9 +103,11 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 		instanceID := instance.Metadata.Labels["fdb-instance-id"]
 
 		_, pendingRemoval := cluster.Spec.PendingRemovals[instance.Metadata.Name]
-		if !pendingRemoval {
-			status.ProcessCounts.IncreaseCount(processClass, 1)
+		if pendingRemoval {
+			continue
 		}
+
+		status.ProcessCounts.IncreaseCount(processClass, 1)
 
 		processStatus := processMap[instanceID]
 		if len(processStatus) == 0 {


### PR DESCRIPTION
Resolves #76 