### PR TITLE
Move backup states into constants

### DIFF
--- a/api/v1beta1/foundationdbbackup_types.go
+++ b/api/v1beta1/foundationdbbackup_types.go
@@ -62,17 +62,18 @@ type FoundationDBBackupSpec struct {
 	// +kubebuilder:validation:Enum=Running;Stopped;Paused
 	// The desired state of the backup.
 	// The default is Running.
-	BackupState string `json:"backupState,omitempty"`
+	BackupState BackupState `json:"backupState,omitempty"`
 
 	// The name for the backup.
-	// The default is to use the name from the backup metadata.
+	// If empty defaults to .metadata.name.
 	BackupName string `json:"backupName,omitempty"`
 
 	// The account name to use with the backup destination.
+	// +kubebuilder:validation:Required
 	AccountName string `json:"accountName"`
 
 	// The backup bucket to write to.
-	// The default is to use "fdb-backups".
+	// The default is "fdb-backups".
 	Bucket string `json:"bucket,omitempty"`
 
 	// AgentCount defines the number of backup agents to run.
@@ -159,14 +160,26 @@ type BackupGenerationStatus struct {
 	NeedsBackupReconfiguration int64 `json:"needsBackupModification,omitempty"`
 }
 
+// BackupState defines the desired state of a backup
+type BackupState string
+
+const (
+	// BackupStateRunning defines the running state
+	BackupStateRunning BackupState = "Running"
+	// BackupStatePaused defines the paused state
+	BackupStatePaused BackupState = "Paused"
+	// BackupStateStopped defines the stopped state
+	BackupStateStopped BackupState = "Stopped"
+)
+
 // ShouldRun determines whether a backup should be running.
 func (backup *FoundationDBBackup) ShouldRun() bool {
-	return backup.Spec.BackupState == "" || backup.Spec.BackupState == "Running" || backup.Spec.BackupState == "Paused"
+	return backup.Spec.BackupState == "" || backup.Spec.BackupState == BackupStateRunning || backup.Spec.BackupState == BackupStatePaused
 }
 
 // ShouldBePaused determines whether the backups should be paused.
 func (backup *FoundationDBBackup) ShouldBePaused() bool {
-	return backup.Spec.BackupState == "Paused"
+	return backup.Spec.BackupState == BackupStatePaused
 }
 
 // Bucket gets the bucket this backup will use.

--- a/api/v1beta1/foundationdbbackup_types_test.go
+++ b/api/v1beta1/foundationdbbackup_types_test.go
@@ -110,7 +110,7 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			}))
 
 			backup = createBackup()
-			backup.Spec.BackupState = "Stopped"
+			backup.Spec.BackupState = BackupStateStopped
 			result, err = backup.CheckReconciliation()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeFalse())
@@ -121,7 +121,7 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 
 			backup = createBackup()
 			backup.Status.BackupDetails = nil
-			backup.Spec.BackupState = "Stopped"
+			backup.Spec.BackupState = BackupStateStopped
 			result, err = backup.CheckReconciliation()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())
@@ -131,7 +131,7 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 
 			backup = createBackup()
 			backup.Status.BackupDetails.Running = false
-			backup.Spec.BackupState = "Stopped"
+			backup.Spec.BackupState = BackupStateStopped
 			result, err = backup.CheckReconciliation()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())
@@ -140,7 +140,7 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			}))
 
 			backup = createBackup()
-			backup.Spec.BackupState = "Paused"
+			backup.Spec.BackupState = BackupStatePaused
 			result, err = backup.CheckReconciliation()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeFalse())
@@ -150,7 +150,7 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			}))
 
 			backup = createBackup()
-			backup.Spec.BackupState = "Paused"
+			backup.Spec.BackupState = BackupStatePaused
 			backup.Status.BackupDetails = nil
 			result, err = backup.CheckReconciliation()
 			Expect(err).NotTo(HaveOccurred())
