### PR TITLE
Revert the change for the CRD to use coordinators as strings

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1562,7 +1562,7 @@ type ConnectionString struct {
 	GenerationID string `json:"generationID,omitempty"`
 
 	// Coordinators provides the addresses of the current coordinators.
-	Coordinators []ProcessAddress `json:"coordinators,omitempty"`
+	Coordinators []string `json:"coordinators,omitempty"`
 }
 
 // ParseConnectionString parses a connection string from its string
@@ -1574,14 +1574,14 @@ func ParseConnectionString(str string) (ConnectionString, error) {
 	}
 
 	coordinatorsStrings := strings.Split(components[3], ",")
-	coordinators := make([]ProcessAddress, len(coordinatorsStrings))
+	coordinators := make([]string, len(coordinatorsStrings))
 	for idx, coordinatorsString := range coordinatorsStrings {
 		coordinatorAddress, err := ParseProcessAddress(coordinatorsString)
 		if err != nil {
 			return ConnectionString{}, err
 		}
 
-		coordinators[idx] = coordinatorAddress
+		coordinators[idx] = coordinatorAddress.String()
 	}
 
 	return ConnectionString{
@@ -1593,7 +1593,7 @@ func ParseConnectionString(str string) (ConnectionString, error) {
 
 // String formats a connection string as a string
 func (str *ConnectionString) String() string {
-	return fmt.Sprintf("%s:%s@%s", str.DatabaseName, str.GenerationID, ProcessAddressesString(str.Coordinators, ","))
+	return fmt.Sprintf("%s:%s@%s", str.DatabaseName, str.GenerationID, strings.Join(str.Coordinators, ","))
 }
 
 // GenerateNewGenerationID builds a new generation ID
@@ -1923,7 +1923,7 @@ func (cluster *FoundationDBCluster) GetFullSidecarVersion(useRunningVersion bool
 func (str *ConnectionString) HasCoordinators(coordinators []ProcessAddress) bool {
 	matchedCoordinators := make(map[string]bool, len(str.Coordinators))
 	for _, address := range str.Coordinators {
-		matchedCoordinators[address.String()] = false
+		matchedCoordinators[address] = false
 	}
 
 	for _, pAddr := range coordinators {

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -498,13 +498,19 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 		},
 	}
 
+	coordinatorsStr := []string{
+		"127.0.0.1:4500",
+		"127.0.0.2:4500",
+		"127.0.0.3:4500",
+	}
+
 	When("parsing the connection string", func() {
 		It("should be parsed correctly", func() {
 			str, err := ParseConnectionString("test:abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(str.DatabaseName).To(Equal("test"))
 			Expect(str.GenerationID).To(Equal("abcd"))
-			Expect(str.Coordinators).To(Equal(coordinators))
+			Expect(str.Coordinators).To(Equal(coordinatorsStr))
 
 			str, err = ParseConnectionString("test:abcd")
 			Expect(err).To(HaveOccurred())
@@ -517,7 +523,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			str := ConnectionString{
 				DatabaseName: "test",
 				GenerationID: "abcd",
-				Coordinators: coordinators,
+				Coordinators: coordinatorsStr,
 			}
 			Expect(str.String()).To(Equal("test:abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500"))
 		})
@@ -528,7 +534,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			str := ConnectionString{
 				DatabaseName: "test",
 				GenerationID: "abcd",
-				Coordinators: coordinators,
+				Coordinators: coordinatorsStr,
 			}
 			err := str.GenerateNewGenerationID()
 			Expect(err).NotTo(HaveOccurred())
@@ -541,7 +547,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			str := ConnectionString{
 				DatabaseName: "test",
 				GenerationID: "abcd",
-				Coordinators: coordinators,
+				Coordinators: coordinatorsStr,
 			}
 			Expect(str.HasCoordinators(coordinators)).To(BeTrue())
 			// We have to copy the slice to prevent to modify the original slice

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -132,10 +132,8 @@ func (in *ConnectionString) DeepCopyInto(out *ConnectionString) {
 	*out = *in
 	if in.Coordinators != nil {
 		in, out := &in.Coordinators, &out.Coordinators
-		*out = make([]ProcessAddress, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -1500,17 +1500,7 @@ spec:
                   properties:
                     coordinators:
                       items:
-                        properties:
-                          address:
-                            format: byte
-                            type: string
-                          flags:
-                            additionalProperties:
-                              type: boolean
-                            type: object
-                          port:
-                            type: integer
-                        type: object
+                        type: string
                       type: array
                     databaseName:
                       type: string

--- a/controllers/admin_client.go
+++ b/controllers/admin_client.go
@@ -478,7 +478,12 @@ func (client *MockAdminClient) ChangeCoordinators(addresses []fdbtypes.ProcessAd
 	if err != nil {
 		return "", err
 	}
-	connectionString.Coordinators = addresses
+	newCoord := make([]string, len(addresses))
+	for idx, coord := range addresses {
+		newCoord[idx] = coord.String()
+	}
+
+	connectionString.Coordinators = newCoord
 	return connectionString.String(), err
 }
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1958,7 +1958,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				for _, coordinator := range connectionString.Coordinators {
-					Expect(coordinator.Flags["tls"]).To(BeTrue())
+					Expect(coordinator).To(HaveSuffix("tls"))
 				}
 			})
 		})
@@ -1981,11 +1981,11 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 				addressClassMap := map[string]fdbtypes.ProcessClass{}
 				for _, pGroup := range cluster.Status.ProcessGroups {
-					addressClassMap[pGroup.Addresses[0]] = pGroup.ProcessClass
+					addressClassMap[fmt.Sprintf("%s:4501", pGroup.Addresses[0])] = pGroup.ProcessClass
 				}
 
 				for _, coordinator := range connectionString.Coordinators {
-					Expect(addressClassMap[coordinator.IPAddress.String()]).To(Equal(fdbtypes.ProcessClassStorage))
+					Expect(addressClassMap[coordinator]).To(Equal(fdbtypes.ProcessClassStorage))
 				}
 			})
 
@@ -2008,11 +2008,11 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 					addressClassMap := map[string]fdbtypes.ProcessClass{}
 					for _, pGroup := range cluster.Status.ProcessGroups {
-						addressClassMap[pGroup.Addresses[0]] = pGroup.ProcessClass
+						addressClassMap[fmt.Sprintf("%s:4501", pGroup.Addresses[0])] = pGroup.ProcessClass
 					}
 
 					for _, coordinator := range connectionString.Coordinators {
-						Expect(addressClassMap[coordinator.IPAddress.String()]).To(Equal(fdbtypes.ProcessClassLog))
+						Expect(addressClassMap[coordinator]).To(Equal(fdbtypes.ProcessClassLog))
 					}
 				})
 			})

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -92,7 +92,7 @@ func (g GenerateInitialClusterFile) Reconcile(r *FoundationDBClusterReconciler, 
 	}
 
 	for _, locality := range coordinators {
-		connectionString.Coordinators = append(connectionString.Coordinators, locality.Address)
+		connectionString.Coordinators = append(connectionString.Coordinators, locality.Address.String())
 	}
 
 	cluster.Status.ConnectionString = connectionString.String()

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -106,7 +106,7 @@ ConnectionString models the contents of a cluster file in a structured way
 | ----- | ----------- | ------ | -------- |
 | databaseName | DatabaseName provides an identifier for the database which persists across coordinator changes. | string | false |
 | generationID | GenerationID provides a unique ID for the current generation of coordinators. | string | false |
-| coordinators | Coordinators provides the addresses of the current coordinators. | [][ProcessAddress](#processaddress) | false |
+| coordinators | Coordinators provides the addresses of the current coordinators. | []string | false |
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
# Description

Reverting the change that coordinators in the connection string (CRD) are handled as `ProcessAddress`.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

# Testing

Local, e2e.

# Documentation

None.

# Follow-up

None.
