### PR TITLE
Add test for kubectl rootcmd

### DIFF
--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -111,6 +111,9 @@ kubectl fdb cordon -n default -c cluster node-1
 kubectl fdb cordon -c cluster --node-selector machine=a,disk=fast
 `,
 	}
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
+	cmd.SetIn(o.In)
 
 	cmd.Flags().StringP("fdb-cluster", "c", "", "evacuate instance(s) from the provided cluster.")
 	cmd.Flags().StringToStringVarP(&nodeSelectors, "node-selector", "", nil, "node-selector to select all nodes that should be cordoned. Can't be used with specific nodes.")

--- a/kubectl-fdb/cmd/exec.go
+++ b/kubectl-fdb/cmd/exec.go
@@ -39,7 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
-	controllers "github.com/FoundationDB/fdb-kubernetes-operator/controllers"
+	"github.com/FoundationDB/fdb-kubernetes-operator/controllers"
 )
 
 func newExecCmd(streams genericclioptions.IOStreams) *cobra.Command {
@@ -95,6 +95,9 @@ func newExecCmd(streams genericclioptions.IOStreams) *cobra.Command {
 	if err != nil {
 		log.Fatal(err)
 	}
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
+	cmd.SetIn(o.In)
 
 	o.configFlags.AddFlags(cmd.Flags())
 

--- a/kubectl-fdb/cmd/remove.go
+++ b/kubectl-fdb/cmd/remove.go
@@ -33,7 +33,6 @@ func newRemoveCmd(streams genericclioptions.IOStreams, rootCmd *cobra.Command) *
 		Use:   "remove",
 		Short: "Subcommand to remove instances from a given cluster",
 		Long:  "Subcommand to remove instances from a given cluster",
-
 		RunE: func(c *cobra.Command, args []string) error {
 			return c.Help()
 		},
@@ -49,6 +48,9 @@ kubectl fdb -n default remove instances -c cluster pod-1 pod-2
 kubectl fdb -n default remove instances --use-instance-id -c cluster storage-1 storage-2
 `,
 	}
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
+	cmd.SetIn(o.In)
 
 	cmd.AddCommand(newRemoveInstancesCmd(streams, rootCmd))
 	o.configFlags.AddFlags(cmd.Flags())

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -61,6 +61,9 @@ func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
 			return cmd.Help()
 		},
 	}
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
+	cmd.SetIn(o.In)
 
 	viper.SetDefault("license", "apache 2")
 	cmd.PersistentFlags().StringP("operator-name", "o", "fdb-kubernetes-operator-controller-manager", "Name of the Deployment for the operator.")

--- a/kubectl-fdb/cmd/root_test.go
+++ b/kubectl-fdb/cmd/root_test.go
@@ -1,0 +1,42 @@
+/*
+ * root_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestRootCmd(t *testing.T) {
+	// We use these buffers to theoretically check the input/output
+	outBuffer := bytes.Buffer{}
+	errBuffer := bytes.Buffer{}
+	inBuffer := bytes.Buffer{}
+
+	cmd := NewRootCmd(genericclioptions.IOStreams{In: bufio.NewReader(&inBuffer), Out: bufio.NewWriter(&outBuffer), ErrOut: bufio.NewWriter(&errBuffer)})
+	err := cmd.Execute()
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/kubectl-fdb/cmd/version.go
+++ b/kubectl-fdb/cmd/version.go
@@ -95,6 +95,10 @@ kubectl fdb version
 kubectl fdb -n default version
 `,
 	}
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
+	cmd.SetIn(o.In)
+
 	o.configFlags.AddFlags(cmd.Flags())
 	cmd.Flags().Bool("client-only", false, "Prints out the plugin version only without checking the operator version.")
 	cmd.Flags().String("container-name", "manager", "The container name of Kubernetes Deployment.")


### PR DESCRIPTION
This PR is based on https://github.com/FoundationDB/fdb-kubernetes-operator/pull/505

I added a test case for the `root cmd` we can/will add more test cases for the specific command in a follow up. The simple test allows to test the cmd creation (e.g. all flags are set do we only use referenced flags etc. to prevent some mistakes). 