### PR TITLE
Fix to management of running version during upgrades

### DIFF
--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -97,7 +97,7 @@ func (c ChangeCoordinators) Reconcile(r *FoundationDBClusterReconciler, context 
 
 		candidates := make([]localityInfo, 0, len(status.Cluster.Processes))
 		for _, process := range status.Cluster.Processes {
-			eligible := !process.Excluded && isStateful(process.ProcessClass)
+			eligible := !process.Excluded && isStateful(process.ProcessClass) && !cluster.InstanceIsBeingRemoved(process.Locality["fdb-instance-id"])
 			if eligible {
 				candidates = append(candidates, localityInfoForProcess(process))
 			}


### PR DESCRIPTION
Use the version from the spec as a fallback when we cannot get the cluster status using the running verison, to work around bugs with kills that are done outside of the operator.

Don't allow choosing coordinators that are pending removal but not yet excluded, to work around a bug when processes do not get excluded properly.