### PR TITLE
Update docs for local dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ We encourage your participation asking questions and helping improve the Foundat
 ### Using GitHub Issues and Community Forums
 GitHub issues and the community forums both offer features to facilitate discussion. To clarify how and when to use each tool, here's a quick summary of how we think about them:
 
-GitHub Issues should be used for tracking tasks. If you know the specific code that needs to be changed, then it should go to GitHub Issues. Everything else should go to the Forums. For example: 
+GitHub Issues should be used for tracking tasks. If you know the specific code that needs to be changed, then it should go to GitHub Issues. Everything else should go to the Forums. For example:
 
 * I am experiencing some weird behavior, which I think is a bug, but I don't know where exactly (mysteries and unexpected behaviors): *Forums*
 * I see a bug in this piece of code: *GitHub Issues*

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project provides an experimental operator for managing FoundationDB
 clusters on Kubernetes.
 
-# Running the Operator
+## Running the Operator
 
 To run the operator in your environment, you need to install the controller and
 the CRDs:
@@ -15,13 +15,13 @@ the CRDs:
 
 At that point, you can set up one of the sample clusters:
 
-		kubectl apply -f https://raw.githubusercontent.com/foundationdb/fdb-kubernetes-operator/master/config/samples/cluster_local.yaml
+    kubectl apply -f https://raw.githubusercontent.com/foundationdb/fdb-kubernetes-operator/master/config/samples/cluster_local.yaml
 
 You can see logs from the operator by running
 `kubectl logs -f -l app=fdb-kubernetes-operator-controller-manager --container=manager`. To determine whether the reconciliation has completed, you can run `kubectl get foundationdbcluster sample-cluster`. This will show the latest generation of the
 spec and the last reconciled generation of the spec. Once reconciliation has completed, these values will be the same.
 
-Once the reconciliation is complete, you can run `kubectl exec -it sample-cluster-1 fdbcli` to open up a CLI on your cluster.
+Once the reconciliation is complete, you can run `kubectl exec -it sample-cluster-log-1 -- fdbcli` to open up a CLI on your cluster.
 
 You can also browse the [sample directory](config/samples) for more examples of how to configure a cluster.
 
@@ -38,26 +38,27 @@ For more information on version compatibility, see our [compatibility guide](doc
 For more information on the fields you can define on the cluster resource, see
 the [API documentation](docs/cluster_spec.md).
 
-# Local Development
+## Local Development
 
-## Environment Set-up
+### Environment Set-up
 
 1. Install GO on your machine, see the [Getting Started](https://golang.org/doc/install) guide for more information.
-2. Install KubeBuilder and its dependencies on your machine, see [The KubeBuilder Book](https://book.kubebuilder.io/quick-start.html) for more information.
-3. Set your $GOPATH, e.x. `/Users/me/Code/go`
+2. Install KubeBuilder and its dependencies on your machine, see [The KubeBuilder Book](https://book.kubebuilder.io/quick-start.html) for more information (currently version `2.2.0` is used).
+3. Set your $GOPATH, e.x. `/Users/me/Code/go`.
 4. Install [kustomize](https://github.com/kubernetes-sigs/kustomize).
+5. Install the [foundationDB client package](https://www.foundationdb.org/download).
 
-## Running Locally
+### Running Locally
 
 To get this controller running in a local Kubernetes cluster:
 
-1.  Change your current directory to $GOPATH/src/github.com using the
-	command `cd $GOPATH/src/github.com` and run `mkdir foundationdb`
-	to create the directory `foundationdb`.
-2.	CD into newly created directory and clone this github repo inside
-	the created directory that is `foundationdb`.
-3.	Run `config/test-certs/generate_secrets.bash` to set up a secret with
-	self-signed test certs.
-4.	Run `make rebuild-operator` to install the operator.
-5.	Run `kubectl apply -f config/samples/cluster_local_tls.yaml`
-	to create a new FoundationDB cluster with the operator.
+1. Change your current directory to $GOPATH/src/github.com using the
+   command `cd $GOPATH/src/github.com` and run `mkdir foundationdb`
+   to create the directory `foundationdb`.
+2. CD into newly created directory and clone this github repo inside
+   `$GOPATH/src/github.com/foundationdb`.
+3. Run `config/test-certs/generate_secrets.bash` to set up a secret with
+   self-signed test certs.
+4. Run `make rebuild-operator` to install the operator.
+5. Run `kubectl apply -f config/samples/cluster_local_tls.yaml`
+   to create a new FoundationDB cluster with the operator.

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -57,9 +57,9 @@ To start with, we are going to be creating a cluster with the following configur
       databaseConfiguration:
         storage: 5
 
-This will create a cluster with 5 storage processes, 4 log processes, and 7 stateless processes. Each fdbserver process will be in a separate pod, and the pods will have names of the form `sample-cluster-$n`, where `$n` is the instance ID for the process.
+This will create a cluster with 5 storage processes, 4 log processes, and 7 stateless processes. Each fdbserver process will be in a separate pod, and the pods will have names of the form `sample-cluster-$role-$n`, where `$n` is the instance ID and `$role` is the role for the process.
 
-You can run `kubectl get foundationdbcluster sample-cluster` to check the progress of reconciliation. Once the reconciled generation appears in this output, the cluster should be up and ready. After creating the cluster, you can connect to the cluster by running `kubectl exec -it sample-cluster-1 fdbcli`.
+You can run `kubectl get foundationdbcluster sample-cluster` to check the progress of reconciliation. Once the reconciled generation appears in this output, the cluster should be up and ready. After creating the cluster, you can connect to the cluster by running `kubectl exec -it sample-cluster-log-1 -- fdbcli`.
 
 This example requires non-trivial resources, based on what a process will need in a production environment. This means that is too large to run in a local testing environment. It also requires disk I/O features that are not present in Docker for Mac. If you want to run these tests in that kind of environment, you can try bringing in the resource requirements, knobs, and fault domain information from a [local testing example](../config/samples/cluster_local.yaml).
 


### PR DESCRIPTION
I updated the docs for local testing of the controller (e.g. the step for installing the fdb client packages was missing). I also fixed some markdown lint issues in the Readme (that's the reason why so much lines are moved around).