### PR TITLE
Add livenessProbe to helm chart

### DIFF
--- a/helm/fdb-operator/templates/manager/deployment.yaml
+++ b/helm/fdb-operator/templates/manager/deployment.yaml
@@ -35,6 +35,10 @@ spec:
         ports:
         - containerPort: 8080
           name: metrics
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics            
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
... and another one :)

This PR adds a livenessProbe to the helm chart. Why? Because we validate all our helm charts before application using [kube-score,](https://github.com/zegl/kube-score) which complains if we don't have probes in our pods. I understand that this is not, by itself, a good enough reason to add some arbitrary podProbes, but a livenessProbe **will** force Kubernetes to restart the pod if it happens to crash in a nasty way. And it is the "right" thing to do ;)

(_I didn't bother with a readinessProbe, since an operator doesn't need to receive any ingress traffic_)

Cheers!
D