### PR TITLE
Calculate ConfigMap hash based on process class and servers per pod

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2273,7 +2273,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				expectedConf, err := GetMonitorConf(cluster, fdbtypes.ProcessClassStorage, nil, 1)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(configMap.Data[clusterFile]).To(Equal("operator-test:asdfasf@127.0.0.1:4501"))
+				Expect(configMap.Data[clusterFileKey]).To(Equal("operator-test:asdfasf@127.0.0.1:4501"))
 				Expect(configMap.Data["fdbmonitor-conf-storage"]).To(Equal(expectedConf))
 				Expect(configMap.Data["running-version"]).To(Equal(Versions.Default.String()))
 				Expect(configMap.Data["sidecar-conf"]).To(Equal(""))
@@ -2357,7 +2357,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			})
 
 			It("should empty the monitor conf and cluster file", func() {
-				Expect(configMap.Data[clusterFile]).To(Equal(""))
+				Expect(configMap.Data[clusterFileKey]).To(Equal(""))
 				Expect(configMap.Data["fdbmonitor-conf-storage"]).To(Equal(""))
 			})
 		})

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -177,10 +177,10 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 					fdbtypes.ProcessClassClusterController: 1,
 				}))
 
-				configMapHash, err := GetConfigMapHash(cluster)
+				pod := &pods.Items[0]
+				configMapHash, err := getConfigMapHash(cluster, GetProcessClassFromMeta(pod.ObjectMeta), pod)
 				Expect(err).NotTo(HaveOccurred())
-
-				Expect(pods.Items[0].ObjectMeta.Annotations[fdbtypes.LastConfigMapKey]).To(Equal(configMapHash))
+				Expect(pod.ObjectMeta.Annotations[fdbtypes.LastConfigMapKey]).To(Equal(configMapHash))
 				Expect(len(cluster.Status.ProcessGroups)).To(Equal(len(pods.Items)))
 			})
 
@@ -1014,7 +1014,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 					err = k8sClient.Update(context.TODO(), cluster)
 
 					result, err := reconcileCluster(cluster)
-					Expect(err).NotTo((HaveOccurred()))
+					Expect(err).NotTo(HaveOccurred())
 					Expect(result.Requeue).To(BeFalse())
 
 					generation, err := reloadCluster(cluster)
@@ -1230,9 +1230,8 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 					hash, err := GetPodSpecHash(cluster, processClassFromLabels(item.Labels), id, nil)
 					Expect(err).NotTo(HaveOccurred())
 
-					configMapHash, err := GetConfigMapHash(cluster)
+					configMapHash, err := getConfigMapHash(cluster, GetProcessClassFromMeta(item.ObjectMeta), &item)
 					Expect(err).NotTo(HaveOccurred())
-
 					if item.Labels[fdbtypes.FDBInstanceIDLabel] == "storage-1" {
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
 							"foundationdb.org/last-applied-config-map": configMapHash,
@@ -1370,9 +1369,8 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 						hash, err := GetPodSpecHash(cluster, processClassFromLabels(item.Labels), id, nil)
 						Expect(err).NotTo(HaveOccurred())
 
-						configMapHash, err := GetConfigMapHash(cluster)
+						configMapHash, err := getConfigMapHash(cluster, GetProcessClassFromMeta(item.ObjectMeta), &item)
 						Expect(err).NotTo(HaveOccurred())
-
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
 							"foundationdb.org/last-applied-config-map": configMapHash,
 							"foundationdb.org/last-applied-spec":       hash,
@@ -1479,9 +1477,8 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 					hash, err := GetPodSpecHash(cluster, processClassFromLabels(item.Labels), id, nil)
 					Expect(err).NotTo(HaveOccurred())
 
-					configMapHash, err := GetConfigMapHash(cluster)
+					configMapHash, err := getConfigMapHash(cluster, GetProcessClassFromMeta(item.ObjectMeta), &item)
 					Expect(err).NotTo(HaveOccurred())
-
 					Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
 						"foundationdb.org/last-applied-config-map": configMapHash,
 						"foundationdb.org/last-applied-spec":       hash,
@@ -2276,7 +2273,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				expectedConf, err := GetMonitorConf(cluster, fdbtypes.ProcessClassStorage, nil, 1)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(configMap.Data["cluster-file"]).To(Equal("operator-test:asdfasf@127.0.0.1:4501"))
+				Expect(configMap.Data[clusterFile]).To(Equal("operator-test:asdfasf@127.0.0.1:4501"))
 				Expect(configMap.Data["fdbmonitor-conf-storage"]).To(Equal(expectedConf))
 				Expect(configMap.Data["running-version"]).To(Equal(Versions.Default.String()))
 				Expect(configMap.Data["sidecar-conf"]).To(Equal(""))
@@ -2360,7 +2357,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			})
 
 			It("should empty the monitor conf and cluster file", func() {
-				Expect(configMap.Data["cluster-file"]).To(Equal(""))
+				Expect(configMap.Data[clusterFile]).To(Equal(""))
 				Expect(configMap.Data["fdbmonitor-conf-storage"]).To(Equal(""))
 			})
 		})
