### PR TITLE
Refactor sidecar

### DIFF
--- a/foundationdb-kubernetes-sidecar/sidecar.py
+++ b/foundationdb-kubernetes-sidecar/sidecar.py
@@ -35,9 +35,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from http.server import HTTPServer, BaseHTTPRequestHandler
-from socketserver import ThreadingMixIn
-import threading
+from http.server import HTTPServer, ThreadingHTTPServer, BaseHTTPRequestHandler
 
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
@@ -309,10 +307,6 @@ class Config(object):
         )
 
 
-class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
-    """Handle requests in a separate thread."""
-
-
 class Server(BaseHTTPRequestHandler):
     ssl_context = None
 
@@ -324,7 +318,7 @@ class Server(BaseHTTPRequestHandler):
         config = Config.shared()
         (address, port) = config.bind_address.split(":")
         log.info(f"Listening on {address}:{port}")
-        server = ThreadedHTTPServer((address, int(port)), cls)
+        server = ThreadingHTTPServer((address, int(port)), cls)
 
         if config.enable_tls:
             context = Server.load_ssl_context()
@@ -644,5 +638,7 @@ if __name__ == "__main__":
     copy_libraries()
     copy_monitor_conf()
 
-    if not Config.shared().init_mode:
-        Server.start()
+    if Config.shared().init_mode:
+        sys.exit(0)
+
+    Server.start()

--- a/foundationdb-kubernetes-sidecar/sidecar.py
+++ b/foundationdb-kubernetes-sidecar/sidecar.py
@@ -487,17 +487,8 @@ class Server(http.server.BaseHTTPRequestHandler):
                 return
             if self.path == "/copy_files":
                 self.send_text(copy_files())
-            elif self.path == "/copy_binaries":
-                self.send_text(copy_binaries())
-            elif self.path == "/copy_libraries":
-                self.send_text(copy_libraries())
             elif self.path == "/copy_monitor_conf":
                 self.send_text(copy_monitor_conf())
-            elif self.path == "/refresh_certs":
-                self.send_text(refresh_certs())
-            elif self.path == "/restart":
-                self.send_text("OK")
-                exit(1)
             else:
                 self.send_error(404, "Path not found")
                 self.end_headers()


### PR DESCRIPTION
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/563
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/683

I added threading to the sidecar and removed the client auth for the `ready` endpoint, that will allow us to actually use a HTTP probe instead of an TCP probe.