### PR TITLE
Add securityContext to helm chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Create user and group here since we don't have the tools
 # in distroless
-RUN groupadd --gid 4059 fdb && \
-	useradd --gid 4059 --uid 4059 --create-home --shell /bin/bash fdb && \
+RUN groupadd --gid 40590 fdb && \
+	useradd --gid 40590 --uid 40590 --create-home --shell /bin/bash fdb && \
 	mkdir -p /var/log/fdb && \
 	touch /var/log/fdb/.keep
 
@@ -64,7 +64,7 @@ COPY --from=builder /usr/lib/libfdb_c.so /usr/lib/
 COPY --from=builder /usr/lib/fdb /usr/lib/fdb/
 COPY --chown=fdb:fdb --from=builder /var/log/fdb/.keep /var/log/fdb/.keep
 
-USER fdb
+USER 40590
 
 ENV FDB_NETWORK_OPTION_TRACE_LOG_GROUP=fdb-kubernetes-operator
 ENV FDB_NETWORK_OPTION_TRACE_ENABLE=/var/log/fdb

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Create user and group here since we don't have the tools
 # in distroless
-RUN groupadd --gid 40590 fdb && \
-	useradd --gid 40590 --uid 40590 --create-home --shell /bin/bash fdb && \
+RUN groupadd --gid 4059 fdb && \
+	useradd --gid 4059 --uid 4059 --create-home --shell /bin/bash fdb && \
 	mkdir -p /var/log/fdb && \
 	touch /var/log/fdb/.keep
 
@@ -64,7 +64,8 @@ COPY --from=builder /usr/lib/libfdb_c.so /usr/lib/
 COPY --from=builder /usr/lib/fdb /usr/lib/fdb/
 COPY --chown=fdb:fdb --from=builder /var/log/fdb/.keep /var/log/fdb/.keep
 
-USER 40590
+# Set to the numeric UID of fdb user to satisfy PodSecurityPolices which enforce runAsNonRoot
+USER 4059
 
 ENV FDB_NETWORK_OPTION_TRACE_LOG_GROUP=fdb-kubernetes-operator
 ENV FDB_NETWORK_OPTION_TRACE_ENABLE=/var/log/fdb

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -126,5 +126,13 @@ spec:
           requests:
             cpu: 500m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+      securityContext:
+        fsGroup: 4059
+        runAsGroup: 4059
+        runAsUser: 4059
       serviceAccountName: fdb-kubernetes-operator-controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -130,9 +130,19 @@ spec:
           allowPrivilegeEscalation: false
           privileged: false
           readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /var/log/fdb
+          name: logs
       securityContext:
         fsGroup: 4059
         runAsGroup: 4059
         runAsUser: 4059
       serviceAccountName: fdb-kubernetes-operator-controller-manager
       terminationGracePeriodSeconds: 10
+      volumes:
+      - emptyDir: {}
+        name: tmp
+      - emptyDir: {}
+        name: logs

--- a/config/samples/deployment/manager.yaml
+++ b/config/samples/deployment/manager.yaml
@@ -19,7 +19,12 @@ spec:
       securityContext:
         runAsUser: 4059
         runAsGroup: 4059
-        fsGroup: 4059      
+        fsGroup: 4059
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: logs
+        emptyDir: {}
       serviceAccountName: fdb-kubernetes-operator-controller-manager
       containers:
       - command:
@@ -43,7 +48,12 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
-          privileged: false            
+          privileged: false
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: logs
+          mountPath: /var/log/fdb
       terminationGracePeriodSeconds: 10
 ---
 apiVersion: v1

--- a/config/samples/deployment/manager.yaml
+++ b/config/samples/deployment/manager.yaml
@@ -16,6 +16,10 @@ spec:
         control-plane: controller-manager
         app: fdb-kubernetes-operator-controller-manager
     spec:
+      securityContext:
+        runAsUser: 4059
+        runAsGroup: 4059
+        fsGroup: 4059      
       serviceAccountName: fdb-kubernetes-operator-controller-manager
       containers:
       - command:
@@ -36,6 +40,10 @@ spec:
           requests:
             cpu: 500m
             memory: 256Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          privileged: false            
       terminationGracePeriodSeconds: 10
 ---
 apiVersion: v1

--- a/helm/fdb-operator/templates/manager/deployment.yaml
+++ b/helm/fdb-operator/templates/manager/deployment.yaml
@@ -20,6 +20,13 @@ spec:
       labels:
         {{- include "chart.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsUser: 40590
+        runAsGroup: 40590
+        fsGroup: 40590
+      volumes:
+      - name: tmp
+        emptyDir: {}
       containers:
       - args:
         - --enable-leader-election
@@ -35,6 +42,9 @@ spec:
         ports:
         - containerPort: 8080
           name: metrics
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           limits:
             cpu: 500m
@@ -42,5 +52,9 @@ spec:
           requests:
             cpu: 500m
             memory: 256Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          privileged: false
       serviceAccountName: fdb-kubernetes-operator-controller-manager
       terminationGracePeriodSeconds: 10

--- a/helm/fdb-operator/templates/manager/deployment.yaml
+++ b/helm/fdb-operator/templates/manager/deployment.yaml
@@ -21,9 +21,9 @@ spec:
         {{- include "chart.labels" . | nindent 8 }}
     spec:
       securityContext:
-        runAsUser: 40590
-        runAsGroup: 40590
-        fsGroup: 40590
+        runAsUser: 4059
+        runAsGroup: 4059
+        fsGroup: 4059
       volumes:
       - name: tmp
         emptyDir: {}

--- a/helm/fdb-operator/templates/manager/deployment.yaml
+++ b/helm/fdb-operator/templates/manager/deployment.yaml
@@ -27,6 +27,8 @@ spec:
       volumes:
       - name: tmp
         emptyDir: {}
+      - name: logs
+        emptyDir: {}        
       containers:
       - args:
         - --enable-leader-election
@@ -45,6 +47,8 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        - name: logs
+          mountPath: /var/log/fdb   
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
Hey guys,

This PR adds a securityContext to both the manager pod, and the specific manager container. Because we enforce `readOnlyRootFilesystem` in `container.securityContext`, we also add an `emptyDir` volumeMount to allow `/tmp` to be read/write, without allowing the **rest** of the pod to be read/write.

I also adjusted the UID to 40590 in both the `pod.securityContext` and the `Dockerfile`, so that subsequent CI actions (_coming in a separate PR_) using [kube-score](_https://github.com/zegl/kube-score_) will pass the manifests (_since the UID will be > 10000_). Additionally, clusters employing PSPs enforcing containers to run as non-root will allow the container image to run, since the `USER` value is now numeric (_this PR supercedes my previous PR #424_)

Cheers!
D