### PR TITLE
Check for nil before casting

### DIFF
--- a/controllers/lock_client.go
+++ b/controllers/lock_client.go
@@ -73,6 +73,11 @@ func (client *RealLockClient) TakeLock() (bool, error) {
 	hasLock, err := client.database.Transact(func(transaction fdb.Transaction) (interface{}, error) {
 		return client.takeLockInTransaction(transaction)
 	})
+
+	if hasLock == nil {
+		return false, err
+	}
+
 	return hasLock.(bool), err
 }
 
@@ -129,6 +134,7 @@ func (client *RealLockClient) takeLockInTransaction(transaction fdb.Transaction)
 		client.updateLock(transaction, startTime)
 		return true, nil
 	}
+
 	log.Info("Failed to get lock", "namespace", cluster.Namespace, "cluster", cluster.Name, "owner", ownerID, "startTime", time.Unix(startTime, 0), "endTime", time.Unix(endTime, 0))
 	return false, nil
 }


### PR DESCRIPTION
Currently we can run in this nasty error:

```bash
E0204 15:03:11.712420       1 runtime.go:78] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(0x1468ee0), concrete:(*runtime._type)(nil), asserted:(*runtime._type)(0x13ff780), missingMethod:""} (interface conversion: interface {} is nil, not bool)
goroutine 679 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x14a2240, 0xc0007bb1d0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.0/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.0/pkg/util/runtime/runtime.go:48 +0x82
panic(0x14a2240, 0xc0007bb1d0)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/FoundationDB/fdb-kubernetes-operator/controllers.(*RealLockClient).TakeLock(0xc0021ba420, 0x183a660, 0xc0021ba420, 0x0)
	/go/pkg/mod/github.com/!foundation!d!b/fdb-kubernetes-operator@v0.27.0/controllers/lock_client.go:76 +0xc8
github.com/FoundationDB/fdb-kubernetes-operator/controllers.(*FoundationDBClusterReconciler).takeLock(0xc0001555f0, 0xc0035c2000, 0xc001d52000, 0x1d4, 0x1, 0xc001d52000, 0x1d4)
	/go/pkg/mod/github.com/!foundation!d!b/fdb-kubernetes-operator@v0.27.0/controllers/cluster_controller.go:741 +0x1b8
github.com/FoundationDB/fdb-kubernetes-operator/controllers.BounceProcesses.Reconcile(0xc0001555f0, 0x186af20, 0xc000110210, 0xc0035c2000, 0x6000100, 0x0, 0x0)
	/go/pkg/mod/github.com/!foundation!d!b/fdb-kubernetes-operator@v0.27.0/controllers/bounce_processes.go:119 +0x10c0
github.com/FoundationDB/fdb-kubernetes-operator/controllers.(*FoundationDBClusterReconciler).Reconcile(0xc0001555f0, 0xc00160f350, 0xe, 0xc00160f330, 0xd, 0xc00044bc00, 0x0, 0x0, 0x0)
	/go/pkg/mod/github.com/!foundation!d!b/fdb-kubernetes-operator@v0.27.0/controllers/cluster_controller.go:144 +0x5e7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0001fe900, 0x14e3860, 0xc000870060, 0x0)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:256 +0x162
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0001fe900, 0x10e2d00)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:232 +0xcb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc0001fe900)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:211 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc0038684f0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.0/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0038684f0, 0x3b9aca00, 0x0, 0xc00035ea01, 0xc00031e180)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.0/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc0038684f0, 0x3b9aca00, 0xc00031e180)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.0/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:193 +0x328
panic: interface conversion: interface {} is nil, not bool [recovered]
	panic: interface conversion: interface {} is nil, not bool
```