### PR TITLE
Drop support for old sidecar environment variables in newer versions of FDB.

### DIFF
--- a/foundationdb-kubernetes-sidecar/Dockerfile
+++ b/foundationdb-kubernetes-sidecar/Dockerfile
@@ -20,8 +20,8 @@
 FROM python:3.6
 
 WORKDIR /var/fdb/tmp
-ARG FDB_VERSION=6.2.7
-ARG FDB_LIBRARY_VERSIONS="6.2.7 6.1.8 6.0.18 5.2.8 5.1.7"
+ARG FDB_VERSION=6.2.15
+ARG FDB_LIBRARY_VERSIONS="6.2.15 6.1.8"
 ARG FDB_WEBSITE=https://www.foundationdb.org
 
 ADD website /mnt/website
@@ -43,10 +43,6 @@ COPY requirements.txt /
 COPY sidecar.py /
 
 RUN pip install -r /requirements.txt && rm /requirements.txt && chmod a+x /entrypoint.bash
-
-ENV COPY_ONCE 0
-ENV SIDECAR_CONF_DIR /var/sidecar-conf
-COPY default_config.json $SIDECAR_CONF_DIR/config.json
 
 VOLUME /var/input-files
 VOLUME /var/output-files

--- a/foundationdb-kubernetes-sidecar/default_config.json
+++ b/foundationdb-kubernetes-sidecar/default_config.json
@@ -1,7 +1,0 @@
-{
-  "COPY_FILES": [],
-  "COPY_BINARIES": [],
-  "COPY_LIBRARIES": [],
-  "INPUT_MONITOR_CONF": null,
-  "ADDITIONAL_SUBSTITUTIONS": []
-}


### PR DESCRIPTION
This establishes a hard cut-off with FDB 6.3 where using the old environment variables and the JSON config file are no longer supported. Once we stop doing patch releases for FDB 6.2, we can remove this code completely.

Related to #84 