### PR TITLE
Add namespace to clusterrolebinding in global mode (helm chart)

### DIFF
--- a/helm/fdb-operator/templates/rbac/rbac_role_binding.yaml
+++ b/helm/fdb-operator/templates/rbac/rbac_role_binding.yaml
@@ -20,3 +20,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "fdb-operator.serviceAccountName" . }}
+  {{- if .Values.globalMode.enabled }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}


### PR DESCRIPTION
# Description

When deploying the helm chart in global mode, a clusterrolebinding is created. This PR fixes the fact that the clusterrolebinding's subject needs to include a namespace, and sets the namespace to the release namespace. (A namespace is not required when deploying a simple roleBinding, when global mode is disabled)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?* No

# Testing

Tested in multiple clusters, and observed to work (previously the helm install would fail, having generated an invalid clusterrolebinding)

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No

# Documentation

*Did you update relevant documentation within this repository?* No, since this PR just fixes something which should already work as documented :)

# Follow-up

*Are there any follow-up issues that we should pursue in the future?* No

*Does this introduce new defaults that we should re-evaluate in the future?* No
