### PR TITLE
Add explicit schema for podTemplateSpec.metadata

### DIFF
--- a/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml
@@ -65,6 +65,23 @@ spec:
                 podTemplateSpec:
                   properties:
                     metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
                       type: object
                     spec:
                       properties:

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -1522,6 +1522,23 @@ spec:
                 podTemplate:
                   properties:
                     metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
                       type: object
                     spec:
                       properties:
@@ -4368,6 +4385,23 @@ spec:
                       podTemplate:
                         properties:
                           metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              finalizers:
+                                items:
+                                  type: string
+                                type: array
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              name:
+                                type: string
+                              namespace:
+                                type: string
                             type: object
                           spec:
                             properties:


### PR DESCRIPTION
Unknown metadata fields are pruned https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning
If you change from v1beta CRDs to v1 CRDs the metadata field is pruned and the operator believes that every podSpec is incorrect.
Related to https://github.com/kubernetes-sigs/controller-tools/issues/448