### PR TITLE
Use an annotation to track which version of a config map a pod has seen.

### DIFF
--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -64,6 +64,11 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 		return false, err
 	}
 
+	configMapHash, err := GetDynamicConfHash(configMap)
+	if err != nil {
+		return false, err
+	}
+
 	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, getPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return false, err
@@ -202,6 +207,8 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 				if err != nil {
 					return false, err
 				}
+				pod.ObjectMeta.Annotations[LastConfigMapKey] = configMapHash
+
 				err = r.PodLifecycleManager.CreateInstance(r, context, pod)
 				if err != nil {
 					return false, err

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -159,6 +159,11 @@ var _ = Describe("cluster_controller", func() {
 					"stateless":          8,
 					"cluster_controller": 1,
 				}))
+
+				configMapHash, err := GetConfigMapHash(context.TODO(), cluster, k8sClient)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(pods.Items[0].ObjectMeta.Annotations[LastConfigMapKey]).To(Equal(configMapHash))
 			})
 
 			It("should not create any services", func() {
@@ -961,16 +966,22 @@ var _ = Describe("cluster_controller", func() {
 
 					hash, err := GetPodSpecHash(cluster, item.Labels["fdb-process-class"], id, nil)
 					Expect(err).NotTo(HaveOccurred())
+
+					configMapHash, err := GetConfigMapHash(context.TODO(), cluster, k8sClient)
+					Expect(err).NotTo(HaveOccurred())
+
 					if item.Labels["fdb-instance-id"] == "storage-1" {
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-							"foundationdb.org/last-applied-spec":   hash,
-							"foundationdb.org/existing-annotation": "test-value",
-							"fdb-annotation":                       "value1",
+							"foundationdb.org/last-applied-config-map": configMapHash,
+							"foundationdb.org/last-applied-spec":       hash,
+							"foundationdb.org/existing-annotation":     "test-value",
+							"fdb-annotation":                           "value1",
 						}))
 					} else {
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-							"foundationdb.org/last-applied-spec": hash,
-							"fdb-annotation":                     "value1",
+							"foundationdb.org/last-applied-config-map": configMapHash,
+							"foundationdb.org/last-applied-spec":       hash,
+							"fdb-annotation":                           "value1",
 						}))
 					}
 				}
@@ -1087,8 +1098,13 @@ var _ = Describe("cluster_controller", func() {
 
 					hash, err := GetPodSpecHash(cluster, item.Labels["fdb-process-class"], id, nil)
 					Expect(err).NotTo(HaveOccurred())
+
+					configMapHash, err := GetConfigMapHash(context.TODO(), cluster, k8sClient)
+					Expect(err).NotTo(HaveOccurred())
+
 					Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-						"foundationdb.org/last-applied-spec": hash,
+						"foundationdb.org/last-applied-config-map": configMapHash,
+						"foundationdb.org/last-applied-spec":       hash,
 					}))
 				}
 
@@ -1184,8 +1200,13 @@ var _ = Describe("cluster_controller", func() {
 
 					hash, err := GetPodSpecHash(cluster, item.Labels["fdb-process-class"], id, nil)
 					Expect(err).NotTo(HaveOccurred())
+
+					configMapHash, err := GetConfigMapHash(context.TODO(), cluster, k8sClient)
+					Expect(err).NotTo(HaveOccurred())
+
 					Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-						"foundationdb.org/last-applied-spec": hash,
+						"foundationdb.org/last-applied-config-map": configMapHash,
+						"foundationdb.org/last-applied-spec":       hash,
 					}))
 				}
 
@@ -1764,7 +1785,6 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should have the sidecar conf", func() {
 				sidecarConf := make(map[string]interface{})
-				log.Info("JPB got config map", "confMap", configMap.Data)
 				err = json.Unmarshal([]byte(configMap.Data["sidecar-conf"]), &sidecarConf)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(sidecarConf)).To(Equal(5))

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -31,6 +31,10 @@ var log = logf.Log.WithName("controller")
 // pod spec.
 const LastSpecKey = "foundationdb.org/last-applied-spec"
 
+// LastConfigMapKey provides the annotation name we use to store the hash of the
+// config map.
+const LastConfigMapKey = "foundationdb.org/last-applied-config-map"
+
 // BackupDeploymentLabel probvides the label we use to connect backup
 // deployments to a cluster.
 const BackupDeploymentLabel = "foundationdb.org/backup-for"


### PR DESCRIPTION
Mark pods as incorrect when they do not have the latest config map.

Resolves #42 
Resolves #280 