### PR TITLE
Add methods to get the next version based on the current version

### DIFF
--- a/api/v1beta1/foundationdb_version.go
+++ b/api/v1beta1/foundationdb_version.go
@@ -156,6 +156,21 @@ func (version FdbVersion) HasNonBlockingExcludes() bool {
 	return version.IsAtLeast(FdbVersion{Major: 6, Minor: 3, Patch: 5})
 }
 
+// NextMajorVersion returns the next major version of FoundationDB.
+func (version FdbVersion) NextMajorVersion() FdbVersion {
+	return FdbVersion{Major: version.Major + 1, Minor: 0, Patch: 0}
+}
+
+// NextMinorVersion returns the next minor version of FoundationDB.
+func (version FdbVersion) NextMinorVersion() FdbVersion {
+	return FdbVersion{Major: version.Major, Minor: version.Minor + 1, Patch: 0}
+}
+
+// NextPatchVersion returns the next path version of FoundationDB.
+func (version FdbVersion) NextPatchVersion() FdbVersion {
+	return FdbVersion{Major: version.Major, Minor: version.Minor, Patch: version.Patch + 1}
+}
+
 // Versions provides a shorthand for known versions.
 // This is only to be used in testing.
 var Versions = struct {

--- a/api/v1beta1/foundationdb_version.go
+++ b/api/v1beta1/foundationdb_version.go
@@ -166,9 +166,16 @@ func (version FdbVersion) NextMinorVersion() FdbVersion {
 	return FdbVersion{Major: version.Major, Minor: version.Minor + 1, Patch: 0}
 }
 
-// NextPatchVersion returns the next path version of FoundationDB.
+// NextPatchVersion returns the next patch version of FoundationDB.
 func (version FdbVersion) NextPatchVersion() FdbVersion {
 	return FdbVersion{Major: version.Major, Minor: version.Minor, Patch: version.Patch + 1}
+}
+
+// Equal checks if two FdbVersion are the same.
+func (version FdbVersion) Equal(other FdbVersion) bool {
+	return version.Major == other.Major &&
+		version.Minor == other.Minor &&
+		version.Patch == other.Patch
 }
 
 // Versions provides a shorthand for known versions.

--- a/api/v1beta1/foundationdb_version_test.go
+++ b/api/v1beta1/foundationdb_version_test.go
@@ -80,4 +80,15 @@ var _ = Describe("[api] FDBVersion", func() {
 			Expect(version.NextPatchVersion()).To(Equal(FdbVersion{Major: version.Major, Minor: version.Minor, Patch: 21}))
 		})
 	})
+
+	When("comparing two FDBVersions", func() {
+		It("should return if they are euqal", func() {
+			version := FdbVersion{Major: 6, Minor: 2, Patch: 20}
+			Expect(version.Equal(version)).To(BeTrue())
+			Expect(version.Equal(FdbVersion{Major: 7, Minor: 0, Patch: 0})).To(BeFalse())
+			Expect(version.Equal(FdbVersion{Major: 7, Minor: 0, Patch: 0})).To(BeFalse())
+			Expect(version.Equal(FdbVersion{Major: 6, Minor: 3, Patch: 20})).To(BeFalse())
+			Expect(version.Equal(FdbVersion{Major: 6, Minor: 2, Patch: 21})).To(BeFalse())
+		})
+	})
 })

