### PR TITLE
Update go version to 1.15.2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,24 +7,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
       id: go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
     - name: Get dependencies
+      env:
+        KUBEBUILDER_VER: "2.2.0"
       run: |
         go get -v -t -d ./...
         curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
         sudo mv kustomize /usr/local/bin/
         os=$(go env GOOS)
         arch=$(go env GOARCH)
-        curl -L https://go.kubebuilder.io/dl/2.2.0/${os}/${arch} | tar -xz -C /tmp/
-        sudo mv /tmp/kubebuilder_2.2.0_${os}_${arch} /usr/local/kubebuilder
+        curl -L "https://go.kubebuilder.io/dl/${KUBEBUILDER_VER}/${os}/${arch}" | tar -xz -C /tmp/
+        sudo mv "/tmp/kubebuilder_${KUBEBUILDER_VER}_${os}_${arch}" /usr/local/kubebuilder
         export PATH=$PATH:/usr/local/kubebuilder/bin
         curl https://www.foundationdb.org/downloads/6.2.20/ubuntu/installers/foundationdb-clients_6.2.20-1_amd64.deb -o fdb.deb
         sudo dpkg -i fdb.deb
@@ -34,4 +36,3 @@ jobs:
 
     - name: Check for uncommitted changes
       run: git diff --exit-code
-

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,10 +36,7 @@ jobs:
       # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
       env:
         GOMAXPROCS: "2"
-      run: |
-        nproc || true
-        cat /proc/cpuinfo
-        make clean all
+      run: make clean all
 
     - name: Check for uncommitted changes
       run: git diff --exit-code

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,14 @@ jobs:
         sudo dpkg -i fdb.deb
 
     - name: Build
-      run: make clean all
+      # Currently the default runner has 2 vCPU:
+      # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
+      env:
+        GOMAXPROCS: "2"
+      run: |
+        nproc || true
+        cat /proc/cpuinfo
+        make clean all
 
     - name: Check for uncommitted changes
       run: git diff --exit-code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13.15 as builder
+FROM golang:1.15.2 as builder
 
 # Install FDB
 ARG FDB_VERSION=6.2.25


### PR DESCRIPTION
Update the go version for building the operator to `1.15.2`. This is the same go version that is be used for Kubernetes `1.20` see: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#feature.

So far I didn't discovered any strange behaviour in during testing.

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/278