### PR TITLE
Adds additional checks for deprecated fields in container overrides.

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1717,67 +1717,6 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			})
 		})
 
-		Context("with a change to environment variables with the deprecated field", func() {
-			BeforeEach(func() {
-				cluster.Spec.MainContainer.Env = append(cluster.Spec.MainContainer.Env, corev1.EnvVar{
-					Name:  "TEST_CHANGE",
-					Value: "1",
-				})
-			})
-
-			Context("with deletion enabled", func() {
-				BeforeEach(func() {
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("should set the environment variable on the pods", func() {
-					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
-
-					for _, pod := range pods.Items {
-						Expect(len(pod.Spec.Containers[0].Env)).To(Equal(2))
-						Expect(pod.Spec.Containers[0].Env[0].Name).To(Equal("TEST_CHANGE"))
-						Expect(pod.Spec.Containers[0].Env[0].Value).To(Equal("1"))
-					}
-				})
-			})
-
-			Context("with deletion disabled", func() {
-				BeforeEach(func() {
-					var flag = false
-					cluster.Spec.AutomationOptions.DeletePods = &flag
-
-					shouldCompleteReconciliation = false
-
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				JustBeforeEach(func() {
-					generations, err := reloadClusterGenerations(cluster)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(generations).To(Equal(fdbtypes.ClusterGenerationStatus{
-						Reconciled:          originalVersion,
-						NeedsPodDeletion:    originalVersion + 1,
-						HasUnhealthyProcess: originalVersion + 1,
-					}))
-				})
-
-				It("should not set the environment variable on the pods", func() {
-					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
-
-					for _, pod := range pods.Items {
-						Expect(len(pod.Spec.Containers[0].Env)).To(Equal(1))
-						Expect(pod.Spec.Containers[0].Env[0].Name).To(Equal("FDB_CLUSTER_FILE"))
-					}
-				})
-			})
-		})
-
 		Context("with a change to the public IP source", func() {
 			BeforeEach(func() {
 				source := fdbtypes.PublicIPSourceService

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -236,15 +236,11 @@ func GetPodSpec(cluster *fdbtypes.FoundationDBCluster, processClass fdbtypes.Pro
 		mainContainer.SecurityContext.ReadOnlyRootFilesystem = &readOnlyRootFilesystem
 	}
 
-	customizeContainer(mainContainer, cluster.Spec.MainContainer)
-
-	customizeContainer(initContainer, cluster.Spec.SidecarContainer)
 	err = configureSidecarContainerForCluster(cluster, initContainer, true, instanceID, processSettings.GetAllowTagOverride())
 	if err != nil {
 		return nil, err
 	}
 
-	customizeContainer(sidecarContainer, cluster.Spec.SidecarContainer)
 	err = configureSidecarContainerForCluster(cluster, sidecarContainer, false, instanceID, processSettings.GetAllowTagOverride())
 	if err != nil {
 		return nil, err
@@ -690,34 +686,6 @@ func extendEnv(container *corev1.Container, env ...corev1.EnvVar) {
 		if !existingVars[envVar.Name] {
 			container.Env = append(container.Env, envVar)
 		}
-	}
-}
-
-// customizeContainer adds container overrides from the cluster spec to a
-// container.
-func customizeContainer(container *corev1.Container, overrides fdbtypes.ContainerOverrides) {
-	envOverrides := make(map[string]bool)
-
-	fullEnv := make([]corev1.EnvVar, 0)
-	for _, envVar := range overrides.Env {
-		fullEnv = append(fullEnv, *envVar.DeepCopy())
-		envOverrides[envVar.Name] = true
-	}
-
-	for _, envVar := range container.Env {
-		if !envOverrides[envVar.Name] {
-			fullEnv = append(fullEnv, envVar)
-		}
-	}
-
-	container.Env = fullEnv
-
-	for _, volume := range overrides.VolumeMounts {
-		container.VolumeMounts = append(container.VolumeMounts, *volume.DeepCopy())
-	}
-
-	if overrides.SecurityContext != nil {
-		container.SecurityContext = overrides.SecurityContext
 	}
 }
 


### PR DESCRIPTION
# Description

This moves the logic for handling 3 deprecated fields in ContainerOverrides into the NormalizeClusterSpec method.

Resolves #888 

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

No

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

Manual tests and unit tests

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No

# Documentation

*Did you update relevant documentation within this repository?*

I don't think there are any documentation updates necessary.

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.