### PR TITLE
Ignore the values for version flags in the live configuration when those flags are omitted in the cluster spec.

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -206,7 +206,10 @@ var _ = Describe("cluster_controller", func() {
 
 				status, err := adminClient.GetStatus()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cluster.Status.DatabaseConfiguration).To(Equal(status.Cluster.DatabaseConfiguration))
+
+				configuration := status.Cluster.DatabaseConfiguration.DeepCopy()
+				configuration.LogSpill = 0
+				Expect(cluster.Status.DatabaseConfiguration).To(Equal(*configuration))
 
 				Expect(cluster.Status.Health).To(Equal(fdbtypes.ClusterHealth{
 					Available:            true,
@@ -627,6 +630,41 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should configure the database", func() {
 					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal("triple"))
+				})
+			})
+
+			Context("with a change to the log version", func() {
+				BeforeEach(func() {
+					cluster.Spec.DatabaseConfiguration.LogVersion = 3
+					cluster.Spec.DatabaseConfiguration.RedundancyMode = "double"
+					generationGap = 1
+					err = k8sClient.Update(context.TODO(), cluster)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should configure the database", func() {
+					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal("double"))
+					Expect(adminClient.DatabaseConfiguration.LogVersion).To(Equal(3))
+				})
+			})
+
+			Context("with a change to the log version that is not set in the spec", func() {
+				BeforeEach(func() {
+					cluster.Spec.DatabaseConfiguration.RedundancyMode = "double"
+					cluster.Spec.SeedConnectionString = "touch"
+
+					configuration := cluster.DesiredDatabaseConfiguration()
+					configuration.LogVersion = 3
+					err = adminClient.ConfigureDatabase(configuration, false)
+					Expect(err).NotTo(HaveOccurred())
+
+					generationGap = 1
+					err = k8sClient.Update(context.TODO(), cluster)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should not reconfigure the database", func() {
+					Expect(adminClient.DatabaseConfiguration.LogVersion).To(Equal(3))
 				})
 			})
 

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -58,7 +58,7 @@ func (u UpdateDatabaseConfiguration) Reconcile(r *FoundationDBClusterReconciler,
 
 	healthy = initialConfig || status.Client.DatabaseStatus.Healthy
 	currentConfiguration = status.Cluster.DatabaseConfiguration.NormalizeConfiguration()
-	desiredConfiguration.FillInDefaultVersionFlags(currentConfiguration)
+	cluster.ClearMissingVersionFlags(&currentConfiguration)
 	needsChange = initialConfig || !reflect.DeepEqual(desiredConfiguration, currentConfiguration)
 
 	if needsChange {

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -73,6 +73,7 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 	}
 
 	status.DatabaseConfiguration = databaseStatus.Cluster.DatabaseConfiguration.NormalizeConfiguration()
+	cluster.ClearMissingVersionFlags(&status.DatabaseConfiguration)
 	status.Configured = cluster.Status.Configured || (databaseStatus.Client.DatabaseStatus.Available && databaseStatus.Cluster.Layers.Error != "configurationMissing")
 
 	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, getPodListOptions(cluster, "", "")...)


### PR DESCRIPTION
Resolves #217 