### PR TITLE
Prevent executing a bounce when the minimum process uptime is below a certain limit.

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1019,6 +1019,9 @@ type FoundationDBStatusProcessInfo struct {
 
 	// The version of FoundationDB the process is running.
 	Version string `json:"version,omitempty"`
+
+	// The time that the process has been up for.
+	UptimeSeconds float64 `json:"uptime_seconds,omitempty"`
 }
 
 // FoundationDBStatusDataStatistics provides information about the data in

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -496,7 +496,8 @@ func TestParsingClusterStatusWithSixOneCluster(t *testing.T) {
 						"processid":   "c813e585043a7ab55a4905f465c4aa52",
 						"zoneid":      "sample-cluster-storage-3",
 					},
-					Version: "6.1.12",
+					Version:       "6.1.12",
+					UptimeSeconds: 160.009,
 				},
 				"f9efa90fc104f4e277b140baf89aab66": {
 					Address:      "10.1.38.82:4501",
@@ -509,7 +510,8 @@ func TestParsingClusterStatusWithSixOneCluster(t *testing.T) {
 						"processid":   "f9efa90fc104f4e277b140baf89aab66",
 						"zoneid":      "sample-cluster-storage-1",
 					},
-					Version: "6.1.12",
+					Version:       "6.1.12",
+					UptimeSeconds: 160.008,
 				},
 				"5a633d7f4e98a6c938c84b97ec4aedbf": {
 					Address:      "10.1.38.89:4501",
@@ -522,7 +524,8 @@ func TestParsingClusterStatusWithSixOneCluster(t *testing.T) {
 						"processid":   "5a633d7f4e98a6c938c84b97ec4aedbf",
 						"zoneid":      "sample-cluster-log-2",
 					},
-					Version: "6.1.12",
+					Version:       "6.1.12",
+					UptimeSeconds: 160.009,
 				},
 				"5c1b68147a0ef34ce005a38245851270": {
 					Address:      "10.1.38.88:4501",
@@ -535,7 +538,8 @@ func TestParsingClusterStatusWithSixOneCluster(t *testing.T) {
 						"zoneid":      "sample-cluster-log-4",
 						"instance_id": "log-4",
 					},
-					Version: "6.1.12",
+					Version:       "6.1.12",
+					UptimeSeconds: 160.008,
 				},
 				"653defde43cf1fdef131e2fb82bd192d": {
 					Address:      "10.1.38.87:4501",
@@ -548,7 +552,8 @@ func TestParsingClusterStatusWithSixOneCluster(t *testing.T) {
 						"processid":   "653defde43cf1fdef131e2fb82bd192d",
 						"zoneid":      "sample-cluster-log-1",
 					},
-					Version: "6.1.12",
+					Version:       "6.1.12",
+					UptimeSeconds: 160.01,
 				},
 				"9c93d3b70118f16c72f7cb3f53e49f4c": {
 					Address:      "10.1.38.86:4501",
@@ -561,7 +566,8 @@ func TestParsingClusterStatusWithSixOneCluster(t *testing.T) {
 						"instance_id": "storage-2",
 						"machineid":   "sample-cluster-storage-2",
 					},
-					Version: "6.1.12",
+					Version:       "6.1.12",
+					UptimeSeconds: 160.008,
 				},
 				"b9c25278c0fa207bc2a73bda2300d0a9": {
 					Address:      "10.1.38.90:4501",
@@ -574,7 +580,8 @@ func TestParsingClusterStatusWithSixOneCluster(t *testing.T) {
 						"instance_id": "log-3",
 						"machineid":   "sample-cluster-log-3",
 					},
-					Version: "6.1.12",
+					Version:       "6.1.12",
+					UptimeSeconds: 160.01,
 				},
 			},
 			Data: FoundationDBStatusDataStatistics{
@@ -714,7 +721,8 @@ func TestParsingClusterStatusWithSixTwoCluster(t *testing.T) {
 						"instance_id": "log-3",
 						"machineid":   "sample-cluster-log-3",
 					},
-					Version: "6.2.15",
+					Version:       "6.2.15",
+					UptimeSeconds: 2955.58,
 				},
 				"c813e585043a7ab55a4905f465c4aa52": {
 					Address:      "10.1.38.95:4501",
@@ -727,7 +735,8 @@ func TestParsingClusterStatusWithSixTwoCluster(t *testing.T) {
 						"processid":   "c813e585043a7ab55a4905f465c4aa52",
 						"zoneid":      "sample-cluster-storage-3",
 					},
-					Version: "6.2.15",
+					Version:       "6.2.15",
+					UptimeSeconds: 2475.33,
 				},
 				"f9efa90fc104f4e277b140baf89aab66": {
 					Address:      "10.1.38.92:4501",
@@ -740,7 +749,8 @@ func TestParsingClusterStatusWithSixTwoCluster(t *testing.T) {
 						"processid":   "f9efa90fc104f4e277b140baf89aab66",
 						"zoneid":      "sample-cluster-storage-1",
 					},
-					Version: "6.2.15",
+					Version:       "6.2.15",
+					UptimeSeconds: 2951.17,
 				},
 				"5a633d7f4e98a6c938c84b97ec4aedbf": {
 					Address:      "10.1.38.105:4501",
@@ -753,7 +763,8 @@ func TestParsingClusterStatusWithSixTwoCluster(t *testing.T) {
 						"processid":   "5a633d7f4e98a6c938c84b97ec4aedbf",
 						"zoneid":      "sample-cluster-log-2",
 					},
-					Version: "6.2.15",
+					Version:       "6.2.15",
+					UptimeSeconds: 710.119,
 				},
 				"5c1b68147a0ef34ce005a38245851270": {
 					Address:      "10.1.38.102:4501",
@@ -766,7 +777,8 @@ func TestParsingClusterStatusWithSixTwoCluster(t *testing.T) {
 						"machineid":   "sample-cluster-log-4",
 						"processid":   "5c1b68147a0ef34ce005a38245851270",
 					},
-					Version: "6.2.15",
+					Version:       "6.2.15",
+					UptimeSeconds: 1095.18,
 				},
 				"653defde43cf1fdef131e2fb82bd192d": {
 					Address:      "10.1.38.104:4501",
@@ -779,7 +791,8 @@ func TestParsingClusterStatusWithSixTwoCluster(t *testing.T) {
 						"processid":   "653defde43cf1fdef131e2fb82bd192d",
 						"zoneid":      "sample-cluster-log-1",
 					},
-					Version: "6.2.15",
+					Version:       "6.2.15",
+					UptimeSeconds: 880.18,
 				},
 				"9c93d3b70118f16c72f7cb3f53e49f4c": {
 					Address:      "10.1.38.94:4501",
@@ -792,7 +805,8 @@ func TestParsingClusterStatusWithSixTwoCluster(t *testing.T) {
 						"processid":   "9c93d3b70118f16c72f7cb3f53e49f4c",
 						"zoneid":      "sample-cluster-storage-2",
 					},
-					Version: "6.2.15",
+					Version:       "6.2.15",
+					UptimeSeconds: 2650.5,
 				},
 			},
 			Data: FoundationDBStatusDataStatistics{

--- a/controllers/admin_client.go
+++ b/controllers/admin_client.go
@@ -645,7 +645,8 @@ func (client *MockAdminClient) GetStatus() (*fdbtypes.FoundationDBStatus, error)
 				"zoneid":      pod.Name,
 				"dcid":        client.Cluster.Spec.DataCenter,
 			},
