### PR TITLE
Make use of constant for event type and remove invalid error type

### DIFF
--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -77,7 +77,7 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 
 			pod, err := GetPod(cluster, processGroup.ProcessClass, idNum)
 			if err != nil {
-				r.Recorder.Event(cluster, "Error", "GetPod", fmt.Sprintf("failed to get the PodSpec for %s/%d with error: %s", processGroup.ProcessClass, idNum, err))
+				r.Recorder.Event(cluster, corev1.EventTypeWarning, "GetPod", fmt.Sprintf("failed to get the PodSpec for %s/%d with error: %s", processGroup.ProcessClass, idNum, err))
 				return false, err
 			}
 

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 )
 
@@ -71,7 +73,7 @@ func (a AddProcessGroups) Reconcile(r *FoundationDBClusterReconciler, context ct
 		if newCount <= 0 {
 			continue
 		}
-		r.Recorder.Event(cluster, "Normal", "AddingProcesses", fmt.Sprintf("Adding %d %s processes", newCount, processClass))
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "AddingProcesses", fmt.Sprintf("Adding %d %s processes", newCount, processClass))
 		idNum := 1
 
 		if processGroupIDs[processClass] == nil {

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 )
 
@@ -51,7 +53,7 @@ func (c ChangeCoordinators) Reconcile(r *FoundationDBClusterReconciler, context 
 
 	if connectionString != cluster.Status.ConnectionString {
 		log.Info("Updating out-of-date connection string", "namespace", cluster.Namespace, "cluster", cluster.Name)
-		r.Recorder.Event(cluster, "Normal", "UpdatingConnectionString", fmt.Sprintf("Setting connection string to %s", connectionString))
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpdatingConnectionString", fmt.Sprintf("Setting connection string to %s", connectionString))
 		cluster.Status.ConnectionString = connectionString
 		err = r.Status().Update(context, cluster)
 
@@ -78,12 +80,12 @@ func (c ChangeCoordinators) Reconcile(r *FoundationDBClusterReconciler, context 
 
 		if !allAddressesValid {
 			log.Info("Deferring coordinator change", "namespace", cluster.Namespace, "cluster", cluster.Name)
-			r.Recorder.Event(cluster, "Normal", "DeferringCoordinatorChange", "Deferring coordinator change until all processes have consistent address TLS settings")
+			r.Recorder.Event(cluster, corev1.EventTypeNormal, "DeferringCoordinatorChange", "Deferring coordinator change until all processes have consistent address TLS settings")
 			return true, nil
 		}
 
 		log.Info("Changing coordinators", "namespace", cluster.Namespace, "cluster", cluster.Name)
-		r.Recorder.Event(cluster, "Normal", "ChangingCoordinators", "Choosing new coordinators")
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "ChangingCoordinators", "Choosing new coordinators")
 
 		candidates := make([]localityInfo, 0, len(status.Cluster.Processes))
 		for _, process := range status.Cluster.Processes {

--- a/controllers/check_client_compatibility.go
+++ b/controllers/check_client_compatibility.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 )
 
@@ -118,7 +120,7 @@ func (c CheckClientCompatibility) Reconcile(r *FoundationDBClusterReconciler, co
 				"%d clients do not support version %s: %s", len(unsupportedClients),
 				cluster.Spec.Version, strings.Join(unsupportedClients, ", "),
 			)
-			r.Recorder.Event(cluster, "Normal", "UnsupportedClient", message)
+			r.Recorder.Event(cluster, corev1.EventTypeNormal, "UnsupportedClient", message)
 			log.Info("Deferring reconciliation due to unsupported clients", "namespace", cluster.Namespace, "name", cluster.Name, "message", message)
 			return false, nil
 		}

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 )
 
@@ -84,7 +86,7 @@ func (c ChooseRemovals) Reconcile(r *FoundationDBClusterReconciler, context ctx.
 		}
 
 		if removedCount > 0 {
-			r.Recorder.Event(cluster, "Normal", "ShrinkingProcesses", fmt.Sprintf("Removing %d %s processes", removedCount, processClass))
+			r.Recorder.Event(cluster, corev1.EventTypeNormal, "ShrinkingProcesses", fmt.Sprintf("Removing %d %s processes", removedCount, processClass))
 
 			remainingProcesses, err := chooseDistributedProcesses(processClassLocality, desiredCount, processSelectionConstraint{})
 			if err != nil {

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -764,7 +764,7 @@ func (r *FoundationDBClusterReconciler) takeLock(cluster *fdbtypes.FoundationDBC
 	}
 
 	if !hasLock {
-		r.Recorder.Event(cluster, "Normal", "LockAcquisitionFailed", fmt.Sprintf("Lock required before %s", action))
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "LockAcquisitionFailed", fmt.Sprintf("Lock required before %s", action))
 	}
 	return hasLock, nil
 }

