### PR TITLE
Apply an annotation when we see an out-of-date config map.

### DIFF
--- a/api/v1beta1/foundationdb_labels.go
+++ b/api/v1beta1/foundationdb_labels.go
@@ -29,6 +29,10 @@ const (
 	// config map.
 	LastConfigMapKey = "foundationdb.org/last-applied-config-map"
 
+	// OutdatedConfigMapKey provides the annotation name we use to store the
+	// timestamp when we saw an outdated config map.
+	OutdatedConfigMapKey = "foundationdb.org/outdated-config-map-seen"
+
 	// BackupDeploymentLabel provides the label we use to connect backup
 	// deployments to a cluster.
 	BackupDeploymentLabel = "foundationdb.org/backup-for"

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -71,7 +71,7 @@ func (u UpdatePodConfig) Reconcile(r *FoundationDBClusterReconciler, context ctx
 			err = r.PodLifecycleManager.UpdateMetadata(r, context, cluster, instance)
 			if err != nil {
 				allSynced = false
-				log.Info("Update Pod metadata", "namespace", configMap.Namespace, "cluster", cluster.Name, "processGroupID", instance.GetInstanceID(), "error", err)
+				log.Info("Update Pod ConfigMap annotation", "namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", instance.GetInstanceID(), "error", err)
 			}
 			continue
 		}

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -66,10 +66,18 @@ func (u UpdatePodConfig) Reconcile(r *FoundationDBClusterReconciler, context ctx
 		if !synced {
 			allSynced = false
 			log.Info("Update dynamic Pod config", "namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", instance.GetInstanceID(), "synced", synced, "error", err)
+
+			instance.Metadata.Annotations[fdbtypes.OutdatedConfigMapKey] = time.Now().Format(time.RFC3339)
+			err = r.PodLifecycleManager.UpdateMetadata(r, context, cluster, instance)
+			if err != nil {
+				allSynced = false
+				log.Info("Update Pod metadata", "namespace", configMap.Namespace, "cluster", cluster.Name, "processGroupID", instance.GetInstanceID(), "error", err)
+			}
 			continue
 		}
 
 		instance.Metadata.Annotations[fdbtypes.LastConfigMapKey] = configMapHash
+		delete(instance.Metadata.Annotations, fdbtypes.OutdatedConfigMapKey)
 		err = r.PodLifecycleManager.UpdateMetadata(r, context, cluster, instance)
 		if err != nil {
 			allSynced = false


### PR DESCRIPTION
Resolves #731

I did a test run of this locally, and it reduced the initial cluster creation time from 115 seconds to 40 seconds.