### PR TITLE
Remove Pods before running the bounce command

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -152,10 +152,10 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 		ExcludeInstances{},
 		ChangeCoordinators{},
 		ConfirmExclusionCompletion{},
+		RemovePods{},
 		BounceProcesses{},
 		UpdatePods{},
 		RemoveServices{},
-		RemovePods{},
 		UpdateStatus{},
 	}
 


### PR DESCRIPTION
Otherwise the waiting for a bounce can block the deletion of Pods.