### PR TITLE
Build and push docker images for releases and on master

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,13 +12,10 @@ jobs:
       matrix:
         image:
           - fdb-kubernetes-operator
-          - foundationdb-kubernetes-sidecar
           - fdb-data-loader
         include:
           - image: fdb-kubernetes-operator
             context: ./
-          - image: foundationdb-kubernetes-sidecar
-            context: ./foundationdb-kubernetes-sidecar
           - image: fdb-data-loader
             context: ./sample-apps/data-loader
     steps:
@@ -26,25 +23,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      # Will be deprecated -> https://github.com/docker/login-action#github-packages-docker-registry
-      # but GitHub Container Registry is still in beta and only works with a personal access token (PAT)
-      # See: https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images
-      - name: Login to GitHub Container Registry
+      - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push to registry
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.context }}
-          tags: docker.pkg.github.com/${{ github.repository }}/${{ matrix.image }}:latest
-          # push: true
-          # Workaround: otherwise we have a multi-arch image which is not supported by the deprecated
-          # GitHub packages but GHCR doesn't support the workflow credentials and is only in public beta :(
-          # https://github.com/docker/build-push-action/blob/master/TROUBLESHOOTING.md#errors-on-pushing-to-registry
-          outputs: type=docker
-      # Really? -> https://github.community/t/docker-pull-from-public-github-package-registry-fail-with-no-basic-auth-credentials-error/16358/85
-      - name: Push the image with docker
-        run: docker push docker.pkg.github.com/${{ github.repository }}/${{ matrix.image }}:latest
+          tags: ${{ github.repository }}/${{ matrix.image }}:latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,50 @@
+name: CI for master branch
+
+on:
+  push:
+    branches: master
+
+jobs:
+  push_images:
+    name: Push Docker images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - fdb-kubernetes-operator
+          - foundationdb-kubernetes-sidecar
+          - fdb-data-loader
+        include:
+          - image: fdb-kubernetes-operator
+            context: ./
+          - image: foundationdb-kubernetes-sidecar
+            context: ./foundationdb-kubernetes-sidecar
+          - image: fdb-data-loader
+            context: ./sample-apps/data-loader
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      # Will be deprecated -> https://github.com/docker/login-action#github-packages-docker-registry
+      # but GitHub Container Registry is still in beta and only works with a personal access token (PAT)
+      # See: https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push to registry
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.context }}
+          tags: docker.pkg.github.com/${{ github.repository }}/${{ matrix.image }}:latest
+          # push: true
+          # Workaround: otherwise we have a multi-arch image which is not supported by the deprecated
+          # GitHub packages but GHCR doesn't support the workflow credentials and is only in public beta :(
+          # https://github.com/docker/build-push-action/blob/master/TROUBLESHOOTING.md#errors-on-pushing-to-registry
+          outputs: type=docker
+      # Really? -> https://github.community/t/docker-pull-from-public-github-package-registry-fail-with-no-basic-auth-credentials-error/16358/85
+      - name: Push the image with docker
+        run: docker push docker.pkg.github.com/${{ github.repository }}/${{ matrix.image }}:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,13 +98,10 @@ jobs:
       matrix:
         image:
           - fdb-kubernetes-operator
-          - foundationdb-kubernetes-sidecar
           - fdb-data-loader
         include:
           - image: fdb-kubernetes-operator
             context: ./
-          - image: foundationdb-kubernetes-sidecar
-            context: ./foundationdb-kubernetes-sidecar
           - image: fdb-data-loader
             context: ./sample-apps/data-loader
     steps:
@@ -115,28 +112,13 @@ jobs:
         run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      # Will be deprecated -> https://github.com/docker/login-action#github-packages-docker-registry
