### PR TITLE
Reset the args to prevent test failure

### DIFF
--- a/kubectl-fdb/cmd/root_test.go
+++ b/kubectl-fdb/cmd/root_test.go
@@ -43,6 +43,7 @@ var _ = Describe("[plugin] root command", func() {
 
 		It("should not throw an error", func() {
 			cmd := NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer})
+			cmd.SetArgs([]string{})
 			Expect(cmd.Execute()).NotTo(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/648

Interestingly the args passed to the framework will be passed to the `cmd` if we don't overwrite it 🤔 