### PR TITLE
Add a command to fix coordinator IPs after a majority of coordinators get new IPs.

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -468,7 +468,7 @@ func (processGroupStatus *ProcessGroupStatus) NeedsReplacement(failureTime int) 
 
 // AddAddresses adds the new address to the ProcessGroupStatus and removes duplicates and old addresses
 // if the process group is not marked as removal.
-func (processGroupStatus *ProcessGroupStatus) AddAddresses(addresses []string) {
+func (processGroupStatus *ProcessGroupStatus) AddAddresses(addresses []string, includeOldAddresses bool) {
 	newAddresses := make([]string, 0, len(addresses))
 	// Currently this only contains one address but might include in the future multiple addresses
 	// e.g. for dual stack
@@ -483,14 +483,12 @@ func (processGroupStatus *ProcessGroupStatus) AddAddresses(addresses []string) {
 
 	// If the newAddresses contains at least one IP address use this list as the new addresses
 	// and return
-	if len(newAddresses) > 0 && !processGroupStatus.Remove {
+	if len(newAddresses) > 0 && !includeOldAddresses {
 		processGroupStatus.Addresses = newAddresses
 		return
 	}
 
-	// The process group is marked for removal so we want to track all addresses during that removal
-	// to ensure we exclude and include all addresses during the removal process.
-	if processGroupStatus.Remove {
+	if includeOldAddresses {
 		processGroupStatus.Addresses = cleanAddressList(append(processGroupStatus.Addresses, newAddresses...))
 		return
 	}

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -2873,12 +2873,13 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 		type testCase struct {
 			initialProcessGroup  ProcessGroupStatus
 			inputAddresses       []string
+			keepOldAddresses     bool
 			expectedProcessGroup ProcessGroupStatus
 		}
 
 		DescribeTable("should add or ignore the addresses",
 			func(tc testCase) {
-				tc.initialProcessGroup.AddAddresses(tc.inputAddresses)
+				tc.initialProcessGroup.AddAddresses(tc.inputAddresses, tc.keepOldAddresses)
 				Expect(tc.expectedProcessGroup).To(Equal(tc.initialProcessGroup))
 
 			},
@@ -2905,20 +2906,21 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 						"2.2.2.2",
 					}},
 				}),
-			Entry("New Pod IP and process group is marked for removal",
+			Entry("New Pod IP and keep old addresses",
 				testCase{
 					initialProcessGroup: ProcessGroupStatus{
 						Addresses: []string{
 							"1.1.1.1",
 						},
-						Remove: true},
+					},
 					inputAddresses: []string{
 						"2.2.2.2",
 					},
+					keepOldAddresses: true,
 					expectedProcessGroup: ProcessGroupStatus{Addresses: []string{
 						"1.1.1.1",
 						"2.2.2.2",
-					}, Remove: true},
+					}},
 				}),
 		)
 	})

--- a/kubectl-fdb/cmd/fix_coordinator_ips.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips.go
@@ -216,9 +216,8 @@ func runFixCoordinatorIPs(kubeClient client.Client, cluster *fdbtypes.Foundation
 		return err
 	}
 
-	logger := log.Default()
 	if dryRun {
-		logger.Printf("New connection string: %s", cluster.Status.ConnectionString)
+		log.Printf("New connection string: %s", cluster.Status.ConnectionString)
 	}
 
 	commands, err := buildClusterFileUpdateCommands(cluster, kubeClient, context, namespace)
@@ -227,11 +226,11 @@ func runFixCoordinatorIPs(kubeClient client.Client, cluster *fdbtypes.Foundation
 	}
 	for _, command := range commands {
 		if dryRun {
-			logger.Printf("Update command: %s", strings.Join(command.Args, " "))
+			log.Printf("Update command: %s", strings.Join(command.Args, " "))
 		} else {
 			err := command.Run()
 			if err != nil {
-				logger.Print(err.Error())
+				log.Print(err.Error())
 			}
 		}
 	}

