### PR TITLE
Allow to remove instances by pod name

### DIFF
--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -23,6 +23,8 @@ package cmd
 import (
 	ctx "context"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/controllers"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
@@ -68,4 +70,17 @@ func getNodes(kubeClient client.Client, nodeSelector map[string]string) ([]strin
 	}
 
 	return nodes, nil
+}
+
+func getPodsForCluster(kubeClient client.Client, clusterName string, namespace string) (*corev1.PodList, error) {
+	var podList corev1.PodList
+	err := kubeClient.List(
+		ctx.Background(),
+		&podList,
+		client.MatchingLabels(map[string]string{
+			controllers.FDBClusterLabel: clusterName,
+		}),
+		client.InNamespace(namespace))
+
+	return &podList, err
 }

--- a/kubectl-fdb/cmd/remove.go
+++ b/kubectl-fdb/cmd/remove.go
@@ -1,5 +1,5 @@
 /*
- * remove_instances.go
+ * remove.go
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/kubectl-fdb/cmd/remove.go
+++ b/kubectl-fdb/cmd/remove.go
@@ -39,10 +39,14 @@ func newRemoveCmd(streams genericclioptions.IOStreams, rootCmd *cobra.Command) *
 		},
 		Example: `
 # Remove instances for a cluster in the current namespace
-kubectl fdb remove instances -c cluster instance-1 instance-2
+kubectl fdb remove instances -c cluster pod-1 -i pod-2
 
 # Remove instances for a cluster in the namespace default
-kubectl fdb -n default remove instances -c cluster instance-1 instance-2
+kubectl fdb -n default remove instances -c cluster pod-1 pod-2
+
+# Remove instances for a cluster with the instance ID.
+# The instance ID of a Pod can be fetched with "kubectl get po -L fdb-instance-id"
+kubectl fdb -n default remove instances --use-instance-id -c cluster storage-1 storage-2
 `,
 	}
 

--- a/kubectl-fdb/cmd/remove.go
+++ b/kubectl-fdb/cmd/remove.go
@@ -1,5 +1,5 @@
 /*
- * remove.go
+ * remove_instances.go
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -21,22 +21,9 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
-
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/FoundationDB/fdb-kubernetes-operator/controllers"
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	ctx "context"
-
-	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 )
 
 func newRemoveCmd(streams genericclioptions.IOStreams, rootCmd *cobra.Command) *cobra.Command {
@@ -44,132 +31,23 @@ func newRemoveCmd(streams genericclioptions.IOStreams, rootCmd *cobra.Command) *
 
 	cmd := &cobra.Command{
 		Use:   "remove",
-		Short: "Adds an instance (or multiple) to the remove list of the given cluster",
-		Long:  "Adds an instance (or multiple) to the remove list field of the given cluster",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			force, err := rootCmd.Flags().GetBool("force")
-			if err != nil {
-				return err
-			}
-			cluster, err := cmd.Flags().GetString("fdb-cluster")
-			if err != nil {
-				return err
-			}
-			instances, err := cmd.Flags().GetStringSlice("instances")
-			if err != nil {
-				return err
-			}
-			withExclusion, err := cmd.Flags().GetBool("exclusion")
-			if err != nil {
-				return err
-			}
-			withShrink, err := cmd.Flags().GetBool("shrink")
-			if err != nil {
-				return err
-			}
+		Short: "Subcommand to remove instances from a given cluster",
+		Long:  "Subcommand to remove instances from a given cluster",
 
-			config, err := o.configFlags.ToRESTConfig()
-			if err != nil {
-				return err
-			}
-
-			scheme := runtime.NewScheme()
-			_ = clientgoscheme.AddToScheme(scheme)
-			_ = fdbtypes.AddToScheme(scheme)
-
-			kubeClient, err := client.New(config, client.Options{Scheme: scheme})
-			if err != nil {
-				return err
-			}
-
-			namespace, err := getNamespace(*o.configFlags.Namespace)
-			if err != nil {
-				return err
-			}
-
-			return removeInstances(kubeClient, cluster, instances, namespace, withExclusion, withShrink, force)
+		RunE: func(c *cobra.Command, args []string) error {
+			return c.Help()
 		},
 		Example: `
 # Remove instances for a cluster in the current namespace
-kubectl fdb remove -c cluster -i instance-1 -i instance-2
+kubectl fdb remove instances -c cluster instance-1 instance-2
 
 # Remove instances for a cluster in the namespace default
-kubectl fdb -n default remove -c cluster -i instance-1 -i instance-2
+kubectl fdb -n default remove instances -c cluster instance-1 instance-2
 `,
 	}
 
-	cmd.Flags().StringP("fdb-cluster", "c", "", "remove instance(s) from the provided cluster.")
-	cmd.Flags().StringSliceP("instances", "i", []string{}, "instances to be removed.")
-	cmd.Flags().BoolP("exclusion", "e", true, "define if the instances should be remove with exclusion.")
-	cmd.Flags().Bool("shrink", false, "define if the removed instances should not be replaced.")
-	err := cmd.MarkFlagRequired("fdb-cluster")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = cmd.MarkFlagRequired("instances")
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	cmd.AddCommand(newRemoveInstancesCmd(streams, rootCmd))
 	o.configFlags.AddFlags(cmd.Flags())
 
 	return cmd
-}
-
-// removeInstances adds instances to the instancesToRemove field
-func removeInstances(kubeClient client.Client, clusterName string, instances []string, namespace string, withExclusion bool, withShrink bool, force bool) error {
-	if len(instances) == 0 {
-		return nil
-	}
-
-	shrinkMap := make(map[string]int)
-
-	if withShrink {
-		var pods corev1.PodList
-		err := kubeClient.List(ctx.Background(), &pods,
-			client.InNamespace(namespace),
-			client.MatchingLabels(map[string]string{
-				controllers.FDBClusterLabel: clusterName,
-			}))
-
-		if err != nil {
-			return err
-		}
-
-		for _, pod := range pods.Items {
-			class := controllers.GetProcessClassFromMeta(pod.ObjectMeta)
-			shrinkMap[class]++
-		}
-	}
-
-	var cluster fdbtypes.FoundationDBCluster
-	err := kubeClient.Get(ctx.Background(), client.ObjectKey{
-		Namespace: namespace,
-		Name:      clusterName,
-	}, &cluster)
-
-	if err != nil {
-		return err
-	}
-
-	for class, amount := range shrinkMap {
-		cluster.Spec.ProcessCounts.DecreaseCount(class, amount)
-	}
-
-	if !force {
-		confirmed := confirmAction(fmt.Sprintf("Remove %v from cluster %s/%s with exclude: %t and shrink: %t", instances, namespace, clusterName, withExclusion, withShrink))
-		if !confirmed {
-			print("Abort")
-			return nil
-		}
-	}
-
-	if withExclusion {
-		cluster.Spec.InstancesToRemove = append(cluster.Spec.InstancesToRemove, instances...)
-	} else {
-		cluster.Spec.InstancesToRemoveWithoutExclusion = append(cluster.Spec.InstancesToRemoveWithoutExclusion, instances...)
-	}
-
-	return kubeClient.Update(ctx.TODO(), &cluster)
 }

--- a/kubectl-fdb/cmd/remove_instances.go
+++ b/kubectl-fdb/cmd/remove_instances.go
@@ -118,11 +118,6 @@ kubectl fdb -n default remove instances --use-instance-id -c cluster storage-1 s
 		log.Fatal(err)
 	}
 
-	err = cmd.MarkFlagRequired("instances")
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	o.configFlags.AddFlags(cmd.Flags())
 
 	return cmd

--- a/kubectl-fdb/cmd/remove_instances.go
+++ b/kubectl-fdb/cmd/remove_instances.go
@@ -1,0 +1,210 @@
+/*
+ * remove_instances.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/FoundationDB/fdb-kubernetes-operator/controllers"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ctx "context"
+
+	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+)
+
+func newRemoveInstancesCmd(streams genericclioptions.IOStreams, rootCmd *cobra.Command) *cobra.Command {
+	o := NewFDBOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "instances",
+		Short: "Adds an instance (or multiple) to the remove list of the given cluster",
+		Long:  "Adds an instance (or multiple) to the remove list field of the given cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			force, err := rootCmd.Flags().GetBool("force")
+			if err != nil {
+				return err
+			}
+			cluster, err := cmd.Flags().GetString("fdb-cluster")
+			if err != nil {
+				return err
+			}
+			withExclusion, err := cmd.Flags().GetBool("exclusion")
+			if err != nil {
+				return err
+			}
+			withShrink, err := cmd.Flags().GetBool("shrink")
+			if err != nil {
+				return err
+			}
+			useInstanceID, err := cmd.Flags().GetBool("use-instance-id")
+			if err != nil {
+				return err
+			}
+
+			config, err := o.configFlags.ToRESTConfig()
+			if err != nil {
+				return err
+			}
+
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = fdbtypes.AddToScheme(scheme)
+
+			kubeClient, err := client.New(config, client.Options{Scheme: scheme})
+			if err != nil {
+				return err
+			}
+
+			namespace, err := getNamespace(*o.configFlags.Namespace)
+			if err != nil {
+				return err
+			}
+
+			instances := args
+			if !useInstanceID {
+				instances, err = getInstanceIDsFromPod(kubeClient, cluster, instances, namespace)
+				if err != nil {
+					return err
+				}
+			}
+
+			return removeInstances(kubeClient, cluster, instances, namespace, withExclusion, withShrink, force)
+		},
+		Example: `
+# Remove instances for a cluster in the current namespace
+kubectl fdb remove instances -c cluster instance-1 -i instance-2
+
+# Remove instances for a cluster in the namespace default
+kubectl fdb -n default remove instances -c cluster instance-1 instance-2
+
+# Remove instances for a cluster with the instance-id
+kubectl fdb -n default remove instances --use-instance-id -c cluster storage-1 storage-2
+`,
+	}
+
+	cmd.Flags().StringP("fdb-cluster", "c", "", "remove instance(s) from the provided cluster.")
+	cmd.Flags().BoolP("exclusion", "e", true, "define if the instances should be remove with exclusion.")
+	cmd.Flags().Bool("use-instance-id", false, "if set the operator will use the instance ID to remove it rather than the Pod name.")
+	cmd.Flags().Bool("shrink", false, "define if the removed instances should not be replaced.")
+	err := cmd.MarkFlagRequired("fdb-cluster")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = cmd.MarkFlagRequired("instances")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func getInstanceIDsFromPod(kubeClient client.Client, clusterName string, podNames []string, namespace string) ([]string, error) {
+	var instances []string
+	// Build a map to filter faster
+	podNameMap := map[string]bool{}
+	for _, instance := range podNames {
+		podNameMap[instance] = true
+	}
+
+	pods, err := getPodsForCluster(kubeClient, clusterName, namespace)
+	if err != nil {
+		return instances, err
+	}
+
+	for _, pod := range pods.Items {
+		if _, ok := podNameMap[pod.Name]; !ok {
+			continue
+		}
+
+		instances = append(instances, pod.Labels[controllers.FDBInstanceIDLabel])
+	}
+
+	return instances, nil
+}
+
+// removeInstances adds instances to the instancesToRemove field
+func removeInstances(kubeClient client.Client, clusterName string, instances []string, namespace string, withExclusion bool, withShrink bool, force bool) error {
+	if len(instances) == 0 {
+		return nil
+	}
+
+	shrinkMap := make(map[string]int)
+
+	if withShrink {
+		var pods corev1.PodList
+		err := kubeClient.List(ctx.Background(), &pods,
+			client.InNamespace(namespace),
+			client.MatchingLabels(map[string]string{
+				controllers.FDBClusterLabel: clusterName,
+			}))
+
+		if err != nil {
+			return err
+		}
+
+		for _, pod := range pods.Items {
+			class := controllers.GetProcessClassFromMeta(pod.ObjectMeta)
+			shrinkMap[class]++
+		}
+	}
+
+	var cluster fdbtypes.FoundationDBCluster
+	err := kubeClient.Get(ctx.Background(), client.ObjectKey{
+		Namespace: namespace,
+		Name:      clusterName,
+	}, &cluster)
+
+	if err != nil {
+		return err
+	}
+
+	for class, amount := range shrinkMap {
+		cluster.Spec.ProcessCounts.DecreaseCount(class, amount)
+	}
+
+	if !force {
+		confirmed := confirmAction(fmt.Sprintf("Remove %v from cluster %s/%s with exclude: %t and shrink: %t", instances, namespace, clusterName, withExclusion, withShrink))
+		if !confirmed {
+			print("Abort")
+			return nil
+		}
+	}
+
+	if withExclusion {
+		cluster.Spec.InstancesToRemove = append(cluster.Spec.InstancesToRemove, instances...)
+	} else {
+		cluster.Spec.InstancesToRemoveWithoutExclusion = append(cluster.Spec.InstancesToRemoveWithoutExclusion, instances...)
+	}
+
+	return kubeClient.Update(ctx.TODO(), &cluster)
+}

--- a/kubectl-fdb/cmd/remove_instances.go
+++ b/kubectl-fdb/cmd/remove_instances.go
@@ -129,7 +129,7 @@ kubectl fdb -n default remove instances --use-instance-id -c cluster storage-1 s
 }
 
 func getInstanceIDsFromPod(kubeClient client.Client, clusterName string, podNames []string, namespace string) ([]string, error) {
-	var instances []string
+	instances := make([]string, 0, len(podNames))
 	// Build a map to filter faster
 	podNameMap := map[string]bool{}
 	for _, instance := range podNames {

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -53,13 +53,12 @@ func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewFDBOptions(streams)
 
 	cmd := &cobra.Command{
-		Use:   "kubectl-fdb",
-		Short: "kubectl plugin for the FoundationDB operator.",
-		Long:  `kubectl fdb plugin for the interaction with the FoundationDB operator.`,
-		// TODO: Example:      fmt.Sprintf(fdbexample, "kubectl"),
+		Use:          "kubectl-fdb",
+		Short:        "kubectl plugin for the FoundationDB operator.",
+		Long:         `kubectl fdb plugin for the interaction with the FoundationDB operator.`,
 		SilenceUsage: true,
-		RunE: func(c *cobra.Command, args []string) error {
-			return nil
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
 		},
 	}
 

--- a/kubectl-fdb/cmd/version.go
+++ b/kubectl-fdb/cmd/version.go
@@ -81,10 +81,10 @@ func newVersionCmd(streams genericclioptions.IOStreams, rootCmd *cobra.Command) 
 				if err != nil {
 					return err
 				}
-				fmt.Printf("foundationdb-operator: %s\n", operatorVersion)
+				cmd.Printf("foundationdb-operator: %s\n", operatorVersion)
 			}
 
-			fmt.Printf("kubectl-fdb: %s\n", pluginVersion)
+			cmd.Printf("kubectl-fdb: %s\n", pluginVersion)
 
 			return nil
 		},

--- a/kubectl-fdb/main.go
+++ b/kubectl-fdb/main.go
@@ -39,6 +39,7 @@ func main() {
 
 	root := cmd.NewRootCmd(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	if err := root.Execute(); err != nil {
+		root.PrintErrln(err)
 		os.Exit(1)
 	}
 }

--- a/kubectl-fdb/main.go
+++ b/kubectl-fdb/main.go
@@ -39,7 +39,6 @@ func main() {
 
 	root := cmd.NewRootCmd(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	if err := root.Execute(); err != nil {
-		root.PrintErrln(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/481

I made this option the default since I think most operators will use the Pod name rather than the instance name. I also restructured the remove command a little bit so that we have now:

```bash
kubectl fdb -n default remove instances -c cluster instance-1 instance-2
```

So that we can add later on the possibility to remove also clusters, backups, etc.