### PR TITLE
Correct image tag for operator in samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ At that point, you can set up one of the sample clusters:
 		kubectl apply -f https://raw.githubusercontent.com/foundationdb/fdb-kubernetes-operator/master/config/samples/cluster_local.yaml
 
 You can see logs from the operator by running
-`kubectl logs -l fdb-kubernetes-operator-controller-manager-0 --container=manager`. To determine whether the reconciliation has completed, you can run `kubectl get foundationdbcluster sample-cluster`. This will show the latest generation of the
+`kubectl logs -f -l app=fdb-kubernetes-operator-controller-manager --container=manager`. To determine whether the reconciliation has completed, you can run `kubectl get foundationdbcluster sample-cluster`. This will show the latest generation of the
 spec and the last reconciled generation of the spec. Once reconciliation has completed, these values will be the same.
 
 Once the reconciliation is complete, you can run `kubectl exec -it sample-cluster-1 fdbcli` to open up a CLI on your cluster.

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -139,7 +139,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: foundationdb/fdb-kubernetes-operator:7.0
+        image: foundationdb/fdb-kubernetes-operator:0.17.0
         name: manager
         resources:
           limits:


### PR DESCRIPTION
I also corrected the log command in the top level Readme.md

The previous defined docker tag was not available (and also looked compared to the other tags wrong):

```bash
$ docker pull foundationdb/fdb-kubernetes-operator:7.0
Error response from daemon: manifest for foundationdb/fdb-kubernetes-operator:7.0 not found: manifest unknown: manifest unknown


$ kubectl get po --show-labels
NAME                                                         READY   STATUS             RESTARTS   AGE   LABELS
fdb-kubernetes-operator-controller-manager-67b88c647-78jj6   0/1     ImagePullBackOff   0          56s   app=fdb-kubernetes-operator-controller-manager,control-plane=controller-manager,pod-template-hash=67b88c647
```