### PR TITLE
Change the kubebuilder download path in the PR build.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -66,7 +66,7 @@ jobs:
         curl --fail -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VER}/kustomize_${KUSTOMIZE_VER}_linux_amd64.tar.gz" -o kustomize.tar.gz
         os=$(go env GOOS)
         arch=$(go env GOARCH)
-        curl --fail -L "https://go.kubebuilder.io/dl/${KUBEBUILDER_VER}/${os}/${arch}" -o kubebuilder.tar.gz
+        curl --fail -L "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VER}/kubebuilder_${KUBEBUILDER_VER}_${os}_${arch}.tar.gz" -o kubebuilder.tar.gz
         curl --fail "https://www.foundationdb.org/downloads/${{ matrix.fdbver }}/ubuntu/installers/foundationdb-clients_${{ matrix.fdbver }}-1_amd64.deb" -o fdb.deb
         curl -Lo kind https://kind.sigs.k8s.io/dl/${KIND_VER}/kind-linux-amd64
         curl -Lo yq.tar.gz https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz


### PR DESCRIPTION
# Description

Our PRBs have been broken because of an issue with one of our dependencies. This changes the download path to work around this issue.

Upstream issue: https://github.com/kubernetes-sigs/kubebuilder/issues/2311

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

No.

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

PRB.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

# Documentation

*Did you update relevant documentation within this repository?*

No.

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.