### PR TITLE
Replace instances if PVC hash/name does not match

### DIFF
--- a/controllers/replace_misconfigured_pods.go
+++ b/controllers/replace_misconfigured_pods.go
@@ -64,11 +64,11 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 			continue
 		}
 
-		hasNewRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
+		needsNewRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
 		if err != nil {
 			return &Requeue{Error: err}
 		}
-		if hasNewRemoval {
+		if needsNewRemoval {
 			instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetSinglePodListOptions(cluster, instanceID)...)
 			if err != nil {
 				return &Requeue{Error: err}
@@ -153,7 +153,7 @@ func instanceNeedsRemovalForPVC(cluster *fdbtypes.FoundationDBCluster, pvc corev
 			"cluster", cluster.Name,
 			"processGroupID", instanceID,
 			"pvc", pvc.Name,
-			"reason", fmt.Sprintf("PVC name has changed %s to %s", desiredPVC.Name, pvc.Name))
+			"reason", fmt.Sprintf("PVC name has changed from %s to %s", desiredPVC.Name, pvc.Name))
 		return true, nil
 	}
 	return false, nil

--- a/controllers/replace_misconfigured_pods.go
+++ b/controllers/replace_misconfigured_pods.go
@@ -54,20 +54,6 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 	}
 
 	for _, pvc := range pvcs.Items {
-		ownedByCluster := !cluster.ShouldFilterOnOwnerReferences()
-		if !ownedByCluster {
-			for _, ownerReference := range pvc.OwnerReferences {
-				if ownerReference.UID == cluster.UID {
-					ownedByCluster = true
-					break
-				}
-			}
-		}
-
-		if !ownedByCluster {
-			continue
-		}
-
 		instanceID := internal.GetInstanceIDFromMeta(pvc.ObjectMeta)
 		processGroupStatus := processGroups[instanceID]
 		if processGroupStatus == nil {
@@ -78,22 +64,8 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 			continue
 		}
 
-		_, idNum, err := ParseInstanceID(instanceID)
-		if err != nil {
-			return &Requeue{Error: err}
-		}
-
-		processClass := internal.GetProcessClassFromMeta(pvc.ObjectMeta)
-		desiredPVC, err := internal.GetPvc(cluster, processClass, idNum)
-		if err != nil {
-			return &Requeue{Error: err}
-		}
-		pvcHash, err := internal.GetJSONHash(desiredPVC.Spec)
-		if err != nil {
-			return &Requeue{Error: err}
-		}
-
-		if pvc.Annotations[fdbtypes.LastSpecKey] != pvcHash {
+		hasNewRemovals, err = instanceNeedsRemovalForPVC(pvc, cluster)
+		if  hasNewRemovals {
 			instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetSinglePodListOptions(cluster, instanceID)...)
 			if err != nil {
 				return &Requeue{Error: err}
@@ -102,13 +74,6 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 			if len(instances) > 0 {
 				processGroupStatus.Remove = true
 				hasNewRemovals = true
-
-				log.Info("Replace instance",
-					"namespace", cluster.Namespace,
-					"cluster", cluster.Name,
-					"processGroupID", instanceID,
-					"pvc", pvc.Name,
-					"reason", fmt.Sprintf("PVC spec has changed from %s to %s", pvcHash, pvc.Annotations[fdbtypes.LastSpecKey]))
 			}
 		}
 	}
@@ -141,6 +106,54 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 	}
 
 	return nil
+}
+
+func instanceNeedsRemovalForPVC(pvc corev1.PersistentVolumeClaim, cluster  *fdbtypes.FoundationDBCluster) (bool, error) {
+	ownedByCluster := !cluster.ShouldFilterOnOwnerReferences()
+	if !ownedByCluster {
+		for _, ownerReference := range pvc.OwnerReferences {
+			if ownerReference.UID == cluster.UID {
+				ownedByCluster = true
+				break
+			}
+		}
+	}
+	if !ownedByCluster {
+		return false, nil
+	}
+	instanceID := internal.GetInstanceIDFromMeta(pvc.ObjectMeta)
+	_, idNum, err := ParseInstanceID(instanceID)
+	if err != nil {
+		return false, err
+	}
+	processClass := internal.GetProcessClassFromMeta(pvc.ObjectMeta)
+	desiredPVC, err := internal.GetPvc(cluster, processClass, idNum)
+	if err != nil {
+		return false, err
+	}
+	pvcHash, err := internal.GetJSONHash(desiredPVC.Spec)
+	if err != nil {
+		return false, err
+	}
+	if pvc.Annotations[fdbtypes.LastSpecKey] != pvcHash {
+		log.Info("Replace instance",
+			"namespace", cluster.Namespace,
+			"cluster", cluster.Name,
+			"processGroupID", instanceID,
+			"pvc", pvc.Name,
+			"reason", fmt.Sprintf("PVC spec has changed from %s to %s", pvcHash, pvc.Annotations[fdbtypes.LastSpecKey]))
+		return  true, nil
+	}
+	if pvc.Name != desiredPVC.Name {
+		log.Info("Replace instance",
+			"namespace", cluster.Namespace,
+			"cluster", cluster.Name,
+			"processGroupID", instanceID,
+			"pvc", pvc.Name,
+			"reason", fmt.Sprintf("PVC spec has changed from %s to %s", desiredPVC.Name , pvc.Name))
+		return true, nil
+	}
+	return false, nil
 }
 
 func instanceNeedsRemoval(cluster *fdbtypes.FoundationDBCluster, instance FdbInstance, processGroupStatus *fdbtypes.ProcessGroupStatus) (bool, error) {

--- a/controllers/replace_misconfigured_pods_test.go
+++ b/controllers/replace_misconfigured_pods_test.go
@@ -387,7 +387,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 		})
 	})
 