@@ -3484,4 +3481,19 @@ func getProcessClassMap(pods []corev1.Pod) map[fdbtypes.ProcessClass]int {
 		counts[ProcessClass]++
 	}
 	return counts
+}
+
+// getConfigMapHash gets the hash of the data for a cluster's dynamic config.
+func getConfigMapHash(cluster *fdbtypes.FoundationDBCluster, pClass fdbtypes.ProcessClass, pod *corev1.Pod) (string, error) {
+	configMap, err := GetConfigMap(cluster)
+	if err != nil {
+		return "", err
+	}
+
+	serversPerPod, err := getStorageServersPerPodForPod(pod)
+	if err != nil {
+		return "", err
+	}
+
+	return getDynamicConfHash(configMap, pClass, serversPerPod)
 }

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -33,7 +33,7 @@ var log = logf.Log.WithName("controller")
 var DefaultCLITimeout = 10
 
 const (
-	clusterFile = "cluster-file"
+	clusterFileKey = "cluster-file"
 )
 
 // metadataMatches determines if the current metadata on an object matches the

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -32,6 +32,10 @@ var log = logf.Log.WithName("controller")
 // DefaultCLITimeout is the default timeout for CLI commands.
 var DefaultCLITimeout = 10
 
+const (
+	clusterFile = "cluster-file"
+)
+
 // metadataMatches determines if the current metadata on an object matches the
 // metadata specified by the cluster spec.
 func metadataMatches(currentMetadata metav1.ObjectMeta, desiredMetadata metav1.ObjectMeta) bool {

--- a/controllers/pod_models.go
+++ b/controllers/pod_models.go
@@ -288,7 +288,7 @@ func GetPodSpec(cluster *fdbtypes.FoundationDBCluster, processClass fdbtypes.Pro
 
 	configMapItems := []corev1.KeyToPath{
 		{Key: monitorConf, Path: "fdbmonitor.conf"},
-		{Key: clusterFile, Path: "fdb.cluster"},
+		{Key: clusterFileKey, Path: "fdb.cluster"},
 	}
 
 	if useCustomCAs {
@@ -848,7 +848,7 @@ func GetBackupDeployment(backup *fdbtypes.FoundationDBBackup) (*appsv1.Deploymen
 			VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", backup.Spec.ClusterName)},
 				Items: []corev1.KeyToPath{
-					{Key: clusterFile, Path: "fdb.cluster"},
+					{Key: clusterFileKey, Path: "fdb.cluster"},
 				},
 			}},
 		},

--- a/controllers/pod_models.go
+++ b/controllers/pod_models.go
@@ -288,7 +288,7 @@ func GetPodSpec(cluster *fdbtypes.FoundationDBCluster, processClass fdbtypes.Pro
 
 	configMapItems := []corev1.KeyToPath{
 		{Key: monitorConf, Path: "fdbmonitor.conf"},
-		{Key: "cluster-file", Path: "fdb.cluster"},
+		{Key: clusterFile, Path: "fdb.cluster"},
 	}
 
 	if useCustomCAs {
@@ -848,7 +848,7 @@ func GetBackupDeployment(backup *fdbtypes.FoundationDBBackup) (*appsv1.Deploymen
 			VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", backup.Spec.ClusterName)},
 				Items: []corev1.KeyToPath{
-					{Key: "cluster-file", Path: "fdb.cluster"},
+					{Key: clusterFile, Path: "fdb.cluster"},
 				},
 			}},
 		},

--- a/controllers/pod_models_test.go
+++ b/controllers/pod_models_test.go
@@ -307,7 +307,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
-							{Key: clusterFile, Path: "fdb.cluster"},
+							{Key: clusterFileKey, Path: "fdb.cluster"},
 						},
 					}},
 				}))
