### PR TITLE
Update to golang 1.15.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15.5 as builder
+FROM golang:1.15.8 as builder
 
 # Install FDB
 ARG FDB_VERSION=6.2.28


### PR DESCRIPTION
Updates the golang version to the latest 1.15.8 to build the operator.