### PR TITLE
Avoid removing instances that do not have an IP address to prevent losing volumes that are temporarily inaccessible.

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -97,6 +97,15 @@ type FoundationDBClusterSpec struct {
 	// cluster. This list contains the instance IDs.
 	InstancesToRemove []string `json:"instancesToRemove,omitempty"`
 
+	// InstancesToRemoveWithoutExclusion defines the instances that we should
+	// remove from the cluster without excluding them. This list contains the
+	// instance IDs.
+	//
+	// This should be used for cases where a pod does not have an IP address and
+	// you want to remove it and destroy its volume without confirming the data
+	// is fully replicated.
+	InstancesToRemoveWithoutExclusion []string `json:"instancesToRemoveWithoutExclusion,omitempty"`
+
 	// ConfigMap allows customizing the config map the operator creates.
 	ConfigMap *corev1.ConfigMap `json:"configMap,omitempty"`
 
@@ -1535,6 +1544,12 @@ func (cluster *FoundationDBCluster) InstanceIsBeingRemoved(instanceID string) bo
 	}
 
 	for _, id := range cluster.Spec.InstancesToRemove {
+		if id == instanceID {
+			return true
+		}
+	}
+
+	for _, id := range cluster.Spec.InstancesToRemoveWithoutExclusion {
 		if id == instanceID {
 			return true
 		}

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -438,6 +438,11 @@ func (in *FoundationDBClusterSpec) DeepCopyInto(out *FoundationDBClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.InstancesToRemoveWithoutExclusion != nil {
+		in, out := &in.InstancesToRemoveWithoutExclusion, &out.InstancesToRemoveWithoutExclusion
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ConfigMap != nil {
 		in, out := &in.ConfigMap, &out.ConfigMap
 		*out = new(corev1.ConfigMap)

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -1190,6 +1190,10 @@ spec:
               items:
                 type: string
               type: array
+            instancesToRemoveWithoutExclusion:
+              items:
+                type: string
+              type: array
             lockOptions:
               properties:
                 disableLocks:

--- a/controllers/check_instances_to_remove.go
+++ b/controllers/check_instances_to_remove.go
@@ -22,6 +22,7 @@ package controllers
 
 import (
 	ctx "context"
+	"reflect"
 	"time"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
@@ -34,8 +35,6 @@ type CheckInstancesToRemove struct{}
 
 // Reconcile runs the reconciler's work.
 func (c CheckInstancesToRemove) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) (bool, error) {
-	hasNewRemovals := false
-
 	var removals = cluster.Status.PendingRemovals
 
 	if removals == nil {
@@ -43,20 +42,46 @@ func (c CheckInstancesToRemove) Reconcile(r *FoundationDBClusterReconciler, cont
 	}
 
 	for _, instanceID := range cluster.Spec.InstancesToRemove {
+		_, present := removals[instanceID]
+		if !present {
+			removals[instanceID] = fdbtypes.PendingRemovalState{}
+		}
+	}
+
+	for _, instanceID := range cluster.Spec.InstancesToRemoveWithoutExclusion {
+		_, present := removals[instanceID]
+		removalState := fdbtypes.PendingRemovalState{}
+		if !present {
+			removalState = removals[instanceID]
+		}
+		removalState.ExclusionComplete = true
+		removalState.ExclusionStarted = true
+		removals[instanceID] = removalState
+	}
+
+	var finalRemovals = make(map[string]fdbtypes.PendingRemovalState, len(removals))
+
+	for instanceID, oldRemovalState := range removals {
 		instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, client.InNamespace(cluster.Namespace), client.MatchingLabels(map[string]string{"fdb-instance-id": instanceID}))
 		if err != nil {
 			return false, err
 		}
-		_, present := removals[instanceID]
-		if !present && len(instances) > 0 {
-			hasNewRemovals = true
-			state := r.getPendingRemovalState(instances[0])
-			removals[instanceID] = state
+		if len(instances) > 0 {
+			newRemovalState := r.getPendingRemovalState(instances[0])
+			newRemovalState.ExclusionStarted = oldRemovalState.ExclusionStarted
+			newRemovalState.ExclusionComplete = oldRemovalState.ExclusionComplete
+			finalRemovals[instanceID] = newRemovalState
+		} else if oldRemovalState.PodName != "" {
+			finalRemovals[instanceID] = oldRemovalState
 		}
 	}
 
-	if hasNewRemovals {
-		cluster.Status.PendingRemovals = removals
+	if len(finalRemovals) == 0 {
+		finalRemovals = nil
+	}
+
+	if !reflect.DeepEqual(cluster.Status.PendingRemovals, finalRemovals) {
+		cluster.Status.PendingRemovals = finalRemovals
 		err := r.updatePendingRemovals(context, cluster)
 		if err != nil {
 			return false, err

--- a/controllers/check_instances_to_remove.go
+++ b/controllers/check_instances_to_remove.go
@@ -49,11 +49,7 @@ func (c CheckInstancesToRemove) Reconcile(r *FoundationDBClusterReconciler, cont
 	}
 
 	for _, instanceID := range cluster.Spec.InstancesToRemoveWithoutExclusion {
-		_, present := removals[instanceID]
-		removalState := fdbtypes.PendingRemovalState{}
-		if !present {
-			removalState = removals[instanceID]
-		}
+		removalState := removals[instanceID]
 		removalState.ExclusionComplete = true
 		removalState.ExclusionStarted = true
 		removals[instanceID] = removalState

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -597,7 +597,7 @@ var _ = Describe("cluster_controller", func() {
 					mockMissingPodIPs = map[string]bool{
 						originalPods.Items[firstStorageIndex].ObjectMeta.Name: true,
 					}
-					cluster.Spec.InstancesToRemove = []string{
+					cluster.Spec.InstancesToRemoveWithoutExclusion = []string{
 						originalPods.Items[firstStorageIndex].ObjectMeta.Labels["fdb-instance-id"],
 					}
 					err := k8sClient.Update(context.TODO(), cluster)
@@ -633,7 +633,7 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should clear the removal list", func() {
 					Expect(cluster.Spec.PendingRemovals).To(BeNil())
-					Expect(cluster.Spec.InstancesToRemove).To(Equal([]string{
+					Expect(cluster.Spec.InstancesToRemoveWithoutExclusion).To(Equal([]string{
 						originalPods.Items[firstStorageIndex].ObjectMeta.Labels["fdb-instance-id"],
 					}))
 				})

--- a/controllers/confirm_exclusion_completion.go
+++ b/controllers/confirm_exclusion_completion.go
@@ -22,6 +22,7 @@ package controllers
 
 import (
 	ctx "context"
+	"fmt"
 	"time"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
@@ -41,12 +42,13 @@ func (c ConfirmExclusionCompletion) Reconcile(r *FoundationDBClusterReconciler, 
 
 	addresses := make([]string, 0, len(cluster.Status.PendingRemovals))
 
-	for _, state := range cluster.Status.PendingRemovals {
-		if state.Address != "" {
-			address := cluster.GetFullAddress(state.Address)
-			if !state.ExclusionComplete {
-				addresses = append(addresses, address)
+	for instanceID, state := range cluster.Status.PendingRemovals {
+		if !state.ExclusionComplete {
+			if state.Address == "" {
+				return false, fmt.Errorf("Cannot check the exclusion state of instance %s, which has no IP address", instanceID)
 			}
+			address := cluster.GetFullAddress(state.Address)
+			addresses = append(addresses, address)
 		}
 	}
 

--- a/controllers/exclude_instances.go
+++ b/controllers/exclude_instances.go
@@ -57,12 +57,6 @@ func (e ExcludeInstances) Reconcile(r *FoundationDBClusterReconciler, context ct
 				cluster.Status.PendingRemovals[id] = newState
 				hasExclusionUpdates = true
 			}
-		} else if !state.ExclusionStarted || !state.ExclusionComplete {
-			newState := state
-			newState.ExclusionStarted = true
-			newState.ExclusionComplete = true
-			cluster.Status.PendingRemovals[id] = newState
-			hasExclusionUpdates = true
 		}
 	}
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -208,6 +208,7 @@ FoundationDBClusterSpec defines the desired state of a cluster.
 | seedConnectionString | SeedConnectionString provides a connection string for the initial reconciliation.  After the initial reconciliation, this will not be used. | string | false |
 | faultDomain | FaultDomain defines the rules for what fault domain to replicate across. | [FoundationDBClusterFaultDomain](#foundationdbclusterfaultdomain) | false |
 | instancesToRemove | InstancesToRemove defines the instances that we should remove from the cluster. This list contains the instance IDs. | []string | false |
+| instancesToRemoveWithoutExclusion | InstancesToRemoveWithoutExclusion defines the instances that we should remove from the cluster without excluding them. This list contains the instance IDs.  This should be used for cases where a pod does not have an IP address and you want to remove it and destroy its volume without confirming the data is fully replicated. | []string | false |
 | configMap | ConfigMap allows customizing the config map the operator creates. | *[corev1.ConfigMap](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#configmap-v1-core) | false |
 | mainContainer | MainContainer defines customization for the foundationdb container. | [ContainerOverrides](#containeroverrides) | false |
 | sidecarContainer | SidecarContainer defines customization for the foundationdb-kubernetes-sidecar container. | [ContainerOverrides](#containeroverrides) | false |


### PR DESCRIPTION
Update the IP address in the pending removal state automatically when the pod gets rescheduled.
Add an option to remove an instance without excluding it to work around issues with stuck pods.

Fixes #303