### PR TITLE
Add a check for container readiness when determining if reconciliation is complete.

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -264,6 +264,11 @@ type FoundationDBClusterStatus struct {
 	// This will contain the name of the pod.
 	IncorrectPods []string `json:"incorrectPods,omitempty"`
 
+	// FailingPods provides the pods that are not starting correctly.
+	//
+	// This will contain the name of the pod.
+	FailingPods []string `json:"failingPods,omitempty"`
+
 	// MissingProcesses provides the processes that are not reporting to the
 	// cluster.
 	// This will map the names of the pod to the timestamp when we observed
@@ -376,6 +381,10 @@ type ClusterGenerationStatus struct {
 	// the status to allow users of the operator to track when the removal
 	// is fully complete.
 	HasPendingRemoval int64 `json:"hasPendingRemoval,omitempty"`
+
+	// HasFailingPods provides the last generation that has pods that are
+	// failing to start.
+	HasFailingPods int64 `json:"hasFailingPods,omitempty"`
 }
 
 // ClusterHealth represents different views into health in the cluster status.
@@ -868,6 +877,11 @@ func (cluster *FoundationDBCluster) CheckReconciliation() (bool, error) {
 
 	if len(cluster.Status.IncorrectPods) > 0 {
 		cluster.Status.Generations.NeedsPodDeletion = cluster.ObjectMeta.Generation
+		reconciled = false
+	}
+
+	if len(cluster.Status.FailingPods) > 0 {
+		cluster.Status.Generations.HasFailingPods = cluster.ObjectMeta.Generation
 		reconciled = false
 	}
 

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -3049,6 +3049,18 @@ func TestCheckingReconciliationForCluster(t *testing.T) {
 		Reconciled:             1,
 		NeedsCoordinatorChange: 2,
 	}))
+
+	cluster = createCluster()
+	cluster.Status.FailingPods = []string{
+		"sample-cluster-storage-1",
+	}
+	result, err = cluster.CheckReconciliation()
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.BeFalse())
+	g.Expect(cluster.Status.Generations).To(gomega.Equal(ClusterGenerationStatus{
+		Reconciled:     1,
+		HasFailingPods: 2,
+	}))
 }
 
 func TestGettingProcessSettings(t *testing.T) {

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -556,6 +556,11 @@ func (in *FoundationDBClusterStatus) DeepCopyInto(out *FoundationDBClusterStatus
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.FailingPods != nil {
+		in, out := &in.FailingPods, &out.FailingPods
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.MissingProcesses != nil {
 		in, out := &in.MissingProcesses, &out.MissingProcesses
 		*out = make(map[string]int64, len(*in))

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -7691,9 +7691,16 @@ spec:
                 usable_regions:
                   type: integer
               type: object
+            failingPods:
+              items:
+                type: string
+              type: array
             generations:
               properties:
                 hasExtraListeners:
+                  format: int64
+                  type: integer
+                hasFailingPods:
                   format: int64
                   type: integer
                 hasPendingRemoval:

--- a/controllers/pod_client.go
+++ b/controllers/pod_client.go
@@ -88,7 +88,7 @@ func NewFdbPodClient(cluster *fdbtypes.FoundationDBCluster, pod *corev1.Pod) (Fd
 		return nil, fdbPodClientErrorNoIP
 	}
 	for _, container := range pod.Status.ContainerStatuses {
-		if !container.Ready {
+		if container.Name == "foundationdb-kubernetes-sidecar" && !container.Ready {
 			return nil, fdbPodClientErrorNotReady
 		}
 	}

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -108,6 +108,7 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 	cluster.Status.RequiredAddresses = status.RequiredAddresses
 
 	status.IncorrectPods = make([]string, 0)
+	status.FailingPods = make([]string, 0)
 
 	configMap, err := GetConfigMap(context, cluster, r)
 	if err != nil {
@@ -215,6 +216,12 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 					if !version.PrefersCommandLineArgumentsInSidecar() {
 						status.NeedsSidecarConfInConfigMap = true
 					}
+				}
+			}
+
+			for _, container := range instance.Pod.Status.ContainerStatuses {
+				if !container.Ready {
+					status.FailingPods = append(status.FailingPods, instance.Metadata.Name)
 				}
 			}
 		}

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -62,6 +62,7 @@ ClusterGenerationStatus stores information on which generations have reached dif
 | needsServiceUpdate | NeedsServiceUpdate provides the last generation that needs an update to the service config. | int64 | false |
 | needsBackupAgentUpdate | NeedsBackupAgentUpdate provides the last generation that could not complete reconciliation because the backup agent deployment needs to be updated. **Deprecated: This needs to get moved into FoundationDBBackup** | int64 | false |
 | hasPendingRemoval | HasPendingRemoval provides the last generation that has pods that have been excluded but are pending being removed.  A cluster in this state is considered reconciled, but we track this in the status to allow users of the operator to track when the removal is fully complete. | int64 | false |
+| hasFailingPods | HasFailingPods provides the last generation that has pods that are failing to start. | int64 | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -251,6 +252,7 @@ FoundationDBClusterStatus defines the observed state of FoundationDBCluster
 | processCounts | ProcessCounts defines the number of processes that are currently running in the cluster. | [ProcessCounts](#processcounts) | false |
 | incorrectProcesses | IncorrectProcesses provides the processes that do not have the correct configuration.  This will map the instance ID to the timestamp when we observed the incorrect configuration. | map[string]int64 | false |
 | incorrectPods | IncorrectPods provides the pods that do not have the correct spec.  This will contain the name of the pod. | []string | false |
+| failingPods | FailingPods provides the pods that are not starting correctly.  This will contain the name of the pod. | []string | false |
 | missingProcesses | MissingProcesses provides the processes that are not reporting to the cluster. This will map the names of the pod to the timestamp when we observed that the process was missing. | map[string]int64 | false |
 | databaseConfiguration | DatabaseConfiguration provides the running configuration of the database. | [DatabaseConfiguration](#databaseconfiguration) | false |
 | generations | Generations provides information about the latest generation to be reconciled, or to reach other stages at which reconciliation can halt. | [ClusterGenerationStatus](#clustergenerationstatus) | false |


### PR DESCRIPTION
Only check the Kubernetes sidecar client when determining if we can construct a client for the sidecar.

Resolves #281 
Resolves #291 