@@ -162,7 +162,7 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			}))
 
 			backup = createBackup()
-			backup.Spec.BackupState = "Paused"
+			backup.Spec.BackupState = BackupStatePaused
 			backup.Status.BackupDetails.Paused = true
 			result, err = backup.CheckReconciliation()
 			Expect(err).NotTo(HaveOccurred())
@@ -201,15 +201,15 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 			Expect(backup.ShouldRun()).To(BeTrue())
 			Expect(backup.ShouldBePaused()).To(BeFalse())
 
-			backup.Spec.BackupState = "Running"
+			backup.Spec.BackupState = BackupStateRunning
 			Expect(backup.ShouldRun()).To(BeTrue())
 			Expect(backup.ShouldBePaused()).To(BeFalse())
 
-			backup.Spec.BackupState = "Stopped"
+			backup.Spec.BackupState = BackupStateStopped
 			Expect(backup.ShouldRun()).To(BeFalse())
 			Expect(backup.ShouldBePaused()).To(BeFalse())
 
-			backup.Spec.BackupState = "Paused"
+			backup.Spec.BackupState = BackupStatePaused
 			Expect(backup.ShouldRun()).To(BeTrue())
 			Expect(backup.ShouldBePaused()).To(BeTrue())
 		})

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -186,7 +186,7 @@ var _ = Describe("backup_controller", func() {
 
 		Context("when stopping a new backup", func() {
 			BeforeEach(func() {
-				backup.Spec.BackupState = "Stopped"
+				backup.Spec.BackupState = fdbtypes.BackupStateStopped
 				err = k8sClient.Update(context.TODO(), backup)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -200,7 +200,7 @@ var _ = Describe("backup_controller", func() {
 
 		Context("when pausing a backup", func() {
 			BeforeEach(func() {
-				backup.Spec.BackupState = "Paused"
+				backup.Spec.BackupState = fdbtypes.BackupStatePaused
 				err = k8sClient.Update(context.TODO(), backup)
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/docs/backup_spec.md
+++ b/docs/backup_spec.md
@@ -59,10 +59,10 @@ FoundationDBBackupSpec describes the desired state of the backup for a cluster.
 | ----- | ----------- | ------ | -------- |
 | version | The version of FoundationDB that the backup agents should run. | string | true |
 | clusterName | The cluster this backup is for. | string | true |
-| backupState | The desired state of the backup. The default is Running. | string | false |
-| backupName | The name for the backup. The default is to use the name from the backup metadata. | string | false |
+| backupState | The desired state of the backup. The default is Running. | BackupState | false |
+| backupName | The name for the backup. If empty defaults to .metadata.name. | string | false |
 | accountName | The account name to use with the backup destination. | string | true |
-| bucket | The backup bucket to write to. The default is to use \"fdb-backups\". | string | false |
+| bucket | The backup bucket to write to. The default is \"fdb-backups\". | string | false |
 | agentCount | AgentCount defines the number of backup agents to run. The default is run 2 agents. | *int | false |
 | snapshotPeriodSeconds | The time window between new snapshots. This is measured in seconds. The default is 864,000, or 10 days. | *int | false |
 | backupDeploymentMetadata | BackupDeploymentMetadata allows customizing labels and annotations on the deployment for the backup agents. | *[metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta) | false |

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -63,7 +63,7 @@ func CreateDefaultBackup(cluster *fdbtypes.FoundationDBCluster) *fdbtypes.Founda
 		Spec: fdbtypes.FoundationDBBackupSpec{
 			AccountName: "test@test-service",
 			BackupName:  "test-backup",
-			BackupState: "Running",
+			BackupState: fdbtypes.BackupStateRunning,
 			Version:     cluster.Spec.Version,
 			ClusterName: cluster.Name,
 			AgentCount:  &agentCount,


### PR DESCRIPTION
# Description

Moved the backup state to a constant for better reusability.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

None

# Testing

Unit + local testing

# Documentation

None.

# Follow-up

None.
