### PR TITLE
Add e2e test to create CRDs against a newer version of the API server

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,6 +40,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # With a new supported Kubernetes version we should adjust the version
+        kubever: [ "v1.17.0", "v1.18.0", "v1.19.0", "v1.20.0" ]
     steps:
     - name: Set up Go 1.15
       uses: actions/setup-go@v1
@@ -53,6 +57,7 @@ jobs:
         KUSTOMIZE_VER: "v3.9.4"
         TEST_RACE_CONDITIONS: "1"
         FDB_VER: "6.2.29"
+        KIND_VER: "v0.10.0"
       run: |
         go get -v -t -d ./...
         curl --fail -LO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VER}/kustomize_${KUSTOMIZE_VER}_linux_amd64.tar.gz"
@@ -66,12 +71,24 @@ jobs:
         curl --cacert ./foundationdb-kubernetes-sidecar/files/GeoTrust_Global_CA.pem \
              --fail "https://www.foundationdb.org/downloads/${FDB_VER}/ubuntu/installers/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
         sudo dpkg -i fdb.deb
-    - name: Build
+        # Install Kind and start a local Kubernetes cluster
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/${KIND_VER}/kind-linux-amd64
+        chmod +x ./kind
+        sudo mv ./kind /usr/local/bin/kind
+        ./scripts/setup_kind_local_registry.sh ${{ matrix.kubever }}
+    - name: Run tests
       # Currently the default runner has 2 vCPU:
       # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
       env:
         GOMAXPROCS: "2"
-      run: make clean all
-
+      run: |
+        # Ensure the Minio CRD is installed and in place
+        kubectl apply -f ./config/minio/operator.yaml
+        ./config/test-certs/generate_secrets.bash
+        IMG=localhost:5000/fdb-kubernetes-operator:latest make clean all docker-build docker-push deploy
+        # Wait for the operator to start
+        kubectl rollout status deploy fdb-kubernetes-operator-controller-manager --timeout=120s
+        # TODO run some e2e tests e.g. create cluster/delete cluster
+        # kubectl apply -f ./config/samples/cluster_local.yamlq
     - name: Check for uncommitted changes
       run: git diff --exit-code

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -89,6 +89,9 @@ jobs:
         # Wait for the operator to start
         kubectl rollout status deploy fdb-kubernetes-operator-controller-manager --timeout=120s
         # TODO run some e2e tests e.g. create cluster/delete cluster
-        # kubectl apply -f ./config/samples/cluster_local.yamlq
+        # kubectl apply -f ./config/samples/cluster_local.yaml
+        # Change the image back to the default otherwise the next check will complain
+        # TODO: changes should be ignored here e.g. template file.
+        cd config/manager && kustomize edit set image controller=fdb-kubernetes-operator:latest
     - name: Check for uncommitted changes
       run: git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ ${MANIFESTS}: ${CONTROLLER_GEN} ${GO_SRC}
 	# ref: https://github.com/kubernetes/kubernetes/issues/91395
 	# in v1beta1 defaulting is not allowed so we remove the default value
 	sed -i '/default: TCP/d' $(GENERATED_CRDS)