-      # but GitHub Container Registry is still in beta and only works with a personal access token (PAT)
-      # See: https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images
-      - name: Login to GitHub Container Registry
+      - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push to registry
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.context }}
-          # todo adjust to FoundationDB
-          # See: https://github.community/t/how-to-get-just-the-tag-name/16241 why we use this weird step
-          # ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.get_tag.outputs.TAG }}
-          tags: docker.pkg.github.com/${{ github.repository }}/${{ matrix.image }}:${{ steps.get_tag.outputs.TAG }}
-          # push: true
-          # Workaround: otherwise we have a multi-arch image which is not supported by the deprecated
-          # GitHub packages but GHCR doesn't support the workflow credentials and is only in public beta :(
-          # https://github.com/docker/build-push-action/blob/master/TROUBLESHOOTING.md#errors-on-pushing-to-registry
-          outputs: type=docker
-      # Really? -> https://github.community/t/docker-pull-from-public-github-package-registry-fail-with-no-basic-auth-credentials-error/16358/85
-      - name: Push the image with docker
-        run: docker push docker.pkg.github.com/${{ github.repository }}/${{ matrix.image }}:${{ steps.get_tag.outputs.TAG }}
+          tags: ${{ github.repository }}/${{ matrix.image }}:${{ steps.get_tag.outputs.TAG }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
       #     go get -v -t -d ./...
       - name: Build
         run: TAG=${{ needs.create-release.outputs.tag }} make plugin package
-      - name: Upload Release Asse
+      - name: Upload Release asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
           asset_content_type: application/gzip
       - name: Create sha256 for assert
         run: echo "${{ hashFiles('./bin/kubectl-fdb.tar.gz') }}" > ./bin/${{ steps.set_package_name.outputs.package_name }}.sha256
-      - name: Upload sha256 for asssert
+      - name: Upload sha256 for asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -90,3 +90,53 @@ jobs:
           asset_path: ./bin/${{ steps.set_package_name.outputs.package_name }}.sha256
           asset_name: ${{ steps.set_package_name.outputs.package_name }}.sha256
           asset_content_type: text/plain
+  push_images:
+    name: Push Docker images
+    needs: create-release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - fdb-kubernetes-operator
+          - foundationdb-kubernetes-sidecar
+          - fdb-data-loader
+        include:
+          - image: fdb-kubernetes-operator
+            context: ./
+          - image: foundationdb-kubernetes-sidecar
+            context: ./foundationdb-kubernetes-sidecar
+          - image: fdb-data-loader
+            context: ./sample-apps/data-loader
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Get the version
+        id: get_tag
+        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      # Will be deprecated -> https://github.com/docker/login-action#github-packages-docker-registry
+      # but GitHub Container Registry is still in beta and only works with a personal access token (PAT)
+      # See: https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push to registry
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.context }}
+          # todo adjust to FoundationDB
+          # See: https://github.community/t/how-to-get-just-the-tag-name/16241 why we use this weird step
+          # ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.get_tag.outputs.TAG }}
+          tags: docker.pkg.github.com/${{ github.repository }}/${{ matrix.image }}:${{ steps.get_tag.outputs.TAG }}
+          # push: true
+          # Workaround: otherwise we have a multi-arch image which is not supported by the deprecated
+          # GitHub packages but GHCR doesn't support the workflow credentials and is only in public beta :(
+          # https://github.com/docker/build-push-action/blob/master/TROUBLESHOOTING.md#errors-on-pushing-to-registry
+          outputs: type=docker
+      # Really? -> https://github.community/t/docker-pull-from-public-github-package-registry-fail-with-no-basic-auth-credentials-error/16358/85
+      - name: Push the image with docker
+        run: docker push docker.pkg.github.com/${{ github.repository }}/${{ matrix.image }}:${{ steps.get_tag.outputs.TAG }}


### PR DESCRIPTION
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/75

You can see the successful workflow here: https://github.com/johscheuer/fdb-kubernetes-operator/actions/runs/522035788

There is a bunch of stuff we should discuss after the weekend to see if we want to use the GitHub solution.