### PR TITLE
Return err if file not found instead of nil

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -419,7 +419,7 @@ func (client *cliAdminClient) VersionSupported(versionString string) (bool, erro
 	_, err = os.Stat(getBinaryPath("fdbcli", versionString))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return false, nil
+			return false, err
 		}
 		return false, err
 	}


### PR DESCRIPTION
# Description

Currently, If the `fdbcli` binary is not present `nil` is returned instead of an error string [here](https://github.com/FoundationDB/fdb-kubernetes-operator/blob/3fac0fbfed79abb4785c77b03dcc69acf11d9981/fdbclient/admin_client.go#L422). This makes debugging difficult.  

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

*Are there any design details that you would like to discuss further?*
NA
# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*
Local testing

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*
NA
# Documentation

*Did you update relevant documentation within this repository?*
NA
*If this change is adding new functionality, do we need to describe it in our user manual?*
NA
*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*
NA
*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*
NA
# Follow-up

*Are there any follow-up issues that we should pursue in the future?*
NA
*Does this introduce new defaults that we should re-evaluate in the future?*
NA