### PR TITLE
Fallback to Pod IP and not to the machine ID

### DIFF
--- a/foundationdb-kubernetes-sidecar/sidecar.py
+++ b/foundationdb-kubernetes-sidecar/sidecar.py
@@ -227,7 +227,7 @@ class Config(object):
         if self.substitutions["FDB_PUBLIC_IP"] == "":
             # As long as the public IP is not set fallback to the
             # Pod IP address.
-            pod_ip = os.getenv('FDB_POD_IP')
+            pod_ip = os.getenv("FDB_POD_IP")
             if pod_ip is none:
                 pod_ip = socket.gethostbyname(socket.gethostname())
             self.substitutions["FDB_PUBLIC_IP"] = pod_ip

--- a/foundationdb-kubernetes-sidecar/sidecar.py
+++ b/foundationdb-kubernetes-sidecar/sidecar.py
@@ -225,13 +225,12 @@ class Config(object):
         if self.substitutions["FDB_ZONE_ID"] == "":
             self.substitutions["FDB_ZONE_ID"] = self.substitutions["FDB_MACHINE_ID"]
         if self.substitutions["FDB_PUBLIC_IP"] == "":
-            address_info = socket.getaddrinfo(
-                self.substitutions["FDB_MACHINE_ID"],
-                4500,
-                family=socket.AddressFamily.AF_INET,
-            )
-            if len(address_info) > 0:
-                self.substitutions["FDB_PUBLIC_IP"] = address_info[0][4][0]
+            # As long as the public IP is not set fallback to the
+            # Pod IP address.
+            pod_ip = os.getenv('FDB_POD_IP')
+            if pod_ip is none:
+                pod_ip = socket.gethostbyname(socket.gethostname())
+            self.substitutions["FDB_PUBLIC_IP"] = pod_ip
 
         if self.main_container_version == self.primary_version:
             self.substitutions["BINARY_DIR"] = "/usr/bin"


### PR DESCRIPTION
I ran into the following error where `FDB_MACHINE_ID` pointed to the node name and obviously on the node itself no FDB process was running. Instead of using the `getaddrinfo` we should just fallback to the `FDB_POD_IP` variable or the IP in the container (should be the same).

```bash
Traceback (most recent call last):
  File "//sidecar.py", line 662, in <module>
    copy_files()
  File "//sidecar.py", line 556, in copy_files
    config = Config.shared()
  File "//sidecar.py", line 297, in shared
    cls.shared_config = Config()
  File "//sidecar.py", line 228, in __init__
    address_info = socket.getaddrinfo(
  File "/usr/local/lib/python3.9/socket.py", line 953, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -3] Temporary failure in name resolution
```