### PR TITLE
When configuring sidecar, use the version number in cluster Status.Ru…

### DIFF
--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 	"time"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
@@ -599,8 +598,7 @@ func validateInstance(r *FoundationDBClusterReconciler, context ctx.Context, clu
 	var needsSidecarConfInConfigMap bool
 	for _, container := range instance.Pod.Spec.Containers {
 		if container.Name == "foundationdb" {
-			image := strings.Split(container.Image, ":")
-			version, err := fdbtypes.ParseFdbVersion(image[len(image)-1])
+			version, err := fdbtypes.ParseFdbVersion(cluster.Status.RunningVersion)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
…nningVersion instead of trying to parse it from the foundationdb image name

I confirmed that (at least in the scenario I tested), the cluster status version is populated before this is called.