### PR TITLE
Printout Pod names instead of Pod struct

### DIFF
--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -341,7 +341,12 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, clusterName st
 
 		pods := filterDeletePods(replaceInstances, killPods)
 		if !force && len(pods) > 0 {
-			confirmed = confirmAction(fmt.Sprintf("Delete Pods %v in cluster %s/%s", killPods, namespace, clusterName))
+			podNames := make([]string, 0, len(killPods))
+			for _, pod := range killPods {
+				podNames = append(podNames, pod.Name)
+			}
+
+			confirmed = confirmAction(fmt.Sprintf("Delete Pods %v in cluster %s/%s", strings.Join(podNames, ","), namespace, clusterName))
 		}
 
 		if force || confirmed {


### PR DESCRIPTION
# Description

Print Pod names instead of Pod structs when running the analyze command.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

# Testing

Unit tests + locally

# Documentation

-
# Follow-up

-
