### PR TITLE
Fetch version plugin

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
       #     msiexec /i "fdb.msi"
       #     go get -v -t -d ./...
       - name: Build
-        run: make plugin package
+        run: TAG=${{ needs.create-release.outputs.tag }} make plugin package
       - name: Upload Release Asse
         uses: actions/upload-release-asset@v1
         env:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ ifneq "$(FDB_WEBSITE)" ""
 	docker_build_args := $(docker_build_args) --build-arg FDB_WEBSITE=$(FDB_WEBSITE)
 endif
 
+# TAG is used to define the version in the kubectl-fdb plugin.
+# If not defined we use the current git hash.
+ifndef TAG
+	TAG := $(shell git rev-parse HEAD)
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -70,7 +76,7 @@ bin/kubectl-fdb.tar.gz:
 plugin: bin/kubectl-fdb
 
 bin/kubectl-fdb: ${GO_SRC}
-	go build -ldflags="-s -w" -o bin/kubectl-fdb ./kubectl-fdb
+	go build -ldflags="-s -w -X github.com/FoundationDB/fdb-kubernetes-operator/kubectl-fdb/cmd.pluginVersion=${TAG}" -o bin/kubectl-fdb ./kubectl-fdb
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate manifests

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -46,12 +46,6 @@ func getNamespace(namespace string) (string, error) {
 	return "default", nil
 }
 
-func getOperator(k8sClient kubernetes.Interface, operatorName string, namespace string) *v1.Deployment {
-	var operator *v1.Deployment
-	operator, err := k8sClient.AppsV1().Deployments(namespace).Get(operatorName, metav1.GetOptions{})
-	if err == nil {
-		return operator
-	}
-
-	return operator
+func getOperator(k8sClient kubernetes.Interface, operatorName string, namespace string) (*v1.Deployment, error) {
+	return k8sClient.AppsV1().Deployments(namespace).Get(operatorName, metav1.GetOptions{})
 }

--- a/kubectl-fdb/cmd/version.go
+++ b/kubectl-fdb/cmd/version.go
@@ -68,7 +68,7 @@ func newVersionCmd(streams genericclioptions.IOStreams, rootCmd *cobra.Command) 
 				return err
 			}
 
-			if ! clientOnly {
+			if !clientOnly {
 				operatorVersion, err := version(client, operatorName, namespace, containerName)
 				if err != nil {
 					return err
@@ -77,7 +77,6 @@ func newVersionCmd(streams genericclioptions.IOStreams, rootCmd *cobra.Command) 
 			}
 
 			fmt.Printf("kubectl-fdb: %s\n", pluginVersion)
-
 
 			return nil
 		},

--- a/kubectl-fdb/cmd/version.go
+++ b/kubectl-fdb/cmd/version.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -31,7 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var pluginVersion = "v0.23.1"
+var pluginVersion = "latest"
 
 func newVersionCmd(streams genericclioptions.IOStreams, rootCmd *cobra.Command) *cobra.Command {
 	o := NewFDBOptions(streams)
@@ -44,6 +43,14 @@ func newVersionCmd(streams genericclioptions.IOStreams, rootCmd *cobra.Command) 
 			operatorName, err := rootCmd.Flags().GetString("operator-name")
 			if err != nil {
 				return err
+			}
+			clientOnly, err := cmd.Flags().GetBool("client-only")
+			if err != nil {
+				return nil
+			}
+			containerName, err := cmd.Flags().GetString("container-name")
+			if err != nil {
+				return nil
 			}
 
 			config, err := o.configFlags.ToRESTConfig()
@@ -61,11 +68,16 @@ func newVersionCmd(streams genericclioptions.IOStreams, rootCmd *cobra.Command) 
 				return err
 			}
 
-			operatorVersion := version(client, operatorName, namespace)
+			if ! clientOnly {
+				operatorVersion, err := version(client, operatorName, namespace, containerName)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("foundationdb-operator: %s\n", operatorVersion)
+			}
 
-			// TODO check: https://github.com/kubernetes/cli-runtime/tree/release-1.20/pkg/printers
 			fmt.Printf("kubectl-fdb: %s\n", pluginVersion)
-			fmt.Printf("foundationdb-operator: %s\n", operatorVersion)
+
 
 			return nil
 		},
