### PR TITLE
Pull the FDB binaries for the operator from init containers to decouple FDB versions and operator versions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,15 @@ COPY foundationdb-kubernetes-sidecar/website/ /mnt/website/
 RUN set -eux && \
 	curl --fail ${FDB_WEBSITE}/downloads/${FDB_VERSION}/ubuntu/installers/foundationdb-clients_${FDB_VERSION}-1_amd64.deb -o fdb.deb && \
 	dpkg -i fdb.deb && rm fdb.deb && \
+	curl --fail $FDB_WEBSITE/downloads/$FDB_VERSION/linux/fdb_$FDB_VERSION.tar.gz -o fdb_$FDB_VERSION.tar.gz && \
+	tar -xzf fdb_$FDB_VERSION.tar.gz --strip-components=1 && \
+	rm fdb_$FDB_VERSION.tar.gz && \
+	chmod u+x fdbbackup fdbcli fdbdr fdbmonitor fdbrestore fdbserver backup_agent dr_agent && \
+	mkdir -p /usr/bin/fdb/${FDB_VERSION%.*} && \
+	mv fdbbackup fdbcli fdbdr fdbmonitor fdbrestore fdbserver backup_agent dr_agent /usr/bin/fdb/${FDB_VERSION%.*} && \
 	mkdir -p /usr/lib/fdb
+
+# TODO: Remove the behavior of copying binaries from the FDB images as part of the 1.0 release of the operator.
 
 # Copy 6.2 binaries
 COPY --from=fdb62 /usr/bin/fdb* /usr/bin/fdb/6.2/

--- a/api/v1beta1/foundationdb_version.go
+++ b/api/v1beta1/foundationdb_version.go
@@ -41,6 +41,7 @@ type FdbVersion struct {
 	Patch int
 }
 
