### PR TITLE
Include the cluster name in the labels we check when fetching a single pod.

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -347,12 +347,16 @@ func getMinimalPodLabels(cluster *fdbtypes.FoundationDBCluster, processClass str
 	return labels
 }
 
+func getMinimalSinglePodLabels(cluster *fdbtypes.FoundationDBCluster, id string) map[string]string {
+	return getMinimalPodLabels(cluster, "", id)
+}
+
 func getPodListOptions(cluster *fdbtypes.FoundationDBCluster, processClass string, id string) []client.ListOption {
 	return []client.ListOption{client.InNamespace(cluster.ObjectMeta.Namespace), client.MatchingLabels(getMinimalPodLabels(cluster, processClass, id))}
 }
 
 func getSinglePodListOptions(cluster *fdbtypes.FoundationDBCluster, instanceID string) []client.ListOption {
-	return []client.ListOption{client.InNamespace(cluster.ObjectMeta.Namespace), client.MatchingLabels(map[string]string{"fdb-instance-id": instanceID})}
+	return []client.ListOption{client.InNamespace(cluster.ObjectMeta.Namespace), client.MatchingLabels(getMinimalSinglePodLabels(cluster, instanceID))}
 }
 
 func buildOwnerReference(ownerType metav1.TypeMeta, ownerMetadata metav1.ObjectMeta) []metav1.OwnerReference {


### PR DESCRIPTION
Add safety checks to ensure that our list calls in RemovePods only return 0 or 1 items.

Part of this was done in a recent commit to master, but we need to get this into a patch release.