### PR TITLE
Remove deprecated metrics

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2326,8 +2326,6 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				} {
 					Expect(re.Match(buf.Bytes())).To(Equal(true))
 				}
-
-				Expect(len(metricFamilies)).To(BeNumerically("==", 35))
 			})
 		})
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2311,14 +2311,14 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				Expect(err).NotTo(HaveOccurred())
 				var buf bytes.Buffer
 				for _, mf := range metricFamilies {
-					if strings.HasPrefix(mf.GetName(), "fdb_cluster_status") {
+					if strings.HasPrefix(mf.GetName(), "fdb_operator_cluster_status") {
 						_, err := expfmt.MetricFamilyToText(&buf, mf)
 						Expect(err).NotTo(HaveOccurred())
 					}
 				}
-				healthMetricOutput := fmt.Sprintf(`\nfdb_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`, cluster.Name, cluster.Namespace, "health")
-				availMetricOutput := fmt.Sprintf(`\nfdb_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`, cluster.Name, cluster.Namespace, "available")
-				replMetricOutput := fmt.Sprintf(`\nfdb_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`, cluster.Name, cluster.Namespace, "replication")
+				healthMetricOutput := fmt.Sprintf(`\nfdb_operator_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`, cluster.Name, cluster.Namespace, "health")
+				availMetricOutput := fmt.Sprintf(`\nfdb_operator_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`, cluster.Name, cluster.Namespace, "available")
+				replMetricOutput := fmt.Sprintf(`\nfdb_operator_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`, cluster.Name, cluster.Namespace, "replication")
 				for _, re := range []*regexp.Regexp{
 					regexp.MustCompile(healthMetricOutput),
 					regexp.MustCompile(availMetricOutput),
@@ -2326,6 +2326,8 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				} {
 					Expect(re.Match(buf.Bytes())).To(Equal(true))
 				}
+
+				Expect(len(metricFamilies)).To(BeNumerically("==", 35))
 			})
 		})
 

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -31,20 +31,6 @@ import (
 var (
 	descClusterDefaultLabels = []string{"namespace", "name"}
 
-	deprecatedDescClusterCreated = prometheus.NewDesc(
-		"fdb_cluster_created_time",
-		"(Deprecated since 0.33.0) Creation time in unix timestamp for Fdb Cluster.",
-		descClusterDefaultLabels,
-		nil,
-	)
-
-	deprecatedDescClusterStatus = prometheus.NewDesc(
-		"fdb_cluster_status",
-		"(Deprecated since 0.33.0) status of the Fdb Cluster.",
-		append(descClusterDefaultLabels, "status_type"),
-		nil,
-	)
-
 	descClusterCreated = prometheus.NewDesc(
 		"fdb_operator_cluster_created_time",
 		"Creation time in unix timestamp for Fdb Cluster.",
@@ -129,12 +115,6 @@ func collectMetrics(ch chan<- prometheus.Metric, cluster *fdbtypes.FoundationDBC
 	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
 		addConstMetric(desc, prometheus.GaugeValue, v, lv...)
 	}
-	// TODO (johscheuer): remove these after 0.34.0
-	addGauge(deprecatedDescClusterCreated, float64(cluster.CreationTimestamp.Unix()))
-	addGauge(deprecatedDescClusterStatus, boolFloat64(cluster.Status.Health.Healthy), "health")
-	addGauge(deprecatedDescClusterStatus, boolFloat64(cluster.Status.Health.Available), "available")
-	addGauge(deprecatedDescClusterStatus, boolFloat64(cluster.Status.Health.FullReplication), "replication")
-	addGauge(deprecatedDescClusterStatus, float64(cluster.Status.Health.DataMovementPriority), "datamovementpriority")
 	// These are the correct metrics with the prefix "fdb_operator"
 	addGauge(descClusterCreated, float64(cluster.CreationTimestamp.Unix()))
 	addGauge(descClusterStatus, boolFloat64(cluster.Status.Health.Healthy), "health")


### PR DESCRIPTION
# Description

Remove old deprecated metrics.

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/651

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

No

# Testing

locally

# Documentation

No

# Follow-up

No