-	When("PVC name and PVC spec doesn't match", func() {
+	When("PVC name doesn't match", func() {
 		It("should need a removal", func() {
 			pvc := corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -441,25 +441,6 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(needsRemoval).To(BeTrue())
-		})
-	})
-
-	When("PVC hash and PVC spec hash match", func() {
-		It("should not need a removal", func() {
-			pvc := corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "operator-test-1-storage-1337-data",
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   instanceName,
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
-					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
-					},
-				},
-			}
-			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
-			Expect(needsRemoval).To(BeFalse())
-			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/controllers/replace_misconfigured_pods_test.go
+++ b/controllers/replace_misconfigured_pods_test.go
@@ -387,11 +387,11 @@ var _ = Describe("replace_misconfigured_pods", func() {
 		})
 	})
 
-	Context("when PVC name and cluster spec doesn't match", func() {
+	When("PVC name and PVC spec doesn't match", func() {
 		It("should need a removal", func() {
 			pvc := corev1.PersistentVolumeClaim{
-				ObjectMeta : metav1.ObjectMeta {
-					Name : "Test-storage",
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "Test-storage",
 					Labels: map[string]string{
 						fdbtypes.FDBInstanceIDLabel:   instanceName,
 						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
@@ -400,17 +400,17 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					},
 				},
 			}
-			needsRemoval, err := instanceNeedsRemovalForPVC(pvc, cluster)
-			Expect(needsRemoval).To(BeTrue())
+			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(needsRemoval).To(BeTrue())
 		})
 	})
 
-	Context("when PVC name and cluster spec match", func() {
+	When("PVC name and PVC spec match", func() {
 		It("should not need a removal", func() {
 			pvc := corev1.PersistentVolumeClaim{
-				ObjectMeta : metav1.ObjectMeta {
-					Name : "operator-test-1-storage-1337-data",
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "operator-test-1-storage-1337-data",
 					Labels: map[string]string{
 						fdbtypes.FDBInstanceIDLabel:   instanceName,
 						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
@@ -419,17 +419,17 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					},
 				},
 			}
-			needsRemoval, err := instanceNeedsRemovalForPVC(pvc, cluster)
-			Expect(needsRemoval).To(BeFalse())
+			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(needsRemoval).To(BeFalse())
 		})
 	})
 
-	Context("when PVC hash and cluster spec doesn't match", func() {
+	When("PVC hash doesn't match", func() {
 		It("should need a removal", func() {
 			pvc := corev1.PersistentVolumeClaim{
-				ObjectMeta : metav1.ObjectMeta {
-					Name : "operator-test-1-storage-1337-data",
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "operator-test-1-storage-1337-data",
 					Labels: map[string]string{
 						fdbtypes.FDBInstanceIDLabel:   instanceName,
 						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
@@ -438,17 +438,17 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					},
 				},
 			}
-			needsRemoval, err := instanceNeedsRemovalForPVC(pvc, cluster)
-			Expect(needsRemoval).To(BeTrue())
+			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(needsRemoval).To(BeTrue())
 		})
 	})
 
-	Context("when PVC hash and cluster spec hash match", func() {
+	When("PVC hash and PVC spec hash match", func() {
 		It("should not need a removal", func() {
 			pvc := corev1.PersistentVolumeClaim{
-				ObjectMeta : metav1.ObjectMeta {
-					Name : "operator-test-1-storage-1337-data",
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "operator-test-1-storage-1337-data",
 					Labels: map[string]string{
 						fdbtypes.FDBInstanceIDLabel:   instanceName,
 						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
@@ -457,7 +457,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					},
 				},
 			}
-			needsRemoval, err := instanceNeedsRemovalForPVC(pvc, cluster)
+			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
 			Expect(needsRemoval).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/controllers/replace_misconfigured_pods_test.go
+++ b/controllers/replace_misconfigured_pods_test.go
@@ -389,18 +389,10 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 	When("PVC name doesn't match", func() {
 		It("should need a removal", func() {
-			pvc := corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "Test-storage",
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   instanceName,
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
-					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
-					},
-				},
-			}
-			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
+			pvc, err := internal.GetPvc(cluster, fdbtypes.ProcessClassStorage, 1)
+			Expect(err).NotTo(HaveOccurred())
+			pvc.Name = "Test-storage"
+			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, *pvc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(needsRemoval).To(BeTrue())
 		})
@@ -408,18 +400,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 	When("PVC name and PVC spec match", func() {
 		It("should not need a removal", func() {
-			pvc := corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "operator-test-1-storage-1337-data",
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   instanceName,
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
-					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
-					},
-				},
-			}
-			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
+			pvc, err := internal.GetPvc(cluster, fdbtypes.ProcessClassStorage, 1)
+			Expect(err).NotTo(HaveOccurred())
+			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, *pvc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(needsRemoval).To(BeFalse())
 		})
@@ -427,18 +410,10 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 	When("PVC hash doesn't match", func() {
 		It("should need a removal", func() {
-			pvc := corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "operator-test-1-storage-1337-data",
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   instanceName,
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
-					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
-					},
-				},
-			}
-			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
+			pvc, err := internal.GetPvc(cluster, fdbtypes.ProcessClassStorage, 1)
+			Expect(err).NotTo(HaveOccurred())
+			pvc.Annotations[fdbtypes.LastSpecKey] = "1"
+			needsRemoval, err := instanceNeedsRemovalForPVC(cluster, *pvc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(needsRemoval).To(BeTrue())
 		})

--- a/controllers/replace_misconfigured_pods_test.go
+++ b/controllers/replace_misconfigured_pods_test.go
@@ -387,6 +387,82 @@ var _ = Describe("replace_misconfigured_pods", func() {
 		})
 	})
 
+	Context("when PVC name and cluster spec doesn't match", func() {
+		It("should need a removal", func() {
+			pvc := corev1.PersistentVolumeClaim{
+				ObjectMeta : metav1.ObjectMeta {
+					Name : "Test-storage",
+					Labels: map[string]string{
+						fdbtypes.FDBInstanceIDLabel:   instanceName,
+						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
+					Annotations: map[string]string{
+						fdbtypes.LastSpecKey: "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
+					},
+				},
+			}
+			needsRemoval, err := instanceNeedsRemovalForPVC(pvc, cluster)
+			Expect(needsRemoval).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when PVC name and cluster spec match", func() {
+		It("should not need a removal", func() {
+			pvc := corev1.PersistentVolumeClaim{
+				ObjectMeta : metav1.ObjectMeta {
+					Name : "operator-test-1-storage-1337-data",
+					Labels: map[string]string{
+						fdbtypes.FDBInstanceIDLabel:   instanceName,
+						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
+					Annotations: map[string]string{
+						fdbtypes.LastSpecKey: "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
+					},
+				},
+			}
+			needsRemoval, err := instanceNeedsRemovalForPVC(pvc, cluster)
+			Expect(needsRemoval).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when PVC hash and cluster spec doesn't match", func() {
+		It("should need a removal", func() {
+			pvc := corev1.PersistentVolumeClaim{
+				ObjectMeta : metav1.ObjectMeta {
+					Name : "operator-test-1-storage-1337-data",
+					Labels: map[string]string{
+						fdbtypes.FDBInstanceIDLabel:   instanceName,
+						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
+					Annotations: map[string]string{
+						fdbtypes.LastSpecKey: "1",
+					},
+				},
+			}
+			needsRemoval, err := instanceNeedsRemovalForPVC(pvc, cluster)
+			Expect(needsRemoval).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when PVC hash and cluster spec hash match", func() {
+		It("should not need a removal", func() {
+			pvc := corev1.PersistentVolumeClaim{
+				ObjectMeta : metav1.ObjectMeta {
+					Name : "operator-test-1-storage-1337-data",
+					Labels: map[string]string{
+						fdbtypes.FDBInstanceIDLabel:   instanceName,
+						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage)},
+					Annotations: map[string]string{
+						fdbtypes.LastSpecKey: "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
+					},
+				},
+			}
+			needsRemoval, err := instanceNeedsRemovalForPVC(pvc, cluster)
+			Expect(needsRemoval).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	Context("when the memory resources are changed", func() {
 		var status *fdbtypes.ProcessGroupStatus
 		var instance FdbInstance


### PR DESCRIPTION
# Description

Replace instances if PVC hash/name does not match with cluster spec. Currently, PVC hash is only validated against cluster spec. This will add the PVC name for validation. 

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

*Are there any design details that you would like to discuss further?*
NA
# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*
Added Unit test cases

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

# Documentation

*Did you update relevant documentation within this repository?*
NA
*If this change is adding new functionality, do we need to describe it in our user manual?*
NA
*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*
NA
*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
