### PR TITLE
Add validation for satellite

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1697,6 +1697,8 @@ type DataCenter struct {
 	// Satellite indicates whether the data center is serving as a satellite for
 	// the region. A value of 1 indicates that it is a satellite, and a value of
 	// 0 indicates that it is not a satellite.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1
 	Satellite int `json:"satellite,omitempty"`
 }
 

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -669,6 +669,8 @@ spec:
                             priority:
                               type: integer
                             satellite:
+                              maximum: 1
+                              minimum: 0
                               type: integer
                           type: object
                         type: array
@@ -8387,6 +8389,8 @@ spec:
                             priority:
                               type: integer
                             satellite:
+                              maximum: 1
+                              minimum: 0
                               type: integer
                           type: object
                         type: array


### PR DESCRIPTION
I stumbled over this when I created a multi dc FDB cluster and used the `satellite` field as `priority`. This can be a little bit tricky to debug so I think it makes sense to add this as a validation check.