@@ -545,7 +545,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage-density-2", Path: "fdbmonitor.conf"},
-							{Key: clusterFile, Path: "fdb.cluster"},
+							{Key: clusterFileKey, Path: "fdb.cluster"},
 						},
 					}},
 				}))
@@ -1299,7 +1299,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
-							{Key: clusterFile, Path: "fdb.cluster"},
+							{Key: clusterFileKey, Path: "fdb.cluster"},
 						},
 					}},
 				}))
@@ -1485,7 +1485,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
-							{Key: clusterFile, Path: "fdb.cluster"},
+							{Key: clusterFileKey, Path: "fdb.cluster"},
 						},
 					}},
 				}))
@@ -1547,7 +1547,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
-							{Key: clusterFile, Path: "fdb.cluster"},
+							{Key: clusterFileKey, Path: "fdb.cluster"},
 							{Key: "sidecar-conf", Path: "config.json"},
 						},
 					}},
@@ -1677,7 +1677,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
-							{Key: clusterFile, Path: "fdb.cluster"},
+							{Key: clusterFileKey, Path: "fdb.cluster"},
 							{Key: "ca-file", Path: "ca.pem"},
 						},
 					}},
@@ -2083,7 +2083,7 @@ var _ = Describe("pod_models", func() {
 						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 							Items: []corev1.KeyToPath{
-								{Key: clusterFile, Path: "fdb.cluster"},
+								{Key: clusterFileKey, Path: "fdb.cluster"},
 							},
 						}},
 					},
@@ -2198,7 +2198,7 @@ var _ = Describe("pod_models", func() {
 						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 							Items: []corev1.KeyToPath{
-								{Key: clusterFile, Path: "fdb.cluster"},
+								{Key: clusterFileKey, Path: "fdb.cluster"},
 							},
 						}},
 					},

--- a/controllers/pod_models_test.go
+++ b/controllers/pod_models_test.go
@@ -307,7 +307,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
-							{Key: "cluster-file", Path: "fdb.cluster"},
+							{Key: clusterFile, Path: "fdb.cluster"},
 						},
 					}},
 				}))
@@ -545,7 +545,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage-density-2", Path: "fdbmonitor.conf"},
-							{Key: "cluster-file", Path: "fdb.cluster"},
+							{Key: clusterFile, Path: "fdb.cluster"},
 						},
 					}},
 				}))
@@ -1299,7 +1299,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
-							{Key: "cluster-file", Path: "fdb.cluster"},
+							{Key: clusterFile, Path: "fdb.cluster"},
 						},
 					}},
 				}))
@@ -1485,7 +1485,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
-							{Key: "cluster-file", Path: "fdb.cluster"},
+							{Key: clusterFile, Path: "fdb.cluster"},
 						},
 					}},
 				}))
@@ -1547,7 +1547,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
-							{Key: "cluster-file", Path: "fdb.cluster"},
+							{Key: clusterFile, Path: "fdb.cluster"},
 							{Key: "sidecar-conf", Path: "config.json"},
 						},
 					}},
@@ -1677,7 +1677,7 @@ var _ = Describe("pod_models", func() {
 						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
-							{Key: "cluster-file", Path: "fdb.cluster"},
+							{Key: clusterFile, Path: "fdb.cluster"},
 							{Key: "ca-file", Path: "ca.pem"},
 						},
 					}},
@@ -2083,7 +2083,7 @@ var _ = Describe("pod_models", func() {
 						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 							Items: []corev1.KeyToPath{
-								{Key: "cluster-file", Path: "fdb.cluster"},
+								{Key: clusterFile, Path: "fdb.cluster"},
 							},
 						}},
 					},
@@ -2198,7 +2198,7 @@ var _ = Describe("pod_models", func() {
 						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
 							Items: []corev1.KeyToPath{
-								{Key: "cluster-file", Path: "fdb.cluster"},
+								{Key: clusterFile, Path: "fdb.cluster"},
 							},
 						}},
 					},

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -212,7 +212,7 @@ func (s UpdateStatus) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 
 	status.ConnectionString = cluster.Status.ConnectionString
 	if status.ConnectionString == "" {
-		status.ConnectionString = existingConfigMap.Data[clusterFile]
+		status.ConnectionString = existingConfigMap.Data[clusterFileKey]
 	}
 
 	if status.ConnectionString == "" {


### PR DESCRIPTION
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/377

With this change it's not that confusing why all processes must be "updated" when we change either the number of storage server per Pod or a class specific setting.