### PR TITLE
Run the race detector in our test suite.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,6 +34,7 @@ jobs:
       env:
         KUBEBUILDER_VER: "2.2.0"
         KUSTOMIZE_VER: "v3.8.8"
+        TEST_RACE_CONDITIONS: "1"
       run: |
         go get -v -t -d ./...
         curl --fail -LO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VER}/kustomize_${KUSTOMIZE_VER}_linux_amd64.tar.gz"

--- a/Makefile
+++ b/Makefile
@@ -39,14 +39,14 @@ clean:
 # Run tests
 test:
 ifneq "$(SKIP_TEST)" "1"
-	go test ./... -coverprofile cover.out
+	go test -race ./... -coverprofile cover.out
 endif
 
 test_if_changed: cover.out
 
 cover.out: ${GO_ALL} ${MANIFESTS}
 ifneq "$(SKIP_TEST)" "1"
-	go test ./... -coverprofile cover.out -tags test
+	go test -race ./... -coverprofile cover.out -tags test
 endif
 
 # Build manager binary

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ GO_ALL=${GO_SRC} ${GENERATED_GO}
 MANIFESTS=config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 
+ifeq "$(TEST_RACE_CONDITIONS)" "1"
+	go_test_flags := $(go_test_flags) -race
+endif
+
 all: generate fmt vet manager plugin manifests samples documentation test_if_changed
 
 .PHONY: clean all manager samples documentation run install uninstall deploy manifests fmt vet generate docker-build docker-push rebuild-operator bounce lint
@@ -39,14 +43,14 @@ clean:
 # Run tests
 test:
 ifneq "$(SKIP_TEST)" "1"
-	go test -race ./... -coverprofile cover.out
+	go test ${go_test_flags} ./... -coverprofile cover.out
 endif
 
 test_if_changed: cover.out
 
 cover.out: ${GO_ALL} ${MANIFESTS}
 ifneq "$(SKIP_TEST)" "1"
-	go test -race ./... -coverprofile cover.out -tags test
+	go test ${go_test_flags} ./... -coverprofile cover.out -tags test
 endif
 
 # Build manager binary