--- a/kubectl-fdb/cmd/fix_coordinator_ips.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips.go
@@ -1,0 +1,247 @@
+/*
+ * fix_coordinator_ips.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	ctx "context"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
+)
+
+func newFixCoordinatorIPsCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newFDBOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "fix-coordinator-ips",
+		Short: "Update the coordinator IPs in the cluster file",
+		Long:  "Update the coordinator IPs in the cluster file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clusterName, err := cmd.Flags().GetString("fdb-cluster")
+			if err != nil {
+				return err
+			}
+
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				return err
+			}
+
+			config, err := o.configFlags.ToRESTConfig()
+			if err != nil {
+				return err
+			}
+
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = fdbtypes.AddToScheme(scheme)
+
+			kubeClient, err := client.New(config, client.Options{Scheme: scheme})
+			if err != nil {
+				return err
+			}
+
+			namespace, err := getNamespace(*o.configFlags.Namespace)
+			if err != nil {
+				return err
+			}
+
+			cluster, err := loadCluster(kubeClient, namespace, clusterName)
+			if err != nil {
+				return err
+			}
+
+			err = runFixCoordinatorIPs(kubeClient, cluster, *o.configFlags.Context, namespace, dryRun)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Example: `
+  # Update the coordinator IPs for the cluster
+  kubectl fdb fix-coordinator-ips -c cluster
+  `,
+	}
+
+	cmd.Flags().StringP("fdb-cluster", "c", "", "update the provided cluster.")
+	err := cmd.MarkFlagRequired("fdb-cluster")
+	cmd.Flags().Bool("dry-run", false, "Print the new connection string without updating it")
+	if err != nil {
+		log.Fatal(err)
+	}
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
+	cmd.SetIn(o.In)
+
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// buildClusterFileUpdateCommands generates commands for using kubectl exec to
+// update the cluster file in the pods for a cluster.
+func buildClusterFileUpdateCommands(cluster *fdbtypes.FoundationDBCluster, kubeClient client.Client, context string, namespace string) ([]exec.Cmd, error) {
+	pods := &corev1.PodList{}
+
+	selector := labels.NewSelector()
+
+	err := internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for key, value := range cluster.Spec.LabelConfig.MatchLabels {
+		requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
+		if err != nil {
+			return nil, err
+		}
+		selector = selector.Add(*requirement)
+	}
+
+	processClassRequirement, err := labels.NewRequirement(fdbtypes.FDBProcessClassLabel, selection.Exists, nil)
+	if err != nil {
+		return nil, err
+	}
+	selector = selector.Add(*processClassRequirement)
+
+	err = kubeClient.List(ctx.Background(), pods,
+		client.InNamespace(namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+		client.MatchingFields{"status.phase": "Running"},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	kubectlPath, err := exec.LookPath("kubectl")
+	if err != nil {
+		return nil, err
+	}
+
+	baseArgs := []string{kubectlPath, "--namespace", namespace}
+	if context != "" {
+		baseArgs = append(baseArgs, "--context", context)
+	}
+	baseArgs = append(baseArgs, "exec", "-it", "-c", "foundationdb")
+
+	execArgs := []string{"--", "bash", "-c", fmt.Sprintf("echo %s > /var/fdb/data/fdb.cluster && pkill fdbserver", cluster.Status.ConnectionString)}
+	execCommands := make([]exec.Cmd, 0, len(pods.Items))
+
+	for _, pod := range pods.Items {
+		args := append(baseArgs, pod.Name)
+		args = append(args, execArgs...)
+		execCommands = append(execCommands, exec.Cmd{
+			Path:   kubectlPath,
+			Args:   args,
+			Stdin:  os.Stdin,
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
+		})
+	}
+
+	return execCommands, nil
+}
+
+// updateIPsInConnectionString updates the connection string in the cluster
+// status by replacing old coordinator IPs with the latest IPs.
+func updateIPsInConnectionString(cluster *fdbtypes.FoundationDBCluster) error {
+	connectionString, err := fdbtypes.ParseConnectionString(cluster.Status.ConnectionString)
+	if err != nil {
+		return err
+	}
+	newCoordinators := make([]string, len(connectionString.Coordinators))
+	for coordinatorIndex, coordinator := range connectionString.Coordinators {
+		coordinatorAddress, err := fdbtypes.ParseProcessAddress(coordinator)
+		if err != nil {
+			return err
+		}
+		for _, processGroup := range cluster.Status.ProcessGroups {
+			for _, address := range processGroup.Addresses {
+				if address == coordinatorAddress.IPAddress.String() {
+					coordinatorAddress.IPAddress = net.ParseIP(processGroup.Addresses[len(processGroup.Addresses)-1])
+					newCoordinators[coordinatorIndex] = coordinatorAddress.String()
+				}
+			}
+		}
+		if newCoordinators[coordinatorIndex] == "" {
+			log.Printf("Could not find process for coordinator IP %s", coordinator)
+			newCoordinators[coordinatorIndex] = coordinator
+		}
+	}
+	connectionString.Coordinators = newCoordinators
+	cluster.Status.ConnectionString = connectionString.String()
+
+	return nil
+}
+
+func runFixCoordinatorIPs(kubeClient client.Client, cluster *fdbtypes.FoundationDBCluster, context string, namespace string, dryRun bool) error {
+	patch := client.MergeFrom(cluster.DeepCopy())
+	err := updateIPsInConnectionString(cluster)
+	if err != nil {
+		return err
+	}
+
+	logger := log.Default()
+	if dryRun {
+		logger.Printf("New connection string: %s", cluster.Status.ConnectionString)
+	}
+
+	commands, err := buildClusterFileUpdateCommands(cluster, kubeClient, context, namespace)
+	if err != nil {
+		return err
+	}
+	for _, command := range commands {
+		if dryRun {
+			logger.Printf("Update command: %s", strings.Join(command.Args, " "))
+		} else {
+			err := command.Run()
+			if err != nil {
+				logger.Print(err.Error())
+			}
+		}
+	}
+
+	if !dryRun {
+		err = kubeClient.Status().Patch(ctx.Background(), cluster, patch)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/kubectl-fdb/cmd/fix_coordinator_ips_test.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips_test.go
@@ -84,7 +84,7 @@ var _ = Describe("[plugin] fix-coordinator-ips command", func() {
 				kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&cluster, &podList).Build()
 				cluster.Status.ConnectionString = "test:test@127.0.0.1:4501"
 
-				commands, err := buildClusterFileUpdateCommands(&cluster, kubeClient, input.Context, namespace)
+				commands, err := buildClusterFileUpdateCommands(&cluster, kubeClient, input.Context, namespace, "/usr/local/bin/kubectl")
 
 				if input.ExpectedError != "" {
 					Expect(err).To(HaveOccurred())

--- a/kubectl-fdb/cmd/fix_coordinator_ips_test.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips_test.go
@@ -1,0 +1,233 @@
+/*
+ * fix_coordinator_ips_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("[plugin] fix-coordinator-ips command", func() {
+	When("building cluster file update commands", func() {
+		clusterName := "test"
+		namespace := "test"
+
+		var cluster fdbtypes.FoundationDBCluster
+		var podList corev1.PodList
+
+		type testCase struct {
+			Context          string
+			ExpectedCommands [][]string
+			ExpectedError    string
+		}
+
+		BeforeEach(func() {
+			cluster = fdbtypes.FoundationDBCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: namespace,
+				},
+				Spec: fdbtypes.FoundationDBClusterSpec{
+					ProcessCounts: fdbtypes.ProcessCounts{
+						Storage: 1,
+					},
+				},
+			}
+
+			podList = corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "instance-1",
+							Namespace: namespace,
+							Labels: map[string]string{
+								fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
+								fdbtypes.FDBClusterLabel:      clusterName,
+							},
+						},
+					},
+				},
+			}
+		})
+
+		DescribeTable("should execute the provided command",
+			func(input testCase) {
+				scheme := runtime.NewScheme()
+				_ = clientgoscheme.AddToScheme(scheme)
+				_ = fdbtypes.AddToScheme(scheme)
+				kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&cluster, &podList).Build()
+				cluster.Status.ConnectionString = "test:test@127.0.0.1:4501"
+
+				commands, err := buildClusterFileUpdateCommands(&cluster, kubeClient, input.Context, namespace)
+
+				if input.ExpectedError != "" {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal(input.ExpectedError))
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(commands).To(HaveLen(len(input.ExpectedCommands)))
+					for index, command := range commands {
+						Expect(command.Args).To(Equal(input.ExpectedCommands[index]))
+					}
+				}
+			},
+			Entry("instance with valid pod",
+				testCase{
+					ExpectedCommands: [][]string{
+						{
+							"/usr/local/bin/kubectl",
+							"--namespace",
+							"test",
+							"exec",
+							"-it",
+							"-c",
+							"foundationdb",
+							"instance-1",
+							"--",
+							"bash",
+							"-c",
+							"echo test:test@127.0.0.1:4501 > /var/fdb/data/fdb.cluster && pkill fdbserver",
+						},
+					},
+				}),
+			Entry("instance with explicit context",
+				testCase{
+					Context: "remote-kc",
+					ExpectedCommands: [][]string{
+						{
+							"/usr/local/bin/kubectl",
+							"--namespace",
+							"test",
+							"--context",
+							"remote-kc",
+							"exec",
+							"-it",
+							"-c",
+							"foundationdb",
+							"instance-1",
+							"--",
+							"bash",
+							"-c",
+							"echo test:test@127.0.0.1:4501 > /var/fdb/data/fdb.cluster && pkill fdbserver",
+						},
+					},
+				},
+			),
+		)
+	})
+	When("updating the connection string", func() {
+		clusterName := "test"
+		namespace := "test"
+
+		var cluster fdbtypes.FoundationDBCluster
+
+		type testCase struct {
+			Context                  string
+			ExpectedConnectionString string
+			ExpectedError            string
+			AddressUpdates           map[string]string
+		}
+
+		BeforeEach(func() {
+			cluster = fdbtypes.FoundationDBCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: namespace,
+				},
+				Spec: fdbtypes.FoundationDBClusterSpec{
+					ProcessCounts: fdbtypes.ProcessCounts{
+						Storage: 1,
+					},
+				},
+				Status: fdbtypes.FoundationDBClusterStatus{
+					ConnectionString: "test:asdfkjh@127.0.0.1:4501,127.0.0.2:4501,127.0.0.3:4501",
+					ProcessGroups: []*fdbtypes.ProcessGroupStatus{
+						{ProcessGroupID: "storage-1", Addresses: []string{"127.0.0.1"}},
+						{ProcessGroupID: "storage-2", Addresses: []string{"127.0.0.2"}},
+						{ProcessGroupID: "storage-3", Addresses: []string{"127.0.0.3"}},
+						{ProcessGroupID: "storage-4", Addresses: []string{"127.0.0.4"}},
+						{ProcessGroupID: "storage-5", Addresses: []string{"127.0.0.5"}},
+					},
+				},
+			}
+		})
+
+		DescribeTable("should execute the provided command",
+			func(input testCase) {
+				scheme := runtime.NewScheme()
+				_ = clientgoscheme.AddToScheme(scheme)
+				_ = fdbtypes.AddToScheme(scheme)
+
+				for processGroupID, address := range input.AddressUpdates {
+					for _, processGroup := range cluster.Status.ProcessGroups {
+						if processGroup.ProcessGroupID == processGroupID {
+							if address == "" {
+								processGroup.Addresses = nil
+							} else {
+								processGroup.Addresses = append(processGroup.Addresses, address)
+							}
+						}
+					}
+				}
+				err := updateIPsInConnectionString(&cluster)
+
+				if input.ExpectedError != "" {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal(input.ExpectedError))
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(cluster.Status.ConnectionString).To(Equal(input.ExpectedConnectionString))
+				}
+			},
+			Entry("healthy cluster",
+				testCase{
+					ExpectedConnectionString: "test:asdfkjh@127.0.0.1:4501,127.0.0.2:4501,127.0.0.3:4501",
+				},
+			),
+			Entry("updated address",
+				testCase{
+					AddressUpdates: map[string]string{
+						"storage-1": "127.0.1.1",
+						"storage-2": "127.0.1.2",
+						"storage-5": "127.0.1.5",
+					},
+					ExpectedConnectionString: "test:asdfkjh@127.0.1.1:4501,127.0.1.2:4501,127.0.0.3:4501",
+				},
+			),
+			Entry("IP address with no process group",
+				testCase{
+					AddressUpdates: map[string]string{
+						"storage-1": "",
+					},
+					ExpectedConnectionString: "test:asdfkjh@127.0.0.1:4501,127.0.0.2:4501,127.0.0.3:4501",
+				},
+			),
+		)
+	})
+})

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -78,6 +78,7 @@ func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
 		newRestartCmd(streams),
 		newAnalyzeCmd(streams),
 		newDeprecationCmd(streams),
+		newFixCoordinatorIPsCmd(streams),
 	)
 
 	return cmd


### PR DESCRIPTION
# Description

This provides tooling and documentation to help with a potential failure scenario where all coordinators get deleted and come up with new IPs.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

*Are there any design details that you would like to discuss further?*

The new command doesn't work for multi-KC clusters, because any given invocation will only have access to the process group information (and thus the new addresses) for the processes in that KC. I think we should address that in the future, as part of the broader work on improving multi-KC support in the plugin.

I changed the logic around tracking process group IPs to keep old IPs around when the database is unavailable. This was necessary to be able to use the process group address list to compare old and new IPs. I verified that once the database recovers, we clear out the old IPs, so we're still fulfilling the requirement to prevent the address list from growing indefinitely.

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I ran manual tests of deleting all pods and then recovering the cluster.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

# Documentation

*Did you update relevant documentation within this repository?*

Yes.

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

I think we'll want a follow-up issue on multi-KC support for the fix-coordinator-ips command.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.