### PR TITLE
Prevent double-encoding IPv6 addresses when translating between pod IPs and process addresses.

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1886,6 +1886,12 @@ func GetProcessPort(processNumber int, tls bool) int {
 // the primary address.
 func (cluster *FoundationDBCluster) GetFullAddressList(address string, primaryOnly bool, processNumber int) []ProcessAddress {
 	addrs := make([]ProcessAddress, 0, 2)
+
+	// If the address is already enclosed in brackets, remove them since they
+	// will be re-added automatically in the ProcessAddress logic.
+	if strings.HasPrefix(address, "[") && strings.HasSuffix(address, "]") {
+		address = address[1 : len(address)-1]
+	}
 	// When a TLS address is provided the TLS address will always be the primary address
 	// see: https://github.com/apple/foundationdb/blob/master/fdbrpc/FlowTransport.h#L49-L56
 	if cluster.Status.RequiredAddresses.TLS {

--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1889,9 +1889,8 @@ func (cluster *FoundationDBCluster) GetFullAddressList(address string, primaryOn
 
 	// If the address is already enclosed in brackets, remove them since they
 	// will be re-added automatically in the ProcessAddress logic.
-	if strings.HasPrefix(address, "[") && strings.HasSuffix(address, "]") {
-		address = address[1 : len(address)-1]
-	}
+	address = strings.TrimPrefix(strings.TrimSuffix(address, "]"), "[")
+
 	// When a TLS address is provided the TLS address will always be the primary address
 	// see: https://github.com/apple/foundationdb/blob/master/fdbrpc/FlowTransport.h#L49-L56
 	if cluster.Status.RequiredAddresses.TLS {

--- a/controllers/admin_client.go
+++ b/controllers/admin_client.go
@@ -233,7 +233,7 @@ func (client *MockAdminClient) GetStatus() (*fdbtypes.FoundationDBStatus, error)
 			var fdbRoles []fdbtypes.FoundationDBStatusProcessRoleInfo
 
 			fullAddress := client.Cluster.GetFullAddress(processIP, processIndex)
-			_, ipExcluded := exclusionMap[pod.Status.PodIP]
+			_, ipExcluded := exclusionMap[processIP]
 			_, addressExcluded := exclusionMap[fullAddress.String()]
 			excluded := ipExcluded || addressExcluded
 			_, isCoordinator := coordinators[fullAddress.String()]


### PR DESCRIPTION
# Description

This fixes a bug where IP addresses would be enclosed in two sets of brackets when we generated the connection string for IPv6 clusters.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

This does fairly primitive parsing, but I don't know if there's a cleaner way of expressing what we're trying to do.

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I added new unit tests for IPv6 clusters, and created a real IPv6 cluster in a test environment.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

# Documentation

*Did you update relevant documentation within this repository?*

No.

*If this change is adding new functionality, do we need to describe it in our user manual?*

No.

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

No.

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

No.

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.
