### PR TITLE
Correct image name for DockerHub

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,8 +16,10 @@ jobs:
         include:
           - image: fdb-kubernetes-operator
             context: ./
+            name: foundationdb/fdb-kubernetes-operator
           - image: fdb-data-loader
             context: ./sample-apps/data-loader
+            name: foundationdb/fdb-data-loader
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -33,4 +35,4 @@ jobs:
         with:
           push: true
           context: ${{ matrix.context }}
-          tags: ${{ github.repository }}/${{ matrix.image }}:latest
+          tags: ${{ matrix.name }}:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,8 +102,10 @@ jobs:
         include:
           - image: fdb-kubernetes-operator
             context: ./
+            name: foundationdb/fdb-kubernetes-operator
           - image: fdb-data-loader
             context: ./sample-apps/data-loader
+            name: foundationdb/fdb-data-loader
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -122,4 +124,4 @@ jobs:
         with:
           push: true
           context: ${{ matrix.context }}
-          tags: ${{ github.repository }}/${{ matrix.image }}:${{ steps.get_tag.outputs.TAG }}
+          tags: ${{ matrix.name }}:${{ steps.get_tag.outputs.TAG }}


### PR DESCRIPTION
The current push to the registry failes because our org uses some uppercase letters:

```
invalid reference format: repository name must be lowercase
```

so the resulted image was:

```
FoundationDB/fdb-data-loader:latest
```

instead I just "hard-coded" the image names since they won't change that often.