### PR TITLE
Only reconcile on generation or annotation change

### DIFF
--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
 	"golang.org/x/net/context"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
@@ -142,6 +144,8 @@ func (r *FoundationDBBackupReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fdbtypes.FoundationDBBackup{}).
 		Owns(&appsv1.Deployment{}).
+		// Only react on generation changes or annotation changes
+		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
 		Complete(r)
 }
 

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -120,7 +120,11 @@ func (b BounceProcesses) Reconcile(r *FoundationDBClusterReconciler, context ctx
 				log.Error(err, "Error updating cluster status", "namespace", cluster.Namespace, "cluster", cluster.Name)
 			}
 
-			return false, ReconciliationNotReadyError{message: "Cluster needs to stabilize before bouncing"}
+			// Retry after we waited the minimum uptime
+			return false, ReconciliationNotReadyError{
+				message:      "Cluster needs to stabilize before bouncing",
+				retryable:    true,
+				requeueAfter: time.Second * time.Duration(cluster.Spec.MinimumUptimeSecondsForBounce-int(minimumUptime))}
 		}
 
 		var lockClient LockClient

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -53,7 +53,7 @@ func (g GenerateInitialClusterFile) Reconcile(r *FoundationDBClusterReconciler, 
 
 	count := cluster.DesiredCoordinatorCount()
 	if len(instances) < count {
-		return false, errors.New("Cannot find enough pods to recruit coordinators")
+		return false, errors.New("cannot find enough pods to recruit coordinators")
 	}
 
 	var clusterName string
@@ -104,5 +104,5 @@ func (g GenerateInitialClusterFile) Reconcile(r *FoundationDBClusterReconciler, 
 // RequeueAfter returns the delay before we should run the reconciliation
 // again.
 func (g GenerateInitialClusterFile) RequeueAfter() time.Duration {
-	return 0
+	return 5 * time.Second
 }

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
 	"golang.org/x/net/context"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
@@ -121,6 +123,8 @@ func (r *FoundationDBRestoreReconciler) AdminClientForRestore(context ctx.Contex
 func (r *FoundationDBRestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fdbtypes.FoundationDBRestore{}).
+		// Only react on generation changes or annotation changes
+		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
 		Complete(r)
 }
 


### PR DESCRIPTION
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/569
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/360

I noticed I got that change on my machine and never pushed it 🤦 I tested that adding/changing the annotation triggers a reconciliation as well a deleting a Pod or changing a Pod annotation.