### PR TITLE
Fix #520: Public NotReady pods to pod cluster IPs

### DIFF
--- a/controllers/pod_models.go
+++ b/controllers/pod_models.go
@@ -94,9 +94,10 @@ func GetService(cluster *fdbtypes.FoundationDBCluster, processClass string, idNu
 	return &corev1.Service{
 		ObjectMeta: metadata,
 		Spec: corev1.ServiceSpec{
-			Type:     corev1.ServiceTypeClusterIP,
-			Ports:    generateServicePorts(processesPerPod),
-			Selector: getMinimalSinglePodLabels(cluster, id),
+			Type:                     corev1.ServiceTypeClusterIP,
+			Ports:                    generateServicePorts(processesPerPod),
+			PublishNotReadyAddresses: true,
+			Selector:                 getMinimalSinglePodLabels(cluster, id),
 		},
 	}, nil
 }


### PR DESCRIPTION
The ClusterIP services are not doing true service discovery, instead
they are just fixed proxies for the pod, and so the readiness of the pod
is not relevant. Pod readiness automatically prevents traffic flow via
the ClusterIP if the pod isn't ready - either during startup, or during
the pod deletion lifecycle, but if the FDB process is running, outbound
connections may be made, and this sets up a grey-failed network scenario
which is poor for FDB.

Signed-off-by: Robert Collins <robert.collins@cognite.com>