### PR TITLE
General cleanups to Makefile.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,7 +28,7 @@ jobs:
         export PATH=$PATH:/usr/local/kubebuilder/bin
 
     - name: Build
-      run: make all test
+      run: make all
 
     - name: Check for uncommitted changes
       run: git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ deploy: install manifests
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: ${MANIFESTS}
 
-${MANIFESTS}:
+${MANIFESTS}: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 # Run go fmt against code
@@ -89,7 +89,7 @@ bin/vet_check: ${GO_ALL}
 # Generate code
 generate: ${GENERATED_GO}
 
-${GENERATED_GO}: ${GO_SRC} hack/boilerplate.go.txt
+${GENERATED_GO}: ${GO_SRC} hack/boilerplate.go.txt controller-gen
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the docker image

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ all: fmt vet manager manifests samples documentation test_if_changed
 clean:
 	find config/crd/bases -type f -name "*.yaml" -delete
 	find api -type f -name "zz_generated.*.go" -delete
-	find bin -type f -delete
+	rm -r bin
 	find config/samples -type f -name deployment.yaml -delete
 	find . -name "cover.out" -delete
 
@@ -77,6 +77,7 @@ fmt: bin/fmt_check
 
 bin/fmt_check: ${GO_ALL}
 	go fmt ./...
+	mkdir -p bin
 	@touch bin/fmt_check
 
 # Run go vet against code
@@ -84,6 +85,7 @@ vet: bin/vet_check
 
 bin/vet_check: ${GO_ALL}
 	go vet ./...
+	mkdir -p bin
 	@touch bin/vet_check
 
 # Generate code


### PR DESCRIPTION
Mark all phony targets.
Prevent some of the phony targets from running when there are no changes to necessitate them running.
Closes #169