### PR TITLE
Ignore removed processes for bounce

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -554,10 +554,14 @@ func CreateProcessCountsFromProcessGroupStatus(processGroupStatus []*ProcessGrou
 }
 
 // FilterByCondition returns a string slice of all ProcessGroupIDs that contains a condition with the given type.
-func FilterByCondition(processGroupStatus []*ProcessGroupStatus, conditionType ProcessGroupConditionType) []string {
+func FilterByCondition(processGroupStatus []*ProcessGroupStatus, conditionType ProcessGroupConditionType, ignoreRemoved bool) []string {
 	result := make([]string, 0)
 
 	for _, groupStatus := range processGroupStatus {
+		if ignoreRemoved && groupStatus.Remove {
+			continue
+		}
+
 		for _, condition := range groupStatus.ProcessGroupConditions {
 			if condition.ProcessGroupConditionType != conditionType {
 				continue

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -59,7 +59,7 @@ func (b BounceProcesses) Reconcile(r *FoundationDBClusterReconciler, context ctx
 		}
 	}
 
-	processesToBounce := fdbtypes.FilterByCondition(cluster.Status.ProcessGroups, fdbtypes.IncorrectCommandLine)
+	processesToBounce := fdbtypes.FilterByCondition(cluster.Status.ProcessGroups, fdbtypes.IncorrectCommandLine, true)
 	addresses := make([]string, 0, len(processesToBounce))
 
 	for _, process := range processesToBounce {

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -238,8 +238,8 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				desiredCounts, err := cluster.GetProcessCountsWithDefaults()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(processCounts).To(Equal(desiredCounts))
-				Expect(len(fdbtypes.FilterByCondition(cluster.Status.ProcessGroups, fdbtypes.IncorrectCommandLine))).To(Equal(0))
-				Expect(len(fdbtypes.FilterByCondition(cluster.Status.ProcessGroups, fdbtypes.MissingProcesses))).To(Equal(0))
+				Expect(len(fdbtypes.FilterByCondition(cluster.Status.ProcessGroups, fdbtypes.IncorrectCommandLine, false))).To(Equal(0))
+				Expect(len(fdbtypes.FilterByCondition(cluster.Status.ProcessGroups, fdbtypes.MissingProcesses, false))).To(Equal(0))
 
 				status, err := adminClient.GetStatus()
 				Expect(err).NotTo(HaveOccurred())

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -305,7 +305,6 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 	sort.Ints(status.StorageServersPerDisk)
 
 	originalStatus := cluster.Status.DeepCopy()
-
 	// Sort ProcessGroups by ProcessGroupID otherwise this can result in an endless loop when the
 	// order changes.
 	sort.SliceStable(status.ProcessGroups, func(i, j int) bool {

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -216,7 +216,7 @@ var _ = Describe("update_status", func() {
 				processGroupStatus, err := validateInstances(clusterReconciler, context.TODO(), cluster, &cluster.Status, processMap, instances, configMap)
 				Expect(err).NotTo(HaveOccurred())
 
-				missingProcesses := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.MissingPod)
+				missingProcesses := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.MissingPod, false)
 				Expect(missingProcesses).To(Equal([]string{"storage-1"}))
 
 				Expect(len(processGroupStatus)).To(BeNumerically(">", 4))
@@ -235,7 +235,7 @@ var _ = Describe("update_status", func() {
 				processGroupStatus, err := validateInstances(clusterReconciler, context.TODO(), cluster, &cluster.Status, processMap, instances, configMap)
 				Expect(err).NotTo(HaveOccurred())
 
-				incorrectProcesses := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.IncorrectCommandLine)
+				incorrectProcesses := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.IncorrectCommandLine, false)
 				Expect(incorrectProcesses).To(Equal([]string{"storage-1"}))
 
 				Expect(len(processGroupStatus)).To(BeNumerically(">", 4))
@@ -254,7 +254,7 @@ var _ = Describe("update_status", func() {
 				processGroupStatus, err := validateInstances(clusterReconciler, context.TODO(), cluster, &cluster.Status, processMap, instances, configMap)
 				Expect(err).NotTo(HaveOccurred())
 
-				missingProcesses := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.MissingProcesses)
+				missingProcesses := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.MissingProcesses, false)
 				Expect(missingProcesses).To(Equal([]string{"storage-1"}))
 
 				Expect(len(processGroupStatus)).To(BeNumerically(">", 4))
@@ -273,7 +273,7 @@ var _ = Describe("update_status", func() {
 				processGroupStatus, err := validateInstances(clusterReconciler, context.TODO(), cluster, &cluster.Status, processMap, instances, configMap)
 				Expect(err).NotTo(HaveOccurred())
 
-				incorrectPods := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.IncorrectPodSpec)
+				incorrectPods := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.IncorrectPodSpec, false)
 				Expect(incorrectPods).To(Equal([]string{"storage-1"}))
 
 				Expect(len(processGroupStatus)).To(BeNumerically(">", 4))
@@ -292,7 +292,7 @@ var _ = Describe("update_status", func() {
 				processGroupStatus, err := validateInstances(clusterReconciler, context.TODO(), cluster, &cluster.Status, processMap, instances, configMap)
 				Expect(err).NotTo(HaveOccurred())
 
-				failingPods := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.PodFailing)
+				failingPods := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.PodFailing, false)
 				Expect(failingPods).To(Equal([]string{"storage-1"}))
 
 				Expect(len(processGroupStatus)).To(BeNumerically(">", 4))
@@ -311,7 +311,7 @@ var _ = Describe("update_status", func() {
 				processGroupStatus, err := validateInstances(clusterReconciler, context.TODO(), cluster, &cluster.Status, processMap, instances, configMap)
 				Expect(err).NotTo(HaveOccurred())
 
-				failingPods := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.PodFailing)
+				failingPods := fdbtypes.FilterByCondition(processGroupStatus, fdbtypes.PodFailing, false)
 				Expect(failingPods).To(Equal([]string{"storage-1"}))
 
 				Expect(len(processGroupStatus)).To(BeNumerically(">", 4))


### PR DESCRIPTION
We can ignore processes that are marked for removal during the bounce.