+	# See: https://github.com/kubernetes-sigs/controller-tools/issues/529
+	sed -i  '/- protocol/d' $(GENERATED_CRDS)
 
 # Run go fmt against code
 fmt: bin/fmt_check

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ the [API documentation](docs/cluster_spec.md).
 3. Set your $GOPATH, e.x. `/Users/me/Code/go`.
 4. Install [kustomize](https://github.com/kubernetes-sigs/kustomize).
 5. Install the [foundationDB client package](https://www.foundationdb.org/download).
+6. If you want to modify the manifests you currently need [gnu-sed](https://formulae.brew.sh/formula/gnu-sed).
 
 ### Running Locally
 

--- a/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml
@@ -621,7 +621,6 @@ spec:
                             type: array
                             x-kubernetes-list-map-keys:
                             - containerPort
-                            - protocol
                             x-kubernetes-list-type: map
                           readinessProbe:
                             properties:
@@ -1759,7 +1758,6 @@ spec:
                             type: array
                             x-kubernetes-list-map-keys:
                             - containerPort
-                            - protocol
                             x-kubernetes-list-type: map
                           readinessProbe:
                             properties:

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -379,7 +379,6 @@ spec:
                     type: array
                     x-kubernetes-list-map-keys:
                     - containerPort
-                    - protocol
                     x-kubernetes-list-type: map
                   readinessProbe:
                     properties:
@@ -992,7 +991,6 @@ spec:
                     type: array
                     x-kubernetes-list-map-keys:
                     - containerPort
-                    - protocol
                     x-kubernetes-list-type: map
                   readinessProbe:
                     properties:
@@ -2060,7 +2058,6 @@ spec:
                             type: array
                             x-kubernetes-list-map-keys:
                             - containerPort
-                            - protocol
                             x-kubernetes-list-type: map
                           readinessProbe:
                             properties:
@@ -3198,7 +3195,6 @@ spec:
                             type: array
                             x-kubernetes-list-map-keys:
                             - containerPort
-                            - protocol
                             x-kubernetes-list-type: map
                           readinessProbe:
                             properties:
@@ -4900,7 +4896,6 @@ spec:
                                   type: array
                                   x-kubernetes-list-map-keys:
                                   - containerPort
-                                  - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
                                   properties:
@@ -6038,7 +6033,6 @@ spec:
                                   type: array
                                   x-kubernetes-list-map-keys:
                                   - containerPort
-                                  - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
                                   properties:

--- a/config/minio/operator.yaml
+++ b/config/minio/operator.yaml
@@ -41,7 +41,7 @@ spec:
       type: integer
       JSONPath: ".spec.replicas"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: minio-operator-role
@@ -101,7 +101,7 @@ metadata:
   namespace: minio-operator-ns
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: minio-operator-binding
   namespace: minio-operator-ns

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -30,3 +30,15 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: default

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -75,6 +75,18 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/config/samples/deployment/rbac_role.yaml
+++ b/config/samples/deployment/rbac_role.yaml
@@ -70,3 +70,15 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var leaderElectionID string
 	var logFile string
 	var cliTimeout int
 	var deprecationOptions controllers.DeprecationOptions
@@ -60,8 +61,8 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&logFile, "log-file", "", "The path to a file to write logs to.")
-	flag.IntVar(&cliTimeout, "cli-timeout", 10, "The timeout to use for CLI commands")
+	flag.StringVar(&leaderElectionID, "leader-election-id", "fdb-kubernetes-operator",
+		"LeaderElectionID determines the name of the resource that leader election will use for holding the leader lock.")
 	flag.BoolVar(&deprecationOptions.UseFutureDefaults, "use-future-defaults", false,
 		"Apply defaults from the next major version of the operator. This is only intended for use in development.",
 	)
@@ -104,6 +105,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   leaderElectionID,
 		Port:               9443,
 	}
 

--- a/main.go
+++ b/main.go
@@ -66,6 +66,8 @@ func main() {
 	flag.BoolVar(&deprecationOptions.UseFutureDefaults, "use-future-defaults", false,
 		"Apply defaults from the next major version of the operator. This is only intended for use in development.",
 	)
+	flag.StringVar(&logFile, "log-file", "", "The path to a file to write logs to.")
+	flag.IntVar(&cliTimeout, "cli-timeout", 10, "The timeout to use for CLI commands")
 	flag.BoolVar(&checkDeprecations, "check-deprecations", false,
 		"Check for deprecated fields and then exit",
 	)

--- a/scripts/setup_kind_local_registry.sh
+++ b/scripts/setup_kind_local_registry.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Script original from: https://kind.sigs.k8s.io/docs/user/local-registry/
+set -o errexit
+
+# create registry container unless it already exists
+version=$1
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:${version}
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:${reg_port}"]
+EOF
+
+# connect the registry to the cluster network
+# (the network may already be connected)
+docker network connect "kind" "${reg_name}" || true
+
+# Document the local registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF


### PR DESCRIPTION
Initially I only wanted to fix this issue https://github.com/kubernetes-sigs/controller-tools/issues/529 (I didn't saw this issue because some older Kubernetes version ignore (e.g. 1.15 which is the default for kube-builder) and I wanted to add a small test to deploy the CRDs against our expected Kubernetes versions.