### PR TITLE
Use slim base image for sample container

### DIFF
--- a/sample-apps/data-loader/Dockerfile
+++ b/sample-apps/data-loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8-slim
 
 COPY app.py /
 

--- a/sample-apps/data-loader/app.py
+++ b/sample-apps/data-loader/app.py
@@ -33,7 +33,7 @@ def load_data(keys, batch_size, value_size):
 	for batch in range(1, batch_count+1):
 		print('Writing batch %d' % batch)
 		write_batch(db, batch_size, value_size)
-		
+
 	pass
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change reduces the size of the resulting container (and also reduces the attack surface) for faster startup of the container:

```bash
REPOSITORY              TAG                 IMAGE ID            CREATED             SIZE
johscheuer/sample-app   latest              b5d4c94a6dfc        2 minutes ago       120MB
johscheuer/sample-app   old                 47b9677ed2f9        3 seconds ago       889MB
```