@@ -77,17 +89,26 @@ kubectl fdb -n default version
 `,
 	}
 	o.configFlags.AddFlags(cmd.Flags())
+	cmd.Flags().Bool("client-only", false, "Prints out the plugin version only without checking the operator version.")
+	cmd.Flags().String("container-name", "manager", "The container name of Kubernetes Deployment.")
 
 	return cmd
 }
 
-func version(client kubernetes.Interface, operatorName string, namespace string) string {
-	operatorDeployment := getOperator(client, operatorName, namespace)
-	if operatorDeployment.Name == "" {
-		log.Fatalf("could not find the foundationdb-operator in the namespace: %s", namespace)
+func version(client kubernetes.Interface, operatorName string, namespace string, containerName string) (string, error) {
+	operatorDeployment, err := getOperator(client, operatorName, namespace)
+	if err != nil {
+		return "", err
 	}
-	operatorImage := operatorDeployment.Spec.Template.Spec.Containers[0].Image
-	imageName := strings.Split(operatorImage, ":")
 
-	return imageName[len(imageName)-1]
+	for _, container := range operatorDeployment.Spec.Template.Spec.Containers {
+		if container.Name != containerName {
+			continue
+		}
+
+		imageName := strings.Split(container.Image, ":")
+		return imageName[len(imageName)-1], nil
+	}
+
+	return "", fmt.Errorf("could not find container: %s in %s/%s", containerName, namespace, operatorName)
 }

--- a/kubectl-fdb/cmd/version_test.go
+++ b/kubectl-fdb/cmd/version_test.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -14,14 +15,14 @@ import (
 func TestVersion(t *testing.T) {
 	operatorName := "fdb-operator"
 
-	tt := []struct{
-		name string
-		deployment *appsv1.Deployment
-		expected string
+	tt := []struct {
+		name          string
+		deployment    *appsv1.Deployment
+		expected      string
 		expectedError error
 	}{
 		{
-			name: "Single container",
+			name:     "Single container",
 			expected: "0.27.0",
 			deployment: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -33,7 +34,7 @@ func TestVersion(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Name: "manager",
+									Name:  "manager",
 									Image: "foundationdb/fdb-kubernetes-operator:0.27.0",
 								},
 							},
@@ -44,7 +45,7 @@ func TestVersion(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "Multi container",
+			name:     "Multi container",
 			expected: "0.27.0",
 			deployment: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -56,15 +57,15 @@ func TestVersion(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Name: "test",
+									Name:  "test",
 									Image: "test:1337",
 								},
 								{
-									Name: "test2",
+									Name:  "test2",
 									Image: "test:1337-2",
 								},
 								{
-									Name: "manager",
+									Name:  "manager",
 									Image: "foundationdb/fdb-kubernetes-operator:0.27.0",
 								},
 							},
@@ -75,7 +76,7 @@ func TestVersion(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "No container",
+			name:     "No container",
 			expected: "",
 			deployment: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -102,7 +103,7 @@ func TestVersion(t *testing.T) {
 
 			operatorVersion, err := version(client, operatorName, "default", "manager")
 
-			if ! reflect.DeepEqual(err, tc.expectedError){
+			if !reflect.DeepEqual(err, tc.expectedError) {
 				t.Errorf("Expected: %s, got: %s", tc.expectedError, err)
 			}
 

--- a/kubectl-fdb/cmd/version_test.go
+++ b/kubectl-fdb/cmd/version_test.go
@@ -1,40 +1,114 @@
 package cmd
 
 import (
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestVersion(t *testing.T) {
-	operatorName := "/dev/random"
-	expectedVersion := "0.27.0"
+	operatorName := "fdb-operator"
 
-	client := fake.NewSimpleClientset(&appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      operatorName,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Image: "foundationdb/fdb-kubernetes-operator:0.27.0",
+	tt := []struct{
+		name string
+		deployment *appsv1.Deployment
+		expected string
+		expectedError error
+	}{
+		{
+			name: "Single container",
+			expected: "0.27.0",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      operatorName,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "manager",
+									Image: "foundationdb/fdb-kubernetes-operator:0.27.0",
+								},
+							},
 						},
 					},
 				},
 			},
+			expectedError: nil,
 		},
-	})
+		{
+			name: "Multi container",
+			expected: "0.27.0",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      operatorName,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test",
+									Image: "test:1337",
+								},
+								{
+									Name: "test2",
+									Image: "test:1337-2",
+								},
+								{
+									Name: "manager",
+									Image: "foundationdb/fdb-kubernetes-operator:0.27.0",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "No container",
+			expected: "",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      operatorName,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{},
+							},
+						},
+					},
+				},
+			},
+			expectedError: fmt.Errorf("could not find container: manager in default/fdb-operator"),
+		},
+	}
 
-	operatorVersion := version(client, operatorName, "default")
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(tc.deployment)
 
-	if operatorVersion != expectedVersion {
-		t.Logf("expected version: %s, but got: %s", expectedVersion, operatorVersion)
-		t.Fail()
+			operatorVersion, err := version(client, operatorName, "default", "manager")
+
+			if ! reflect.DeepEqual(err, tc.expectedError){
+				t.Errorf("Expected: %s, got: %s", tc.expectedError, err)
+			}
+
+			if operatorVersion != tc.expected {
+				t.Errorf("expected version: %s, but got: %s", tc.expected, operatorVersion)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/484
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/483

This PR ensures we fetch the operator version from the correct container and during the release process we set the tag for the plugin.