### PR TITLE
Correct v0.29.0 image tag in helm chart

### DIFF
--- a/helm/fdb-operator/values.yaml
+++ b/helm/fdb-operator/values.yaml
@@ -1,7 +1,7 @@
 operator:
   name: fdb-kubernetes-operator-controller-manager
   image: foundationdb/fdb-kubernetes-operator
-  tag: 0.29.0
+  tag: v0.29.0
   role: fdb-kubernetes-operator-manager-role
   rolebinding: fdb-kubernetes-operator-manager-rolebinding
   replicas: 1


### PR DESCRIPTION
Hey guys,

This PR simply corrects what seems to be an error in the latest helm chart - the desired container image should be `v0.29.0`, rather than `0.29.0` (which doesn't exist)

Cheers!
D