### PR TITLE
Start using non-blocking excludes with FDB 6.3.5.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY foundationdb-kubernetes-sidecar/website/ /mnt/website/
 # adds GeoTrust_Global_CA.crt during install and removes it afterwards
 COPY ./foundationdb-kubernetes-sidecar/files/GeoTrust_Global_CA.pem /usr/local/share/ca-certificates/GeoTrust_Global_CA.crt
 RUN set -eux && \
-    update-ca-certificates --fresh && \
+	update-ca-certificates --fresh && \
 	curl $FDB_WEBSITE/downloads/$FDB_VERSION/ubuntu/installers/foundationdb-clients_$FDB_VERSION-1_amd64.deb -o fdb.deb && \
 	dpkg -i fdb.deb && rm fdb.deb && \
 	for version in ${FDB_VERSION} ${FDB_ADDITIONAL_VERSIONS}; do \
@@ -25,14 +25,16 @@ RUN set -eux && \
 			mv /usr/bin/fdb/$minor/tmp/$binary /usr/bin/fdb/$minor/$binary; \
 		done && \
 		rm -r /usr/bin/fdb/$minor/tmp && \
-		chmod u+x /usr/bin/fdb/$minor/fdb*; \
+		chmod u+x /usr/bin/fdb/$minor/fdb* \
+		|| exit; \
 	done && \
 	mkdir -p /usr/lib/fdb && \
 	for VERSION in ${FDB_ADDITIONAL_VERSIONS}; do \
-		curl $FDB_WEBSITE/downloads/$VERSION/linux/libfdb_c_$VERSION.so -o /usr/lib/fdb/libfdb_c_$VERSION.so; \
+		curl $FDB_WEBSITE/downloads/$VERSION/linux/libfdb_c_$VERSION.so -o /usr/lib/fdb/libfdb_c_$VERSION.so \
+		|| exit; \
 	done && \
-    rm /usr/local/share/ca-certificates/GeoTrust_Global_CA.crt && \
-    update-ca-certificates --fresh
+	rm /usr/local/share/ca-certificates/GeoTrust_Global_CA.crt && \
+	update-ca-certificates --fresh
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -2085,5 +2085,5 @@ func (version FdbVersion) HasSidecarCrashOnEmpty() bool {
 // This is currently set to false across the board, pending investigation into
 // potential bugs with non-blocking excludes.
 func (version FdbVersion) HasNonBlockingExcludes() bool {
-	return false
+	return version.IsAtLeast(FdbVersion{Major: 6, Minor: 3, Patch: 5})
 }

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,9 +26,9 @@ spec:
         name: manager
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 500m
+            memory: 128Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 500m
+            memory: 128Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Ensure that the docker build script will fail if the downloads fail.
Give more resources to the controller in the local test environment to help with CLI timeouts.

Fixes #11 