### PR TITLE
Add flag to enable verbose development/console logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.3.2
+	go.uber.org/zap v1.9.1
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func main() {
 	flag.BoolVar(&development, "development", false,
 		"Enable verbose development logs",
 	)
+	level := uzap.LevelFlag("log-level", uzap.InfoLevel, "The log level")
 	flag.Parse()
 
 	deprecationOptions.OnlyShowChanges = checkDeprecations

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ func main() {
 	var deprecationOptions controllers.DeprecationOptions
 	var useFutureDefaults bool
 	var checkDeprecations bool
+	var development bool
 
 	fdb.MustAPIVersion(610)
 
@@ -65,6 +66,9 @@ func main() {
 	)
 	flag.BoolVar(&checkDeprecations, "check-deprecations", false,
 		"Check for deprecated fields and then exit",
+	)
+	flag.BoolVar(&development, "development", false,
+		"Enable verbose development logs",
 	)
 	flag.Parse()
 
@@ -84,7 +88,7 @@ func main() {
 	}
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
-		o.Development = true
+		o.Development = development
 		o.DestWritter = logWriter
 	}))
 

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	appsv1beta1 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 	"github.com/FoundationDB/fdb-kubernetes-operator/controllers"
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
+	uzap "go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -88,9 +89,11 @@ func main() {
 		logWriter = os.Stdout
 	}
 
+	logLevel := uzap.NewAtomicLevelAt(*level)
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
 		o.Development = development
 		o.DestWritter = logWriter
+		o.Level = &logLevel
 	}))
 
 	controllers.DefaultCLITimeout = cliTimeout

--- a/main.go
+++ b/main.go
@@ -90,11 +90,13 @@ func main() {
 	}
 
 	logLevel := uzap.NewAtomicLevelAt(*level)
-	ctrl.SetLogger(zap.New(func(o *zap.Options) {
-		o.Development = development
-		o.DestWritter = logWriter
-		o.Level = &logLevel
-	}))
+	ctrl.SetLogger(
+		zap.New(
+			zap.UseDevMode(development),
+			zap.WriteTo(logWriter),
+			zap.Level(&logLevel),
+		),
+	)
 
 	controllers.DefaultCLITimeout = cliTimeout
 


### PR DESCRIPTION
Default is json logs

See https://github.com/FoundationDB/fdb-kubernetes-operator/issues/464