### PR TITLE
Bump the FDB version in our examples and tests to 6.2.20

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1846,7 +1846,7 @@ func (version FdbVersion) HasMaxProtocolClientsInStatus() bool {
 // HasSidecarCrashOnEmpty determines if a version has the flag to have the
 // sidecar crash on a file being empty.
 func (version FdbVersion) HasSidecarCrashOnEmpty() bool {
-	return version.IsAtLeast(FdbVersion{Major: 6, Minor: 3, Patch: 0})
+	return version.IsAtLeast(FdbVersion{Major: 6, Minor: 2, Patch: 20})
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/suite_test.go
+++ b/api/v1beta1/suite_test.go
@@ -22,9 +22,10 @@ var Versions = struct {
 	WithCommandLineVariablesForSidecar, WithEnvironmentVariablesForSidecar,
 	WithBinariesFromMainContainer, WithoutBinariesFromMainContainer,
 	WithRatekeeperRole, WithoutRatekeeperRole,
+	WithSidecarCrashOnEmpty, WithoutSidecarCrashOnEmpty,
 	Default FdbVersion
 }{
-	Default:                              FdbVersion{Major: 6, Minor: 2, Patch: 15},
+	Default:                              FdbVersion{Major: 6, Minor: 2, Patch: 20},
 	NextMajorVersion:                     FdbVersion{Major: 7, Minor: 0, Patch: 0},
 	WithSidecarInstanceIDSubstitution:    FdbVersion{Major: 6, Minor: 2, Patch: 15},
 	WithoutSidecarInstanceIDSubstitution: FdbVersion{Major: 6, Minor: 2, Patch: 11},
@@ -34,4 +35,6 @@ var Versions = struct {
 	WithoutBinariesFromMainContainer:     FdbVersion{Major: 6, Minor: 2, Patch: 11},
 	WithRatekeeperRole:                   FdbVersion{Major: 6, Minor: 2, Patch: 15},
 	WithoutRatekeeperRole:                FdbVersion{Major: 6, Minor: 1, Patch: 12},
+	WithSidecarCrashOnEmpty:              FdbVersion{Major: 6, Minor: 2, Patch: 20},
+	WithoutSidecarCrashOnEmpty:           FdbVersion{Major: 6, Minor: 2, Patch: 15},
 }

--- a/config/samples/cluster_large.yaml
+++ b/config/samples/cluster_large.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: sample-cluster
 spec:
-  version: 6.2.15
+  version: 6.2.20
   podTemplate:
     spec:
       automountServiceAccountToken: false

--- a/config/samples/cluster_local.yaml
+++ b/config/samples/cluster_local.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: sample-cluster
 spec:
-  version: 6.2.15
+  version: 6.2.20
   faultDomain:
     key: foundationdb.org/none
   processCounts:

--- a/config/samples/cluster_local_tls.yaml
+++ b/config/samples/cluster_local_tls.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: sample-cluster
 spec:
-  version: 6.2.15
+  version: 6.2.20
   faultDomain:
     key: foundationdb.org/none
   processCounts:

--- a/config/samples/cluster_with_backup.yaml
+++ b/config/samples/cluster_with_backup.yaml
@@ -28,7 +28,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: sample-cluster
 spec:
-  version: 6.2.15
+  version: 6.2.20
   volumeClaim:
     spec:
       resources:
@@ -65,7 +65,7 @@ kind: FoundationDBBackup
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.15
+  version: 6.2.20
   clusterName: sample-cluster
   accountName: minio@minio-service:9000
   podTemplateSpec:

--- a/config/samples/cluster_with_client.yaml
+++ b/config/samples/cluster_with_client.yaml
@@ -3,14 +3,6 @@
 # The client app will get its cluster file from a config map that is managed
 # by the operator. It will also use the sidecar to include multiple client
 # libraries to support upgrades of FoundationDB.
-#
-# Because the app depends on the config map created by the operator, it will
-# not be able to launch until the cluster gets far enough in reconciliation to
-# generate a cluster file. You can work around this by creating the cluster
-# first and then applying the rest of the file to create the app. As an
-# alternative, you can apply the entire file and then run
-# `kubectl delete pod -l app=sample-cluster-client` to bounce the clients and
-# pick up the final cluster file.
 apiVersion: apps.foundationdb.org/v1beta1
 kind: FoundationDBCluster
 metadata:
@@ -18,7 +10,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: sample-cluster
 spec:
-  version: 6.2.15
+  version: 6.2.20
   faultDomain:
     key: foundationdb.org/none
   processCounts:
@@ -68,7 +60,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: foundationdb-kubernetes-init
-          image: foundationdb/foundationdb-kubernetes-sidecar:6.2.15-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:6.2.20-1
           args:
             - "--copy-file"
             - "fdb.cluster"
@@ -77,6 +69,8 @@ spec:
             - "--copy-library"
             - "6.2"
             - "--init-mode"
+            - "--require-not-empty"
+            - "fdb.cluster"
           volumeMounts:
             - name: config-map
               mountPath: /var/input-files

--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -88,7 +88,7 @@ var _ = Describe("admin_client_test", func() {
 					Locality: map[string]string{
 						"instance_id": "storage-1",
 					},
-					Version: "6.2.15",
+					Version: "6.2.20",
 				}))
 			})
 		})

