### PR TITLE
Set the WATCH_NAMESPACE field in more example deployments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ clusters on Kubernetes.
 To run the operator in your environment, you need to install the controller and
 the CRDs:
 
-		kubectl apply -f https://raw.githubusercontent.com/foundationdb/fdb-kubernetes-operator/master/config/samples/deployment.yaml
 		(kubectl create -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml) || (kubectl replace -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml)
 		(kubectl create -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml) || (kubectl replace -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml)
+		kubectl apply -f https://raw.githubusercontent.com/foundationdb/fdb-kubernetes-operator/master/config/samples/deployment.yaml
 
 At that point, you can set up one of the sample clusters:
 

--- a/config/rbac/foundationdbcluster_editor_role.yaml
+++ b/config/rbac/foundationdbcluster_editor_role.yaml
@@ -2,12 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: foundationdbcluster-editor-role
+  name: foundationdb-editor-role
 rules:
 - apiGroups:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters
+  - foundationdbbackups
   verbs:
   - create
   - delete
@@ -20,6 +21,7 @@ rules:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters/status
+  - foundationdbbackups/status
   verbs:
   - get
   - patch

--- a/config/rbac/foundationdbcluster_viewer_role.yaml
+++ b/config/rbac/foundationdbcluster_viewer_role.yaml
@@ -2,12 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: foundationdbcluster-viewer-role
+  name: foundationdb-viewer-role
 rules:
 - apiGroups:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters
+  - foundationdbbackups
   verbs:
   - get
   - list
@@ -16,5 +17,6 @@ rules:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters/status
+  - foundationdbbackups/status
   verbs:
   - get

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -1,3 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fdb-kubernetes-operator-controller-manager
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -23,6 +28,7 @@ rules:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters
+  - foundationdbbackups
   verbs:
   - get
   - list
@@ -35,6 +41,7 @@ rules:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters/status
+  - foundationdbbackups/status
   verbs:
   - get
   - update
@@ -88,7 +95,7 @@ roleRef:
   name: fdb-kubernetes-operator-manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: fdb-kubernetes-operator-controller-manager
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -114,7 +121,7 @@ spec:
         command:
         - /manager
         env:
-        - name: POD_NAMESPACE
+        - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -127,4 +134,5 @@ spec:
           requests:
             cpu: 500m
             memory: 256Mi
+      serviceAccountName: fdb-kubernetes-operator-controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/samples/deployment/manager.yaml
+++ b/config/samples/deployment/manager.yaml
@@ -16,6 +16,7 @@ spec:
         control-plane: controller-manager
         app: fdb-kubernetes-operator-controller-manager
     spec:
+      serviceAccountName: fdb-kubernetes-operator-controller-manager
       containers:
       - command:
         - /manager
@@ -24,7 +25,7 @@ spec:
         image: foundationdb/fdb-kubernetes-operator:0.6.0
         name: manager
         env:
-          - name: POD_NAMESPACE
+          - name: WATCH_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
@@ -36,3 +37,8 @@ spec:
             cpu: 500m
             memory: 256Mi
       terminationGracePeriodSeconds: 10
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager

--- a/config/samples/deployment/rbac_role.yaml
+++ b/config/samples/deployment/rbac_role.yaml
@@ -23,6 +23,7 @@ rules:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters
+  - foundationdbbackups
   verbs:
   - get
   - list
@@ -35,6 +36,7 @@ rules:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters/status
+  - foundationdbbackups/status
   verbs:
   - get
   - update

--- a/config/samples/deployment/rbac_role_binding.yaml
+++ b/config/samples/deployment/rbac_role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager

--- a/helm/fdb-operator/templates/manager/deployment.yaml
+++ b/helm/fdb-operator/templates/manager/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         command:
         - /manager
         env:
-        - name: POD_NAMESPACE
+        - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace

--- a/helm/fdb-operator/templates/rbac/rbac_role.yaml
+++ b/helm/fdb-operator/templates/rbac/rbac_role.yaml
@@ -23,6 +23,7 @@ rules:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters
+  - foundationdbbackups
   verbs:
   - get
   - list
@@ -35,6 +36,7 @@ rules:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters/status
+  - foundationdbbackups/status
   verbs:
   - get
   - update


### PR DESCRIPTION
Add the backup permissions to more default roles.
Add documentation on the WATCH_NAMESPACE option to the user manual.
Closes #156