### PR TITLE
Add a timeout to the transactions for managing locks.

### DIFF
--- a/config/samples/multi_dc/final.yaml
+++ b/config/samples/multi_dc/final.yaml
@@ -28,15 +28,17 @@ spec:
     regions:
       - datacenters:
           - id: dc1
+            priority: 1
           - id: dc3
             satellite: 1
-        priority: 1
+            priority: 1
         satellite_logs: 3
       - datacenters:
           - id: dc2
+            priority: 0
           - id: dc3
             satellite: 1
-        priority: 0
+            priority: 1
         satellite_logs: 3
   processes:
     general:

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -743,6 +743,7 @@ func (r *FoundationDBClusterReconciler) getLockClient(cluster *fdbtypes.Foundati
 
 // takeLock attempts to acquire a lock.
 func (r *FoundationDBClusterReconciler) takeLock(cluster *fdbtypes.FoundationDBCluster, action string) (bool, error) {
+	log.Info("Taking lock on cluster", "namespace", cluster.Namespace, "cluster", cluster.Name, "action", action)
 	lockClient, err := r.getLockClient(cluster)
 	if err != nil {
 		return false, err

--- a/controllers/lock_client.go
+++ b/controllers/lock_client.go
@@ -30,6 +30,10 @@ import (
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
 )
 
+const (
+	defaultTransactionTimeout int64 = 5000
+)
+
 // LockClient provides a client for getting locks on operations for a cluster.
 type LockClient interface {
 	// Disabled determines whether the locking is disabled.
@@ -223,6 +227,11 @@ func getFDBDatabase(cluster *fdbtypes.FoundationDBCluster) (fdb.Database, error)
 	}
 
 	database, err = fdb.OpenDatabase(clusterFilePath)
+	if err != nil {
+		return fdb.Database{}, err
+	}
+
+	err = database.Options().SetTransactionTimeout(defaultTransactionTimeout)
 	if err != nil {
 		return fdb.Database{}, err
 	}


### PR DESCRIPTION
Add more logging when taking locks.
Fix the priorities in the database config in the multi-DC sample.

Resolves #459