### PR TITLE
Add the fully replicated information into the status printout

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -43,6 +43,7 @@ import (
 // +kubebuilder:printcolumn:name="Generation",type="integer",JSONPath=".metadata.generation",description="Latest generation of the spec",priority=0
 // +kubebuilder:printcolumn:name="Reconciled",type="integer",JSONPath=".status.generations.reconciled",description="Last reconciled generation of the spec",priority=0
 // +kubebuilder:printcolumn:name="Available",type="boolean",JSONPath=".status.health.available",description="Database available",priority=0
+// +kubebuilder:printcolumn:name="FullReplication",type="boolean",JSONPath=".status.health.fullReplication",description="Database fully replicated",priority=0
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.runningVersion",description="Running version",priority=0
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -29,6 +29,10 @@ spec:
           jsonPath: .status.health.available
           name: Available
           type: boolean
+        - description: Database fully replicated
+          jsonPath: .status.health.fullReplication
+          name: FullReplication
+          type: boolean
         - description: Running version
           jsonPath: .status.runningVersion
           name: Version


### PR DESCRIPTION
# Description

Adding the fully replicated information to the status printout:

```bash
$ kubectl get fdb
NAME                                                     GENERATION   RECONCILED   AVAILABLE   FULLREPLICATION   VERSION   AGE
foundationdbcluster.apps.foundationdb.org/test-cluster   1            1            true        true              6.2.30    44s
```

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

None

# Testing

Locally

# Documentation

None

# Follow-up

None
