### PR TITLE
Wrap error with additional process group info

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -553,7 +553,7 @@ func GetMonitorConf(cluster *fdbtypes.FoundationDBCluster, processClass fdbtypes
 func GetStartCommand(cluster *fdbtypes.FoundationDBCluster, instance FdbInstance, podClient FdbPodClient, processNumber int, processCount int) (string, error) {
 	lines, err := getStartCommandLines(cluster, instance.GetProcessClass(), podClient, processNumber, processCount)
 	if err != nil {
-		return "", fmt.Errorf("GetStartCommand: %w for prcoess group %s", err, instance.GetInstanceID())
+		return "", fmt.Errorf("GetStartCommand: %w for process group %s", err, instance.GetInstanceID())
 	}
 
 	regex := regexp.MustCompile(`^(\w+)\s*=\s*(.*)`)

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -553,7 +553,7 @@ func GetMonitorConf(cluster *fdbtypes.FoundationDBCluster, processClass fdbtypes
 func GetStartCommand(cluster *fdbtypes.FoundationDBCluster, instance FdbInstance, podClient FdbPodClient, processNumber int, processCount int) (string, error) {
 	lines, err := getStartCommandLines(cluster, instance.GetProcessClass(), podClient, processNumber, processCount)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("GetStartCommand: %w for prcoess group %s", err, instance.GetInstanceID())
 	}
 
 	regex := regexp.MustCompile(`^(\w+)\s*=\s*(.*)`)

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -423,8 +423,6 @@ func CheckAndSetProcessStatus(r *FoundationDBClusterReconciler, cluster *fdbtype
 			return err
 		}
 
-		correct = commandLine == process.CommandLine
-
 		settings := cluster.GetProcessSettings(instance.GetProcessClass())
 		versionMatch := true
 		// if we allow to override the tag we can't compare the versions here
@@ -433,7 +431,7 @@ func CheckAndSetProcessStatus(r *FoundationDBClusterReconciler, cluster *fdbtype
 		}
 
 		// If the `EmptyMonitorConf` is set, the commandline is by definition wrong since there should be no running processes.
-		correct = correct && versionMatch && !cluster.Spec.Buggify.EmptyMonitorConf
+		correct = commandLine == process.CommandLine && versionMatch && !cluster.Spec.Buggify.EmptyMonitorConf
 
 		if !correct {
 			log.Info("IncorrectProcess", "namespace", cluster.Namespace, "cluster", cluster.Name, "expected", commandLine, "got", process.CommandLine, "expectedVersion", cluster.Spec.Version, "version", process.Version, "processGroupID", instanceID)


### PR DESCRIPTION
# Description

Add more context when a failure happens during the `GetStartCommand` e.g. when the sidecar is not available.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

None

# Testing

Locally

# Documentation

No

# Follow-up

No
