### PR TITLE
Prevent reconfiguring the database once we have detected a configured database.

### DIFF
--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -54,7 +54,7 @@ func (u UpdateDatabaseConfiguration) Reconcile(r *FoundationDBClusterReconciler,
 		return false, err
 	}
 
-	initialConfig := status.Cluster.Layers.Error == "configurationMissing"
+	initialConfig := !cluster.Status.Configured
 
 	healthy = initialConfig || status.Client.DatabaseStatus.Healthy
 	currentConfiguration = status.Cluster.DatabaseConfiguration.NormalizeConfiguration()

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -73,7 +73,7 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 	}
 
 	status.DatabaseConfiguration = databaseStatus.Cluster.DatabaseConfiguration.NormalizeConfiguration()
-	status.Configured = databaseStatus.Cluster.Layers.Error != "configurationMissing"
+	status.Configured = cluster.Status.Configured || (databaseStatus.Client.DatabaseStatus.Available && databaseStatus.Cluster.Layers.Error != "configurationMissing")
 
 	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, getPodListOptions(cluster, "", "")...)
 	if err != nil {


### PR DESCRIPTION
Resolves #247 