### PR TITLE
Add the number of desired Pods in the message for initial cluster file generation

### DIFF
--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -22,6 +22,7 @@ package controllers
 
 import (
 	ctx "context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -51,7 +52,10 @@ func (g GenerateInitialClusterFile) Reconcile(r *FoundationDBClusterReconciler, 
 
 	count := cluster.DesiredCoordinatorCount()
 	if len(instances) < count {
-		return &Requeue{Message: "cannot find enough pods to recruit coordinators", Delay: podSchedulingDelayDuration}
+		return &Requeue{
+			Message: fmt.Sprintf("cannot find enough Pods to recruit coordinators. Require %d, got %d Pods", count, len(instances)),
+			Delay:   podSchedulingDelayDuration,
+		}
 	}
 
 	var clusterName string


### PR DESCRIPTION
# Description

Just adding the desired count and the current running Pods to the message to help the human operator to see why the operator is not able to reconcile.

This came up in: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/839

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

-

# Testing

Locally

# Documentation

-

# Follow-up

-
