### PR TITLE
Make use of the standard logging flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ import (
 	appsv1beta1 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 	"github.com/FoundationDB/fdb-kubernetes-operator/controllers"
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
-	uzap "go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -54,7 +53,6 @@ func main() {
 	var deprecationOptions controllers.DeprecationOptions
 	var useFutureDefaults bool
 	var checkDeprecations bool
-	var development bool
 
 	fdb.MustAPIVersion(610)
 
@@ -71,10 +69,8 @@ func main() {
 	flag.BoolVar(&checkDeprecations, "check-deprecations", false,
 		"Check for deprecated fields and then exit",
 	)
-	flag.BoolVar(&development, "development", false,
-		"Enable verbose development logs",
-	)
-	level := uzap.LevelFlag("log-level", uzap.InfoLevel, "The log level")
+	opts := zap.Options{}
+	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
 	deprecationOptions.OnlyShowChanges = checkDeprecations
@@ -92,12 +88,10 @@ func main() {
 		logWriter = os.Stdout
 	}
 
-	logLevel := uzap.NewAtomicLevelAt(*level)
 	ctrl.SetLogger(
 		zap.New(
-			zap.UseDevMode(development),
+			zap.UseFlagOptions(&opts),
 			zap.WriteTo(logWriter),
-			zap.Level(&logLevel),
 		),
 	)
 


### PR DESCRIPTION
Instead of defining our own custom flags we should use the standard flags of the controller-runtime. This will be a breaking change and we should note this in the new release as action required during the update of the operator. e.g. `log-level` will be `zap-log-level` (see: https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/log/zap/zap.go#L235-L242).