### PR TITLE
Update go to version 1.16.8

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,10 +41,10 @@ jobs:
         kubever: [ "v1.19.0", "v1.20.0", "v1.21.1" ]
         fdbver: ["6.2.30", "6.3.15"]
     steps:
-    - name: Set up Go 1.15
+    - name: Set up Go 1.16.8
       uses: actions/setup-go@v1
       with:
-        go-version: 1.15
+        go-version: 1.16.8
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - uses: actions/cache@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,10 +44,10 @@ jobs:
       - name: Set package name
         id: set_package_name
         run: echo ::set-output name=package_name::kubectl-fdb-${{ needs.create-release.outputs.tag }}-$(echo ${RUNNER_OS} | tr [:upper:] [:lower:])
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16.8
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16.8
       - name: Get FDB client
         if: runner.os != 'Windows'
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM foundationdb/foundationdb:6.1.13 as fdb61
 FROM foundationdb/foundationdb:6.3.10 as fdb63
 
 # Build the manager binary
-FROM golang:1.15.13 as builder
+FROM golang:1.16.8 as builder
 
 # Install FDB
 ARG FDB_VERSION=6.2.30

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -72,7 +71,7 @@ type cliAdminClient struct {
 
 // NewCliAdminClient generates an Admin client for a cluster
 func NewCliAdminClient(cluster *fdbtypes.FoundationDBCluster, _ client.Client) (controllers.AdminClient, error) {
-	clusterFile, err := ioutil.TempFile("", "")
+	clusterFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +368,7 @@ func (client *cliAdminClient) ChangeCoordinators(addresses []fdbtypes.ProcessAdd
 		return "", err
 	}
 
-	connectionStringBytes, err := ioutil.ReadFile(client.clusterFilePath)
+	connectionStringBytes, err := os.ReadFile(client.clusterFilePath)
 	if err != nil {
 		return "", err
 	}
@@ -392,7 +391,7 @@ func (client *cliAdminClient) GetConnectionString() (string, error) {
 		return "", fmt.Errorf("unable to fetch connection string: %s", output)
 	}
 
-	connectionStringBytes, err := ioutil.ReadFile(client.clusterFilePath)
+	connectionStringBytes, err := os.ReadFile(client.clusterFilePath)
 	if err != nil {
 		return "", err
 	}

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -23,10 +23,10 @@ package fdbclient
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
-	controllers "github.com/FoundationDB/fdb-kubernetes-operator/controllers"
+	"github.com/FoundationDB/fdb-kubernetes-operator/controllers"
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -44,7 +44,7 @@ var DefaultCLITimeout = 10
 // getFDBDatabase opens an FDB database. The result will be cached for
 // subsequent calls, based on the cluster namespace and name.
 func getFDBDatabase(cluster *fdbtypes.FoundationDBCluster) (fdb.Database, error) {
-	clusterFile, err := ioutil.TempFile("", "")
+	clusterFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return fdb.Database{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/FoundationDB/fdb-kubernetes-operator
 
-go 1.12
+go 1.16
 
 require (
 	github.com/apple/foundationdb/bindings/go v0.0.0-20190724023245-90ba203c166c

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -29,7 +29,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -124,7 +124,7 @@ func NewFdbPodClient(cluster *fdbtypes.FoundationDBCluster, pod *corev1.Pod) (Fd
 			tlsConfig.InsecureSkipVerify = true
 		}
 		certPool := x509.NewCertPool()
-		caList, err := ioutil.ReadFile(caFile)
+		caList, err := os.ReadFile(caFile)
 		if err != nil {
 			return nil, err
 		}
@@ -196,7 +196,7 @@ func (client *realFdbPodClient) makeRequest(method string, path string) (string,
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	bodyText := string(body)
 
 	if err != nil {


### PR DESCRIPTION
# Description

Update to go `1.16.8`. Release notes for https://golang.org/doc/go1.16 since go `1.17` was released `1.15` is no longer "supported". 

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

None.

# Testing

Unit + local.

# Documentation

None.

# Follow-up

None.
