### PR TITLE
Ignore process groups without an address

### DIFF
--- a/controllers/replace_failed_pods.go
+++ b/controllers/replace_failed_pods.go
@@ -63,6 +63,11 @@ func chooseNewRemovals(cluster *fdbtypes.FoundationDBCluster) bool {
 	for _, processGroupStatus := range cluster.Status.ProcessGroups {
 		needsReplacement, missingTime := processGroupStatus.NeedsReplacement(*cluster.Spec.AutomationOptions.Replacements.FailureDetectionTimeSeconds)
 		if needsReplacement && *cluster.Spec.AutomationOptions.Replacements.Enabled {
+			if len(processGroupStatus.Addresses) == 0 {
+				log.Info("Ignore failed process group with missing address", "namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", processGroupStatus.ProcessGroupID, "failureTime", missingTime)
+				continue
+			}
+
 			log.Info("Replacing failed process group", "namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", processGroupStatus.ProcessGroupID, "failureTime", missingTime)
 			processGroupStatus.Remove = true
 			return true

--- a/controllers/replace_failed_pods_test.go
+++ b/controllers/replace_failed_pods_test.go
@@ -130,6 +130,21 @@ var _ = Describe("replace_failed_pods", func() {
 					Expect(getRemovedProcessGroupIDs(cluster)).To(Equal([]string{"storage-2", "storage-3"}))
 				})
 			})
+
+			Context("with no addresses", func() {
+				BeforeEach(func() {
+					processGroup := fdbtypes.FindProcessGroupByID(cluster.Status.ProcessGroups, "storage-2")
+					processGroup.Addresses = []string{}
+				})
+
+				It("should return false", func() {
+					Expect(result).To(BeFalse())
+				})
+
+				It("should not mark the process group for removal", func() {
+					Expect(getRemovedProcessGroupIDs(cluster)).To(Equal([]string{}))
+				})
+			})
 		})
 
 		Context("with a process that has been missing for a brief time", func() {


### PR DESCRIPTION
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/640 for now we just ignore process groups without an address.