### PR TITLE
Remove all leading non JSON output

### DIFF
--- a/controllers/admin_client.go
+++ b/controllers/admin_client.go
@@ -600,6 +600,11 @@ func (client *CliAdminClient) GetBackupStatus() (*fdbtypes.FoundationDBLiveBacku
 	}
 
 	status := &fdbtypes.FoundationDBLiveBackupStatus{}
+	statusString, err = removeWarningsInJSON(statusString)
+	if err != nil {
+		return nil, err
+	}
+
 	err = json.Unmarshal([]byte(statusString), &status)
 	if err != nil {
 		return nil, err
@@ -638,6 +643,15 @@ func (client *CliAdminClient) Close() error {
 		return err
 	}
 	return nil
+}
+
+func removeWarningsInJSON(jsonString string) (string, error) {
+	idx := strings.Index(jsonString, "{")
+	if idx == -1 {
+		return "", fmt.Errorf("the JSON string doesn't contain a starting '{'")
+	}
+
+	return strings.TrimSpace(jsonString[idx:]), nil
 }
 
 // MockAdminClient provides a mock implementation of the cluster admin interface

--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -22,8 +22,10 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
@@ -352,4 +354,51 @@ var _ = Describe("admin_client_test", func() {
 			})
 		})
 	})
+
+	type testCase struct {
+		input       string
+		expected    string
+		expectedErr error
+	}
+
+	DescribeTable("Test remove warnings in JSON string",
+		func(tc testCase) {
+			result, err := removeWarningsInJSON(tc.input)
+			// We need the if statement to make ginkgo happy:
+			//   Refusing to compare <nil> to <nil>.
+			//   Be explicit and use BeNil() instead.
+			//   This is to avoid mistakes where both sides of an assertion are erroneously uninitialized.
+			// ¯\_(ツ)_/¯
+			if tc.expectedErr == nil {
+				Expect(err).To(BeNil())
+			} else {
+				Expect(err).To(Equal(tc.expectedErr))
+			}
+			Expect(result).To(Equal(tc.expected))
+		},
+		Entry("Valid JSON without warning",
+			testCase{
+				input:       "{}",
+				expected:    "{}",
+				expectedErr: nil,
+			},
+		),
+		Entry("Valid JSON with warning",
+			testCase{
+				input: `
+# Warning Slow response
+
+{}`,
+				expected:    "{}",
+				expectedErr: nil,
+			},
+		),
+		Entry("Invalid JSON",
+			testCase{
+				input:       "}",
+				expected:    "",
+				expectedErr: fmt.Errorf("the JSON string doesn't contain a starting '{'"),
+			},
+		),
+	)
 })


### PR DESCRIPTION
We still have an issue when we use the `fdbcli status` e.g. for backups or when we want to call it in the kubectl plugin the new version of fdbcli should report warnings and errors to stderr (https://github.com/apple/foundationdb/pull/4332) so we shouldn't see this error anymore until all of the old version are deprecated we should have a workaround for these cases. This PR removes all leading characters of the JSON output that is not a `{`.

