### PR TITLE
Correct roles and deployment for getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ clusters on Kubernetes.
 To run the operator in your environment, you need to install the controller and
 the CRDs:
 
-		(kubectl create -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml) || (kubectl replace -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml)
-		(kubectl create -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml) || (kubectl replace -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml)
-		kubectl apply -f https://raw.githubusercontent.com/foundationdb/fdb-kubernetes-operator/master/config/samples/deployment.yaml
+    kubectl apply -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+    kubectl apply -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml
+    kubectl apply -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
+    kubectl apply -f https://raw.githubusercontent.com/foundationdb/fdb-kubernetes-operator/master/config/samples/deployment.yaml
 
 At that point, you can set up one of the sample clusters:
 
 		kubectl apply -f https://raw.githubusercontent.com/foundationdb/fdb-kubernetes-operator/master/config/samples/cluster_local.yaml
 
 You can see logs from the operator by running
-`kubectl logs fdb-kubernetes-operator-controller-manager-0 --container=manager`. To determine whether the reconciliation has completed, you can run `kubectl get foundationdbcluster sample-cluster`. This will show the latest generation of the
+`kubectl logs -l fdb-kubernetes-operator-controller-manager-0 --container=manager`. To determine whether the reconciliation has completed, you can run `kubectl get foundationdbcluster sample-cluster`. This will show the latest generation of the
 spec and the last reconciled generation of the spec. Once reconciliation has completed, these values will be the same.
 
 Once the reconciliation is complete, you can run `kubectl exec -it sample-cluster-1 fdbcli` to open up a CLI on your cluster.

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -29,6 +29,7 @@ rules:
   resources:
   - foundationdbclusters
   - foundationdbbackups
+  - foundationdbrestores
   verbs:
   - get
   - list
@@ -42,6 +43,7 @@ rules:
   resources:
   - foundationdbclusters/status
   - foundationdbbackups/status
+  - foundationdbrestores/status
   verbs:
   - get
   - update
@@ -75,6 +77,18 @@ rules:
   - ""
   resources:
   - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
   verbs:
   - get
   - list


### PR DESCRIPTION
I followed the steps described in https://github.com/FoundationDB/fdb-kubernetes-operator/blob/master/docs/user_manual.md#introduction to setup the operator. During the process I ran into some minor issues which will be fixed with this PR:

1.) Missing RBAC for `deployments`:

```bash
E0811 06:10:46.431800       1 reflector.go:156] pkg/mod/k8s.io/client-go@v0.17.0/tools/cache/reflector.go:108: Failed to list *v1.Deployment: deployments.apps is forbidden: User "system:serviceaccount:default:fdb-kubernetes-operator-controller-manager" cannot list resource "deployments" in API group "apps" in the namespace "default"
```

2.) Missing CRD in the install steps:

```bash
2020-08-11T06:20:28.904Z        ERROR   controller-runtime.source       if kind is a CRD, it should be installed before calling Start   {"kind": "FoundationDBRestore.apps.foundationdb.org", "error": "no matches for kind \"FoundationDBRestore\" in version \"apps.foundationdb.org/v1beta1\""}
github.com/go-logr/zapr.(*zapLogger).Error
        /go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
sigs.k8s.io/controller-runtime/pkg/source.(*Kind).Start
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/source/source.go:88
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:165
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:198
sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).startLeaderElectionRunnables.func1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/manager/internal.go:477
2020-08-11T06:20:28.905Z        DEBUG   controller-runtime.manager      leader-election runnable finished       {"runnable type": "*controller.Controller"}
2020-08-11T06:20:28.905Z        ERROR   setup   problem running manager {"error": "no matches for kind \"FoundationDBRestore\" in version \"apps.foundationdb.org/v1beta1\""}
github.com/go-logr/zapr.(*zapLogger).Error
        /go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
main.main
        /workspace/main.go:145
runtime.main
        /usr/local/go/src/runtime/proc.go:203
2020-08-11T06:20:28.905Z        DEBUG   controller-runtime.manager      leader-election runnable finished       {"runnable type": "*controller.Controller"}
```