### PR TITLE
Make use of combined output

### DIFF
--- a/controllers/admin_client.go
+++ b/controllers/admin_client.go
@@ -248,7 +248,7 @@ func (client *CliAdminClient) runCommand(command cliCommand) (string, error) {
 
 	log.Info("Running command", "namespace", client.Cluster.Namespace, "cluster", client.Cluster.Name, "path", execCommand.Path, "args", execCommand.Args)
 
-	output, err := execCommand.Output()
+	output, err := execCommand.CombinedOutput()
 	if err != nil {
 		exitError, canCast := err.(*exec.ExitError)
 		if canCast {


### PR DESCRIPTION
In `fdbcli` support to output errors and warnings on stderr instead of stdout (https://github.com/apple/foundationdb/pull/4332) was added. To read all messages (stdout and stderr) we have to use `CombinedOutput` instead of `Output` only.