### PR TITLE
Ignore PVCs that are not owned by the cluster when checking for misconfigured pods.

### DIFF
--- a/controllers/replace_misconfigured_pods.go
+++ b/controllers/replace_misconfigured_pods.go
@@ -49,6 +49,18 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 	}
 
 	for _, pvc := range pvcs.Items {
+		ownedByCluster := false
+		for _, ownerReference := range pvc.OwnerReferences {
+			if ownerReference.UID == cluster.UID {
+				ownedByCluster = true
+				break
+			}
+		}
+
+		if !ownedByCluster {
+			continue
+		}
+
 		instanceID := GetInstanceIDFromMeta(pvc.ObjectMeta)
 		if instancesToRemove[instanceID] {
 			continue


### PR DESCRIPTION
Resolves #232 