### PR TITLE
Show available instead of healthy in the kubectl get command

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -37,7 +37,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Generation",type="integer",JSONPath=".metadata.generation",description="Latest generation of the spec",priority=0
 // +kubebuilder:printcolumn:name="Reconciled",type="integer",JSONPath=".status.generations.reconciled",description="Last reconciled generation of the spec",priority=0
-// +kubebuilder:printcolumn:name="Healthy",type="boolean",JSONPath=".status.health.healthy",description="Database health",priority=0
+// +kubebuilder:printcolumn:name="Available",type="boolean",JSONPath=".status.health.available",description="Database available",priority=0
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.runningVersion",description="Running version",priority=0
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -25,9 +25,9 @@ spec:
           jsonPath: .status.generations.reconciled
           name: Reconciled
           type: integer
-        - description: Database health
-          jsonPath: .status.health.healthy
-          name: Healthy
+        - description: Database available
+          jsonPath: .status.health.available
+          name: Available
           type: boolean
         - description: Running version
           jsonPath: .status.runningVersion


### PR DESCRIPTION
I think the healthy output is too flaky to be useful.