### PR TITLE
Leave the IP address empty in the choose_removals step when the pod does not have an IP.

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -625,7 +625,9 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should clear the removal list", func() {
 					Expect(cluster.Spec.PendingRemovals).To(BeNil())
-					Expect(cluster.Spec.InstancesToRemove).To(BeNil())
+					Expect(cluster.Spec.InstancesToRemove).To(Equal([]string{
+						originalPods.Items[firstStorageIndex].ObjectMeta.Labels["fdb-instance-id"],
+					}))
 				})
 			})
 		})

--- a/controllers/pod_client.go
+++ b/controllers/pod_client.go
@@ -250,8 +250,13 @@ func NewMockFdbPodClient(cluster *fdbtypes.FoundationDBCluster, pod *corev1.Pod)
 	return &mockFdbPodClient{Cluster: cluster, Pod: pod}, nil
 }
 
+var mockMissingPodIPs map[string]bool
+
 // MockPodIP generates a mock IP for FDB pod
 func MockPodIP(pod *corev1.Pod) string {
+	if mockMissingPodIPs != nil && mockMissingPodIPs[pod.ObjectMeta.Name] {
+		return ""
+	}
 	components := strings.Split(GetInstanceIDFromMeta(pod.ObjectMeta), "-")
 	for index, class := range fdbtypes.ProcessClasses {
 		if class == components[len(components)-2] {


### PR DESCRIPTION
Resolves #246 