### PR TITLE
Make use of build tags to prevent running e2e tests with go test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ ifneq "$(FDB_WEBSITE)" ""
 	docker_build_args := $(docker_build_args) --build-arg FDB_WEBSITE=$(FDB_WEBSITE)
 endif
 
-ifndef RUN_E2E
-	 GINKGO_SKIP := -ginkgo.skip='^\[e2e\]'
+ifdef RUN_E2E
+	 E2E_TAG := --tags=e2e
 endif
 
 
@@ -52,14 +52,14 @@ clean:
 # Run tests
 test:
 ifneq "$(SKIP_TEST)" "1"
-	go test ${go_test_flags} ./... -coverprofile cover.out $(GINKGO_SKIP)
+	go test ${go_test_flags} ./... -coverprofile cover.out $(E2E_TAG)
 endif
 
 test_if_changed: cover.out
 
 cover.out: ${GO_ALL} ${MANIFESTS}
 ifneq "$(SKIP_TEST)" "1"
-	go test ${go_test_flags} ./... -coverprofile cover.out -tags test $(GINKGO_SKIP)
+	go test ${go_test_flags} ./... -coverprofile cover.out -tags test $(E2E_TAG)
 endif
 
 # Build manager binary

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 package e2e
 
 import (


### PR DESCRIPTION
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/685 CC: @rbtcollins  