--- a/api/v1beta1/foundationdb_version_test.go
+++ b/api/v1beta1/foundationdb_version_test.go
@@ -1,0 +1,83 @@
+/*
+ * foundationdb_version_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("[api] FDBVersion", func() {
+	When("checking if the protocol and the version are compatible", func() {
+		It("should return the correct compatibility", func() {
+			version := FdbVersion{Major: 6, Minor: 2, Patch: 20}
+			Expect(version.IsProtocolCompatible(FdbVersion{Major: 6, Minor: 2, Patch: 20})).To(BeTrue())
+			Expect(version.IsProtocolCompatible(FdbVersion{Major: 6, Minor: 2, Patch: 22})).To(BeTrue())
+			Expect(version.IsProtocolCompatible(FdbVersion{Major: 6, Minor: 3, Patch: 0})).To(BeFalse())
+			Expect(version.IsProtocolCompatible(FdbVersion{Major: 6, Minor: 3, Patch: 20})).To(BeFalse())
+			Expect(version.IsProtocolCompatible(FdbVersion{Major: 7, Minor: 2, Patch: 20})).To(BeFalse())
+		})
+	})
+
+	Context("Using the fdb version", func() {
+		It("should return the fdb version struct", func() {
+			version, err := ParseFdbVersion("6.2.11")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(FdbVersion{Major: 6, Minor: 2, Patch: 11}))
+
+			version, err = ParseFdbVersion("prerelease-6.2.11")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(FdbVersion{Major: 6, Minor: 2, Patch: 11}))
+
+			version, err = ParseFdbVersion("test-6.2.11-test")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(FdbVersion{Major: 6, Minor: 2, Patch: 11}))
+
+			_, err = ParseFdbVersion("6.2")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("could not parse FDB version from 6.2"))
+		})
+
+		It("should format the version correctly", func() {
+			version := FdbVersion{Major: 6, Minor: 2, Patch: 11}
+			Expect(version.String()).To(Equal("6.2.11"))
+		})
+
+		It("should validate the flags for the version correct", func() {
+			version := FdbVersion{Major: 6, Minor: 2, Patch: 0}
+			Expect(version.HasInstanceIDInSidecarSubstitutions()).To(BeFalse())
+			Expect(version.PrefersCommandLineArgumentsInSidecar()).To(BeFalse())
+
+			version = FdbVersion{Major: 7, Minor: 0, Patch: 0}
+			Expect(version.HasInstanceIDInSidecarSubstitutions()).To(BeTrue())
+			Expect(version.PrefersCommandLineArgumentsInSidecar()).To(BeTrue())
+		})
+	})
+
+	When("getting the next version of the current FDBVersion", func() {
+		It("should return the correct next version", func() {
+			version := FdbVersion{Major: 6, Minor: 2, Patch: 20}
+			Expect(version.NextMajorVersion()).To(Equal(FdbVersion{Major: 7, Minor: 0, Patch: 0}))
+			Expect(version.NextMinorVersion()).To(Equal(FdbVersion{Major: version.Major, Minor: 3, Patch: 0}))
+			Expect(version.NextPatchVersion()).To(Equal(FdbVersion{Major: version.Major, Minor: version.Minor, Patch: 21}))
+		})
+	})
+})

--- a/api/v1beta1/foundationdbbackup_types_test.go
+++ b/api/v1beta1/foundationdbbackup_types_test.go
@@ -21,8 +21,6 @@
 package v1beta1
 
 import (
-	"github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
@@ -74,18 +72,18 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup = createBackup()
 
 			result, err := backup.CheckReconciliation()
-			Expect(result).To(gomega.BeTrue())
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(result).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled: 2,
 			}))
 
 			backup = createBackup()
 			backup.Status.AgentCount = 5
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(result).To(gomega.BeFalse())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled:             1,
 				NeedsBackupAgentUpdate: 2,
 			}))
@@ -94,9 +92,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			agentCount = 0
 			backup.Status.AgentCount = 0
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(result).To(gomega.BeTrue())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled: 2,
 			}))
 
@@ -104,9 +102,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			agentCount = 3
 			backup.Status.BackupDetails = nil
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(result).To(gomega.BeFalse())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled:       1,
 				NeedsBackupStart: 2,
 			}))
@@ -114,9 +112,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup = createBackup()
 			backup.Spec.BackupState = "Stopped"
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(result).To(gomega.BeFalse())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled:      1,
 				NeedsBackupStop: 2,
 			}))
@@ -125,9 +123,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup.Status.BackupDetails = nil
 			backup.Spec.BackupState = "Stopped"
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(result).To(gomega.BeTrue())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled: 2,
 			}))
 
@@ -135,18 +133,18 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup.Status.BackupDetails.Running = false
 			backup.Spec.BackupState = "Stopped"
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(result).To(gomega.BeTrue())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled: 2,
 			}))
 
 			backup = createBackup()
 			backup.Spec.BackupState = "Paused"
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(result).To(gomega.BeFalse())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled:             1,
 				NeedsBackupPauseToggle: 2,
 			}))
@@ -155,9 +153,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup.Spec.BackupState = "Paused"
 			backup.Status.BackupDetails = nil
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(result).To(gomega.BeFalse())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled:             1,
 				NeedsBackupStart:       2,
 				NeedsBackupPauseToggle: 2,
@@ -167,18 +165,18 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup.Spec.BackupState = "Paused"
 			backup.Status.BackupDetails.Paused = true
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(result).To(gomega.BeTrue())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled: 2,
 			}))
 
 			backup = createBackup()
 			backup.Status.BackupDetails.Paused = true
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(result).To(gomega.BeFalse())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled:             1,
 				NeedsBackupPauseToggle: 2,
 			}))
@@ -187,9 +185,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			var time = 100000
 			backup.Spec.SnapshotPeriodSeconds = &time
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(gomega.HaveOccurred())
-			Expect(result).To(gomega.BeFalse())
-			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
 				Reconciled:                 1,
 				NeedsBackupReconfiguration: 2,
 			}))
@@ -200,36 +198,36 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 
 	When("checking the backup state", func() {
 		It("should show the correct state", func() {
-			Expect(backup.ShouldRun()).To(gomega.BeTrue())
-			Expect(backup.ShouldBePaused()).To(gomega.BeFalse())
+			Expect(backup.ShouldRun()).To(BeTrue())
+			Expect(backup.ShouldBePaused()).To(BeFalse())
 
 			backup.Spec.BackupState = "Running"
-			Expect(backup.ShouldRun()).To(gomega.BeTrue())
-			Expect(backup.ShouldBePaused()).To(gomega.BeFalse())
+			Expect(backup.ShouldRun()).To(BeTrue())
+			Expect(backup.ShouldBePaused()).To(BeFalse())
 
 			backup.Spec.BackupState = "Stopped"
-			Expect(backup.ShouldRun()).To(gomega.BeFalse())
-			Expect(backup.ShouldBePaused()).To(gomega.BeFalse())
+			Expect(backup.ShouldRun()).To(BeFalse())
+			Expect(backup.ShouldBePaused()).To(BeFalse())
 
 			backup.Spec.BackupState = "Paused"
-			Expect(backup.ShouldRun()).To(gomega.BeTrue())
-			Expect(backup.ShouldBePaused()).To(gomega.BeTrue())
+			Expect(backup.ShouldRun()).To(BeTrue())
+			Expect(backup.ShouldBePaused()).To(BeTrue())
 		})
 	})
 
 	When("getting the bucket name", func() {
 		It("should return the bucket name", func() {
-			Expect(backup.Bucket()).To(gomega.Equal("fdb-backups"))
+			Expect(backup.Bucket()).To(Equal("fdb-backups"))
 			backup.Spec.Bucket = "fdb-backup-v2"
-			Expect(backup.Bucket()).To(gomega.Equal("fdb-backup-v2"))
+			Expect(backup.Bucket()).To(Equal("fdb-backup-v2"))
 		})
 	})
 
 	When("getting the backup name", func() {
 		It("should return the backup name", func() {
-			Expect(backup.BackupName()).To(gomega.Equal("sample-cluster"))
+			Expect(backup.BackupName()).To(Equal("sample-cluster"))
 			backup.Spec.BackupName = "sample_cluster_2020_03_22"
-			Expect(backup.BackupName()).To(gomega.Equal("sample_cluster_2020_03_22"))
+			Expect(backup.BackupName()).To(Equal("sample_cluster_2020_03_22"))
 		})
 	})
 
@@ -239,7 +237,7 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 		})
 
 		It("should create the correct url", func() {
-			Expect(backup.BackupURL()).To(gomega.Equal("blobstore://test@test-service/sample-cluster?bucket=fdb-backups"))
+			Expect(backup.BackupURL()).To(Equal("blobstore://test@test-service/sample-cluster?bucket=fdb-backups"))
 		})
 	})
 
@@ -249,11 +247,11 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 		})
 
 		It("should return the snapshot time", func() {
-			Expect(backup.SnapshotPeriodSeconds()).To(gomega.Equal(864000))
+			Expect(backup.SnapshotPeriodSeconds()).To(Equal(864000))
 
 			period := 60
 			backup.Spec.SnapshotPeriodSeconds = &period
-			Expect(backup.SnapshotPeriodSeconds()).To(gomega.Equal(60))
+			Expect(backup.SnapshotPeriodSeconds()).To(Equal(60))
 		})
 	})
 })

--- a/api/v1beta1/foundationdbbackup_types_test.go
+++ b/api/v1beta1/foundationdbbackup_types_test.go
@@ -21,6 +21,8 @@
 package v1beta1
 
 import (
+	"github.com/onsi/gomega"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
@@ -72,18 +74,18 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup = createBackup()
 
 			result, err := backup.CheckReconciliation()
-			Expect(result).To(BeTrue())
-			Expect(err).NotTo(HaveOccurred())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(result).To(gomega.BeTrue())
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled: 2,
 			}))
 
 			backup = createBackup()
 			backup.Status.AgentCount = 5
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(result).To(gomega.BeFalse())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled:             1,
 				NeedsBackupAgentUpdate: 2,
 			}))
@@ -92,9 +94,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			agentCount = 0
 			backup.Status.AgentCount = 0
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeTrue())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(result).To(gomega.BeTrue())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled: 2,
 			}))
 
@@ -102,9 +104,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			agentCount = 3
 			backup.Status.BackupDetails = nil
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(result).To(gomega.BeFalse())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled:       1,
 				NeedsBackupStart: 2,
 			}))
@@ -112,9 +114,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup = createBackup()
 			backup.Spec.BackupState = "Stopped"
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(result).To(gomega.BeFalse())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled:      1,
 				NeedsBackupStop: 2,
 			}))
@@ -123,9 +125,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup.Status.BackupDetails = nil
 			backup.Spec.BackupState = "Stopped"
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeTrue())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(result).To(gomega.BeTrue())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled: 2,
 			}))
 
@@ -133,18 +135,18 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup.Status.BackupDetails.Running = false
 			backup.Spec.BackupState = "Stopped"
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeTrue())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(result).To(gomega.BeTrue())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled: 2,
 			}))
 
 			backup = createBackup()
 			backup.Spec.BackupState = "Paused"
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(result).To(gomega.BeFalse())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled:             1,
 				NeedsBackupPauseToggle: 2,
 			}))
@@ -153,9 +155,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup.Spec.BackupState = "Paused"
 			backup.Status.BackupDetails = nil
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(result).To(gomega.BeFalse())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled:             1,
 				NeedsBackupStart:       2,
 				NeedsBackupPauseToggle: 2,
@@ -165,18 +167,18 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			backup.Spec.BackupState = "Paused"
 			backup.Status.BackupDetails.Paused = true
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeTrue())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(result).To(gomega.BeTrue())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled: 2,
 			}))
 
 			backup = createBackup()
 			backup.Status.BackupDetails.Paused = true
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(result).To(gomega.BeFalse())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled:             1,
 				NeedsBackupPauseToggle: 2,
 			}))
@@ -185,9 +187,9 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			var time = 100000
 			backup.Spec.SnapshotPeriodSeconds = &time
 			result, err = backup.CheckReconciliation()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
-			Expect(backup.Status.Generations).To(Equal(BackupGenerationStatus{
+			Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(result).To(gomega.BeFalse())
+			Expect(backup.Status.Generations).To(gomega.Equal(BackupGenerationStatus{
 				Reconciled:                 1,
 				NeedsBackupReconfiguration: 2,
 			}))
@@ -198,36 +200,36 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 
 	When("checking the backup state", func() {
 		It("should show the correct state", func() {
-			Expect(backup.ShouldRun()).To(BeTrue())
-			Expect(backup.ShouldBePaused()).To(BeFalse())
+			Expect(backup.ShouldRun()).To(gomega.BeTrue())
+			Expect(backup.ShouldBePaused()).To(gomega.BeFalse())
 
 			backup.Spec.BackupState = "Running"
-			Expect(backup.ShouldRun()).To(BeTrue())
-			Expect(backup.ShouldBePaused()).To(BeFalse())
+			Expect(backup.ShouldRun()).To(gomega.BeTrue())
+			Expect(backup.ShouldBePaused()).To(gomega.BeFalse())
 
 			backup.Spec.BackupState = "Stopped"
-			Expect(backup.ShouldRun()).To(BeFalse())
-			Expect(backup.ShouldBePaused()).To(BeFalse())
+			Expect(backup.ShouldRun()).To(gomega.BeFalse())
+			Expect(backup.ShouldBePaused()).To(gomega.BeFalse())
 
 			backup.Spec.BackupState = "Paused"
-			Expect(backup.ShouldRun()).To(BeTrue())
-			Expect(backup.ShouldBePaused()).To(BeTrue())
+			Expect(backup.ShouldRun()).To(gomega.BeTrue())
+			Expect(backup.ShouldBePaused()).To(gomega.BeTrue())
 		})
 	})
 
 	When("getting the bucket name", func() {
 		It("should return the bucket name", func() {
-			Expect(backup.Bucket()).To(Equal("fdb-backups"))
+			Expect(backup.Bucket()).To(gomega.Equal("fdb-backups"))
 			backup.Spec.Bucket = "fdb-backup-v2"
-			Expect(backup.Bucket()).To(Equal("fdb-backup-v2"))
+			Expect(backup.Bucket()).To(gomega.Equal("fdb-backup-v2"))
 		})
 	})
 
 	When("getting the backup name", func() {
 		It("should return the backup name", func() {
-			Expect(backup.BackupName()).To(Equal("sample-cluster"))
+			Expect(backup.BackupName()).To(gomega.Equal("sample-cluster"))
 			backup.Spec.BackupName = "sample_cluster_2020_03_22"
-			Expect(backup.BackupName()).To(Equal("sample_cluster_2020_03_22"))
+			Expect(backup.BackupName()).To(gomega.Equal("sample_cluster_2020_03_22"))
 		})
 	})
 
@@ -237,7 +239,7 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 		})
 
 		It("should create the correct url", func() {
-			Expect(backup.BackupURL()).To(Equal("blobstore://test@test-service/sample-cluster?bucket=fdb-backups"))
+			Expect(backup.BackupURL()).To(gomega.Equal("blobstore://test@test-service/sample-cluster?bucket=fdb-backups"))
 		})
 	})
 
@@ -247,11 +249,11 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 		})
 
 		It("should return the snapshot time", func() {
-			Expect(backup.SnapshotPeriodSeconds()).To(Equal(864000))
+			Expect(backup.SnapshotPeriodSeconds()).To(gomega.Equal(864000))
 
 			period := 60
 			backup.Spec.SnapshotPeriodSeconds = &period
-			Expect(backup.SnapshotPeriodSeconds()).To(Equal(60))
+			Expect(backup.SnapshotPeriodSeconds()).To(gomega.Equal(60))
 		})
 	})
 })

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -639,41 +639,6 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 		})
 	})
 
-	Context("Using the fdb version", func() {
-		It("should return the fdb version struct", func() {
-			version, err := ParseFdbVersion("6.2.11")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(version).To(Equal(FdbVersion{Major: 6, Minor: 2, Patch: 11}))
-
-			version, err = ParseFdbVersion("prerelease-6.2.11")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(version).To(Equal(FdbVersion{Major: 6, Minor: 2, Patch: 11}))
-
-			version, err = ParseFdbVersion("test-6.2.11-test")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(version).To(Equal(FdbVersion{Major: 6, Minor: 2, Patch: 11}))
-
-			_, err = ParseFdbVersion("6.2")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("could not parse FDB version from 6.2"))
-		})
-
-		It("should format the version correctly", func() {
-			version := FdbVersion{Major: 6, Minor: 2, Patch: 11}
-			Expect(version.String()).To(Equal("6.2.11"))
-		})
-
-		It("should validate the flags for the version correct", func() {
-			version := FdbVersion{Major: 6, Minor: 2, Patch: 0}
-			Expect(version.HasInstanceIDInSidecarSubstitutions()).To(BeFalse())
-			Expect(version.PrefersCommandLineArgumentsInSidecar()).To(BeFalse())
-
-			version = FdbVersion{Major: 7, Minor: 0, Patch: 0}
-			Expect(version.HasInstanceIDInSidecarSubstitutions()).To(BeTrue())
-			Expect(version.PrefersCommandLineArgumentsInSidecar()).To(BeTrue())
-		})
-	})
-
 	When("changing the redundancy mode", func() {
 		It("should return the new redundancy mode", func() {
 			currentConfig := DatabaseConfiguration{
@@ -2609,17 +2574,6 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			settings := cluster.GetProcessSettings(ProcessClassStorage)
 			Expect(settings.PodTemplate.ObjectMeta.Labels).To(Equal(map[string]string{"test-label": "label2"}))
 			Expect(settings.CustomParameters).To(Equal(&[]string{"test_knob=value1"}))
-		})
-	})
-
-	When("checking if the protocol and the version are compatible", func() {
-		It("should return the correct compatibility", func() {
-			version := FdbVersion{Major: 6, Minor: 2, Patch: 20}
-			Expect(version.IsProtocolCompatible(FdbVersion{Major: 6, Minor: 2, Patch: 20})).To(BeTrue())
-			Expect(version.IsProtocolCompatible(FdbVersion{Major: 6, Minor: 2, Patch: 22})).To(BeTrue())
-			Expect(version.IsProtocolCompatible(FdbVersion{Major: 6, Minor: 3, Patch: 0})).To(BeFalse())
-			Expect(version.IsProtocolCompatible(FdbVersion{Major: 6, Minor: 3, Patch: 20})).To(BeFalse())
-			Expect(version.IsProtocolCompatible(FdbVersion{Major: 7, Minor: 2, Patch: 20})).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
# Description

This change adds methods to the `FDBVersion` struct to get the next versions. This will be useful e.g. for testing purposes.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

No

# Testing

Unit tests

# Documentation

No

# Follow-up

Nothing
