### PR TITLE
Pin kustomize version

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,9 +33,11 @@ jobs:
     - name: Get dependencies
       env:
         KUBEBUILDER_VER: "2.2.0"
+        KUSTOMIZE_VER: "v3.8.8"
       run: |
         go get -v -t -d ./...
-        curl --fail -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+        curl --fail -LO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VER}/kustomize_${KUSTOMIZE_VER}_linux_amd64.tar.gz"
+        tar xvfz kustomize_${KUSTOMIZE_VER}_linux_amd64.tar.gz
         sudo mv kustomize /usr/local/bin/
         os=$(go env GOOS)
         arch=$(go env GOARCH)


### PR DESCRIPTION
customise released a new version which breaks our build so I pinned it to `v3.8.8` which works (on my machine 😄) I open an issue to check what breaks https://github.com/kubernetes-sigs/kustomize/releases.