### PR TITLE
Add devcontainer for GitHub codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,118 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# This Dockerfile copied from https://github.com/alitari/vscode-kubebuilder
+
+FROM golang:1
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt, install packages and tools
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git openssh-client less iproute2 procps lsb-release bash-completion software-properties-common apt-transport-https ca-certificates acl \
+    #
+    # Build Go tools w/module support
+    && mkdir -p /tmp/gotools \
+    && cd /tmp/gotools \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -v golang.org/x/tools/gopls@latest 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -v \
+        honnef.co/go/tools/...@latest \
+        golang.org/x/tools/cmd/gorename@latest \
+        golang.org/x/tools/cmd/goimports@latest \
+        golang.org/x/tools/cmd/guru@latest \
+        golang.org/x/lint/golint@latest \
+        github.com/mdempsky/gocode@latest \
+        github.com/cweill/gotests/...@latest \
+        github.com/haya14busa/goplay/cmd/goplay@latest \
+        github.com/sqs/goreturns@latest \
+        github.com/josharian/impl@latest \
+        github.com/davidrjenni/reftools/cmd/fillstruct@latest \
+        github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest  \
+        github.com/ramya-rao-a/go-outline@latest  \
+        github.com/acroca/go-symbols@latest  \
+        github.com/godoctor/godoctor@latest  \
+        github.com/rogpeppe/godef@latest  \
+        github.com/zmb3/gogetdoc@latest \
+        github.com/fatih/gomodifytags@latest  \
+        github.com/mgechev/revive@latest  \
+        github.com/go-delve/delve/cmd/dlv@latest 2>&1 \
+    #
+    # Build Go tools w/o module support
+    && GOPATH=/tmp/gotools go get -v github.com/alecthomas/gometalinter 2>&1 \
+    #
+    # Build gocode-gomod
+    && GOPATH=/tmp/gotools go get -x -d github.com/stamblerre/gocode 2>&1 \
+    && GOPATH=/tmp/gotools go build -o gocode-gomod github.com/stamblerre/gocode \
+    #
+    # Install Go tools
+    && mv /tmp/gotools/bin/* /usr/local/bin/ \
+    && mv gocode-gomod /usr/local/bin/ \
+    #
+    # Install golangci-lint
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin 2>&1 \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/gotools
+
+# Update this to "on" or "off" as appropriate
+ENV GO111MODULE=on
+
+# kubectl
+ENV KUBECTL_VERSION=v1.16.2
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+    && chmod +x ./kubectl \
+    && mv ./kubectl /usr/local/bin/kubectl
+
+# skaffold
+RUN curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 \
+    && chmod +x skaffold \
+    && mv skaffold /usr/local/bin
+
+# helm
+RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 > get_helm.sh \
+    && chmod 700 get_helm.sh \
+    && ./get_helm.sh
+
+#kubebuilder
+RUN curl -L https://go.kubebuilder.io/dl/2.3.1/linux/amd64 | tar -xz -C /tmp/ \
+    && mv /tmp/kubebuilder_2.3.1_linux_amd64 /usr/local/kubebuilder
+
+# kustomize
+RUN curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash \
+    && mv kustomize /usr/bin/kustomize
+ENV PATH=${PATH}:/usr/local/kubebuilder/bin
+
+# fdb-client (yes, we're ignoring SSL certificates here - I have no idea why golang image thinks the cert is untrusted, but I'm sure the Apple team can fix it!)
+RUN curl -k -Lo  foundationdb-clients_6.2.28-1_amd64.deb "https://foundationdb-origin.apple.com/downloads/6.2.28/ubuntu/installers/foundationdb-clients_6.2.28-1_amd64.deb" \
+    && dpkg -i foundationdb-clients_6.2.28-1_amd64.deb \
+    && rm foundationdb-clients_6.2.28-1_amd64.deb
+
+# bash-git-prompt
+RUN git clone https://github.com/magicmonty/bash-git-prompt.git /home/vscode/.bash-git-prompt --depth=1
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"name": "kubebuilder",
+	"dockerFile": "Dockerfile",
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		9000
+	],
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.gopath": "/go",
+		"go.inferGopath": false,
+		"go.useLanguageServer": true
+	},
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": [
+		"ms-vscode.go",
+		"ms-kubernetes-tools.vscode-kubernetes-tools"
+	],
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "go version",
+	// Comment out the next line to run as root
+	"remoteUser": "vscode"
+	// "postCreateCommand": ". /workspaces/vscode-kubebuilder/init.sh"
+}


### PR DESCRIPTION
Hey guys!

I had a horrible time trying to get the dev environment dependencies working on my MacOS desktop, for my recent PRs (https://github.com/FoundationDB/fdb-kubernetes-operator/pull/425).

This PR contributes a `.devcontainer` folder, which provides the dev environment within GitHub Codespaces - I used it to run `make clean all` on my recent PR, it worked great :)

You may want to make some improvements (_specifically to the fact that golang:1 thinks that the SSL cert for https://foundationdb-origin.apple.com contains an untrusted, self-signed cert_), but I hope it'll be useful ;)

Cheers!
D