--- a/controllers/pod_models_test.go
+++ b/controllers/pod_models_test.go
@@ -205,7 +205,7 @@ var _ = Describe("pod_models", func() {
 					"--copy-binary",
 					"fdbcli",
 					"--main-container-version",
-					"6.2.15",
+					"6.2.20",
 					"--init-mode",
 				}))
 				Expect(initContainer.Env).To(Equal([]corev1.EnvVar{
@@ -275,7 +275,7 @@ var _ = Describe("pod_models", func() {
 					"--copy-binary",
 					"fdbcli",
 					"--main-container-version",
-					"6.2.15",
+					"6.2.20",
 				}))
 				Expect(sidecarContainer.Env).To(Equal([]corev1.EnvVar{
 					corev1.EnvVar{Name: "FDB_PUBLIC_IP", ValueFrom: &corev1.EnvVarSource{
@@ -797,7 +797,7 @@ var _ = Describe("pod_models", func() {
 					"--copy-binary",
 					"fdbcli",
 					"--main-container-version",
-					"6.2.15",
+					"6.2.20",
 					"--init-mode",
 				}))
 				Expect(initContainer.Env).To(Equal([]corev1.EnvVar{
@@ -1393,7 +1393,7 @@ var _ = Describe("pod_models", func() {
 					"--copy-binary",
 					"fdbcli",
 					"--main-container-version",
-					"6.2.15",
+					"6.2.20",
 					"--init-mode",
 				}))
 			})
@@ -1413,7 +1413,7 @@ var _ = Describe("pod_models", func() {
 					"--copy-binary",
 					"fdbcli",
 					"--main-container-version",
-					"6.2.15",
+					"6.2.20",
 				}))
 
 				Expect(sidecarContainer.Env).To(Equal([]corev1.EnvVar{
@@ -1697,7 +1697,7 @@ var _ = Describe("pod_models", func() {
 					"foundationdb.org/backup-for": string(cluster.ObjectMeta.UID),
 				}))
 				Expect(deployment.ObjectMeta.Annotations).To(Equal(map[string]string{
-					"foundationdb.org/last-applied-spec": "930784c79792aa8f1d329e086986389a293ecb7ca70278dbee43d1fa527cbd1b",
+					"foundationdb.org/last-applied-spec": "53bf93c896578af51723c0db12e884751be4ee702c7487a1a57108fa111a23d6",
 				}))
 			})
 
@@ -1793,6 +1793,8 @@ var _ = Describe("pod_models", func() {
 					Expect(container.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
 					Expect(container.Args).To(Equal([]string{
 						"--copy-file",
+						"fdb.cluster",
+						"--require-not-empty",
 						"fdb.cluster",
 						"--init-mode",
 					}))

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -139,7 +139,7 @@ var Versions = struct {
 	WithSidecarCrashOnEmpty, WithoutSidecarCrashOnEmpty,
 	Default fdbtypes.FdbVersion
 }{
-	Default:                              fdbtypes.FdbVersion{Major: 6, Minor: 2, Patch: 15},
+	Default:                              fdbtypes.FdbVersion{Major: 6, Minor: 2, Patch: 20},
 	NextMajorVersion:                     fdbtypes.FdbVersion{Major: 7, Minor: 0, Patch: 0},
 	WithSidecarInstanceIDSubstitution:    fdbtypes.FdbVersion{Major: 6, Minor: 2, Patch: 15},
 	WithoutSidecarInstanceIDSubstitution: fdbtypes.FdbVersion{Major: 6, Minor: 2, Patch: 11},
@@ -149,7 +149,7 @@ var Versions = struct {
 	WithoutBinariesFromMainContainer:     fdbtypes.FdbVersion{Major: 6, Minor: 2, Patch: 11},
 	WithRatekeeperRole:                   fdbtypes.FdbVersion{Major: 6, Minor: 2, Patch: 15},
 	WithoutRatekeeperRole:                fdbtypes.FdbVersion{Major: 6, Minor: 1, Patch: 12},
-	WithSidecarCrashOnEmpty:              fdbtypes.FdbVersion{Major: 6, Minor: 3, Patch: 0},
+	WithSidecarCrashOnEmpty:              fdbtypes.FdbVersion{Major: 6, Minor: 2, Patch: 20},
 	WithoutSidecarCrashOnEmpty:           fdbtypes.FdbVersion{Major: 6, Minor: 2, Patch: 15},
 }
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -51,7 +51,7 @@ To start with, we are going to be creating a cluster with the following configur
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         storage: 5
 
@@ -84,7 +84,7 @@ Now that your cluster is deployed, you can easily access the cluster. As an exam
               restartPolicy: OnFailure
               containers:
               - name: fdbcli-status-cronjob
-                image: foundationdb/foundationdb:6.2.11
+                image: foundationdb/foundationdb:6.2.20
                 args:
                 - /usr/bin/fdbcli
                 - --exec
@@ -116,7 +116,7 @@ To explicitly set process counts, you could configure the cluster as follows:
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       processCounts:
         storage: 6
         log: 5
@@ -142,7 +142,7 @@ Instead of setting the counts directly, let's update the counts of recruited rol
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         storage: 6
         logs: 4 # default is 3
@@ -160,7 +160,7 @@ You can shrink a cluster by changing the database configuration or process count
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         storage: 4
 
@@ -183,7 +183,7 @@ As an alternative, you can replace a pod by explicitly placing it in the pending
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         storage: 5
       instancesToRemove:
@@ -200,7 +200,7 @@ You can reconfigure the database by changing the fields in the database configur
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         redundancy_mode: triple
         storage: 5
@@ -216,7 +216,7 @@ To add a knob, you can change the customParameters in the cluster spec:
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         storage: 5
       customParameters:
@@ -235,7 +235,7 @@ To upgrade a cluster, you can change the version in the cluster spec:
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.15
+      version: 6.2.20
       databaseConfiguration:
         storage: 5
 
@@ -268,7 +268,7 @@ You can make the values from this secret available through a custom volume mount
     metadata:
         name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         storage: 5
       podTemplate:
@@ -345,7 +345,7 @@ The default fault domain strategy is to replicate across nodes in a single Kuber
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         storage: 5
       faultDomain:
@@ -362,7 +362,7 @@ If you have some other mechanism to make this information available in your pod'
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         storage: 5
       faultDomain:
@@ -378,7 +378,7 @@ Our second strategy is to run multiple Kubernetes cluster, each as its own fault
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         storage: 5
       volumeSize: "128G"
@@ -401,7 +401,7 @@ Example with automation options disabled:
     metadata:
         name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         storage: 5
       automationOptions:
@@ -422,7 +422,7 @@ In local test environments, you may not having any real fault domains to use, an
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       databaseConfiguration:
         storage: 5
       automationOptions:
@@ -443,7 +443,7 @@ The replication strategies above all describe how data is replicated within a da
     metadata:
       name: sample-cluster
     spec:
-      version: 6.2.10
+      version: 6.2.20
       dataCenter: dc1
       processCounts:
         stateless: -1


### PR DESCRIPTION
Enable the require-not-present flag starting with FDB 6.2.20
Add the require-not-present flag to the cluster_with_client example.

Closes #199 