### PR TITLE
Replace pods if PVC name in cluster spec changes

### DIFF
--- a/controllers/replace_misconfigured_pods.go
+++ b/controllers/replace_misconfigured_pods.go
@@ -89,6 +89,25 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 			return &Requeue{Error: err}
 		}
 
+		if pvc.Name != desiredPVC.Name {
+			log.Info("PVC Name and desired PVC  Names are different", "Current PVC name", pvc.Name, "Cluster spec PVC name", desiredPVC.Name)
+			instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, getSinglePodListOptions(cluster, instanceID)...)
+			if err != nil {
+				return &Requeue{Error: err}
+			}
+
+			if len(instances) > 0 {
+				processGroupStatus.Remove = true
+				hasNewRemovals = true
+
+				log.Info("Replace instance",
+					"namespace", cluster.Namespace,
+					"cluster", cluster.Name,
+					"processGroupID", instanceID,
+					"pvc", pvc.Name,
+					"reason", fmt.Sprintf("Cluster spec has changed from %s to %s", pvc.Name, desiredPVC.Name))
+			}
+		}
 		pvcHash, err := GetJSONHash(desiredPVC.Spec)
 		if err != nil {
 			return &Requeue{Error: err}

--- a/controllers/replace_misconfigured_pods.go
+++ b/controllers/replace_misconfigured_pods.go
@@ -88,26 +88,6 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 		if err != nil {
 			return &Requeue{Error: err}
 		}
-
-		if pvc.Name != desiredPVC.Name {
-			log.Info("PVC Name and desired PVC  Names are different", "Current PVC name", pvc.Name, "Cluster spec PVC name", desiredPVC.Name)
-			instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, getSinglePodListOptions(cluster, instanceID)...)
-			if err != nil {
-				return &Requeue{Error: err}
-			}
-
-			if len(instances) > 0 {
-				processGroupStatus.Remove = true
-				hasNewRemovals = true
-
-				log.Info("Replace instance",
-					"namespace", cluster.Namespace,
-					"cluster", cluster.Name,
-					"processGroupID", instanceID,
-					"pvc", pvc.Name,
-					"reason", fmt.Sprintf("Cluster spec has changed from %s to %s", pvc.Name, desiredPVC.Name))
-			}
-		}
 		pvcHash, err := GetJSONHash(desiredPVC.Spec)
 		if err != nil {
 			return &Requeue{Error: err}


### PR DESCRIPTION
# Description

This is to solve [issue 369](https://github.com/FoundationDB/fdb-kubernetes-operator/issues/369), Replacing pods when changing volume name

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*
NA
# Testing
Local testing
*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

# Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
