### PR TITLE
Switch to numeric USER value in Dockerfile for Kubernetes PSPs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,9 @@ COPY --from=builder /usr/lib/libfdb_c.so /usr/lib/
 COPY --from=builder /usr/lib/fdb /usr/lib/fdb/
 COPY --chown=fdb:fdb --from=builder /var/log/fdb/.keep /var/log/fdb/.keep
 
-USER fdb
+# Specify the fdb user by UID to satisfy Kubernetes PSPs, which 
+# require numeric UIDs to be assured a pod is not running as root
+USER 4059
 
 ENV FDB_NETWORK_OPTION_TRACE_LOG_GROUP=fdb-kubernetes-operator
 ENV FDB_NETWORK_OPTION_TRACE_ENABLE=/var/log/fdb


### PR DESCRIPTION
Hey guys!

We're experimenting with the operator in our clusters, but we enforce some fairly rigorous PSPs, which including forcing pods to `runAsNonRoot`

When the current image is deployed, the following error is logged:

```
  Warning  Failed     0s (x4 over 14s)  kubelet            Error: container has runAsNonRoot and image has non-numeric user (fdb), cannot verify user is non-root
```

This PR fixes the issue by using the numeric ID of the fdb user in the Dockerfile, instead of the username :)

Cheers!
D