-			Version: client.Cluster.Status.RunningVersion,
+			Version:       client.Cluster.Status.RunningVersion,
+			UptimeSeconds: 60000,
 		}
 	}
 

--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -90,7 +90,8 @@ var _ = Describe("admin_client_test", func() {
 						"zoneid":      "operator-test-1-storage-1",
 						"dcid":        "",
 					},
-					Version: "6.2.20",
+					Version:       "6.2.20",
+					UptimeSeconds: 60000,
 				}))
 			})
 		})

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -42,6 +42,11 @@ const BackupDeploymentLabel = "foundationdb.org/backup-for"
 // The default timeout for CLI commands.
 var DefaultCLITimeout = 10
 
+// MinimumUptimeSecondsForBounce defines the minimum time, in seconds, that the
+// processes in the cluster must have been up for before the operator can
+// execute a bounce.
+const MinimumUptimeSecondsForBounce = 600
+
 // metadataMatches determines if the current metadata on an object matches the
 // metadata specified by the cluster spec.
 func metadataMatches(currentMetadata metav1.ObjectMeta, desiredMetadata metav1.ObjectMeta) bool {

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -427,6 +427,7 @@ FoundationDBStatusProcessInfo describes the \"processes\" portion of the cluster
 | excluded | Excluded indicates whether the process has been excluded. | bool | false |
 | locality | The locality information for the process. | map[string]string | false |
 | version | The version of FoundationDB the process is running. | string | false |
+| uptime_seconds | The time that the process has been up for. | float64 | false |
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
Resolves #2 