### PR TITLE
Add script to setup ramdisk for macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ To get this controller running in a local Kubernetes cluster:
 5. Run `kubectl apply -f config/samples/cluster_local_tls.yaml`
    to create a new FoundationDB cluster with the operator.
 
-
 ### Testing
 
 The test suite runs a live copy of etcd which is heavily dependent on disk I/O
@@ -80,3 +79,6 @@ export TMPDIR=$(pwd)/ramdisk
 ```
 
 Then run the test suite under that environment.
+
+For `MacOS` you can use the script located under `./scripts/setup_ramdisk_macos.sh`.
+This script will setup a ramdisk and mount it (the default location will be `${HOME}/volatile`).

--- a/scripts/setup_ramdisk_macos.sh
+++ b/scripts/setup_ramdisk_macos.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ramfs_size_mb=1024
+mount_point="${1:-${HOME}/volatile}"
+
+if grep -qs "${mount_point}" <(mount) > /dev/null;
+then
+  echo "${mount_point} already mounted."
+  exit 1
+fi
+
+mkdir -p "${mount_point}"
+
+ramfs_size_sectors=$((ramfs_size_mb*1024*1024/512))
+ramdisk_dev=$(hdiutil attach -nobrowse -nomount ram://${ramfs_size_sectors})
+# remove whitespaces included in the hdutil output
+ramdisk_dev="${ramdisk_dev%"${ramdisk_dev##*[![:space:]]}"}"
+newfs_hfs -v 'Volatile' "${ramdisk_dev}"
+mount -o noatime -t hfs "${ramdisk_dev}" "${mount_point}"
+
+echo "In order to use the ramdisk set export TMPDIR=${mount_point}"
+
+echo "cleanup:"
+echo "umount ${mount_point}"
+echo "diskutil eject ${ramdisk_dev}"


### PR DESCRIPTION
With the feedback and the analyse from @rbtcollins I added a script to setup a `ramdisk` for MacOS which brings a nice performance boost (at least at my machine):

```bash
# nothing changed
make test
go test ./... -coverprofile cover.out
?       github.com/FoundationDB/fdb-kubernetes-operator [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1     0.337s  coverage: 44.7% of statements
?       github.com/FoundationDB/fdb-kubernetes-operator/cmd/po-docgen   [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/controllers     449.010s        coverage: 74.5% of statements


# ramdisk
make test
go test ./... -coverprofile cover.out
?       github.com/FoundationDB/fdb-kubernetes-operator [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1     0.227s  coverage: 44.7% of statements
?       github.com/FoundationDB/fdb-kubernetes-operator/cmd/po-docgen   [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/controllers     50.518s coverage: 74.5% of statements
```