### PR TITLE
Check for fault tolerance and not cluster health when deleting Pods

### DIFF
--- a/controllers/pod_lifecycle_manager.go
+++ b/controllers/pod_lifecycle_manager.go
@@ -108,7 +108,7 @@ func (manager StandardPodLifecycleManager) CanDeletePods(adminClient AdminClient
 		return false, err
 	}
 
-	return status.Client.DatabaseStatus.Healthy, nil
+	return status.Cluster.FullReplication && status.Client.DatabaseStatus.Available, nil
 }
 
 // UpdatePods updates a list of pods to match the latest specs.


### PR DESCRIPTION
# Description

Ironically the FDB cluster health is a bad indicator of the actual cluster health. Instead we should look if the cluster is fully replicated and if the cluster is available. Otherwise different things that are unrelated to the actual cluster health can block deletions e.g. a test process that is not running any more or clients with a wrong cluster file.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

None.

# Testing

Locally.

# Documentation

None.

# Follow-up

None.
