### PR TITLE
Add default resource requirements for the sidecar

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -87,6 +87,8 @@ func (r *FoundationDBClusterReconciler) Reconcile(request ctrl.Request) (ctrl.Re
 		return ctrl.Result{}, err
 	}
 
+	NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
+
 	adminClient, err := r.AdminClientProvider(cluster, r)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -61,6 +61,7 @@ type FoundationDBClusterReconciler struct {
 	AdminClientProvider func(*fdbtypes.FoundationDBCluster, client.Client) (AdminClient, error)
 	LockClientProvider  LockClientProvider
 	lockClients         map[string]LockClient
+	UseFutureDefaults   bool
 }
 
 // +kubebuilder:rbac:groups=apps.foundationdb.org,resources=foundationdbclusters,verbs=get;list;watch;create;update;patch;delete
@@ -87,7 +88,7 @@ func (r *FoundationDBClusterReconciler) Reconcile(request ctrl.Request) (ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
+	NormalizeClusterSpec(&cluster.Spec, defaultsSelection{UseFutureDefaults: r.UseFutureDefaults})
 	normalizedSpec := cluster.Spec.DeepCopy()
 
 	adminClient, err := r.AdminClientProvider(cluster, r)

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1175,6 +1175,7 @@ var _ = Describe("cluster_controller", func() {
 				It("should not update the annotations on other resources", func() {
 					pods := &corev1.PodList{}
 
+					NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
 					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 					Expect(err).NotTo(HaveOccurred())
 					for _, item := range pods.Items {
@@ -1249,6 +1250,9 @@ var _ = Describe("cluster_controller", func() {
 
 					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 					Expect(err).NotTo(HaveOccurred())
+
+					NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
+
 					for _, item := range pods.Items {
 						_, id, err := ParseInstanceID(item.Labels["fdb-instance-id"])
 						Expect(err).NotTo(HaveOccurred())

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -960,6 +960,8 @@ var _ = Describe("cluster_controller", func() {
 				pods := &corev1.PodList{}
 				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 				Expect(err).NotTo(HaveOccurred())
+
+				NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
 				for _, item := range pods.Items {
 					_, id, err := ParseInstanceID(item.Labels["fdb-instance-id"])
 					Expect(err).NotTo(HaveOccurred())
@@ -1288,6 +1290,8 @@ var _ = Describe("cluster_controller", func() {
 							},
 						},
 					}
+
+					NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
 					err := k8sClient.Update(context.TODO(), cluster)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1421,6 +1425,9 @@ var _ = Describe("cluster_controller", func() {
 				pods := &corev1.PodList{}
 				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 				Expect(err).NotTo(HaveOccurred())
+
+				NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
+
 				for _, item := range pods.Items {
 					_, id, err := ParseInstanceID(item.Labels["fdb-instance-id"])
 					Expect(err).NotTo(HaveOccurred())

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -74,3 +74,15 @@ func mergeAnnotations(target *metav1.ObjectMeta, desired metav1.ObjectMeta) bool
 	}
 	return changed
 }
+
+// defaultsSelection controls how defaults that are changing get applied to our
+// specs.
+type defaultsSelection struct {
+	// Whether we should apply the latest defaults rather than the defaults that
+	// were initially established for this major version.
+	ApplyLatestDefaults bool
+
+	// Whether we should only fill in defaults that have changes between major
+	// versions of the operator.
+	OnlyShowChanges bool
+}

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -80,7 +80,7 @@ func mergeAnnotations(target *metav1.ObjectMeta, desired metav1.ObjectMeta) bool
 type defaultsSelection struct {
 	// Whether we should apply the latest defaults rather than the defaults that
 	// were initially established for this major version.
-	ApplyLatestDefaults bool
+	UseFutureDefaults bool
 
 	// Whether we should only fill in defaults that have changes between major
 	// versions of the operator.

--- a/controllers/pod_client_test.go
+++ b/controllers/pod_client_test.go
@@ -33,6 +33,7 @@ var _ = Describe("pod_client", func() {
 
 	BeforeEach(func() {
 		cluster = createDefaultCluster()
+		NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
 	})
 
 	Context("with TLS disabled", func() {

--- a/controllers/pod_models.go
+++ b/controllers/pod_models.go
@@ -876,7 +876,7 @@ func NormalizeClusterSpec(spec *fdbtypes.FoundationDBClusterSpec, defaults defau
 		}
 
 		sidecarUpdater := func(container *corev1.Container) {
-			if defaults.ApplyLatestDefaults {
+			if defaults.UseFutureDefaults {
 				if container.Resources.Requests == nil {
 					container.Resources.Requests = corev1.ResourceList{
 						"cpu":    resource.MustParse("100m"),

--- a/controllers/pod_models_test.go
+++ b/controllers/pod_models_test.go
@@ -133,31 +133,9 @@ var _ = Describe("pod_models", func() {
 			})
 		})
 
-		Context("with custom annotations from the spec.PodTemplate field", func() {
-			BeforeEach(func() {
-				cluster.Spec.PodTemplate = &corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							"fdb-annotation": "value1",
-						},
-					},
-				}
-				pod, err = GetPod(context.TODO(), cluster, "storage", 1, k8sClient)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("should add the annotations to the metadata", func() {
-				hash, err := GetPodSpecHash(cluster, pod.Labels["fdb-process-class"], 1, &pod.Spec)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
-					"fdb-annotation":                     "value1",
-					"foundationdb.org/last-applied-spec": hash,
-				}))
-			})
-		})
-
 		Context("with custom labels", func() {
 			BeforeEach(func() {
+				cluster = createDefaultCluster()
 				cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{"general": {PodTemplate: &corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
@@ -165,29 +143,8 @@ var _ = Describe("pod_models", func() {
 						},
 					},
 				}}}
-				pod, err = GetPod(context.TODO(), cluster, "storage", 1, k8sClient)
-				Expect(err).NotTo(HaveOccurred())
-			})
+				NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
 
-			It("should add the labels to the metadata", func() {
-				Expect(pod.ObjectMeta.Labels).To(Equal(map[string]string{
-					"fdb-cluster-name":  cluster.Name,
-					"fdb-process-class": "storage",
-					"fdb-instance-id":   "storage-1",
-					"fdb-label":         "value2",
-				}))
-			})
-		})
-
-		Context("with custom labels from the Spec.PodTemplate field", func() {
-			BeforeEach(func() {
-				cluster.Spec.PodTemplate = &corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							"fdb-label": "value2",
-						},
-					},
-				}
 				pod, err = GetPod(context.TODO(), cluster, "storage", 1, k8sClient)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -410,6 +367,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("with custom resources", func() {
 			BeforeEach(func() {
+				cluster = createDefaultCluster()
 				cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{"general": {PodTemplate: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -429,40 +387,8 @@ var _ = Describe("pod_models", func() {
 						},
 					},
 				}}}
-				spec, err = GetPodSpec(cluster, "storage", 1)
-			})
+				NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
 
-			It("should set the resources on the main container", func() {
-				mainContainer := spec.Containers[0]
-				Expect(mainContainer.Name).To(Equal("foundationdb"))
-				Expect(*mainContainer.Resources.Limits.Cpu()).To(Equal(resource.MustParse("4")))
-				Expect(*mainContainer.Resources.Limits.Memory()).To(Equal(resource.MustParse("16Gi")))
-				Expect(*mainContainer.Resources.Requests.Cpu()).To(Equal(resource.MustParse("2")))
-				Expect(*mainContainer.Resources.Requests.Memory()).To(Equal(resource.MustParse("8Gi")))
-			})
-		})
-
-		Context("with custom resources from the Spec.PodTemplate field", func() {
-			BeforeEach(func() {
-				cluster.Spec.PodTemplate = &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							corev1.Container{
-								Name: "foundationdb",
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										"cpu":    resource.MustParse("2"),
-										"memory": resource.MustParse("8Gi"),
-									},
-									Limits: corev1.ResourceList{
-										"cpu":    resource.MustParse("4"),
-										"memory": resource.MustParse("16Gi"),
-									},
-								},
-							},
-						},
-					},
-				}
 				spec, err = GetPodSpec(cluster, "storage", 1)
 			})
 
@@ -639,6 +565,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("with custom containers", func() {
 			BeforeEach(func() {
+				cluster = createDefaultCluster()
 				cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{"general": {PodTemplate: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						InitContainers: []corev1.Container{corev1.Container{
@@ -653,57 +580,8 @@ var _ = Describe("pod_models", func() {
 						}},
 					},
 				}}}
-				spec, err = GetPodSpec(cluster, "storage", 1)
-				Expect(err).NotTo(HaveOccurred())
-			})
+				NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
 
-			It("should have both init containers", func() {
-				Expect(len(spec.InitContainers)).To(Equal(2))
-
-				testInitContainer := spec.InitContainers[0]
-				Expect(testInitContainer.Name).To(Equal("test-container"))
-				Expect(testInitContainer.Image).To(Equal("foundationdb/" + cluster.Name))
-				Expect(testInitContainer.Command).To(Equal([]string{"echo", "test1"}))
-
-				initContainer := spec.InitContainers[1]
-				Expect(initContainer.Name).To(Equal("foundationdb-kubernetes-init"))
-				Expect(initContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
-			})
-
-			It("should have all three containers", func() {
-				Expect(len(spec.Containers)).To(Equal(3))
-
-				mainContainer := spec.Containers[0]
-				Expect(mainContainer.Name).To(Equal("foundationdb"))
-				Expect(mainContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
-
-				testContainer := spec.Containers[1]
-				Expect(testContainer.Name).To(Equal("test-container"))
-				Expect(testContainer.Image).To(Equal("foundationdb/" + cluster.Name))
-				Expect(testContainer.Command).To(Equal([]string{"echo", "test2"}))
-
-				sidecarContainer := spec.Containers[2]
-				Expect(sidecarContainer.Name).To(Equal("foundationdb-kubernetes-sidecar"))
-				Expect(sidecarContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
-			})
-		})
-
-		Context("with custom containers from the Spec.PodTemplate field", func() {
-			BeforeEach(func() {
-				cluster.Spec.PodTemplate = &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{corev1.Container{
-							Name:    "test-container",
-							Image:   "foundationdb/" + cluster.Name,
-							Command: []string{"echo", "test1"},
-						}},
-						Containers: []corev1.Container{corev1.Container{
-							Name:    "test-container",
-							Image:   "foundationdb/" + cluster.Name,
-							Command: []string{"echo", "test2"},
-						}},
-					},
-				}
 				spec, err = GetPodSpec(cluster, "storage", 1)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -815,86 +693,6 @@ var _ = Describe("pod_models", func() {
 						},
 					},
 				}}}
-
-				spec, err = GetPodSpec(cluster, "storage", 1)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("should set the environment variables on the containers", func() {
-				initContainer := spec.InitContainers[0]
-				Expect(initContainer.Name).To(Equal("foundationdb-kubernetes-init"))
-				Expect(initContainer.Env).To(Equal([]corev1.EnvVar{
-					corev1.EnvVar{Name: "ADDITIONAL_ENV_FILE", Value: "/var/custom-env-init"},
-					corev1.EnvVar{Name: "FDB_PUBLIC_IP", ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-					}},
-					corev1.EnvVar{Name: "FDB_MACHINE_ID", ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					}},
-					corev1.EnvVar{Name: "FDB_ZONE_ID", ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					}},
-					corev1.EnvVar{Name: "FDB_INSTANCE_ID", Value: "storage-1"},
-				}))
-
-				mainContainer := spec.Containers[0]
-				Expect(mainContainer.Name).To(Equal("foundationdb"))
-				Expect(mainContainer.Env).To(Equal([]corev1.EnvVar{
-					corev1.EnvVar{Name: "FDB_TLS_CERTIFICATE_FILE", Value: "/var/secrets/cert.pem"},
-					corev1.EnvVar{Name: "FDB_TLS_CA_FILE", Value: "/var/secrets/cert.pem"},
-					corev1.EnvVar{Name: "FDB_TLS_KEY_FILE", Value: "/var/secrets/cert.pem"},
-					corev1.EnvVar{Name: "FDB_CLUSTER_FILE", Value: "/var/dynamic-conf/fdb.cluster"},
-				}))
-
-				sidecarContainer := spec.Containers[1]
-				Expect(sidecarContainer.Name).To(Equal("foundationdb-kubernetes-sidecar"))
-				Expect(sidecarContainer.Env).To(Equal([]corev1.EnvVar{
-					corev1.EnvVar{Name: "ADDITIONAL_ENV_FILE", Value: "/var/custom-env"},
-					corev1.EnvVar{Name: "FDB_PUBLIC_IP", ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-					}},
-					corev1.EnvVar{Name: "FDB_MACHINE_ID", ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					}},
-					corev1.EnvVar{Name: "FDB_ZONE_ID", ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					}},
-					corev1.EnvVar{Name: "FDB_INSTANCE_ID", Value: "storage-1"},
-					corev1.EnvVar{Name: "FDB_TLS_VERIFY_PEERS", Value: ""},
-				}))
-			})
-		})
-
-		Context("with custom environment from the Spec.PodTemplate field", func() {
-			BeforeEach(func() {
-				cluster.Spec.PodTemplate = &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							corev1.Container{
-								Name: "foundationdb",
-								Env: []corev1.EnvVar{
-									corev1.EnvVar{Name: "FDB_TLS_CERTIFICATE_FILE", Value: "/var/secrets/cert.pem"},
-									corev1.EnvVar{Name: "FDB_TLS_CA_FILE", Value: "/var/secrets/cert.pem"},
-									corev1.EnvVar{Name: "FDB_TLS_KEY_FILE", Value: "/var/secrets/cert.pem"},
-								},
-							},
-							corev1.Container{
-								Name: "foundationdb-kubernetes-sidecar",
-								Env: []corev1.EnvVar{
-									corev1.EnvVar{Name: "ADDITIONAL_ENV_FILE", Value: "/var/custom-env"},
-								},
-							},
-						},
-						InitContainers: []corev1.Container{
-							corev1.Container{
-								Name: "foundationdb-kubernetes-init",
-								Env: []corev1.EnvVar{
-									corev1.EnvVar{Name: "ADDITIONAL_ENV_FILE", Value: "/var/custom-env-init"},
-								},
-							},
-						},
-					},
-				}
 
 				spec, err = GetPodSpec(cluster, "storage", 1)
 				Expect(err).NotTo(HaveOccurred())
@@ -1089,6 +887,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("with custom volumes", func() {
 			BeforeEach(func() {
+				cluster = createDefaultCluster()
 				cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{"general": {PodTemplate: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{corev1.Volume{
@@ -1108,88 +907,8 @@ var _ = Describe("pod_models", func() {
 						},
 					},
 				}}}
-				spec, err = GetPodSpec(cluster, "storage", 1)
-				Expect(err).NotTo(HaveOccurred())
-			})
+				NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
 
-			It("adds volumes to the container", func() {
-				mainContainer := spec.Containers[0]
-				Expect(mainContainer.Name).To(Equal("foundationdb"))
-				Expect(mainContainer.VolumeMounts).To(Equal([]corev1.VolumeMount{
-					corev1.VolumeMount{Name: "test-secrets", MountPath: "/var/secrets"},
-					corev1.VolumeMount{Name: "data", MountPath: "/var/fdb/data"},
-					corev1.VolumeMount{Name: "dynamic-conf", MountPath: "/var/dynamic-conf"},
-					corev1.VolumeMount{Name: "fdb-trace-logs", MountPath: "/var/log/fdb-trace-logs"},
-				}))
-			})
-
-			It("does not add volumes to the sidecar container", func() {
-				sidecarContainer := spec.Containers[1]
-				Expect(sidecarContainer.Name).To(Equal("foundationdb-kubernetes-sidecar"))
-
-				Expect(sidecarContainer.VolumeMounts).To(Equal([]corev1.VolumeMount{
-					corev1.VolumeMount{Name: "config-map", MountPath: "/var/input-files"},
-					corev1.VolumeMount{Name: "dynamic-conf", MountPath: "/var/output-files"},
-				}))
-
-			})
-
-			It("adds volumes to the pod spec", func() {
-				Expect(len(spec.Volumes)).To(Equal(5))
-				Expect(spec.Volumes[0]).To(Equal(corev1.Volume{
-					Name: "test-secrets",
-					VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
-						SecretName: "test-secrets",
-					}},
-				}))
-				Expect(spec.Volumes[1]).To(Equal(corev1.Volume{
-					VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: fmt.Sprintf("%s-storage-1-data", cluster.Name),
-					}},
-					Name: "data",
-				}))
-				Expect(spec.Volumes[2]).To(Equal(corev1.Volume{
-					Name:         "dynamic-conf",
-					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-				}))
-				Expect(spec.Volumes[3]).To(Equal(corev1.Volume{
-					Name: "config-map",
-					VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
-						Items: []corev1.KeyToPath{
-							corev1.KeyToPath{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
-							corev1.KeyToPath{Key: "cluster-file", Path: "fdb.cluster"},
-						},
-					}},
-				}))
-				Expect(spec.Volumes[4]).To(Equal(corev1.Volume{
-					Name:         "fdb-trace-logs",
-					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-				}))
-			})
-		})
-
-		Context("with custom volumes from the Spec.PodTemplate field", func() {
-			BeforeEach(func() {
-				cluster.Spec.PodTemplate = &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Volumes: []corev1.Volume{corev1.Volume{
-							Name: "test-secrets",
-							VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
-								SecretName: "test-secrets",
-							}},
-						}},
-						Containers: []corev1.Container{
-							corev1.Container{
-								Name: "foundationdb",
-								VolumeMounts: []corev1.VolumeMount{corev1.VolumeMount{
-									Name:      "test-secrets",
-									MountPath: "/var/secrets",
-								}},
-							},
-						},
-					},
-				}
 				spec, err = GetPodSpec(cluster, "storage", 1)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1404,64 +1123,6 @@ var _ = Describe("pod_models", func() {
 						},
 					},
 				}}}
