### PR TITLE
Fix bug to update storageServerPerPod

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -2179,7 +2179,7 @@ const (
 )
 
 // AddStorageServerPerDisk adds serverPerDisk to the status field to keep track which ConfigMaps should be kept
-func (clusterStatus FoundationDBClusterStatus) AddStorageServerPerDisk(serversPerDisk int) {
+func (clusterStatus *FoundationDBClusterStatus) AddStorageServerPerDisk(serversPerDisk int) {
 	for _, curServersPerDisk := range clusterStatus.StorageServersPerDisk {
 		if curServersPerDisk == serversPerDisk {
 			return

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -3189,3 +3189,55 @@ func TestGetProcessPort(t *testing.T) {
 		})
 	}
 }
+
+func TestAddStorageServerPerDisk(t *testing.T) {
+	tt := []struct {
+		Name                          string
+		ValuesToAdd                   []int
+		ExpectedLen                   int
+		ExpectedStorageServersPerDisk []int
+	}{
+		{
+			Name:                          "Add missing element",
+			ValuesToAdd:                   []int{1},
+			ExpectedLen:                   1,
+			ExpectedStorageServersPerDisk: []int{1},
+		},
+		{
+			Name:                          "Duplicates should only inserted once",
+			ValuesToAdd:                   []int{1, 1},
+			ExpectedLen:                   1,
+			ExpectedStorageServersPerDisk: []int{1},
+		},
+		{
+			Name:                          "Multiple elements should be added",
+			ValuesToAdd:                   []int{1, 2},
+			ExpectedLen:                   2,
+			ExpectedStorageServersPerDisk: []int{1, 2},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			status := FoundationDBClusterStatus{
+				StorageServersPerDisk: []int{},
+			}
+
+			for _, val := range tc.ValuesToAdd {
+				status.AddStorageServerPerDisk(val)
+			}
+
+			if len(status.StorageServersPerDisk) != tc.ExpectedLen {
+				t.Logf("Expected len %d, got %d: %v", tc.ExpectedLen, len(status.StorageServersPerDisk), status.StorageServersPerDisk)
+				t.FailNow()
+			}
+
+			for i, val := range tc.ExpectedStorageServersPerDisk {
+				if val != status.StorageServersPerDisk[i] {
+					t.Logf("Expected %v, got %v", tc.ExpectedStorageServersPerDisk, status.StorageServersPerDisk)
+					t.FailNow()
+				}
+			}
+		})
+	}
+}

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -49,7 +49,6 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 	status.MissingProcesses = make(map[string]int64)
 	// Initialize with the current desired storage servers per Pod
 	status.StorageServersPerDisk = []int{cluster.GetStorageServersPerPod()}
-	log.Info("first status.StorageServersPerDisk", "status.StorageServersPerDisk", status.StorageServersPerDisk)
 
 	var databaseStatus *fdbtypes.FoundationDBStatus
 	processMap := make(map[string][]fdbtypes.FoundationDBStatusProcessInfo)

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -46,10 +47,9 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 	status.Generations.Reconciled = cluster.Status.Generations.Reconciled
 	status.IncorrectProcesses = make(map[string]int64)
 	status.MissingProcesses = make(map[string]int64)
-	status.StorageServersPerDisk = make([]int, 0)
-
 	// Initialize with the current desired storage servers per Pod
-	status.AddStorageServerPerDisk(cluster.GetStorageServersPerPod())
+	status.StorageServersPerDisk = []int{cluster.GetStorageServersPerPod()}
+	log.Info("first status.StorageServersPerDisk", "status.StorageServersPerDisk", status.StorageServersPerDisk)
 
 	var databaseStatus *fdbtypes.FoundationDBStatus
 	processMap := make(map[string][]fdbtypes.FoundationDBStatusProcessInfo)
@@ -210,6 +210,7 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 	if status.ConnectionString == "" {
 		status.ConnectionString = existingConfigMap.Data["cluster-file"]
 	}
+
 	if status.ConnectionString == "" {
 		status.ConnectionString = cluster.Spec.SeedConnectionString
 	}
@@ -266,6 +267,7 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 	if len(status.IncorrectProcesses) == 0 {
 		status.IncorrectProcesses = nil
 	}
+
 	if len(status.MissingProcesses) == 0 {
 		status.MissingProcesses = nil
 	}
@@ -287,9 +289,8 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 		status.FailingPods = nil
 	}
 
-	if len(status.StorageServersPerDisk) == 0 {
-		status.StorageServersPerDisk = nil
-	}
+	// Sort the storage servers per Disk to prevent a reodering to issue a new reconcile loop.
+	sort.Ints(status.StorageServersPerDisk)
 
 	originalStatus := cluster.Status.DeepCopy()
 


### PR DESCRIPTION
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/441 since we passed `clusterStatus FoundationDBClusterStatus` by value and not by reference the "real" status was always empty.