+// FDBVersionRegex describes the format of a FoundationDB version.
 var FDBVersionRegex = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)$`)
 
 // ParseFdbVersion parses a version from its string representation.

--- a/api/v1beta1/foundationdb_version.go
+++ b/api/v1beta1/foundationdb_version.go
@@ -41,11 +41,11 @@ type FdbVersion struct {
 	Patch int
 }
 
-var fdbVersionRegex = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)$`)
+var FDBVersionRegex = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)$`)
 
 // ParseFdbVersion parses a version from its string representation.
 func ParseFdbVersion(version string) (FdbVersion, error) {
-	matches := fdbVersionRegex.FindStringSubmatch(version)
+	matches := FDBVersionRegex.FindStringSubmatch(version)
 	if matches == nil {
 		return FdbVersion{}, fmt.Errorf("could not parse FDB version from %s", version)
 	}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,12 +16,67 @@ spec:
         control-plane: controller-manager
         app: fdb-kubernetes-operator-controller-manager
     spec:
+      initContainers:
+        - name: foundationdb-kubernetes-init-6-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:6.1.13-1
+          args:
+            - "--copy-library"
+            - "6.1"
+            - "--copy-binary"
+            - "fdbcli"
+            - "--copy-binary"
+            - "fdbbackup"
+            - "--copy-binary"
+            - "fdbrestore"
+            - "--output-dir"
+            - "/var/output-files/6.1.12"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
+        - name: foundationdb-kubernetes-init-6-2
+          image: foundationdb/foundationdb-kubernetes-sidecar:6.2.30-1
+          args:
+            - "--copy-library"
+            - "6.2"
+            - "--copy-binary"
+            - "fdbcli"
+            - "--copy-binary"
+            - "fdbbackup"
+            - "--copy-binary"
+            - "fdbrestore"
+            - "--output-dir"
+            - "/var/output-files/6.2.30"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
+        - name: foundationdb-kubernetes-init-6-3
+          image: foundationdb/foundationdb-kubernetes-sidecar:6.3.10-1
+          args:
+            - "--copy-library"
+            - "6.3"
+            - "--copy-binary"
+            - "fdbcli"
+            - "--copy-binary"
+            - "fdbbackup"
+            - "--copy-binary"
+            - "fdbrestore"
+            - "--output-dir"
+            - "/var/output-files/6.3.10"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
       containers:
       - command:
         - /manager
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager
+        env:
+          - name: FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY
+            value: /usr/bin/fdb
         ports:
           - name: metrics
             containerPort: 8080
@@ -41,6 +96,8 @@ spec:
             mountPath: /tmp
           - name: logs
             mountPath: /var/log/fdb
+          - name: fdb-binaries
+            mountPath: /usr/bin/fdb
       terminationGracePeriodSeconds: 10
       securityContext:
         runAsUser: 4059
@@ -50,4 +107,6 @@ spec:
         - name: tmp
           emptyDir: {}
         - name: logs
+          emptyDir: {}
+        - name: fdb-binaries
           emptyDir: {}

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -123,6 +123,8 @@ spec:
       - command:
         - /manager
         env:
+        - name: FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY
+          value: /usr/bin/fdb
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
@@ -148,6 +150,60 @@ spec:
           name: tmp
         - mountPath: /var/log/fdb
           name: logs
+        - mountPath: /usr/bin/fdb
+          name: fdb-binaries
+      initContainers:
+      - args:
+        - --copy-library
+        - "6.1"
+        - --copy-binary
+        - fdbcli
+        - --copy-binary
+        - fdbbackup
+        - --copy-binary
+        - fdbrestore
+        - --output-dir
+        - /var/output-files/6.1.12
+        - --init-mode
+        image: foundationdb/foundationdb-kubernetes-sidecar:6.1.13-1
+        name: foundationdb-kubernetes-init-6-1
+        volumeMounts:
+        - mountPath: /var/output-files
+          name: fdb-binaries
+      - args:
+        - --copy-library
+        - "6.2"
+        - --copy-binary
+        - fdbcli
+        - --copy-binary
+        - fdbbackup
+        - --copy-binary
+        - fdbrestore
+        - --output-dir
+        - /var/output-files/6.2.30
+        - --init-mode
+        image: foundationdb/foundationdb-kubernetes-sidecar:6.2.30-1
+        name: foundationdb-kubernetes-init-6-2
+        volumeMounts:
+        - mountPath: /var/output-files
+          name: fdb-binaries
+      - args:
+        - --copy-library
+        - "6.3"
+        - --copy-binary
+        - fdbcli
+        - --copy-binary
+        - fdbbackup
+        - --copy-binary
+        - fdbrestore
+        - --output-dir
+        - /var/output-files/6.3.10
+        - --init-mode
+        image: foundationdb/foundationdb-kubernetes-sidecar:6.3.10-1
+        name: foundationdb-kubernetes-init-6-3
+        volumeMounts:
+        - mountPath: /var/output-files
+          name: fdb-binaries
       securityContext:
         fsGroup: 4059
         runAsGroup: 4059
@@ -159,3 +215,5 @@ spec:
         name: tmp
       - emptyDir: {}
         name: logs
+      - emptyDir: {}
+        name: fdb-binaries

--- a/config/samples/deployment/manager.yaml
+++ b/config/samples/deployment/manager.yaml
@@ -25,13 +25,69 @@ spec:
         emptyDir: {}
       - name: logs
         emptyDir: {}
+      - name: fdb-binaries
+        emptyDir: {}
       serviceAccountName: fdb-kubernetes-operator-controller-manager
+      initContainers:
+        - name: foundationdb-kubernetes-init-6-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:6.1.13-1
+          args:
+            - "--copy-library"
+            - "6.1"
+            - "--copy-binary"
+            - "fdbcli"
+            - "--copy-binary"
+            - "fdbbackup"
+            - "--copy-binary"
+            - "fdbrestore"
+            - "--output-dir"
+            - "/var/output-files/6.1.12"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
+        - name: foundationdb-kubernetes-init-6-2
+          image: foundationdb/foundationdb-kubernetes-sidecar:6.2.30-1
+          args:
+            - "--copy-library"
+            - "6.2"
+            - "--copy-binary"
+            - "fdbcli"
+            - "--copy-binary"
+            - "fdbbackup"
+            - "--copy-binary"
+            - "fdbrestore"
+            - "--output-dir"
+            - "/var/output-files/6.2.30"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
+        - name: foundationdb-kubernetes-init-6-3
+          image: foundationdb/foundationdb-kubernetes-sidecar:6.3.10-1
+          args:
+            - "--copy-library"
+            - "6.3"
+            - "--copy-binary"
+            - "fdbcli"
+            - "--copy-binary"
+            - "fdbbackup"
+            - "--copy-binary"
+            - "fdbrestore"
+            - "--output-dir"
+            - "/var/output-files/6.3.10"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
       containers:
       - command:
         - /manager
         image: foundationdb/fdb-kubernetes-operator:v0.33.0
         name: manager
         env:
+          - name: FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY
+            value: /usr/bin/fdb
           - name: WATCH_NAMESPACE
             valueFrom:
               fieldRef:
@@ -55,6 +111,8 @@ spec:
           mountPath: /tmp
         - name: logs
           mountPath: /var/log/fdb
+        - name: fdb-binaries
+          mountPath: /usr/bin/fdb
       terminationGracePeriodSeconds: 10
 ---
 apiVersion: v1

--- a/helm/fdb-operator/templates/manager/deployment.yaml
+++ b/helm/fdb-operator/templates/manager/deployment.yaml
@@ -29,12 +29,68 @@ spec:
       - name: tmp
         emptyDir: {}
       - name: logs
-        emptyDir: {}        
+        emptyDir: {}
+      - name: fdb-binaries
+        emptyDir: {}
+      initContainers:
+        - name: foundationdb-kubernetes-init-6-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:6.1.13-1
+          args:
+            - "--copy-library"
+            - "6.1"
+            - "--copy-binary"
+            - "fdbcli"
+            - "--copy-binary"
+            - "fdbbackup"
+            - "--copy-binary"
+            - "fdbrestore"
+            - "--output-dir"
+            - "/var/output-files/6.1.12"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
+        - name: foundationdb-kubernetes-init-6-2
+          image: foundationdb/foundationdb-kubernetes-sidecar:6.2.30-1
+          args:
+            - "--copy-library"
+            - "6.2"
+            - "--copy-binary"
+            - "fdbcli"
+            - "--copy-binary"
+            - "fdbbackup"
+            - "--copy-binary"
+            - "fdbrestore"
+            - "--output-dir"
+            - "/var/output-files/6.2.30"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
+        - name: foundationdb-kubernetes-init-6-3
+          image: foundationdb/foundationdb-kubernetes-sidecar:6.3.10-1
+          args:
+            - "--copy-library"
+            - "6.3"
+            - "--copy-binary"
+            - "fdbcli"
+            - "--copy-binary"
+            - "fdbbackup"
+            - "--copy-binary"
+            - "fdbrestore"
+            - "--output-dir"
+            - "/var/output-files/6.3.10"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
       containers:
       - command:
         - /manager
-        {{- if not .Values.operator.globalMode.enabled }}
         env:
+        - name: FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY
+          value: /usr/bin/fdb
+        {{- if not .Values.operator.globalMode.enabled }}
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
@@ -49,7 +105,9 @@ spec:
         - name: tmp
           mountPath: /tmp
         - name: logs
-          mountPath: /var/log/fdb   
+          mountPath: /var/log/fdb
+        - name: fdb-binaries
+          mountPath: /usr/bin/fdb
         resources:
           limits:
             cpu: 500m

--- a/main.go
+++ b/main.go
@@ -196,7 +196,10 @@ func MoveFDBBinaries() error {
 			}
 			if err == nil {
 				minorVersionPath := path.Join(binFile.Name(), fmt.Sprintf("%d.%d", version.Major, version.Minor))
-				os.MkdirAll(minorVersionPath, os.ModeDir|os.ModePerm)
+				err = os.MkdirAll(minorVersionPath, os.ModeDir|os.ModePerm)
+				if err != nil {
+					return err
+				}
 
 				versionBinDir, err := versionBinFile.Readdir(0)
 				if err != nil {


### PR DESCRIPTION
Resolves #610 