### PR TITLE
Add initial support for golangci-lint support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,7 @@ name: Pull Request Checks
 on: [pull_request]
 jobs:
   lint-go:
-    name: Lint Go code
+    name: Lint code
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,20 @@
 name: Pull Request Checks
 on: [pull_request]
 jobs:
+  lint-go:
+    name: Lint Go code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get dependencies
+        run: |
+          curl https://www.foundationdb.org/downloads/6.2.20/ubuntu/installers/foundationdb-clients_6.2.20-1_amd64.deb -o fdb.deb
+          sudo dpkg -i fdb.deb
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.31
 
   build:
     name: Build
@@ -34,4 +48,3 @@ jobs:
 
     - name: Check for uncommitted changes
       run: git diff --exit-code
-

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,35 +6,52 @@ issues:
   # exclude deprecation warning otherwise we get an error for our own deprecations
   - linters: [staticcheck]
     text: "SA1019:"
+  # TODO(johscheuer): run gofmt -s as part of the github actions
+  - linters: [gofmt]
+    text: "File is not `gofmt`-ed with `-s`"
 linters:
   disable-all: true
+  # TODO(johscheuer): activate linters again and fix issuess
   enable:
     - deadcode
-    - dupl
+    #- dupl
     - errcheck
-    - goconst
-    - gocyclo
+    #- goconst
+    #- gocyclo
     - gofmt
     - goimports
     - golint
-    - gosec
+    #- gosec
     - gosimple
     - govet
     - ineffassign
     - interfacer
-    - lll
-    - maligned
+    #- lll
+    #- maligned
     - misspell
     - nakedret
     - prealloc
-    - scopelint
+    #- scopelint
     - staticcheck
     - structcheck
     - typecheck
     - unconvert
-    - unparam
+    #- unparam
     - unused
     - varcheck
 
+linters-settings:
+  errcheck:
+    # path to a file containing a list of functions to exclude from checking
+    # see https://github.com/kisielk/errcheck#excluding-functions for details
+    exclude: errcheck_excludes.txt
 run:
   deadline: 5m
+  skip-dirs:
+    # TODO (johscheuer): fix issues and remove
+    - cmd
+
+  skip-files:
+    # TODO (johscheuer): fix issues and remove
+    - ".*_test.go$"
+    - ".*_generated.*.go$"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,40 @@
+issues:
+  # don't skip warning about doc comments
+  # don't exclude the default set of lint
+  exclude-use-default: false
+  exclude-rules:
+  # exclude deprecation warning otherwise we get an error for our own deprecations
+  - linters: [staticcheck]
+    text: "SA1019:"
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - dupl
+    - errcheck
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - maligned
+    - misspell
+    - nakedret
+    - prealloc
+    - scopelint
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+
+run:
+  deadline: 5m

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ docs/restore_spec.md: bin/po-docgen api/v1beta1/foundationdbrestore_types.go
 documentation: docs/cluster_spec.md docs/backup_spec.md docs/restore_spec.md
 
 lint:
-	go run golang.org/x/lint/golint -set_exit_status ./...
+	golangci-lint run -v ./...
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ docs/restore_spec.md: bin/po-docgen api/v1beta1/foundationdbrestore_types.go
 documentation: docs/cluster_spec.md docs/backup_spec.md docs/restore_spec.md
 
 lint:
-	golangci-lint run -v ./...
+	golangci-lint run ./...
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1515,7 +1515,7 @@ func (cluster *FoundationDBCluster) DesiredDatabaseConfiguration() DatabaseConfi
 	return configuration
 }
 
-// This method clears any version flags in the given configuration that are not
+// ClearMissingVersionFlags clears any version flags in the given configuration that are not
 // set in the configuration in the cluster spec.
 //
 // This allows us to compare the spec to the live configuration while ignoring
@@ -1979,7 +1979,7 @@ type FdbVersion struct {
 	Patch int
 }
 