-
-				spec, err = GetPodSpec(cluster, "storage", 1)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("should set the security contexts", func() {
-
-				Expect(*spec.SecurityContext.FSGroup).To(Equal(int64(5000)))
-
-				Expect(len(spec.InitContainers)).To(Equal(1))
-				initContainer := spec.InitContainers[0]
-				Expect(*initContainer.SecurityContext.RunAsGroup).To(Equal(int64(1000)))
-				Expect(*initContainer.SecurityContext.RunAsUser).To(Equal(int64(2000)))
-
-				mainContainer := spec.Containers[0]
-				Expect(*mainContainer.SecurityContext.RunAsGroup).To(Equal(int64(3000)))
-				Expect(*mainContainer.SecurityContext.RunAsUser).To(Equal(int64(4000)))
-
-				sidecarContainer := spec.Containers[1]
-				Expect(*sidecarContainer.SecurityContext.RunAsGroup).To(Equal(int64(1000)))
-				Expect(*sidecarContainer.SecurityContext.RunAsUser).To(Equal(int64(2000)))
-
-			})
-		})
-
-		Context("with a custom security context from the Spec.PodTemplate field", func() {
-			BeforeEach(func() {
-
-				podSecurityContext := &corev1.PodSecurityContext{FSGroup: new(int64)}
-				*podSecurityContext.FSGroup = 5000
-				mainSecurityContext := &corev1.SecurityContext{RunAsGroup: new(int64), RunAsUser: new(int64)}
-				*mainSecurityContext.RunAsGroup = 3000
-				*mainSecurityContext.RunAsUser = 4000
-				sidecarSecurityContext := &corev1.SecurityContext{RunAsGroup: new(int64), RunAsUser: new(int64)}
-				*sidecarSecurityContext.RunAsGroup = 1000
-				*sidecarSecurityContext.RunAsUser = 2000
-
-				cluster.Spec.PodTemplate = &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						SecurityContext: podSecurityContext,
-						Containers: []corev1.Container{
-							corev1.Container{
-								Name:            "foundationdb",
-								SecurityContext: mainSecurityContext,
-							},
-							corev1.Container{
-								Name:            "foundationdb-kubernetes-sidecar",
-								SecurityContext: sidecarSecurityContext,
-							},
-						},
-						InitContainers: []corev1.Container{
-							corev1.Container{
-								Name:            "foundationdb-kubernetes-init",
-								SecurityContext: sidecarSecurityContext,
-							},
-						},
-					},
-				}
 
 				spec, err = GetPodSpec(cluster, "storage", 1)
 				Expect(err).NotTo(HaveOccurred())
@@ -2641,6 +2302,66 @@ var _ = Describe("pod_models", func() {
 			}
 		})
 
+		Describe("deprecations", func() {
+			JustBeforeEach(func() {
+				NormalizeClusterSpec(spec, defaultsSelection{})
+			})
+
+			Context("with a custom value for the Spec.PodTemplate field", func() {
+				BeforeEach(func() {
+					spec.PodTemplate = &corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"fdb-label": "value2",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{corev1.Volume{
+								Name: "test-secrets",
+								VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+									SecretName: "test-secrets",
+								}},
+							}},
+							Containers: []corev1.Container{
+								corev1.Container{
+									Name: "foundationdb",
+									VolumeMounts: []corev1.VolumeMount{corev1.VolumeMount{
+										Name:      "test-secrets",
+										MountPath: "/var/secrets",
+									}},
+								},
+							},
+						},
+					}
+				})
+
+				It("should add the labels to the metadata", func() {
+					metadata := spec.Processes["general"].PodTemplate.ObjectMeta
+					Expect(metadata.Labels).To(Equal(map[string]string{
+						"fdb-label": "value2",
+					}))
+				})
+
+				It("adds volumes to the process settings", func() {
+					podSpec := spec.Processes["general"].PodTemplate.Spec
+
+					mainContainer := podSpec.Containers[0]
+					Expect(mainContainer.Name).To(Equal("foundationdb"))
+					Expect(mainContainer.VolumeMounts).To(Equal([]corev1.VolumeMount{
+						corev1.VolumeMount{Name: "test-secrets", MountPath: "/var/secrets"},
+					}))
+
+					Expect(len(podSpec.Volumes)).To(Equal(1))
+					Expect(podSpec.Volumes[0]).To(Equal(corev1.Volume{
+						Name: "test-secrets",
+						VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+							SecretName: "test-secrets",
+						}},
+					}))
+				})
+			})
+		})
+
 		Describe("defaults", func() {
 			Context("with the current defaults", func() {
 				JustBeforeEach(func() {
@@ -2760,11 +2481,11 @@ var _ = Describe("pod_models", func() {
 						Expect(present).To(BeTrue())
 						containers := generalProcessConfig.PodTemplate.Spec.Containers
 						Expect(len(containers)).To(Equal(2))
-						Expect(containers[0].Name).To(Equal("foundationdb-kubernetes-sidecar"))
-						Expect(containers[0].Resources.Requests).To(Equal(corev1.ResourceList{
+						Expect(containers[1].Name).To(Equal("foundationdb-kubernetes-sidecar"))
+						Expect(containers[1].Resources.Requests).To(Equal(corev1.ResourceList{
 							"cpu": resource.MustParse("1"),
 						}))
-						Expect(containers[0].Resources.Limits).To(Equal(corev1.ResourceList{
+						Expect(containers[1].Resources.Limits).To(Equal(corev1.ResourceList{
 							"cpu": resource.MustParse("2"),
 						}))
 					})
@@ -2845,11 +2566,11 @@ var _ = Describe("pod_models", func() {
 						Expect(present).To(BeTrue())
 						containers := generalProcessConfig.PodTemplate.Spec.Containers
 						Expect(len(containers)).To(Equal(2))
-						Expect(containers[0].Name).To(Equal("foundationdb-kubernetes-sidecar"))
-						Expect(containers[0].Resources.Requests).To(Equal(corev1.ResourceList{
+						Expect(containers[1].Name).To(Equal("foundationdb-kubernetes-sidecar"))
+						Expect(containers[1].Resources.Requests).To(Equal(corev1.ResourceList{
 							"cpu": resource.MustParse("1"),
 						}))
-						Expect(containers[0].Resources.Limits).To(Equal(corev1.ResourceList{
+						Expect(containers[1].Resources.Limits).To(Equal(corev1.ResourceList{
 							"cpu": resource.MustParse("2"),
 						}))
 					})
@@ -2880,11 +2601,11 @@ var _ = Describe("pod_models", func() {
 						Expect(present).To(BeTrue())
 						containers := generalProcessConfig.PodTemplate.Spec.Containers
 						Expect(len(containers)).To(Equal(2))
-						Expect(containers[0].Name).To(Equal("foundationdb-kubernetes-sidecar"))
-						Expect(containers[0].Resources.Requests).To(Equal(corev1.ResourceList{
+						Expect(containers[1].Name).To(Equal("foundationdb-kubernetes-sidecar"))
+						Expect(containers[1].Resources.Requests).To(Equal(corev1.ResourceList{
 							"cpu": resource.MustParse("1"),
 						}))
-						Expect(containers[0].Resources.Limits).To(Equal(corev1.ResourceList{
+						Expect(containers[1].Resources.Limits).To(Equal(corev1.ResourceList{
 							"cpu": resource.MustParse("1"),
 						}))
 					})
@@ -2914,9 +2635,9 @@ var _ = Describe("pod_models", func() {
 						Expect(present).To(BeTrue())
 						containers := generalProcessConfig.PodTemplate.Spec.Containers
 						Expect(len(containers)).To(Equal(2))
-						Expect(containers[0].Name).To(Equal("foundationdb-kubernetes-sidecar"))
-						Expect(containers[0].Resources.Requests).To(Equal(corev1.ResourceList{}))
-						Expect(containers[0].Resources.Limits).To(Equal(corev1.ResourceList{}))
+						Expect(containers[1].Name).To(Equal("foundationdb-kubernetes-sidecar"))
+						Expect(containers[1].Resources.Requests).To(Equal(corev1.ResourceList{}))
+						Expect(containers[1].Resources.Limits).To(Equal(corev1.ResourceList{}))
 					})
 				})
 			})

--- a/controllers/pod_models_test.go
+++ b/controllers/pod_models_test.go
@@ -1382,6 +1382,8 @@ var _ = Describe("pod_models", func() {
 		Context("with custom pvc", func() {
 			BeforeEach(func() {
 				cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{"general": {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "claim1"}}}}
+				NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
+
 				spec, err = GetPodSpec(cluster, "storage", 1)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1398,6 +1400,8 @@ var _ = Describe("pod_models", func() {
 				generalSettings.VolumeClaim = &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "claim1"}}
 				cluster.Spec.Processes["general"] = generalSettings
 
+				NormalizeClusterSpec(&cluster.Spec, defaultsSelection{})
+
 				spec, err = GetPodSpec(cluster, "storage", 1)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1410,6 +1414,7 @@ var _ = Describe("pod_models", func() {
 		Context("with custom pvc from the Spec.VolumeClaim field", func() {
 			BeforeEach(func() {
 				cluster.Spec.VolumeClaim = &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "claim1"}}
+
 				spec, err = GetPodSpec(cluster, "storage", 1)
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/controllers/pod_models_test.go
+++ b/controllers/pod_models_test.go
@@ -2365,7 +2365,7 @@ var _ = Describe("pod_models", func() {
 		Describe("defaults", func() {
 			Context("with the current defaults", func() {
 				JustBeforeEach(func() {
-					NormalizeClusterSpec(spec, defaultsSelection{ApplyLatestDefaults: false, OnlyShowChanges: false})
+					NormalizeClusterSpec(spec, defaultsSelection{UseFutureDefaults: false, OnlyShowChanges: false})
 				})
 
 				It("should have both containers", func() {
@@ -2494,7 +2494,7 @@ var _ = Describe("pod_models", func() {
 
 			Context("with the current defaults, changes only", func() {
 				JustBeforeEach(func() {
-					NormalizeClusterSpec(spec, defaultsSelection{ApplyLatestDefaults: false, OnlyShowChanges: true})
+					NormalizeClusterSpec(spec, defaultsSelection{UseFutureDefaults: false, OnlyShowChanges: true})
 				})
 
 				It("should have a single container", func() {
@@ -2519,7 +2519,7 @@ var _ = Describe("pod_models", func() {
 
 			Context("with the future defaults", func() {
 				JustBeforeEach(func() {
-					NormalizeClusterSpec(spec, defaultsSelection{ApplyLatestDefaults: true, OnlyShowChanges: false})
+					NormalizeClusterSpec(spec, defaultsSelection{UseFutureDefaults: true, OnlyShowChanges: false})
 				})
 
 				It("should have default sidecar resource requirements", func() {
@@ -2644,7 +2644,7 @@ var _ = Describe("pod_models", func() {
 
 			Context("with the future defaults, changes only", func() {
 				JustBeforeEach(func() {
-					NormalizeClusterSpec(spec, defaultsSelection{ApplyLatestDefaults: true, OnlyShowChanges: true})
+					NormalizeClusterSpec(spec, defaultsSelection{UseFutureDefaults: true, OnlyShowChanges: true})
 				})
 
 				It("should have default sidecar resource requirements", func() {
@@ -2668,12 +2668,12 @@ var _ = Describe("pod_models", func() {
 				var originalSpec *fdbtypes.FoundationDBClusterSpec
 
 				BeforeEach(func() {
-					NormalizeClusterSpec(spec, defaultsSelection{ApplyLatestDefaults: false, OnlyShowChanges: true})
+					NormalizeClusterSpec(spec, defaultsSelection{UseFutureDefaults: false, OnlyShowChanges: true})
 					originalSpec = spec.DeepCopy()
 				})
 
 				JustBeforeEach(func() {
-					NormalizeClusterSpec(spec, defaultsSelection{ApplyLatestDefaults: true, OnlyShowChanges: true})
+					NormalizeClusterSpec(spec, defaultsSelection{UseFutureDefaults: true, OnlyShowChanges: true})
 				})
 
 				It("should be equal to the version with the old explicit defaults", func() {

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -55,13 +55,6 @@ func (u UpdateSidecarVersions) Reconcile(r *FoundationDBClusterReconciler, conte
 				}
 			}
 		}
-		if cluster.Spec.PodTemplate != nil {
-			for _, container := range cluster.Spec.PodTemplate.Spec.Containers {
-				if container.Name == "foundationdb-kubernetes-sidecar" && container.Image != "" {
-					image = container.Image
-				}
-			}
-		}
 		if image == "" {
 			image = "foundationdb/foundationdb-kubernetes-sidecar"
 		}

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 	var enableLeaderElection bool
 	var logFile string
 	var cliTimeout int
+	var useFutureDefaults bool
 
 	fdb.MustAPIVersion(610)
 
@@ -56,6 +57,9 @@ func main() {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&logFile, "log-file", "", "The path to a file to write logs to.")
 	flag.IntVar(&cliTimeout, "cli-timeout", 10, "The timeout to use for CLI commands")
+	flag.BoolVar(&useFutureDefaults, "use-future-defaults", false,
+		"Apply defaults from the next major version of the operator. This is only intended for use in development.",
+	)
 	flag.Parse()
 
 	var logWriter io.Writer
@@ -105,6 +109,7 @@ func main() {
 		PodClientProvider:   controllers.NewFdbPodClient,
 		AdminClientProvider: controllers.NewCliAdminClient,
 		LockClientProvider:  controllers.NewRealLockClient,
+		UseFutureDefaults:   useFutureDefaults,
 	}
 
 	if err = clusterReconciler.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
Resolves #99 

This solution is a little more complex than might be required for this specific issue, but I wanted to accomplish a couple of other goals:

1. This establishes a general pattern for defining new defaults that won't take effect until the next major version. This will let us define changes to the defaults gradually, without disrupting any existing clusters immediately.
2. This lays some of the groundwork for #282, where we are going to be defining new tools to analyze out-of-date configurations in advance of a major upgrade of the operator