### PR TITLE
Expose the GetPodSpec method in the controller package

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -669,3 +669,8 @@ func checkCoordinatorValidity(cluster *fdbtypes.FoundationDBCluster, status *fdb
 func NewFdbPodClient(cluster *fdbtypes.FoundationDBCluster, pod *corev1.Pod) (internal.FdbPodClient, error) {
 	return internal.NewFdbPodClient(cluster, pod)
 }
+
+// GetPodSpec provides an external interface for the internal GetPodSpec method
+func GetPodSpec(cluster *fdbtypes.FoundationDBCluster, processClass fdbtypes.ProcessClass, idNum int) (*corev1.PodSpec, error) {
+	return internal.GetPodSpec(cluster, processClass, idNum)
+}

--- a/main.go
+++ b/main.go
@@ -50,15 +50,13 @@ func main() {
 	logOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	clusterReconciler := controllers.NewFoundationDBClusterReconciler(
-		controllers.StandardPodLifecycleManager{},
-	)
-
 	mgr, file := setup.StartManager(
 		scheme,
 		operatorOpts,
 		logOpts,
-		clusterReconciler,
+		controllers.NewFoundationDBClusterReconciler(
+			controllers.StandardPodLifecycleManager{},
+		),
 		&controllers.FoundationDBBackupReconciler{},
 		&controllers.FoundationDBRestoreReconciler{},
 		ctrl.Log)


### PR DESCRIPTION
# Description

Expose the `GetPodSpec` in the controllers until `UpdatePods` is refactored.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

Otherwise external clients are not able to implement the `UpdatePods` logic to check the Pod Spec.

# Testing

Locally, unit tests

# Documentation

None.

# Follow-up

None.