--- a/controllers/exclude_instances.go
+++ b/controllers/exclude_instances.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 )
 
@@ -89,7 +91,7 @@ func (e ExcludeInstances) Reconcile(r *FoundationDBClusterReconciler, context ct
 			return false, err
 		}
 
-		r.Recorder.Event(cluster, "Normal", "ExcludingProcesses", fmt.Sprintf("Excluding %v", addresses))
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "ExcludingProcesses", fmt.Sprintf("Excluding %v", addresses))
 
 		err = adminClient.ExcludeInstances(addresses)
 

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -25,6 +25,8 @@ import (
 	"errors"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 )
 
@@ -39,7 +41,7 @@ func (g GenerateInitialClusterFile) Reconcile(r *FoundationDBClusterReconciler, 
 	}
 
 	log.Info("Generating initial cluster file", "namespace", cluster.Namespace, "cluster", cluster.Name)
-	r.Recorder.Event(cluster, "Normal", "ChangingCoordinators", "Choosing initial coordinators")
+	r.Recorder.Event(cluster, corev1.EventTypeNormal, "ChangingCoordinators", "Choosing initial coordinators")
 	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, getPodListOptions(cluster, fdbtypes.ProcessClassStorage, "")...)
 	if err != nil {
 		return false, err

--- a/controllers/remove_pods.go
+++ b/controllers/remove_pods.go
@@ -58,7 +58,7 @@ func (u RemovePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 		}
 	}
 
