### PR TITLE
Remove sort from initial file generation

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -777,27 +777,6 @@ func sortPodsByID(pods *corev1.PodList) {
 	})
 }
 
-func sortInstancesByID(instances []FdbInstance) error {
-	var err error
-	sort.Slice(instances, func(i, j int) bool {
-		prefix1, id1, err1 := ParseInstanceID(instances[i].GetInstanceID())
-		prefix2, id2, err2 := ParseInstanceID(instances[j].GetInstanceID())
-		if err1 != nil {
-			err = err1
-			return false
-		}
-		if err2 != nil {
-			err = err2
-			return false
-		}
-		if prefix1 != prefix2 {
-			return prefix1 < prefix2
-		}
-		return id1 < id2
-	})
-	return err
-}
-
 var connectionStringNameRegex, _ = regexp.Compile("[^A-Za-z0-9_]")
 
 // FdbInstance represents an instance of FDB that has been configured in

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -44,10 +44,6 @@ func (g GenerateInitialClusterFile) Reconcile(r *FoundationDBClusterReconciler, 
 	if err != nil {
 		return &Requeue{Error: err}
 	}
-	err = sortInstancesByID(instances)
-	if err != nil {
-		return &Requeue{Error: err}
-	}
 
 	count := cluster.DesiredCoordinatorCount()
 	if len(instances) < count {


### PR DESCRIPTION
# Description

Remove a useless sort of the instances. The problem is that we always sort even if we don't have enough processes for our desired coordinator count and in [chooseDistributedProcesses](https://github.com/FoundationDB/fdb-kubernetes-operator/blob/1dade55f1efa1ee6135cec5846538d7490785c5d/controllers/cluster_controller.go#L1226) we also sort the processes so there is no need to pre-sort them.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

Nothing.

# Testing

locally.

# Documentation

None.

# Follow-up

None.