-var fdbVersionRegex = regexp.MustCompile("^(\\d+)\\.(\\d+)\\.(\\d+)$")
+var fdbVersionRegex = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)$`)
 
 // ParseFdbVersion parses a version from its string representation.
 func ParseFdbVersion(version string) (FdbVersion, error) {

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -104,7 +104,10 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 			r.Recorder.Event(cluster, "Normal", "AddingProcesses", fmt.Sprintf("Adding %d %s processes", newCount, processClass))
 
 			pvcs := &corev1.PersistentVolumeClaimList{}
-			r.List(context, pvcs, getPodListOptions(cluster, processClass, "")...)
+			err = r.List(context, pvcs, getPodListOptions(cluster, processClass, "")...)
+			if err != nil {
+				return false, err
+			}
 			reusablePvcs := make(map[int]bool, len(pvcs.Items))
 
 			for index, pvc := range pvcs.Items {

--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -35,6 +35,10 @@ type AddServices struct{}
 // Reconcile runs the reconciler's work.
 func (a AddServices) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) (bool, error) {
 	service, err := GetHeadlessService(cluster)
+	if err != nil {
+		return false, err
+	}
+
 	if service == nil {
 		return true, nil
 	}

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -119,9 +119,12 @@ func (r *FoundationDBBackupReconciler) AdminClientForBackup(context ctx.Context,
 
 // SetupWithManager prepares a reconciler for use.
 func (r *FoundationDBBackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	mgr.GetFieldIndexer().IndexField(&appsv1.Deployment{}, "metadata.name", func(o runtime.Object) []string {
+	err := mgr.GetFieldIndexer().IndexField(&appsv1.Deployment{}, "metadata.name", func(o runtime.Object) []string {
 		return []string{o.(*appsv1.Deployment).Name}
 	})
+	if err != nil {
+		return err
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fdbtypes.FoundationDBBackup{}).

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -89,7 +89,7 @@ func (b BounceProcesses) Reconcile(r *FoundationDBClusterReconciler, context ctx
 			}
 
 			r.Recorder.Event(cluster, "Normal", "NeedsBounce",
-				fmt.Sprintf("Spec require a bounce of some processes, but killing processes is disabled"))
+				"Spec require a bounce of some processes, but killing processes is disabled")
 			cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
 			err = r.Status().Update(context, cluster)
 			if err != nil {

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -35,11 +35,11 @@ const LastSpecKey = "foundationdb.org/last-applied-spec"
 // config map.
 const LastConfigMapKey = "foundationdb.org/last-applied-config-map"
 
-// BackupDeploymentLabel probvides the label we use to connect backup
+// BackupDeploymentLabel provides the label we use to connect backup
 // deployments to a cluster.
 const BackupDeploymentLabel = "foundationdb.org/backup-for"
 
-// The default timeout for CLI commands.
+// DefaultCLITimeout is the default timeout for CLI commands.
 var DefaultCLITimeout = 10
 
 // MinimumUptimeSecondsForBounce defines the minimum time, in seconds, that the

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -61,9 +61,9 @@ func collectMetrics(ch chan<- prometheus.Metric, cluster *v1beta1.FoundationDBCl
 		addConstMetric(desc, prometheus.GaugeValue, v, lv...)
 	}
 	addGauge(descClusterCreated, float64(cluster.CreationTimestamp.Unix()))
-	addGauge(descClusterStatus, boolFloat64(cluster.Status.Health.Healthy == true), "health")
-	addGauge(descClusterStatus, boolFloat64(cluster.Status.Health.Available == true), "available")
-	addGauge(descClusterStatus, boolFloat64(cluster.Status.Health.FullReplication == true), "replication")
+	addGauge(descClusterStatus, boolFloat64(cluster.Status.Health.Healthy), "health")
+	addGauge(descClusterStatus, boolFloat64(cluster.Status.Health.Available), "available")
+	addGauge(descClusterStatus, boolFloat64(cluster.Status.Health.FullReplication), "replication")
 	addGauge(descClusterStatus, float64(cluster.Status.Health.DataMovementPriority), "datamovementpriority")
 }
 

--- a/controllers/remove_services.go
+++ b/controllers/remove_services.go
@@ -35,6 +35,10 @@ type RemoveServices struct{}
 // Reconcile runs the reconciler's work.
 func (u RemoveServices) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) (bool, error) {
 	service, err := GetHeadlessService(cluster)
+	if err != nil {
+		return false, err
+	}
+
 	if service != nil {
 		return true, nil
 	}

--- a/controllers/replace_misconfigured_pods.go
+++ b/controllers/replace_misconfigured_pods.go
@@ -73,7 +73,14 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 
 		processClass := GetProcessClassFromMeta(pvc.ObjectMeta)
 		desiredPVC, err := GetPvc(cluster, processClass, idNum)
+		if err != nil {
+			return false, err
+		}
 		pvcHash, err := GetJSONHash(desiredPVC.Spec)
+		if err != nil {
+			return false, err
+		}
+
 		if pvc.Annotations[LastSpecKey] != pvcHash {
 			instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, getSinglePodListOptions(cluster, instanceID)...)
 			if err != nil {
@@ -84,9 +91,6 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 				removals[instanceID] = removalState
 				hasNewRemovals = true
 			}
-		}
-		if err != nil {
-			return false, err
 		}
 	}
 
@@ -114,9 +118,6 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 		needsRemoval := false
 
 		_, desiredInstanceID := getInstanceID(cluster, instance.GetProcessClass(), idNum)
-		if err != nil {
-			return false, err
-		}
 
 		if instanceID != desiredInstanceID {
 			needsRemoval = true

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -106,7 +106,7 @@ func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 			}
 
 			r.Recorder.Event(cluster, "Normal", "NeedsPodsDeletion",
-				fmt.Sprintf("Spec require deleting some pods, but deleting pods is disabled"))
+				"Spec require deleting some pods, but deleting pods is disabled")
 			cluster.Status.Generations.NeedsPodDeletion = cluster.ObjectMeta.Generation
 			err = r.Status().Update(context, cluster)
 			if err != nil {

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -207,6 +207,9 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 
 			pvcs := &corev1.PersistentVolumeClaimList{}
 			err = r.List(context, pvcs, getPodListOptions(cluster, processClass, id)...)
+			if err != nil {
+				return false, err
+			}
 			desiredPvc, err := GetPvc(cluster, processClass, idNum)
 			if err != nil {
 				return false, err

--- a/errcheck_excludes.txt
+++ b/errcheck_excludes.txt
@@ -1,0 +1,3 @@
+(io.Closer).Close
+(*os.File).Close
+(github.com/FoundationDB/fdb-kubernetes-operator/controllers.AdminClient).Close

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 	if logFile != "" {
 		file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 		if err != nil {
-			os.Stderr.WriteString(err.Error())
+			_, _ = os.Stderr.WriteString(err.Error())
 			os.Exit(1)
 		}
 		defer file.Close()


### PR DESCRIPTION
[golangci-lint](https://github.com/golangci/golangci-lint) is used by many golang based repositories as linter. The current configuration is inspired by the [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.golangci.yml) repository.