--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -41,6 +41,10 @@ var _ = Describe("admin_client_test", func() {
 		err = k8sClient.Create(context.TODO(), cluster)
 		Expect(err).NotTo(HaveOccurred())
 
+		result, err := reconcileCluster(cluster)
+		Expect(err).NotTo((HaveOccurred()))
+		Expect(result.Requeue).To(BeFalse())
+
 		Eventually(func() (int64, error) {
 			return reloadCluster(cluster)
 		}).ShouldNot(Equal(int64(0)))

--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -45,16 +45,12 @@ var _ = Describe("admin_client_test", func() {
 		Expect(err).NotTo((HaveOccurred()))
 		Expect(result.Requeue).To(BeFalse())
 
-		Eventually(func() (int64, error) {
-			return reloadCluster(cluster)
-		}).ShouldNot(Equal(int64(0)))
+		generation, err := reloadCluster(cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(generation).NotTo(Equal(int64(0)))
 
 		client, err = newMockAdminClientUncast(cluster, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		cleanupCluster(cluster)
 	})
 
 	Describe("JSON status", func() {

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -75,9 +75,9 @@ var _ = Describe("backup_controller", func() {
 			Expect(err).NotTo((HaveOccurred()))
 			Expect(result.Requeue).To(BeFalse())
 
-			Eventually(func() (int64, error) {
-				return reloadCluster(cluster)
-			}).ShouldNot(Equal(int64(0)))
+			generation, err := reloadCluster(cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(generation).NotTo(Equal(int64(0)))
 
 			err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, cluster)
 			Expect(err).NotTo(HaveOccurred())
@@ -89,9 +89,9 @@ var _ = Describe("backup_controller", func() {
 			Expect(err).NotTo((HaveOccurred()))
 			Expect(result.Requeue).To(BeFalse())
 
-			Eventually(func() (int64, error) {
-				return reloadBackup(backup)
-			}).ShouldNot(Equal(int64(0)))
+			generation, err = reloadBackup(backup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(generation).NotTo(Equal(int64(0)))
 			err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, cluster)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -105,14 +105,11 @@ var _ = Describe("backup_controller", func() {
 			Expect(err).NotTo((HaveOccurred()))
 			Expect(result.Requeue).To(BeFalse())
 
-			Eventually(func() (int64, error) { return reloadBackup(backup) }).Should(Equal(originalVersion + generationGap))
+			generation, err := reloadBackup(backup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(generation).To(Equal(originalVersion + generationGap))
 			err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: backup.Namespace, Name: backup.Name}, cluster)
 			Expect(err).NotTo(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			cleanupCluster(cluster)
-			cleanupBackup(backup)
 		})
 
 		Context("when reconciling a new backup", func() {
@@ -163,10 +160,9 @@ var _ = Describe("backup_controller", func() {
 
 			It("should set the default replica count", func() {
 				deployments := &appsv1.DeploymentList{}
-				Eventually(func() (int, error) {
-					err := k8sClient.List(context.TODO(), deployments)
-					return len(deployments.Items), err
-				}).Should(Equal(1))
+				err = k8sClient.List(context.TODO(), deployments)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(deployments.Items)).To(Equal(1))
 				Expect(*deployments.Items[0].Spec.Replicas).To(Equal(int32(2)))
 			})
 		})
@@ -181,10 +177,9 @@ var _ = Describe("backup_controller", func() {
 
 			It("should remove the deployment", func() {
 				deployments := &appsv1.DeploymentList{}
-				Eventually(func() (int, error) {
-					err := k8sClient.List(context.TODO(), deployments)
-					return len(deployments.Items), err
-				}).Should(Equal(0))
+				err = k8sClient.List(context.TODO(), deployments)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(deployments.Items)).To(Equal(0))
 			})
 		})
 
@@ -259,10 +254,9 @@ var _ = Describe("backup_controller", func() {
 
 			It("should modify the deployment", func() {
 				deployments := &appsv1.DeploymentList{}
-				Eventually(func() (int, error) {
-					err := k8sClient.List(context.TODO(), deployments)
-					return len(deployments.Items), err
-				}).Should(Equal(1))
+				err = k8sClient.List(context.TODO(), deployments)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(deployments.Items)).To(Equal(1))
 				Expect(deployments.Items[0].ObjectMeta.Labels).To(Equal(map[string]string{
 					"fdb-test":                    "test-value",
 					"foundationdb.org/backup-for": string(backup.ObjectMeta.UID),
@@ -290,10 +284,9 @@ var _ = Describe("backup_controller", func() {
 
 			It("should modify the deployment", func() {
 				deployments := &appsv1.DeploymentList{}
-				Eventually(func() (int, error) {
-					err := k8sClient.List(context.TODO(), deployments)
-					return len(deployments.Items), err
-				}).Should(Equal(1))
+				err = k8sClient.List(context.TODO(), deployments)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(deployments.Items)).To(Equal(1))
 				Expect(deployments.Items[0].ObjectMeta.Annotations).To(Equal(map[string]string{
 					"fdb-test-1":                         "test-value-1",
 					"fdb-test-2":                         "test-value-2",

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -67,6 +67,7 @@ type FoundationDBClusterReconciler struct {
 	UseFutureDefaults   bool
 	Namespace           string
 	DeprecationOptions  DeprecationOptions
+	RequeueOnNotFound   bool
 }
 
 // +kubebuilder:rbac:groups=apps.foundationdb.org,resources=foundationdbclusters,verbs=get;list;watch;create;update;patch;delete
@@ -75,8 +76,6 @@ type FoundationDBClusterReconciler struct {
 
 // Reconcile runs the reconciliation logic.
 func (r *FoundationDBClusterReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
-	// your logic here
-
 	cluster := &fdbtypes.FoundationDBCluster{}
 	context := ctx.Background()
 
@@ -88,7 +87,12 @@ func (r *FoundationDBClusterReconciler) Reconcile(request ctrl.Request) (ctrl.Re
 		if k8serrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
+
+			if r.RequeueOnNotFound {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, nil
+
 		}
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -681,9 +681,9 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 
 			Context("with a removal with no exclusion", func() {
 				BeforeEach(func() {
-					mockMissingPodIPs = map[string]bool{
+					setMissingPodIPs(map[string]bool{
 						originalPods.Items[firstStorageIndex].ObjectMeta.Name: true,
-					}
+					})
 					cluster.Spec.InstancesToRemoveWithoutExclusion = []string{
 						originalPods.Items[firstStorageIndex].ObjectMeta.Labels[FDBInstanceIDLabel],
 					}
@@ -692,7 +692,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				})
 
 				AfterEach(func() {
-					mockMissingPodIPs = nil
+					setMissingPodIPs(nil)
 				})
 
 				It("should replace one of the pods", func() {
@@ -3293,9 +3293,11 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 
 	Describe("GetDeprecations", func() {
 		var deprecationOptions DeprecationOptions
+		var reconciler *FoundationDBClusterReconciler
 
 		BeforeEach(func() {
 			deprecationOptions = DeprecationOptions{OnlyShowChanges: true}
+			reconciler = createTestClusterReconciler()
 
 			cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{
 				fdbtypes.ProcessClassGeneral: {
@@ -3433,7 +3435,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 
 			Context("when specifying the cluster's namespace", func() {
 				JustBeforeEach(func() {
-					clusterReconciler.Namespace = cluster.Namespace
+					reconciler.Namespace = cluster.Namespace
 				})
 
 				It("should include the cluster", func() {
@@ -3448,7 +3450,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 
 			Context("when specifying another namespace", func() {
 				JustBeforeEach(func() {
-					clusterReconciler.Namespace = "bad-namespace"
+					reconciler.Namespace = "bad-namespace"
 				})
 
 				It("should not include the cluster", func() {

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -868,6 +868,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 						NeedsBounce:            originalVersion + 1,
 						NeedsMonitorConfUpdate: originalVersion + 1,
 						NeedsPodDeletion:       originalVersion + 1,
+						HasUnhealthyProcess:    originalVersion + 1,
 					}))
 				})
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -3339,17 +3339,17 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 			generation, err := reloadCluster(cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(generation).To(Equal(int64(1)))
-			clusterReconciler.DeprecationOptions = deprecationOptions
+			reconciler.DeprecationOptions = deprecationOptions
 		})
 
 		AfterEach(func() {
-			clusterReconciler.Namespace = ""
-			clusterReconciler.DeprecationOptions = DeprecationOptions{}
+			reconciler.Namespace = ""
+			reconciler.DeprecationOptions = DeprecationOptions{}
 		})
 
 		Context("with no pending changes", func() {
 			It("should be empty", func() {
-				deprecations, err := clusterReconciler.GetDeprecations(context.TODO())
+				deprecations, err := reconciler.GetDeprecations(context.TODO())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(deprecations).To(HaveLen(0))
 			})
@@ -3366,7 +3366,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				})
 
 				It("should include the cluster with the old default", func() {
-					deprecations, err := clusterReconciler.GetDeprecations(context.TODO())
+					deprecations, err := reconciler.GetDeprecations(context.TODO())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(deprecations).To(HaveLen(1))
 
@@ -3392,7 +3392,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				})
 
 				It("should include the cluster with the new default", func() {
-					deprecations, err := clusterReconciler.GetDeprecations(context.TODO())
+					deprecations, err := reconciler.GetDeprecations(context.TODO())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(deprecations).To(HaveLen(1))
 
@@ -3421,7 +3421,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 			})
 
 			It("should include the cluster", func() {
-				deprecations, err := clusterReconciler.GetDeprecations(context.TODO())
+				deprecations, err := reconciler.GetDeprecations(context.TODO())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(deprecations).To(HaveLen(1))
 
@@ -3439,7 +3439,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				})
 
 				It("should include the cluster", func() {
-					deprecations, err := clusterReconciler.GetDeprecations(context.TODO())
+					deprecations, err := reconciler.GetDeprecations(context.TODO())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(deprecations).To(HaveLen(1))
 
@@ -3454,7 +3454,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				})
 
 				It("should not include the cluster", func() {
-					deprecations, err := clusterReconciler.GetDeprecations(context.TODO())
+					deprecations, err := reconciler.GetDeprecations(context.TODO())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(deprecations).To(HaveLen(0))
 				})

--- a/controllers/replace_failed_pods_test.go
+++ b/controllers/replace_failed_pods_test.go
@@ -38,11 +38,13 @@ var _ = Describe("replace_failed_pods", func() {
 		err = k8sClient.Create(context.TODO(), cluster)
 		Expect(err).NotTo(HaveOccurred())
 
-		Eventually(func() (int64, error) { return reloadCluster(cluster) }).Should(Equal(int64(1)))
-	})
+		result, err := reconcileCluster(cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Requeue).To(BeFalse())
 
-	AfterEach(func() {
-		cleanupCluster(cluster)
+		generation, err := reloadCluster(cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(generation).To(Equal(int64(1)))
 	})
 
 	Describe("chooseNewRemovals", func() {

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -53,6 +53,10 @@ var _ = Describe("restore_controller", func() {
 			err = k8sClient.Create(context.TODO(), cluster)
 			Expect(err).NotTo(HaveOccurred())
 
+			result, err := reconcileCluster(cluster)
+			Expect(err).NotTo((HaveOccurred()))
+			Expect(result.Requeue).To(BeFalse())
+
 			Eventually(func() (int64, error) {
 				return reloadCluster(cluster)
 			}).ShouldNot(Equal(int64(0)))
@@ -61,6 +65,11 @@ var _ = Describe("restore_controller", func() {
 
 			err = k8sClient.Create(context.TODO(), restore)
 			Expect(err).NotTo(HaveOccurred())
+
+			result, err = reconcileRestore(restore)
+			Expect(err).NotTo((HaveOccurred()))
+			Expect(result.Requeue).To(BeFalse())
+
 			Eventually(func() (bool, error) {
 				err := reloadRestore(restore)
 				if err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -83,18 +83,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	k8sClient = &mockclient.MockClient{}
 
-	clusterReconciler = &FoundationDBClusterReconciler{
-		Client:              k8sClient,
-		Log:                 ctrl.Log.WithName("controllers").WithName("FoundationDBCluster"),
-		Recorder:            k8sClient,
-		InSimulation:        true,
-		PodLifecycleManager: StandardPodLifecycleManager{},
-		PodClientProvider:   NewMockFdbPodClient,
-		PodIPProvider:       MockPodIP,
-		AdminClientProvider: NewMockAdminClient,
-		LockClientProvider:  NewMockLockClient,
-		RequeueOnNotFound:   true,
-	}
+	clusterReconciler = createTestClusterReconciler()
 
 	backupReconciler = &FoundationDBBackupReconciler{
 		Client:              k8sClient,
@@ -254,4 +243,18 @@ func reconcileObject(reconciler reconcile.Reconciler, metadata metav1.ObjectMeta
 		}
 	}
 	return result, err
+}
+
+func createTestClusterReconciler() *FoundationDBClusterReconciler {
+	return &FoundationDBClusterReconciler{
+		Client:              k8sClient,
+		Log:                 ctrl.Log.WithName("controllers").WithName("FoundationDBCluster"),
+		Recorder:            k8sClient,
+		InSimulation:        true,
+		PodLifecycleManager: StandardPodLifecycleManager{},
+		PodClientProvider:   NewMockFdbPodClient,
+		PodIPProvider:       MockPodIP,
+		AdminClientProvider: NewMockAdminClient,
+		LockClientProvider:  NewMockLockClient,
+	}
 }

--- a/mock-kubernetes-client/client/client.go
+++ b/mock-kubernetes-client/client/client.go
@@ -1,0 +1,579 @@
+/*
+ * client.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	ctx "context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// MockClient provides a mock Kubernetes client.
+type MockClient struct {
+	// data is the internal mock data.
+	// This maps a type, and then a namespace/name, to the JSON representation of an
+	// object.
+	data map[string]map[string][]byte
+}
+
+// Clear erases any mock data.
+func (client *MockClient) Clear() {
+	client.data = make(map[string]map[string][]byte)
+}
+
+// buildKindKey gets the key identifying an object's type.
+func buildKindKey(object runtime.Object) (string, error) {
+	gvk, err := apiutil.GVKForObject(object, scheme.Scheme)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/%s/%s", gvk.Group, gvk.Version, gvk.Kind), nil
+}
+
+// buildObjectKey gets the key identifying an object.
+func buildObjectKey(key ctrlClient.ObjectKey) string {
+	return fmt.Sprintf("%s/%s", key.Namespace, key.Name)
+}
+
+// buildJSONObjectKey gets the key identifying an object from its JSON
+// representation.
+func buildJSONObjectKey(jsonData []byte) (string, error) {
+	genericData := make(map[string]interface{})
+	err := json.Unmarshal(jsonData, &genericData)
+	if err != nil {
+		return "", err
+	}
+
+	namespace, err := lookupJSONString(genericData, "metadata", "namespace")
+	if err != nil {
+		return "", err
+	}
+	name, err := lookupJSONString(genericData, "metadata", "name")
+	if err != nil {
+		return "", err
+	}
+	return buildObjectKey(types.NamespacedName{Namespace: namespace, Name: name}), nil
+}
+
+// buildRuntimeObjectKey gets the key identifying an object.
+func buildRuntimeObjectKey(object runtime.Object) (string, error) {
+	jsonData, err := json.Marshal(object)
+	if err != nil {
+		return "", err
+	}
+
+	return buildJSONObjectKey(jsonData)
+}
+
+// fillInMaps ensures that we have maps for a given object type.
+func (client *MockClient) fillInMaps(kind string) {
+	if client.data == nil {
+		client.data = make(map[string]map[string][]byte)
+	}
+	if client.data[kind] == nil {
+		client.data[kind] = make(map[string][]byte)
+	}
+}
+
+// lookupJSONString looks up a string in a generic JSON object.
+func lookupJSONString(genericData map[string]interface{}, path ...string) (string, error) {
+	currentData := genericData
+
+	if len(path) == 0 {
+		return "", fmt.Errorf("Cannot look up empty path")
+	}
+	var result string
+	for index, key := range path {
+		var ok bool
+		genericValue, present := currentData[key]
+		if !present {
+			return "", fmt.Errorf("Missing key %v", path[0:index+1])
+		}
+		if index == len(path)-1 {
+			result, ok = genericValue.(string)
+			if !ok {
+				return "", fmt.Errorf("Type error for %v", path)
+			}
+		} else {
+			currentData, ok = genericValue.(map[string]interface{})
+			if !ok {
+				return "", fmt.Errorf("Type error for key %v", path[0:index+1])
+			}
+		}
+	}
+	return result, nil
+}
+
+// lookupJSONStringMap looks up a map of string to string in a generic JSON object.
+func lookupJSONStringMap(genericData map[string]interface{}, path ...string) (map[string]string, error) {
+	currentData := genericData
+
+	if len(path) == 0 {
+		return nil, fmt.Errorf("Cannot look up empty path")
+	}
+	var result = make(map[string]string)
+	for index, key := range path {
+		var ok bool
+		if index == len(path)-1 {
+			genericValue, present := currentData[key]
+			if !present {
+				return nil, nil
+			}
+
+			mapValue, isMap := genericValue.(map[string]interface{})
+			if !isMap {
+				return nil, fmt.Errorf("Type error for %v", path)
+			}
+			for key, value := range mapValue {
+				stringValue, isString := value.(string)
+				if !isString {
+					return nil, fmt.Errorf("Type error for key %s of %v", key, path)
+				}
+				result[key] = stringValue
+			}
+		} else {
+			genericValue, present := currentData[key]
+			if !present {
+				return nil, fmt.Errorf("Missing key %v", path[0:index+1])
+			}
+
+			currentData, ok = genericValue.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("Type error for key %v", path[0:index+1])
+			}
+		}
+	}
+	return result, nil
+}
+
+// lookupJSONStringFields provides a map to all string fields in a generic JSON object.
+// The paths to each field will be represented as a string of the form key1.key2....keyN
+func lookupJSONStringFields(genericData map[string]interface{}) map[string]string {
+	var result = make(map[string]string)
+	for key, genericValue := range genericData {
+		switch castValue := genericValue.(type) {
+		case map[string]interface{}:
+			nestedFields := lookupJSONStringFields(castValue)
+			for nestedKey, value := range nestedFields {
+				result[fmt.Sprintf("%s.%s", key, nestedKey)] = value
+			}
+		case string:
+			result[key] = castValue
+		}
+	}
+	return result
+}
+
+// incrementGeneration increments the generation field in an object's metadata.
+func incrementGeneration(genericData map[string]interface{}) (float64, error) {
+	if genericData["metadata"] == nil {
+		genericData["metadata"] = make(map[string]interface{})
+	}
+
+	metadata, isMap := genericData["metadata"].(map[string]interface{})
+	if !isMap {
+		return 0, fmt.Errorf("Invalid metadata type")
+	}
+	generation, generationPresent := metadata["generation"]
+	var generationNumber float64
+	if generationPresent {
+		var isNumber bool
+		generationNumber, isNumber = generation.(float64)
+		if !isNumber {
+			return 0, fmt.Errorf("Invalid metadata generation type")
+		}
+		generationNumber++
+	} else {
+		generationNumber = 1
+	}
+	metadata["generation"] = generationNumber
+	genericData["metadata"] = metadata
+	return generationNumber, nil
+}
+
+// setGeneration sets the generation field in an object's metadata.
+func setGeneration(genericData map[string]interface{}, generation float64) error {
+	if genericData["metadata"] == nil {
+		genericData["metadata"] = make(map[string]interface{})
+	}
+	metadata, isMap := genericData["metadata"].(map[string]interface{})
+	if !isMap {
+		return fmt.Errorf("Invalid metadata type")
+	}
+	metadata["generation"] = generation
+	genericData["metadata"] = metadata
+	return nil
+}
+
+// setUID sets the UID in the object metadata.
+func setUID(genericData map[string]interface{}) error {
+	if genericData["metadata"] == nil {
+		genericData["metadata"] = make(map[string]interface{})
+	}
+	metadata, isMap := genericData["metadata"].(map[string]interface{})
+	if !isMap {
+		return fmt.Errorf("Invalid metadata type")
+	}
+	metadata["uid"] = uuid.NewUUID()
+	return nil
+}
+
+// checkPresence checks the presence of an object in the data.
+func (client *MockClient) checkPresence(kindKey string, objectKey string) error {
+	client.fillInMaps(kindKey)
+	if client.data[kindKey][objectKey] == nil {
+		return &k8serrors.StatusError{ErrStatus: metav1.Status{
+			Status:  "Failure",
+			Message: "Not Found",
+			Code:    404,
+			Reason:  metav1.StatusReasonNotFound,
+		}}
+	}
+	return nil
+}
+
+// Create creates a new object
+func (client *MockClient) Create(context ctx.Context, object runtime.Object, options ...ctrlClient.CreateOption) error {
+	jsonData, err := json.Marshal(object)
+	if err != nil {
+		return err
+	}
+
+	kindKey, err := buildKindKey(object)
+	if err != nil {
+		return err
+	}
+
+	objectKey, err := buildJSONObjectKey(jsonData)
+	if err != nil {
+		return err
+	}
+
+	genericObject := make(map[string]interface{})
+	err = json.Unmarshal(jsonData, &genericObject)
+	if err != nil {
+		return err
+	}
+
+	_, err = incrementGeneration(genericObject)
+	if err != nil {
+		return err
+	}
+
+	err = setUID(genericObject)
+	if err != nil {
+		return err
+	}
+
+	jsonData, err = json.Marshal(genericObject)
+	if err != nil {
+		return err
+	}
+
+	client.fillInMaps(kindKey)
+	if client.data[kindKey][objectKey] != nil {
+		return &k8serrors.StatusError{ErrStatus: metav1.Status{
+			Status:  "Failure",
+			Message: "Conflict",
+			Code:    409,
+			Reason:  metav1.StatusReasonAlreadyExists,
+		}}
+	}
+	client.data[kindKey][objectKey] = jsonData
+
+	err = json.Unmarshal(jsonData, object)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Get retrieves an object.
+func (client *MockClient) Get(context ctx.Context, key ctrlClient.ObjectKey, object runtime.Object) error {
+	kindKey, err := buildKindKey(object)
+	if err != nil {
+		return err
+	}
+
+	client.fillInMaps(kindKey)
+	objectKey := buildObjectKey(key)
+	err = client.checkPresence(kindKey, objectKey)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(client.data[kindKey][objectKey], object)
+
+	return err
+}
+
+// List lists objects.
+func (client *MockClient) List(context ctx.Context, list runtime.Object, options ...ctrlClient.ListOption) error {
+	kindKey, err := buildKindKey(list)
+	if err != nil {
+		return err
+	}
+	kindKey = strings.TrimSuffix(kindKey, "List")
+
+	objects := make([]map[string]interface{}, 0)
+
+	fullListOptions := &ctrlClient.ListOptions{}
+	for _, option := range options {
+		option.ApplyToList(fullListOptions)
+	}
+
+	client.fillInMaps(kindKey)
+	for _, objectJSON := range client.data[kindKey] {
+		object := make(map[string]interface{})
+		err = json.Unmarshal(objectJSON, &object)
+		if err != nil {
+			return err
+		}
+
+		if fullListOptions.Namespace != "" {
+			namespace, err := lookupJSONString(object, "metadata", "namespace")
+			if err != nil {
+				return err
+			}
+			if namespace != fullListOptions.Namespace {
+				continue
+			}
+		}
+
+		if fullListOptions.LabelSelector != nil {
+			objectLabels, err := lookupJSONStringMap(object, "metadata", "labels")
+			if err != nil {
+				return err
+			}
+			if !fullListOptions.LabelSelector.Matches(labels.Set(objectLabels)) {
+				continue
+			}
+		}
+
+		if fullListOptions.FieldSelector != nil {
+			objectFields := lookupJSONStringFields(object)
+			if err != nil {
+				return err
+			}
+			if !fullListOptions.FieldSelector.Matches(fields.Set(objectFields)) {
+				continue
+			}
+		}
+
+		objects = append(objects, object)
+		if fullListOptions.Limit > 0 && len(objects) >= int(fullListOptions.Limit) {
+			break
+		}
+	}
+
+	listJSON, err := json.Marshal(objects)
+	if err != nil {
+		return err
+	}
+	fullJSON := fmt.Sprintf("{\"items\":%s}", listJSON)
+	err = json.Unmarshal([]byte(fullJSON), list)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete deletes an object.
+// This does not support the options argument yet.
+func (client *MockClient) Delete(context ctx.Context, object runtime.Object, options ...ctrlClient.DeleteOption) error {
+	kindKey, err := buildKindKey(object)
+	if err != nil {
+		return err
+	}
+
+	client.fillInMaps(kindKey)
+
+	objectKey, err := buildRuntimeObjectKey(object)
+	if err != nil {
+		return err
+	}
+
+	err = client.checkPresence(kindKey, objectKey)
+	if err != nil {
+		return err
+	}
+
+	delete(client.data[kindKey], objectKey)
+	return nil
+}
+
+// Update updates an object.
+// This does not support the options argument yet.
+func (client *MockClient) Update(context ctx.Context, object runtime.Object, options ...ctrlClient.UpdateOption) error {
+	kindKey, err := buildKindKey(object)
+	if err != nil {
+		return err
+	}
+
+	client.fillInMaps(kindKey)
+
+	jsonData, err := json.Marshal(object)
+	if err != nil {
+		return err
+	}
+
+	objectKey, err := buildJSONObjectKey(jsonData)
+	if err != nil {
+		return err
+	}
+
+	err = client.checkPresence(kindKey, objectKey)
+	if err != nil {
+		return err
+	}
+
+	existingData := client.data[kindKey][objectKey]
+	existingObject := make(map[string]interface{})
+	err = json.Unmarshal(existingData, &existingObject)
+	if err != nil {
+		return err
+	}
+
+	newObject := make(map[string]interface{})
+	err = json.Unmarshal(jsonData, &newObject)
+	if err != nil {
+		return err
+	}
+
+	if !reflect.DeepEqual(existingObject["spec"], newObject["spec"]) {
+		generation, err := incrementGeneration(existingObject)
+		if err != nil {
+			return err
+		}
+
+		err = setGeneration(newObject, generation)
+		if err != nil {
+			return err
+		}
+	}
+
+	jsonData, err = json.Marshal(newObject)
+	if err != nil {
+		return err
+	}
+
+	client.data[kindKey][objectKey] = jsonData
+
+	err = json.Unmarshal(jsonData, object)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Patch patches an object.
+// This is not yet implemented.
+func (client *MockClient) Patch(context ctx.Context, object runtime.Object, patch ctrlClient.Patch, options ...ctrlClient.PatchOption) error {
+	return fmt.Errorf("Not implemented")
+}
+
+// DeleteAllOf deletes all objects of the given type matching the given options.
+// This is not yet implemented.
+func (client *MockClient) DeleteAllOf(context ctx.Context, object runtime.Object, options ...ctrlClient.DeleteAllOfOption) error {
+	return fmt.Errorf("Not implemented")
+}
+
+// MockStatusClient wraps a client to provide specialized operations for
+// updating status.
+type MockStatusClient struct {
+	rawClient *MockClient
+}
+
+// Update updates an object.
+// This does not support the options argument yet.
+func (client MockStatusClient) Update(context ctx.Context, object runtime.Object, options ...ctrlClient.UpdateOption) error {
+	kindKey, err := buildKindKey(object)
+	if err != nil {
+		return err
+	}
+
+	client.rawClient.fillInMaps(kindKey)
+
+	jsonData, err := json.Marshal(object)
+	if err != nil {
+		return err
+	}
+
+	objectKey, err := buildJSONObjectKey(jsonData)
+	if err != nil {
+		return err
+	}
+
+	err = client.rawClient.checkPresence(kindKey, objectKey)
+	if err != nil {
+		return err
+	}
+
+	existingData := client.rawClient.data[kindKey][objectKey]
+	existingObject := make(map[string]interface{})
+	err = json.Unmarshal(existingData, &existingObject)
+	if err != nil {
+		return err
+	}
+
+	newObject := make(map[string]interface{})
+	err = json.Unmarshal(jsonData, &newObject)
+	if err != nil {
+		return err
+	}
+
+	existingObject["status"] = newObject["status"]
+	jsonData, err = json.Marshal(existingObject)
+	if err != nil {
+		return err
+	}
+
+	client.rawClient.data[kindKey][objectKey] = jsonData
+
+	return nil
+}
+
+// Patch patches an object's status.
+// This is not yet implemented.
+func (client MockStatusClient) Patch(context ctx.Context, object runtime.Object, patch ctrlClient.Patch, options ...ctrlClient.PatchOption) error {
+	return fmt.Errorf("Not implemented")
+}
+
+// Status returns a writer for updating status.
+func (client *MockClient) Status() ctrlClient.StatusWriter {
+	return MockStatusClient{rawClient: client}
+}

--- a/mock-kubernetes-client/client/client_test.go
+++ b/mock-kubernetes-client/client/client_test.go
@@ -1,0 +1,284 @@
+/*
+ * client.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/gomega"
+)
+
+func createDummyPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod1",
+			Labels: map[string]string{
+				"app": "app1",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "test-container"},
+			},
+		},
+	}
+}
+
+func TestBasicCreateAndGetOperations(t *testing.T) {
+	g := NewWithT(t)
+	client := &MockClient{}
+	pod := createDummyPod()
+	err := client.Create(context.TODO(), pod)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pod.ObjectMeta.Generation).To(Equal(int64(1)))
+
+	podCopy := &corev1.Pod{}
+	err = client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, podCopy)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(podCopy.Name).To(Equal("pod1"))
+	g.Expect(len(podCopy.Spec.Containers)).To(Equal(1))
+	g.Expect(podCopy.Spec.Containers[0].Name).To(Equal("test-container"))
+	g.Expect(podCopy.ObjectMeta.Generation).To(Equal(int64(1)))
+}
+
+func TestCreatingObjectTwice(t *testing.T) {
+	g := NewWithT(t)
+	client := &MockClient{}
+	err := client.Create(context.TODO(), createDummyPod())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	err = client.Create(context.TODO(), createDummyPod())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(Equal("Conflict"))
+}
+
+func TestGettingMissingObject(t *testing.T) {
+	g := NewWithT(t)
+	client := &MockClient{}
+
+	err := client.Create(context.TODO(), createDummyPod())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	pod := &corev1.Pod{}
+	err = client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod2"}, pod)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+	deployment := &appsv1.Deployment{}
+	err = client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, deployment)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+}
+
+func TestDeletingObject(t *testing.T) {
+	g := NewWithT(t)
+	client := &MockClient{}
+
+	pod := createDummyPod()
+	err := client.Create(context.TODO(), pod)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	objectKey := types.NamespacedName{Namespace: "default", Name: "pod1"}
+	err = client.Delete(context.TODO(), pod)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	podCopy := &corev1.Pod{}
+	err = client.Get(context.TODO(), objectKey, podCopy)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+
+	err = client.Delete(context.TODO(), pod)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+}
+
+func TestUpdatingObject(t *testing.T) {
+	g := NewWithT(t)
+	client := &MockClient{}
+
+	pod := createDummyPod()
+	err := client.Create(context.TODO(), pod)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	container := &pod.Spec.Containers[0]
+	container.Env = append(container.Env, corev1.EnvVar{Name: "test-env"})
+
+	err = client.Update(context.TODO(), pod)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pod.ObjectMeta.Generation).To(Equal(int64(2)))
+
+	podCopy := &corev1.Pod{}
+	err = client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, podCopy)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(len(podCopy.Spec.Containers)).To(Equal(1))
+	g.Expect(len(podCopy.Spec.Containers[0].Env)).To(Equal(1))
+	g.Expect(podCopy.Spec.Containers[0].Env[0].Name).To(Equal("test-env"))
+	g.Expect(podCopy.ObjectMeta.Generation).To(Equal(int64(2)))
+
+	err = client.Update(context.TODO(), pod)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pod.ObjectMeta.Generation).To(Equal(int64(2)))
+}
+
+func TestUpdatingObjectStatus(t *testing.T) {
+	g := NewWithT(t)
+	client := &MockClient{}
+
+	pod := createDummyPod()
+	err := client.Create(context.TODO(), pod)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	container := &pod.Spec.Containers[0]
+	container.Env = append(container.Env, corev1.EnvVar{Name: "test-env"})
+	pod.Status.HostIP = "foo"
+
+	err = client.Status().Update(context.TODO(), pod)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(pod.ObjectMeta.Generation).To(Equal(int64(1)))
+
+	podCopy := &corev1.Pod{}
+	err = client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, podCopy)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(len(podCopy.Spec.Containers)).To(Equal(1))
+	g.Expect(len(podCopy.Spec.Containers[0].Env)).To(Equal(0))
+	g.Expect(podCopy.Status.HostIP).To(Equal("foo"))
+	g.Expect(podCopy.ObjectMeta.Generation).To(Equal(int64(1)))
+}
+
+func sortPodsByName(pods *corev1.PodList) {
+	sort.Slice(pods.Items, func(i, j int) bool {
+		return pods.Items[i].ObjectMeta.Name < pods.Items[j].ObjectMeta.Name
+	})
+}
+
+func TestListingObjects(t *testing.T) {
+	g := NewWithT(t)
+	client := &MockClient{}
+
+	pod1 := createDummyPod()
+	pod2 := createDummyPod()
+	pod2.Name = "pod2"
+
+	err := client.Create(context.TODO(), pod1)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = client.Create(context.TODO(), pod2)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	pods := &corev1.PodList{}
+	err = client.List(context.TODO(), pods)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(len(pods.Items)).To(Equal(2))
+
+	sortPodsByName(pods)
+	g.Expect(pods.Items[0].Name).To(Equal("pod1"))
+	g.Expect(pods.Items[1].Name).To(Equal("pod2"))
+}
+
+func TestListingObjectsByNamespace(t *testing.T) {
+	g := NewWithT(t)
+	client := &MockClient{}
+
+	pod1 := createDummyPod()
+	pod2 := createDummyPod()
+	pod2.Name = "pod2"
+
+	err := client.Create(context.TODO(), pod1)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = client.Create(context.TODO(), pod2)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	pods := &corev1.PodList{}
+	err = client.List(context.TODO(), pods, ctrlClient.InNamespace("default"))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(len(pods.Items)).To(Equal(2))
+
+	err = client.List(context.TODO(), pods, ctrlClient.InNamespace("not-default"))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(len(pods.Items)).To(Equal(0))
+}
+
+func TestListingObjectsByLabel(t *testing.T) {
+	g := NewWithT(t)
+	client := &MockClient{}
+
+	pod1 := createDummyPod()
+	pod2 := createDummyPod()
+	pod2.Name = "pod2"
+	pod2.ObjectMeta.Labels["app"] = "app2"
+	pod3 := createDummyPod()
+	pod3.Name = "pod3"
+	pod3.Labels = nil
+
+	err := client.Create(context.TODO(), pod1)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = client.Create(context.TODO(), pod2)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = client.Create(context.TODO(), pod3)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	pods := &corev1.PodList{}
+	err = client.List(context.TODO(), pods, ctrlClient.MatchingLabels(map[string]string{"app": "app2"}))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(len(pods.Items)).To(Equal(1))
+	g.Expect(pods.Items[0].Name).To(Equal("pod2"))
+
+	appRequirement, err := labels.NewRequirement("app", selection.Exists, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	pods = &corev1.PodList{}
+	err = client.List(context.TODO(), pods, ctrlClient.MatchingLabelsSelector{Selector: labels.NewSelector().Add(*appRequirement)})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(len(pods.Items)).To(Equal(2))
+	sortPodsByName(pods)
+	g.Expect(pods.Items[0].Name).To(Equal("pod1"))
+	g.Expect(pods.Items[1].Name).To(Equal("pod2"))
+}
+
+func TestListingObjectsByField(t *testing.T) {
+	g := NewWithT(t)
+	client := &MockClient{}
+
+	pod1 := createDummyPod()
+	pod2 := createDummyPod()
+	pod2.Name = "pod2"
+
+	err := client.Create(context.TODO(), pod1)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = client.Create(context.TODO(), pod2)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	pods := &corev1.PodList{}
+	err = client.List(context.TODO(), pods, ctrlClient.MatchingField("metadata.name", "pod1"))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(len(pods.Items)).To(Equal(1))
+	g.Expect(pods.Items[0].Name).To(Equal("pod1"))
+}

--- a/mock-kubernetes-client/client/doc.go
+++ b/mock-kubernetes-client/client/doc.go
@@ -1,0 +1,23 @@
+/*
+ * doc.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package client provides a mock Kubernetes client for use in testing
+// controllers.
+package client


### PR DESCRIPTION
Resolves #406 

This makes larger-scale changes to our test suite to make it more reliable. With this PR, we run the Reconcile method explicitly in the tests, rather than relying on the event stream. It also uses a custom mock Kubernetes client instead of using the standard controller-runtime client, so that we do not have to worry about nondeterministic behavior from the cache.