### PR TITLE
Wait to set the HasPendingRemoval flag in the status until we’ve started terminating the resources.

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -719,7 +719,7 @@ const (
 	MissingService ProcessGroupConditionType = "MissingService"
 	// MissingProcesses represents a process group that misses a process.
 	MissingProcesses ProcessGroupConditionType = "MissingProcesses"
-	// Terminating represents a process group whose resources are being
+	// ResourcesTerminating represents a process group whose resources are being
 	// terminated.
 	ResourcesTerminating ProcessGroupConditionType = "ResourcesTerminating"
 	// ReadyCondition is currently only used in the metrics.

--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1363,17 +1363,14 @@ func (cluster *FoundationDBCluster) CheckReconciliation() (bool, error) {
 	cluster.Status.Generations = ClusterGenerationStatus{Reconciled: cluster.Status.Generations.Reconciled}
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.Remove {
-			terminating := false
-			for _, condition := range processGroup.ProcessGroupConditions {
-				terminating = terminating || condition.ProcessGroupConditionType == ResourcesTerminating
-			}
-			if processGroup.Excluded && terminating {
-				cluster.Status.Generations.HasPendingRemoval = cluster.ObjectMeta.Generation
-			} else {
-				cluster.Status.Generations.NeedsShrink = cluster.ObjectMeta.Generation
-				reconciled = false
-			}
+		if !processGroup.Remove {
+			continue
+		}
+		if processGroup.GetConditionTime(ResourcesTerminating) != nil {
+			cluster.Status.Generations.HasPendingRemoval = cluster.ObjectMeta.Generation
+		} else {
+			cluster.Status.Generations.NeedsShrink = cluster.ObjectMeta.Generation
+			reconciled = false
 		}
 	}
 

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -2473,6 +2473,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			cluster.Spec.ProcessCounts.Storage = 2
 			cluster.Status.ProcessGroups[0].Remove = true
 			cluster.Status.ProcessGroups[0].Excluded = true
+			cluster.Status.ProcessGroups[0].UpdateCondition(ResourcesTerminating, true, nil, "")
 			result, err = cluster.CheckReconciliation()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())
@@ -2484,8 +2485,33 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			cluster = createCluster()
 			cluster.Spec.ProcessCounts.Storage = 2
 			cluster.Status.ProcessGroups[0].Remove = true
+			cluster.Status.ProcessGroups[0].UpdateCondition(ResourcesTerminating, true, nil, "")
+			result, err = cluster.CheckReconciliation()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+			Expect(cluster.Status.Generations).To(Equal(ClusterGenerationStatus{
+				Reconciled:  1,
+				NeedsShrink: 2,
+			}))
+
+			cluster = createCluster()
+			cluster.Spec.ProcessCounts.Storage = 2
+			cluster.Status.ProcessGroups[0].Remove = true
+			cluster.Status.ProcessGroups[0].Excluded = true
+			result, err = cluster.CheckReconciliation()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+			Expect(cluster.Status.Generations).To(Equal(ClusterGenerationStatus{
+				Reconciled:  1,
+				NeedsShrink: 2,
+			}))
+
+			cluster = createCluster()
+			cluster.Spec.ProcessCounts.Storage = 2
+			cluster.Status.ProcessGroups[0].Remove = true
 			cluster.Status.ProcessGroups[0].Excluded = true
 			cluster.Status.ProcessGroups[0].UpdateCondition(IncorrectCommandLine, true, nil, "")
+			cluster.Status.ProcessGroups[0].UpdateCondition(ResourcesTerminating, true, nil, "")
 			result, err = cluster.CheckReconciliation()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -2472,7 +2472,6 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			cluster = createCluster()
 			cluster.Spec.ProcessCounts.Storage = 2
 			cluster.Status.ProcessGroups[0].Remove = true
-			cluster.Status.ProcessGroups[0].Excluded = true
 			cluster.Status.ProcessGroups[0].UpdateCondition(ResourcesTerminating, true, nil, "")
 			result, err = cluster.CheckReconciliation()
 			Expect(err).NotTo(HaveOccurred())
@@ -2480,30 +2479,6 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			Expect(cluster.Status.Generations).To(Equal(ClusterGenerationStatus{
 				Reconciled:        2,
 				HasPendingRemoval: 2,
-			}))
-
-			cluster = createCluster()
-			cluster.Spec.ProcessCounts.Storage = 2
-			cluster.Status.ProcessGroups[0].Remove = true
-			cluster.Status.ProcessGroups[0].UpdateCondition(ResourcesTerminating, true, nil, "")
-			result, err = cluster.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
-			Expect(cluster.Status.Generations).To(Equal(ClusterGenerationStatus{
-				Reconciled:  1,
-				NeedsShrink: 2,
-			}))
-
-			cluster = createCluster()
-			cluster.Spec.ProcessCounts.Storage = 2
-			cluster.Status.ProcessGroups[0].Remove = true
-			cluster.Status.ProcessGroups[0].Excluded = true
-			result, err = cluster.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
-			Expect(cluster.Status.Generations).To(Equal(ClusterGenerationStatus{
-				Reconciled:  1,
-				NeedsShrink: 2,
 			}))
 
 			cluster = createCluster()

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -540,6 +540,8 @@ func validateInstances(r *FoundationDBClusterReconciler, context ctx.Context, cl
 		}
 	}
 
+	// Mark process groups as terminating if the pod has been deleted but other
+	// resources are stuck in terminating.
 	for _, processGroupStatus := range processGroups {
 		_, found := instanceMap[processGroupStatus.ProcessGroupID]
 		if processGroupStatus.Remove && !found {


### PR DESCRIPTION
# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

This adds a new process group condition to track when we've terminated resources, and uses that to track when we want to set the special `HasPendingRemoval` field in the generation status. This means that if we exclude the processes but aren't able to start the termination, we won't set this field, and won't mark the cluster as reconciled.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

This may not be necessary, since the space for failures between finishing exclusions and terminating pods is pretty small, but I think termination is the right condition to act off of.

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I did a replacement in my local environment.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

# Documentation

*Did you update relevant documentation within this repository?*

I don't think this requires any documentation updates.

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.