### PR TITLE
Make ProcessClass a type

### DIFF
--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -52,7 +52,7 @@ func TestGetDefaultRoleCounts(t *testing.T) {
 		RemoteLogs: -1,
 		LogRouters: -1,
 	}))
-	g.Expect(counts.Map()).To(gomega.Equal(map[string]int{
+	g.Expect(counts.Map()).To(gomega.Equal(map[ProcessClass]int{
 		"logs":        3,
 		"proxies":     3,
 		"resolvers":   1,
@@ -71,7 +71,7 @@ func TestGetDefaultRoleCounts(t *testing.T) {
 		RemoteLogs: 3,
 		LogRouters: 3,
 	}))
-	g.Expect(counts.Map()).To(gomega.Equal(map[string]int{
+	g.Expect(counts.Map()).To(gomega.Equal(map[ProcessClass]int{
 		"logs":        3,
 		"proxies":     3,
 		"resolvers":   1,
@@ -150,7 +150,7 @@ func TestGettingDefaultProcessCounts(t *testing.T) {
 		Log:       4,
 		Stateless: 9,
 	}))
-	g.Expect(counts.Map()).To(gomega.Equal(map[string]int{
+	g.Expect(counts.Map()).To(gomega.Equal(map[ProcessClass]int{
 		ProcessClassStorage:   5,
 		ProcessClassLog:       4,
 		ProcessClassStateless: 9,
@@ -171,7 +171,7 @@ func TestGettingDefaultProcessCounts(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(counts.Stateless).To(gomega.Equal(8))
 	g.Expect(counts.ClusterController).To(gomega.Equal(3))
-	g.Expect(counts.Map()).To(gomega.Equal(map[string]int{
+	g.Expect(counts.Map()).To(gomega.Equal(map[ProcessClass]int{
 		ProcessClassStorage:           5,
 		ProcessClassLog:               4,
 		ProcessClassStateless:         8,
@@ -3071,7 +3071,7 @@ func TestGettingProcessSettings(t *testing.T) {
 
 	cluster := &FoundationDBCluster{
 		Spec: FoundationDBClusterSpec{
-			Processes: map[string]ProcessSettings{
+			Processes: map[ProcessClass]ProcessSettings{
 				ProcessClassGeneral: {
 					PodTemplate: &corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -477,7 +477,7 @@ func (in *FoundationDBClusterSpec) DeepCopyInto(out *FoundationDBClusterSpec) {
 	in.DatabaseConfiguration.DeepCopyInto(&out.DatabaseConfiguration)
 	if in.Processes != nil {
 		in, out := &in.Processes, &out.Processes
-		*out = make(map[string]ProcessSettings, len(*in))
+		*out = make(map[ProcessClass]ProcessSettings, len(*in))
 		for key, val := range *in {
 			(*out)[key] = *val.DeepCopy()
 		}

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -39,8 +39,8 @@ func (a AddProcessGroups) Reconcile(r *FoundationDBClusterReconciler, context ct
 	}
 	desiredCounts := desiredCountStruct.Map()
 
-	processCounts := make(map[string]int)
-	processGroupIDs := make(map[string]map[int]bool)
+	processCounts := make(map[fdbtypes.ProcessClass]int)
+	processGroupIDs := make(map[fdbtypes.ProcessClass]map[int]bool)
 	for _, processGroup := range cluster.Status.ProcessGroups {
 
 		processGroupID := processGroup.ProcessGroupID

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -75,7 +75,7 @@ func getListOptions(cluster *fdbtypes.FoundationDBCluster) []client.ListOption {
 	}
 }
 
-var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
+var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 	var cluster *fdbtypes.FoundationDBCluster
 	var fakeConnectionString string
 
@@ -169,7 +169,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				Expect(pods.Items[16].Name).To(Equal("operator-test-1-storage-4"))
 				Expect(pods.Items[16].Labels[FDBInstanceIDLabel]).To(Equal("storage-4"))
 
-				Expect(getProcessClassMap(pods.Items)).To(Equal(map[string]int{
+				Expect(getProcessClassMap(pods.Items)).To(Equal(map[fdbtypes.ProcessClass]int{
 					fdbtypes.ProcessClassStorage:           4,
 					fdbtypes.ProcessClassLog:               4,
 					fdbtypes.ProcessClassStateless:         8,
@@ -273,7 +273,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				Expect(pods.Items[1].Name).To(Equal(originalPods.Items[1].Name))
 				Expect(pods.Items[2].Name).To(Equal(originalPods.Items[2].Name))
 
-				Expect(getProcessClassMap(pods.Items)).To(Equal(map[string]int{
+				Expect(getProcessClassMap(pods.Items)).To(Equal(map[fdbtypes.ProcessClass]int{
 					fdbtypes.ProcessClassStorage:           3,
 					fdbtypes.ProcessClassLog:               4,
 					fdbtypes.ProcessClassStateless:         8,
@@ -309,7 +309,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(pods.Items)).To(Equal(len(originalPods.Items) + 1))
 
-				Expect(getProcessClassMap(pods.Items)).To(Equal(map[string]int{
+				Expect(getProcessClassMap(pods.Items)).To(Equal(map[fdbtypes.ProcessClass]int{
 					fdbtypes.ProcessClassStorage:           5,
 					fdbtypes.ProcessClassLog:               4,
 					fdbtypes.ProcessClassStateless:         8,
@@ -340,7 +340,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(pods.Items)).To(Equal(18))
 
-				Expect(getProcessClassMap(pods.Items)).To(Equal(map[string]int{
+				Expect(getProcessClassMap(pods.Items)).To(Equal(map[fdbtypes.ProcessClass]int{
 					fdbtypes.ProcessClassStorage:           4,
 					fdbtypes.ProcessClassLog:               4,
 					fdbtypes.ProcessClassStateless:         9,
@@ -372,7 +372,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(pods.Items)).To(Equal(18))
 
-				Expect(getProcessClassMap(pods.Items)).To(Equal(map[string]int{
+				Expect(getProcessClassMap(pods.Items)).To(Equal(map[fdbtypes.ProcessClass]int{
 					fdbtypes.ProcessClassStorage:           4,
 					fdbtypes.ProcessClassLog:               4,
 					fdbtypes.ProcessClassStateless:         9,
@@ -394,7 +394,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(pods.Items)).To(Equal(9))
 
-				Expect(getProcessClassMap(pods.Items)).To(Equal(map[string]int{
+				Expect(getProcessClassMap(pods.Items)).To(Equal(map[fdbtypes.ProcessClass]int{
 					fdbtypes.ProcessClassStorage:           4,
 					fdbtypes.ProcessClassLog:               4,
 					fdbtypes.ProcessClassClusterController: 1,
@@ -437,7 +437,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(len(pods.Items)).To(Equal(17))
 
-					Expect(getProcessClassMap(pods.Items)).To(Equal(map[string]int{
+					Expect(getProcessClassMap(pods.Items)).To(Equal(map[fdbtypes.ProcessClass]int{
 						fdbtypes.ProcessClassStorage:           4,
 						fdbtypes.ProcessClassLog:               4,
 						fdbtypes.ProcessClassStateless:         8,
@@ -519,7 +519,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(len(pods.Items)).To(Equal(17))
 
-					Expect(getProcessClassMap(pods.Items)).To(Equal(map[string]int{
+					Expect(getProcessClassMap(pods.Items)).To(Equal(map[fdbtypes.ProcessClass]int{
 						fdbtypes.ProcessClassStorage:           4,
 						fdbtypes.ProcessClassLog:               4,
 						fdbtypes.ProcessClassStateless:         8,
@@ -581,7 +581,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 
 					Expect(len(pods.Items)).To(Equal(17))
 
-					Expect(getProcessClassMap(pods.Items)).To(Equal(map[string]int{
+					Expect(getProcessClassMap(pods.Items)).To(Equal(map[fdbtypes.ProcessClass]int{
 						fdbtypes.ProcessClassStorage:           4,
 						fdbtypes.ProcessClassLog:               4,
 						fdbtypes.ProcessClassStateless:         8,
@@ -831,7 +831,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				Expect(err).NotTo(HaveOccurred())
 				err = adminClient.FreezeStatus()
 				Expect(err).NotTo(HaveOccurred())
-				cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {CustomParameters: &[]string{"knob_disable_posix_kernel_aio=1"}}}
+				cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {CustomParameters: &[]string{"knob_disable_posix_kernel_aio=1"}}}
 			})
 
 			Context("with bounces enabled", func() {
@@ -902,7 +902,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 
 			Context("with multiple storage servers per pod", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {CustomParameters: &[]string{}}}
+					cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {CustomParameters: &[]string{}}}
 					cluster.Spec.StorageServersPerPod = 2
 					adminClient.UnfreezeStatus()
 					Expect(err).NotTo(HaveOccurred())
@@ -926,7 +926,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 					err = adminClient.FreezeStatus()
 					Expect(err).NotTo(HaveOccurred())
 
-					cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {CustomParameters: &[]string{"knob_disable_posix_kernel_aio=1"}}}
+					cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {CustomParameters: &[]string{"knob_disable_posix_kernel_aio=1"}}}
 					err = k8sClient.Update(context.TODO(), cluster)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -935,7 +935,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 					addresses := make([]string, 0, len(originalPods.Items))
 					for _, pod := range originalPods.Items {
 						addresses = append(addresses, cluster.GetFullAddress(MockPodIP(&pod), 1))
-						if pod.ObjectMeta.Labels[FDBProcessClassLabel] == fdbtypes.ProcessClassStorage {
+						if processClassFromLabels(pod.ObjectMeta.Labels) == fdbtypes.ProcessClassStorage {
 							addresses = append(addresses, cluster.GetFullAddress(MockPodIP(&pod), 2))
 						}
 					}
@@ -1047,7 +1047,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 
 		Context("with a change to pod labels", func() {
 			BeforeEach(func() {
-				cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+				cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
 							"fdb-label": "value3",
@@ -1096,7 +1096,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				err = k8sClient.Update(context.TODO(), pod)
 				Expect(err).NotTo(HaveOccurred())
 
-				cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+				cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							"fdb-annotation": "value1",
@@ -1122,7 +1122,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 					_, id, err := ParseInstanceID(item.Labels[FDBInstanceIDLabel])
 					Expect(err).NotTo(HaveOccurred())
 
-					hash, err := GetPodSpecHash(cluster, item.Labels[FDBProcessClassLabel], id, nil)
+					hash, err := GetPodSpecHash(cluster, processClassFromLabels(item.Labels), id, nil)
 					Expect(err).NotTo(HaveOccurred())
 
 					configMapHash, err := GetConfigMapHash(cluster)
@@ -1169,7 +1169,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 		Context("with a change to the PVC labels", func() {
 			Context("with the fields from the processes", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+					cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"fdb-label": "value3",
@@ -1218,7 +1218,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 					err = k8sClient.Update(context.TODO(), pvc)
 					Expect(err).NotTo(HaveOccurred())
 
-					cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+					cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
 								"fdb-annotation": "value1",
@@ -1262,7 +1262,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 						_, id, err := ParseInstanceID(item.Labels[FDBInstanceIDLabel])
 						Expect(err).NotTo(HaveOccurred())
 
-						hash, err := GetPodSpecHash(cluster, item.Labels[FDBProcessClassLabel], id, nil)
+						hash, err := GetPodSpecHash(cluster, processClassFromLabels(item.Labels), id, nil)
 						Expect(err).NotTo(HaveOccurred())
 
 						configMapHash, err := GetConfigMapHash(cluster)
@@ -1371,7 +1371,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 					_, id, err := ParseInstanceID(item.Labels[FDBInstanceIDLabel])
 					Expect(err).NotTo(HaveOccurred())
 
-					hash, err := GetPodSpecHash(cluster, item.Labels[FDBProcessClassLabel], id, nil)
+					hash, err := GetPodSpecHash(cluster, processClassFromLabels(item.Labels), id, nil)
 					Expect(err).NotTo(HaveOccurred())
 
 					configMapHash, err := GetConfigMapHash(cluster)
@@ -1397,7 +1397,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 
 		Context("with a change to environment variables", func() {
 			BeforeEach(func() {
-				cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+				cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
@@ -1647,7 +1647,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 				for _, pod := range pods.Items {
 					Expect(pod.Annotations[PublicIPSourceAnnotation]).To(Equal("service"))
 
-					if pod.Labels[FDBProcessClassLabel] == fdbtypes.ProcessClassStorage && storagePod.Name == "" {
+					if processClassFromLabels(pod.Labels) == fdbtypes.ProcessClassStorage && storagePod.Name == "" {
 						storagePod = pod
 					}
 				}
@@ -1688,7 +1688,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 
 				var storagePod corev1.Pod
 				for _, pod := range pods.Items {
-					if pod.Labels[FDBProcessClassLabel] == fdbtypes.ProcessClassStorage && storagePod.Name == "" {
+					if processClassFromLabels(pod.Labels) == fdbtypes.ProcessClassStorage && storagePod.Name == "" {
 						storagePod = pod
 						break
 					}
@@ -1938,11 +1938,11 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 		Context("with a change to the volume size", func() {
 			Context("with the fields from the processes", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+					cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
 						Spec: corev1.PersistentVolumeClaimSpec{
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									fdbtypes.ProcessClassStorage: resource.MustParse("32Gi"),
+									corev1.ResourceStorage: resource.MustParse("32Gi"),
 								},
 							},
 						},
@@ -1973,7 +1973,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					for _, pvc := range pvcs.Items {
-						Expect(pvc.Spec.Resources.Requests[fdbtypes.ProcessClassStorage]).To(Equal(resource.MustParse("32Gi")))
+						Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("32Gi")))
 					}
 				})
 			})
@@ -2560,7 +2560,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 		Context("with custom parameters", func() {
 			Context("with general parameters", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {CustomParameters: &[]string{
+					cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{fdbtypes.ProcessClassGeneral: {CustomParameters: &[]string{
 						"knob_disable_posix_kernel_aio = 1",
 					}}}
 					conf, err = GetMonitorConf(cluster, fdbtypes.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
@@ -2591,7 +2591,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 
 			Context("with process-class parameters", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{
+					cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{
 						fdbtypes.ProcessClassGeneral: {CustomParameters: &[]string{
 							"knob_disable_posix_kernel_aio = 1",
 						}},
@@ -3043,7 +3043,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 			It("parses the prefix", func() {
 				prefix, id, err := ParseInstanceID("dc1-storage-12")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(prefix).To(Equal("dc1-storage"))
+				Expect(prefix).To(Equal(fdbtypes.ProcessClass("dc1-storage")))
 				Expect(id).To(Equal(12))
 			})
 		})
@@ -3058,7 +3058,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 
 		Context("with no numbers", func() {
 			It("gives a parsing error", func() {
-				_, _, err := ParseInstanceID(fdbtypes.ProcessClassStorage)
+				_, _, err := ParseInstanceID("storage")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("could not parse instance ID storage"))
 			})
@@ -3347,7 +3347,7 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 			deprecationOptions = DeprecationOptions{OnlyShowChanges: true}
 			reconciler = createTestClusterReconciler()
 
-			cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{
+			cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{
 				fdbtypes.ProcessClassGeneral: {
 					PodTemplate: &corev1.PodTemplateSpec{},
 				},
@@ -3511,10 +3511,10 @@ var _ = Describe(fdbtypes.ProcessClassClusterController, func() {
 	})
 })
 
-func getProcessClassMap(pods []corev1.Pod) map[string]int {
-	counts := make(map[string]int)
+func getProcessClassMap(pods []corev1.Pod) map[fdbtypes.ProcessClass]int {
+	counts := make(map[fdbtypes.ProcessClass]int)
 	for _, pod := range pods {
-		ProcessClass := pod.Labels[FDBProcessClassLabel]
+		ProcessClass := processClassFromLabels(pod.Labels)
 		counts[ProcessClass]++
 	}
 	return counts

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -23,6 +23,8 @@ package controllers
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 )
 
 var log = logf.Log.WithName("controller")
@@ -115,6 +117,11 @@ func mergeMap(target map[string]string, desired map[string]string) bool {
 		}
 	}
 	return changed
+}
+
+// processClassFromLabel extracts the ProcessClass label from the metav1.ObjectMeta.Labels map
+func processClassFromLabels(labels map[string]string) fdbtypes.ProcessClass {
+	return fdbtypes.ProcessClass(labels[FDBProcessClassLabel])
 }
 
 // DeprecationOptions controls how deprecations and changes to defaults

--- a/controllers/pod_client.go
+++ b/controllers/pod_client.go
@@ -261,7 +261,7 @@ func MockPodIP(pod *corev1.Pod) string {
 	}
 	components := strings.Split(GetInstanceIDFromMeta(pod.ObjectMeta), "-")
 	for index, class := range fdbtypes.ProcessClasses {
-		if class == components[len(components)-2] {
+		if string(class) == components[len(components)-2] {
 			return fmt.Sprintf("1.1.%d.%s", index, components[len(components)-1])
 		}
 	}

--- a/controllers/replace_misconfigured_pods_test.go
+++ b/controllers/replace_misconfigured_pods_test.go
@@ -38,7 +38,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 	BeforeEach(func() {
 		cluster = createDefaultCluster()
 		cluster.Spec.UpdatePodsByReplacement = false
-		cluster.Spec.Processes = map[string]fdbtypes.ProcessSettings{
+		cluster.Spec.Processes = map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{
 			fdbtypes.ProcessClassGeneral: {
 				PodTemplate: &corev1.PodTemplateSpec{},
 			},
@@ -107,7 +107,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					Metadata: &metav1.ObjectMeta{
 						Labels: map[string]string{
 							FDBInstanceIDLabel:   instanceName,
-							FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+							FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 						},
 					},
 					Pod: &corev1.Pod{
@@ -138,7 +138,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					Metadata: &metav1.ObjectMeta{
 						Labels: map[string]string{
 							FDBInstanceIDLabel:   instanceName,
-							FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+							FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 						},
 						Annotations: map[string]string{},
 					},
@@ -171,7 +171,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				Metadata: &metav1.ObjectMeta{
 					Labels: map[string]string{
 						FDBInstanceIDLabel:   instanceName,
-						FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 					},
 					Annotations: map[string]string{
 						PublicIPSourceAnnotation: string(fdbtypes.PublicIPSourceService),
@@ -207,7 +207,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				Metadata: &metav1.ObjectMeta{
 					Labels: map[string]string{
 						FDBInstanceIDLabel:   instanceName,
-						FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 					},
 					Annotations: map[string]string{},
 				},
@@ -239,7 +239,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				Metadata: &metav1.ObjectMeta{
 					Labels: map[string]string{
 						FDBInstanceIDLabel:   instanceName,
-						FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 					},
 					Annotations: map[string]string{},
 				},
@@ -270,7 +270,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				Metadata: &metav1.ObjectMeta{
 					Labels: map[string]string{
 						FDBInstanceIDLabel:   fmt.Sprintf("%s-1337", fdbtypes.ProcessClassLog),
-						FDBProcessClassLabel: fdbtypes.ProcessClassLog,
+						FDBProcessClassLabel: string(fdbtypes.ProcessClassLog),
 					},
 					Annotations: map[string]string{},
 				},
@@ -301,7 +301,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				Metadata: &metav1.ObjectMeta{
 					Labels: map[string]string{
 						FDBInstanceIDLabel:   instanceName,
-						FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 					},
 					Annotations: map[string]string{},
 				},
@@ -334,7 +334,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				Metadata: &metav1.ObjectMeta{
 					Labels: map[string]string{
 						FDBInstanceIDLabel:   instanceName,
-						FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 					},
 					Annotations: map[string]string{},
 				},
@@ -360,7 +360,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				Metadata: &metav1.ObjectMeta{
 					Labels: map[string]string{
 						FDBInstanceIDLabel:   instanceName,
-						FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 					},
 					Annotations: map[string]string{},
 				},

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -139,7 +139,7 @@ var _ = Describe("update_status", func() {
 				instance := FdbInstance{
 					Metadata: &metav1.ObjectMeta{
 						Labels: map[string]string{
-							FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+							FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 							FDBInstanceIDLabel:   "1337",
 						},
 					},

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -233,7 +233,7 @@ FoundationDBClusterSpec defines the desired state of a cluster.
 | version | Version defines the version of FoundationDB the cluster should run. | string | true |
 | sidecarVersions | SidecarVersions defines the build version of the sidecar to run. This maps an FDB version to the corresponding sidecar build version. | map[string]int | false |
 | databaseConfiguration | DatabaseConfiguration defines the database configuration. | [DatabaseConfiguration](#databaseconfiguration) | false |
-| processes | Processes defines process-level settings. | map[string][ProcessSettings](#processsettings) | false |
+| processes | Processes defines process-level settings. | map[ProcessClass][ProcessSettings](#processsettings) | false |
 | processCounts | ProcessCounts defines the number of processes to configure for each process class. You can generally omit this, to allow the operator to infer the process counts based on the database configuration. | [ProcessCounts](#processcounts) | false |
 | seedConnectionString | SeedConnectionString provides a connection string for the initial reconciliation.  After the initial reconciliation, this will not be used. | string | false |
 | faultDomain | FaultDomain defines the rules for what fault domain to replicate across. | [FoundationDBClusterFaultDomain](#foundationdbclusterfaultdomain) | false |
@@ -460,7 +460,7 @@ FoundationDBStatusProcessInfo describes the \"processes\" portion of the cluster
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | address | Address provides the address of the process. | string | false |
-| class_type | ProcessClass provides the process class the process has been given. | string | false |
+| class_type | ProcessClass provides the process class the process has been given. | ProcessClass | false |
 | command_line | CommandLine provides the command-line invocation for the process. | string | false |
 | excluded | Excluded indicates whether the process has been excluded. | bool | false |
 | locality | The locality information for the process. | map[string]string | false |
@@ -585,7 +585,7 @@ ProcessGroupStatus represents a the status of a ProcessGroup.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | processGroupID | ProcessGroupID represents the ID of the process group | string | false |
-| processClass | ProcessClass represents the class the process group has. | string | false |
+| processClass | ProcessClass represents the class the process group has. | ProcessClass | false |
 | addresses | Addresses represents the list of addresses the process group has been known to have. | []string | false |
 | remove | Remove defines if the process group is marked for removal. | bool | false |
 | excluded | Excluded defines if the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | bool | false |

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -64,7 +64,7 @@ func TestCordonNode(t *testing.T) {
 					Name:      "instance-1",
 					Namespace: namespace,
 					Labels: map[string]string{
-						controllers.FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						controllers.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 						controllers.FDBClusterLabel:      clusterName,
 						controllers.FDBInstanceIDLabel:   "instance-1",
 					},
@@ -78,7 +78,7 @@ func TestCordonNode(t *testing.T) {
 					Name:      "instance-2",
 					Namespace: namespace,
 					Labels: map[string]string{
-						controllers.FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						controllers.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 						controllers.FDBClusterLabel:      clusterName,
 						controllers.FDBInstanceIDLabel:   "instance-2",
 					},

--- a/kubectl-fdb/cmd/exec_test.go
+++ b/kubectl-fdb/cmd/exec_test.go
@@ -57,7 +57,7 @@ func TestBuildCommand(t *testing.T) {
 					Name:      "instance-1",
 					Namespace: namespace,
 					Labels: map[string]string{
-						controllers.FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						controllers.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 						controllers.FDBClusterLabel:      clusterName,
 					},
 				},

--- a/kubectl-fdb/cmd/remove_instances.go
+++ b/kubectl-fdb/cmd/remove_instances.go
@@ -172,7 +172,7 @@ func removeInstances(kubeClient client.Client, clusterName string, instances []s
 		return nil
 	}
 
-	shrinkMap := make(map[string]int)
+	shrinkMap := make(map[fdbtypes.ProcessClass]int)
 
 	if withShrink {
 		var pods corev1.PodList

--- a/kubectl-fdb/cmd/remove_instances_test.go
+++ b/kubectl-fdb/cmd/remove_instances_test.go
@@ -60,7 +60,7 @@ func TestRemoveInstances(t *testing.T) {
 					Name:      "instance-1",
 					Namespace: namespace,
 					Labels: map[string]string{
-						controllers.FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						controllers.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 						controllers.FDBClusterLabel:      clusterName,
 					},
 				},
@@ -172,7 +172,7 @@ func TestGetInstanceIDsFromPod(t *testing.T) {
 					Name:      "instance-1",
 					Namespace: namespace,
 					Labels: map[string]string{
-						controllers.FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						controllers.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 						controllers.FDBClusterLabel:      clusterName,
 						controllers.FDBInstanceIDLabel:   "storage-1",
 					},
@@ -183,7 +183,7 @@ func TestGetInstanceIDsFromPod(t *testing.T) {
 					Name:      "instance-2",
 					Namespace: namespace,
 					Labels: map[string]string{
-						controllers.FDBProcessClassLabel: fdbtypes.ProcessClassStorage,
+						controllers.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
 						controllers.FDBClusterLabel:      clusterName,
 						controllers.FDBInstanceIDLabel:   "storage-2",
 					},


### PR DESCRIPTION
Sorry for this enormous out of the blue patch, and I'll understand if the answer is 'wat, nope.'

It came out of the other coordinator patch where a little more type safety would have been useful. And then the minimum set the tentacles reached to this size.

The basic idea is the usual benefits of type safety - no accidentally assigning random strings to ProcessClass places, etc. 

This version can probably be cleaned up a bit if the basic idea is not objectionable.