### PR TITLE
Allow customization of pod resources in helm chart

### DIFF
--- a/helm/fdb-operator/templates/manager/deployment.yaml
+++ b/helm/fdb-operator/templates/manager/deployment.yaml
@@ -36,11 +36,6 @@ spec:
         - containerPort: 8080
           name: metrics
         resources:
-          limits:
-            cpu: 500m
-            memory: 256Mi
-          requests:
-            cpu: 500m
-            memory: 256Mi
+          {{- toYaml .Values.resources | nindent 12 }}     
       serviceAccountName: fdb-kubernetes-operator-controller-manager
       terminationGracePeriodSeconds: 10

--- a/helm/fdb-operator/values.yaml
+++ b/helm/fdb-operator/values.yaml
@@ -4,3 +4,11 @@ operator:
   tag: 0.24.0
   role: fdb-kubernetes-operator-manager-role
   rolebinding: fdb-kubernetes-operator-manager-rolebinding
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 500m
+    memory: 256Mi


### PR DESCRIPTION
Continuing the PR blitz, this PR adds the option for the user to customize the resource requests/limits in the helm chart, while "falling back" to the existing requests/limits by default.

Why? We like to fine-tune our resource allocations, and being able to control the allocations for the operator pod is desirable ;)

Cheers!
D