-	r.Recorder.Event(cluster, "Normal", "RemovingProcesses", fmt.Sprintf("Removing pods: %v", processGroupsToRemove))
+	r.Recorder.Event(cluster, corev1.EventTypeNormal, "RemovingProcesses", fmt.Sprintf("Removing pods: %v", processGroupsToRemove))
 	removedProcessGroups := make(map[string]bool)
 	allRemoved := true
 	for _, id := range processGroupsToRemove {
@@ -211,7 +211,7 @@ func includeInstance(r *FoundationDBClusterReconciler, context ctx.Context, clus
 	}
 
 	if len(addresses) > 0 {
-		r.Recorder.Event(cluster, "Normal", "IncludingInstances", fmt.Sprintf("Including removed processes: %v", addresses))
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "IncludingInstances", fmt.Sprintf("Including removed processes: %v", addresses))
 
 		err = adminClient.IncludeInstances(addresses)
 		if err != nil {

--- a/controllers/update_backup_agents.go
+++ b/controllers/update_backup_agents.go
@@ -26,6 +26,8 @@ import (
 	"reflect"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
@@ -54,7 +56,7 @@ func (u UpdateBackupAgents) Reconcile(r *FoundationDBBackupReconciler, context c
 
 	deployment, err := GetBackupDeployment(backup)
 	if err != nil {
-		r.Recorder.Event(backup, "Error", "GetBackupDeployment", err.Error())
+		r.Recorder.Event(backup, corev1.EventTypeWarning, "GetBackupDeployment", err.Error())
 		return false, err
 	}
 

--- a/controllers/update_config_map.go
+++ b/controllers/update_config_map.go
@@ -66,7 +66,7 @@ func (u UpdateConfigMap) Reconcile(r *FoundationDBClusterReconciler, context ctx
 
 	if !equality.Semantic.DeepEqual(existing.Data, configMap.Data) || !metadataCorrect {
 		log.Info("Updating config map", "namespace", configMap.Namespace, "cluster", cluster.Name, "name", configMap.Name)
-		r.Recorder.Event(cluster, "Normal", "UpdatingConfigMap", "")
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpdatingConfigMap", "")
 		existing.Data = configMap.Data
 		err = r.Update(context, existing)
 		if err != nil {

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -26,6 +26,8 @@ import (
 	"reflect"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -79,7 +81,7 @@ func (u UpdateDatabaseConfiguration) Reconcile(r *FoundationDBClusterReconciler,
 
 		if !healthy {
 			log.Info("Waiting for database to be healthy", "namespace", cluster.Namespace, "cluster", cluster.Name)
-			r.Recorder.Event(cluster, "Normal", "NeedsConfigurationChange",
+			r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsConfigurationChange",
 				fmt.Sprintf("Spec require configuration change to `%s`, but cluster is not healthy", configurationString))
 			return false, nil
 		}
@@ -89,7 +91,7 @@ func (u UpdateDatabaseConfiguration) Reconcile(r *FoundationDBClusterReconciler,
 				return false, err
 			}
 
-			r.Recorder.Event(cluster, "Normal", "NeedsConfigurationChange",
+			r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsConfigurationChange",
 				fmt.Sprintf("Spec require configuration change to `%s`, but configuration changes are disabled", configurationString))
 			cluster.Status.Generations.NeedsConfigurationChange = cluster.ObjectMeta.Generation
 			err = r.Status().Update(context, cluster)
@@ -108,7 +110,7 @@ func (u UpdateDatabaseConfiguration) Reconcile(r *FoundationDBClusterReconciler,
 		}
 
 		log.Info("Configuring database", "namespace", cluster.Namespace, "cluster", cluster.Name)
-		r.Recorder.Event(cluster, "Normal", "ConfiguringDatabase",
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "ConfiguringDatabase",
 			fmt.Sprintf("Setting database configuration to `%s`", configurationString),
 		)
 		err = adminClient.ConfigureDatabase(nextConfiguration, initialConfig)

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -113,7 +115,7 @@ func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 				return false, err
 			}
 
-			r.Recorder.Event(cluster, "Normal",
+			r.Recorder.Event(cluster, corev1.EventTypeNormal,
 				"NeedsPodsDeletion", "Spec require deleting some pods, but deleting pods is disabled")
 			cluster.Status.Generations.NeedsPodDeletion = cluster.ObjectMeta.Generation
 			err = r.Status().Update(context, cluster)
@@ -139,7 +141,7 @@ func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 		}
 
 		log.Info("Deleting pods", "namespace", cluster.Namespace, "cluster", cluster.Name, "zone", zone, "count", len(zoneInstances))
-		r.Recorder.Event(cluster, "Normal", "UpdatingPods", fmt.Sprintf("Recreating pods in zone %s", zone))
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpdatingPods", fmt.Sprintf("Recreating pods in zone %s", zone))
 
 		err = r.PodLifecycleManager.UpdatePods(r, context, cluster, zoneInstances)
 		if err != nil {

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 )
 
@@ -72,7 +74,7 @@ func (u UpdateSidecarVersions) Reconcile(r *FoundationDBClusterReconciler, conte
 		}
 	}
 	if upgraded {
-		r.Recorder.Event(cluster, "Normal", "SidecarUpgraded", fmt.Sprintf("New version: %s", cluster.Spec.Version))
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "SidecarUpgraded", fmt.Sprintf("New version: %s", cluster.Spec.Version))
 	}
 	return true, nil
 }


### PR DESCRIPTION
Makes use of the `corev1.EventType` and fixed the wrong `error` event.

Before:

```bash
Events:
  Type    Reason           Age   From                            Message
  ----    ------           ----  ----                            -------
  Normal  AddingProcesses  38s   foundationdbcluster-controller  Adding 4 storage processes
  Normal  AddingProcesses  38s   foundationdbcluster-controller  Adding 4 log processes
  Normal  AddingProcesses  38s   foundationdbcluster-controller  Adding 1 cluster_controller processes
```

After:

```bash
  Type     Reason           Age               From                            Message
  ----     ------           ----              ----                            -------
  Normal   AddingProcesses  3m15s             foundationdbcluster-controller  Adding 4 storage processes
  Normal   AddingProcesses  3m15s             foundationdbcluster-controller  Adding 4 log processes
  Normal   AddingProcesses  3m15s             foundationdbcluster-controller  Adding 1 cluster_controller processes
  Warning  GetPod           4s (x11 over 9s)  foundationdbcluster-controller  failed to get the PodSpec for cluster_controller/1 with error: image should not contain a tag but contains the tag "6.3.11", please remove the tag
```

The `error` event was just ignored (fun fact no error message in the controller logs).