### PR TITLE
Set logger for go-client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,12 +13,12 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
-	go.uber.org/zap v1.15.0
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	k8s.io/api v0.20.4
 	k8s.io/apimachinery v0.20.4
 	k8s.io/cli-runtime v0.20.4
 	k8s.io/client-go v0.20.4
 	sigs.k8s.io/controller-runtime v0.8.3
+	k8s.io/klog/v2 v2.4.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
@@ -88,12 +89,13 @@ func main() {
 		logWriter = os.Stdout
 	}
 
-	ctrl.SetLogger(
-		zap.New(
-			zap.UseFlagOptions(&opts),
-			zap.WriteTo(logWriter),
-		),
-	)
+	logger := zap.New(
+		zap.UseFlagOptions(&opts),
+		zap.WriteTo(logWriter))
+	ctrl.SetLogger(logger)
+
+	// Might be called by controller-runtime in the future: https://github.com/kubernetes-sigs/controller-runtime/issues/1420
+	klog.SetLogger(logger)
 
 	controllers.DefaultCLITimeout = cliTimeout
 


### PR DESCRIPTION
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/572

Before:

```
{"level":"info","ts":1616333160.5288906,"logger":"setup","msg":"starting manager"}
I0321 13:26:00.529170       1 leaderelection.go:243] attempting to acquire leader lease default/fdb-kubernetes-operator...
{"level":"info","ts":1616333160.6301408,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
I0321 13:26:18.299225       1 leaderelection.go:253] successfully acquired lease default/fdb-kubernetes-operator
```

After:

```
{"level":"info","ts":1616489413.469807,"logger":"setup","msg":"starting manager"}
{"level":"info","ts":1616489413.4702618,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
{"level":"info","ts":1616489413.4713948,"msg":"attempting to acquire leader lease default/fdb-kubernetes-operator...\n"}
{"level":"info","ts":1616489431.0350301,"msg":"successfully acquired lease default/fdb-kubernetes-operator\n"}
```
