### PR TITLE
Rename destinationClusterName to clusterName to match the other resources

### DIFF
--- a/api/v1beta1/foundationdbrestore_types.go
+++ b/api/v1beta1/foundationdbrestore_types.go
@@ -51,6 +51,7 @@ type FoundationDBRestoreSpec struct {
 	// DestinationClusterName provides the name of the cluster that the data is
 	// being restored into.
 	// Deprecated: Use ClusterName instead.
+	// +kubebuilder:validation:Optional
 	DestinationClusterName string `json:"destinationClusterName"`
 
 	// clusterName provides the name of the cluster that the data is
@@ -87,12 +88,12 @@ type FoundationDBKeyRange struct {
 }
 
 // GetClusterName returns the cluster name for the targeted cluster for the restore.
-// If .Spec.ClusterName is defined the according value is returned otherwise it will fallback
-// to .Spec.DestinationClusterName.
+// If .Spec.DestinationClusterName is defined the according value is returned otherwise it will fallback
+// to .Spec.ClusterName.
 func (restore *FoundationDBRestore) GetClusterName() string {
-	if restore.Spec.ClusterName != "" {
-		return restore.Spec.ClusterName
+	if restore.Spec.DestinationClusterName != "" {
+		return restore.Spec.DestinationClusterName
 	}
 
-	return restore.Spec.DestinationClusterName
+	return restore.Spec.ClusterName
 }

--- a/api/v1beta1/foundationdbrestore_types.go
+++ b/api/v1beta1/foundationdbrestore_types.go
@@ -50,7 +50,13 @@ type FoundationDBRestoreList struct {
 type FoundationDBRestoreSpec struct {
 	// DestinationClusterName provides the name of the cluster that the data is
 	// being restored into.
+	// Deprecated: Use ClusterName instead.
 	DestinationClusterName string `json:"destinationClusterName"`
+
+	// clusterName provides the name of the cluster that the data is
+	// being restored into.
+	// +kubebuilder:validation:Required
+	ClusterName string `json:"clusterName"`
 
 	// BackupURL provides the URL for the backup.
 	BackupURL string `json:"backupURL"`
@@ -78,4 +84,15 @@ type FoundationDBKeyRange struct {
 	// End provides the end of the key range.
 	// +kubebuilder:validation:Pattern:=^[A-Za-z0-9\/\\-]+$
 	End string `json:"end"`
+}
+
+// GetClusterName returns the cluster name for the targeted cluster for the restore.
+// If .Spec.ClusterName is defined the according value is returned otherwise it will fallback
+// to .Spec.DestinationClusterName.
+func (restore *FoundationDBRestore) GetClusterName() string {
+	if restore.Spec.ClusterName != "" {
+		return restore.Spec.ClusterName
+	}
+
+	return restore.Spec.DestinationClusterName
 }

--- a/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
@@ -51,7 +51,6 @@ spec:
               required:
                 - backupURL
                 - clusterName
-                - destinationClusterName
               type: object
             status:
               properties:

--- a/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
@@ -30,6 +30,8 @@ spec:
               properties:
                 backupURL:
                   type: string
+                clusterName:
+                  type: string
                 destinationClusterName:
                   type: string
                 keyRanges:
@@ -48,6 +50,7 @@ spec:
                   type: array
               required:
                 - backupURL
+                - clusterName
                 - destinationClusterName
               type: object
             status:

--- a/config/samples/restore.yaml
+++ b/config/samples/restore.yaml
@@ -1,4 +1,4 @@
-# This is a sample configuratikon for restoring a FoundationDB cluster from a
+# This is a sample configuration for restoring a FoundationDB cluster from a
 # backup.
 #
 # This sample assumes some configuration that you will need to fill in based on
@@ -9,7 +9,7 @@ kind: FoundationDBRestore
 metadata:
   name: sample-cluster
 spec:
-  destinationClusterName: sample-cluster
+  clusterName: sample-cluster
 
   # This assumes that you have an account called `account` at an S3-compatible
   # object store at `https://object-store.example:443`. It also assumes that you

--- a/config/tests/backup/restore/restore.yaml
+++ b/config/tests/backup/restore/restore.yaml
@@ -3,5 +3,5 @@ kind: FoundationDBRestore
 metadata:
  name: test-cluster
 spec:
- destinationClusterName: test-cluster
+ clusterName: test-cluster
  backupURL: "blobstore://minio@minio-service:9000/test-cluster?bucket=fdb-backups"

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -101,7 +101,7 @@ func (r *FoundationDBRestoreReconciler) getDatabaseClientProvider() DatabaseClie
 // AdminClientForRestore provides an admin client for a restore reconciler.
 func (r *FoundationDBRestoreReconciler) AdminClientForRestore(context ctx.Context, restore *fdbtypes.FoundationDBRestore) (AdminClient, error) {
 	cluster := &fdbtypes.FoundationDBCluster{}
-	err := r.Get(context, types.NamespacedName{Namespace: restore.ObjectMeta.Namespace, Name: restore.Spec.DestinationClusterName}, cluster)
+	err := r.Get(context, types.NamespacedName{Namespace: restore.ObjectMeta.Namespace, Name: restore.GetClusterName()}, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -112,8 +112,8 @@ func createDefaultRestore(cluster *fdbtypes.FoundationDBCluster) *fdbtypes.Found
 			Namespace: cluster.Namespace,
 		},
 		Spec: fdbtypes.FoundationDBRestoreSpec{
-			BackupURL:              "blobstore://test@test-service/test-backup?bucket=fdb-backups",
-			DestinationClusterName: cluster.Name,
+			BackupURL:   "blobstore://test@test-service/test-backup?bucket=fdb-backups",
+			ClusterName: cluster.Name,
 		},
 		Status: fdbtypes.FoundationDBRestoreStatus{},
 	}

--- a/docs/manual/backup.md
+++ b/docs/manual/backup.md
@@ -106,7 +106,7 @@ kind: FoundationDBRestore
 metadata:
   name: sample-cluster
 spec:
-  destinationClusterName: sample-cluster
+  clusterName: sample-cluster
   backupURL: "blobstore://account@object-store.example:443/sample-cluster?bucket=fdb-backups"
 ```
 

--- a/docs/restore_spec.md
+++ b/docs/restore_spec.md
@@ -50,7 +50,8 @@ FoundationDBRestoreSpec describes the desired state of the backup for a cluster.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| destinationClusterName | DestinationClusterName provides the name of the cluster that the data is being restored into. | string | true |
+| destinationClusterName | DestinationClusterName provides the name of the cluster that the data is being restored into. **Deprecated: Use ClusterName instead.** | string | true |
+| clusterName | clusterName provides the name of the cluster that the data is being restored into. | string | true |
 | backupURL | BackupURL provides the URL for the backup. | string | true |
 | keyRanges | The key ranges to restore. | [][FoundationDBKeyRange](#foundationdbkeyrange) | false |
 


### PR DESCRIPTION
# Description

In the other resources we always use `clusterName`, for consistency we should use the same in the restore CRD. I think the context already describes that this will be the 'destination" for the restore.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

None.

# Testing

Local.

# Documentation

Adjusted.

# Follow-up

None.