### PR TITLE
Refactor fdb instance

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -2236,6 +2236,10 @@ func (cluster *FoundationDBCluster) IsBeingUpgraded() bool {
 
 // InstanceIsBeingRemoved determines if an instance is pending removal.
 func (cluster *FoundationDBCluster) InstanceIsBeingRemoved(instanceID string) bool {
+	if instanceID == "" {
+		return false
+	}
+
 	if cluster.Status.PendingRemovals != nil {
 		_, present := cluster.Status.PendingRemovals[instanceID]
 		if present {

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -54,19 +54,19 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 		return &Requeue{Error: err}
 	}
 
-	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}
 
-	instanceMap := make(map[string]FdbInstance, len(instances))
-	for _, instance := range instances {
-		instanceMap[instance.GetInstanceID()] = instance
+	podMap := make(map[string]*corev1.Pod, len(pods))
+	for _, pod := range pods {
+		podMap[GetInstanceID(pod)] = pod
 	}
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		_, instanceExists := instanceMap[processGroup.ProcessGroupID]
-		if !instanceExists && !processGroup.Remove {
+		_, podExists := podMap[processGroup.ProcessGroupID]
+		if !podExists && !processGroup.Remove {
 			_, idNum, err := ParseInstanceID(processGroup.ProcessGroupID)
 			if err != nil {
 				return &Requeue{Error: err}

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -61,13 +61,13 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 
 	podMap := make(map[string]*corev1.Pod, len(pods))
 	for _, pod := range pods {
-		podMap[GetInstanceID(pod)] = pod
+		podMap[GetProcessGroupID(pod)] = pod
 	}
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		_, podExists := podMap[processGroup.ProcessGroupID]
 		if !podExists && !processGroup.Remove {
-			_, idNum, err := ParseInstanceID(processGroup.ProcessGroupID)
+			_, idNum, err := ParseProcessGroupID(processGroup.ProcessGroupID)
 			if err != nil {
 				return &Requeue{Error: err}
 			}

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -104,7 +104,7 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 				pod.Annotations[fdbtypes.PublicIPAnnotation] = ip
 			}
 
-			err = r.PodLifecycleManager.CreatePods(r, context, pod)
+			err = r.PodLifecycleManager.CreatePod(r, context, pod)
 			if err != nil {
 				return &Requeue{Error: err}
 			}

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -54,7 +54,7 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 		return &Requeue{Error: err}
 	}
 
-	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}
@@ -104,7 +104,7 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 				pod.Annotations[fdbtypes.PublicIPAnnotation] = ip
 			}
 
-			err = r.PodLifecycleManager.CreateInstance(r, context, pod)
+			err = r.PodLifecycleManager.CreatePods(r, context, pod)
 			if err != nil {
 				return &Requeue{Error: err}
 			}

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -46,7 +46,7 @@ func (a AddProcessGroups) Reconcile(r *FoundationDBClusterReconciler, context ct
 	processGroupIDs := make(map[fdbtypes.ProcessClass]map[int]bool)
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		processGroupID := processGroup.ProcessGroupID
-		_, num, err := ParseInstanceID(processGroupID)
+		_, num, err := ParseProcessGroupID(processGroupID)
 		if err != nil {
 			return &Requeue{Error: err}
 		}

--- a/controllers/add_pvcs.go
+++ b/controllers/add_pvcs.go
@@ -41,7 +41,7 @@ func (a AddPVCs) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 			continue
 		}
 
-		_, idNum, err := ParseInstanceID(processGroup.ProcessGroupID)
+		_, idNum, err := ParseProcessGroupID(processGroup.ProcessGroupID)
 		if err != nil {
 			return &Requeue{Error: err}
 		}

--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -60,7 +60,7 @@ func (a AddServices) Reconcile(r *FoundationDBClusterReconciler, context ctx.Con
 				continue
 			}
 
-			_, idNum, err := ParseInstanceID(processGroup.ProcessGroupID)
+			_, idNum, err := ParseProcessGroupID(processGroup.ProcessGroupID)
 			if err != nil {
 				return &Requeue{Error: err}
 			}

--- a/controllers/admin_client.go
+++ b/controllers/admin_client.go
@@ -212,8 +212,7 @@ func (client *MockAdminClient) GetStatus() (*fdbtypes.FoundationDBStatus, error)
 			return nil, err
 		}
 
-		instance := newFdbInstance(pod)
-		instanceID := instance.GetInstanceID()
+		instanceID := GetProcessGroupID(&pod)
 
 		if client.missingProcessGroups[instanceID] {
 			continue
@@ -241,26 +240,32 @@ func (client *MockAdminClient) GetStatus() (*fdbtypes.FoundationDBStatus, error)
 				coordinators[fullAddress.String()] = true
 				fdbRoles = append(fdbRoles, fdbtypes.FoundationDBStatusProcessRoleInfo{Role: string(fdbtypes.ProcessRoleCoordinator)})
 			}
-			command, err := internal.GetStartCommand(client.Cluster, instance.GetProcessClass(), podClient, processIndex, processCount)
+
+			pClass, err := GetProcessClass(&pod)
 			if err != nil {
 				return nil, err
 			}
-			if client.incorrectCommandLines != nil && client.incorrectCommandLines[instance.GetInstanceID()] {
+
+			command, err := internal.GetStartCommand(client.Cluster, pClass, podClient, processIndex, processCount)
+			if err != nil {
+				return nil, err
+			}
+			if client.incorrectCommandLines != nil && client.incorrectCommandLines[instanceID] {
 				command += " --locality_incorrect=1"
 			}
 
 			locality := map[string]string{
-				fdbtypes.FDBLocalityInstanceIDKey: instance.GetInstanceID(),
+				fdbtypes.FDBLocalityInstanceIDKey: instanceID,
 				fdbtypes.FDBLocalityZoneIDKey:     pod.Name,
 				fdbtypes.FDBLocalityDCIDKey:       client.Cluster.Spec.DataCenter,
 			}
 
-			for key, value := range client.localityInfo[instance.GetInstanceID()] {
+			for key, value := range client.localityInfo[instanceID] {
 				locality[key] = value
 			}
 
 			if processCount > 1 {
-				locality["process_id"] = fmt.Sprintf("%s-%d", instance.GetInstanceID(), processIndex)
+				locality["process_id"] = fmt.Sprintf("%s-%d", instanceID, processIndex)
 			}
 
 			status.Cluster.Processes[fmt.Sprintf("%s-%d", pod.Name, processIndex)] = fdbtypes.FoundationDBStatusProcessInfo{
@@ -281,7 +286,7 @@ func (client *MockAdminClient) GetStatus() (*fdbtypes.FoundationDBStatus, error)
 				fdbtypes.FDBLocalityZoneIDKey:     processGroup.ProcessGroupID,
 			}
 
-			for key, value := range client.localityInfo[instance.GetInstanceID()] {
+			for key, value := range client.localityInfo[instanceID] {
 				locality[key] = value
 			}
 

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -78,8 +78,8 @@ func (b BounceProcesses) Reconcile(r *FoundationDBClusterReconciler, context ctx
 
 		addresses = append(addresses, addressMap[process]...)
 
-		instanceID := GetInstanceIDFromProcessID(process)
-		pod, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetSinglePodListOptions(cluster, instanceID)...)
+		instanceID := GetProcessGroupIDFromProcessID(process)
+		pod, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetSinglePodListOptions(cluster, instanceID)...)
 		if err != nil {
 			return &Requeue{Error: err}
 		}

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -79,15 +79,15 @@ func (b BounceProcesses) Reconcile(r *FoundationDBClusterReconciler, context ctx
 		addresses = append(addresses, addressMap[process]...)
 
 		instanceID := GetInstanceIDFromProcessID(process)
-		instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetSinglePodListOptions(cluster, instanceID)...)
+		pod, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetSinglePodListOptions(cluster, instanceID)...)
 		if err != nil {
 			return &Requeue{Error: err}
 		}
-		if len(instances) == 0 {
+		if len(pod) == 0 {
 			return &Requeue{Message: fmt.Sprintf("No pod defined for instance %s", instanceID), Delay: podSchedulingDelayDuration}
 		}
 
-		synced, err := r.updatePodDynamicConf(cluster, instances[0])
+		synced, err := r.updatePodDynamicConf(cluster, pod[0])
 		if !synced {
 			allSynced = false
 			logger.Info("Update dynamic Pod config", "processGroupID", instanceID, "synced", synced, "error", err)

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -226,12 +226,12 @@ func (r *FoundationDBClusterReconciler) SetupWithManager(mgr ctrl.Manager, maxCo
 }
 
 func (r *FoundationDBClusterReconciler) updatePodDynamicConf(cluster *fdbtypes.FoundationDBCluster, pod *corev1.Pod) (bool, error) {
-	if cluster.InstanceIsBeingRemoved(GetInstanceID(pod)) {
+	if cluster.InstanceIsBeingRemoved(GetProcessGroupID(pod)) {
 		return true, nil
 	}
 	podClient, message := r.getPodClient(cluster, pod)
 	if podClient == nil {
-		log.Info("Unable to generate pod client", "namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", GetInstanceID(pod), "message", message)
+		log.Info("Unable to generate pod client", "namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", GetProcessGroupID(pod), "message", message)
 		return false, nil
 	}
 

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -225,27 +225,31 @@ func (r *FoundationDBClusterReconciler) SetupWithManager(mgr ctrl.Manager, maxCo
 	return builder.Complete(r)
 }
 
-func (r *FoundationDBClusterReconciler) updatePodDynamicConf(cluster *fdbtypes.FoundationDBCluster, instance FdbInstance) (bool, error) {
-	if cluster.InstanceIsBeingRemoved(instance.GetInstanceID()) {
+func (r *FoundationDBClusterReconciler) updatePodDynamicConf(cluster *fdbtypes.FoundationDBCluster, pod *corev1.Pod) (bool, error) {
+	if cluster.InstanceIsBeingRemoved(GetInstanceID(pod)) {
 		return true, nil
 	}
-	podClient, message := r.getPodClient(cluster, instance)
+	podClient, message := r.getPodClient(cluster, pod)
 	if podClient == nil {
-		log.Info("Unable to generate pod client", "namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", instance.GetInstanceID(), "message", message)
+		log.Info("Unable to generate pod client", "namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", GetInstanceID(pod), "message", message)
 		return false, nil
 	}
 
-	var err error
-
 	serversPerPod := 1
-	if instance.GetProcessClass() == fdbtypes.ProcessClassStorage {
-		serversPerPod, err = getStorageServersPerPodForInstance(&instance)
+
+	processClass, err := GetProcessClass(pod)
+	if err != nil {
+		return false, err
+	}
+
+	if processClass == fdbtypes.ProcessClassStorage {
+		serversPerPod, err = internal.GetStorageServersPerPodForPod(pod)
 		if err != nil {
 			return false, err
 		}
 	}
 
-	conf, err := internal.GetMonitorConf(cluster, instance.GetProcessClass(), podClient, serversPerPod)
+	conf, err := internal.GetMonitorConf(cluster, processClass, podClient, serversPerPod)
 	if err != nil {
 		return false, err
 	}
@@ -272,18 +276,17 @@ func (r *FoundationDBClusterReconciler) updatePodDynamicConf(cluster *fdbtypes.F
 	return true, nil
 }
 
-func (r *FoundationDBClusterReconciler) getPodClient(cluster *fdbtypes.FoundationDBCluster, instance FdbInstance) (internal.FdbPodClient, string) {
-	if instance.Pod == nil {
-		return nil, fmt.Sprintf("Instance %s in cluster %s/%s does not have pod defined", instance.GetInstanceID(), cluster.Namespace, cluster.Name)
+func (r *FoundationDBClusterReconciler) getPodClient(cluster *fdbtypes.FoundationDBCluster, pod *corev1.Pod) (internal.FdbPodClient, string) {
+	if pod == nil {
+		return nil, fmt.Sprintf("Process group in cluster %s/%s does not have pod defined", cluster.Namespace, cluster.Name)
 	}
 
-	pod := instance.Pod
-	client, err := r.PodClientProvider(cluster, pod)
+	podClient, err := r.PodClientProvider(cluster, pod)
 	if err != nil {
 		return nil, err.Error()
 	}
 
-	return client, ""
+	return podClient, ""
 }
 
 // getDatabaseClientProvider gets the client provider for a reconciler.

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -332,7 +332,7 @@ func (r *FoundationDBClusterReconciler) clearPendingRemovalsFromSpec(context ctx
 
 func sortPodsByID(pods *corev1.PodList) {
 	sort.Slice(pods.Items, func(i, j int) bool {
-		return internal.GetInstanceIDFromMeta(pods.Items[i].ObjectMeta) < internal.GetInstanceIDFromMeta(pods.Items[j].ObjectMeta)
+		return internal.GetProcessGroupIDFromMeta(pods.Items[i].ObjectMeta) < internal.GetProcessGroupIDFromMeta(pods.Items[j].ObjectMeta)
 	})
 }
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/utils/pointer"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 
 	"github.com/prometheus/common/expfmt"
@@ -1339,7 +1341,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, item := range pods.Items {
-					_, id, err := ParseInstanceID(item.Labels[fdbtypes.FDBInstanceIDLabel])
+					_, id, err := ParseProcessGroupID(item.Labels[fdbtypes.FDBInstanceIDLabel])
 					Expect(err).NotTo(HaveOccurred())
 
 					hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(item.Labels), id, nil)
@@ -1478,7 +1480,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 					Expect(err).NotTo(HaveOccurred())
 					for _, item := range pods.Items {
-						_, id, err := ParseInstanceID(item.Labels[fdbtypes.FDBInstanceIDLabel])
+						_, id, err := ParseProcessGroupID(item.Labels[fdbtypes.FDBInstanceIDLabel])
 						Expect(err).NotTo(HaveOccurred())
 
 						hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(item.Labels), id, nil)
@@ -1586,7 +1588,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, item := range pods.Items {
-					_, id, err := ParseInstanceID(item.Labels[fdbtypes.FDBInstanceIDLabel])
+					_, id, err := ParseProcessGroupID(item.Labels[fdbtypes.FDBInstanceIDLabel])
 					Expect(err).NotTo(HaveOccurred())
 
 					hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(item.Labels), id, nil)
@@ -3263,12 +3265,14 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 		Context("for a basic storage process", func() {
 			It("should substitute the variables in the start command", func() {
-				instance := newFdbInstance(pods.Items[firstStorageIndex])
-				podClient, _ := internal.NewMockFdbPodClient(cluster, instance.Pod)
-				command, err = internal.GetStartCommand(cluster, instance.GetProcessClass(), podClient, 1, 1)
+				podClient, err := internal.NewMockFdbPodClient(cluster, &pods.Items[firstStorageIndex])
+				Expect(err).NotTo(HaveOccurred())
+				pClass, err := GetProcessClass(&pods.Items[firstStorageIndex])
+				Expect(err).NotTo(HaveOccurred())
+				command, err = internal.GetStartCommand(cluster, pClass, podClient, 1, 1)
 				Expect(err).NotTo(HaveOccurred())
 
-				id := instance.GetInstanceID()
+				id := GetProcessGroupID(&pods.Items[firstStorageIndex])
 				Expect(command).To(Equal(strings.Join([]string{
 					"/usr/bin/fdbserver",
 					"--class=storage",
@@ -3287,12 +3291,14 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 		Context("for a basic storage process with multiple storage servers per Pod", func() {
 			It("should substitute the variables in the start command", func() {
-				instance := newFdbInstance(pods.Items[firstStorageIndex])
-				podClient, _ := internal.NewMockFdbPodClient(cluster, instance.Pod)
-				command, err = internal.GetStartCommand(cluster, instance.GetProcessClass(), podClient, 1, 2)
+				podClient, err := internal.NewMockFdbPodClient(cluster, &pods.Items[firstStorageIndex])
+				Expect(err).NotTo(HaveOccurred())
+				pClass, err := GetProcessClass(&pods.Items[firstStorageIndex])
+				Expect(err).NotTo(HaveOccurred())
+				command, err = internal.GetStartCommand(cluster, pClass, podClient, 1, 2)
 				Expect(err).NotTo(HaveOccurred())
 
-				id := instance.GetInstanceID()
+				id := GetProcessGroupID(&pods.Items[firstStorageIndex])
 				Expect(command).To(Equal(strings.Join([]string{
 					"/usr/bin/fdbserver",
 					"--class=storage",
@@ -3308,7 +3314,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 					"--seed_cluster_file=/var/dynamic-conf/fdb.cluster",
 				}, " ")))
 
-				command, err = internal.GetStartCommand(cluster, instance.GetProcessClass(), podClient, 2, 2)
+				command, err = internal.GetStartCommand(cluster, pClass, podClient, 2, 2)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(command).To(Equal(strings.Join([]string{
 					"/usr/bin/fdbserver",
@@ -3332,9 +3338,11 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				pod := pods.Items[firstStorageIndex]
 				pod.Spec.NodeName = "machine1"
 				cluster.Spec.FaultDomain = fdbtypes.FoundationDBClusterFaultDomain{}
+				pClass, err := GetProcessClass(&pods.Items[firstStorageIndex])
+				Expect(err).NotTo(HaveOccurred())
 
 				podClient, _ := internal.NewMockFdbPodClient(cluster, &pod)
-				command, err = internal.GetStartCommand(cluster, newFdbInstance(pod).GetProcessClass(), podClient, 1, 1)
+				command, err = internal.GetStartCommand(cluster, pClass, podClient, 1, 1)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3359,6 +3367,8 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			BeforeEach(func() {
 				pod := pods.Items[firstStorageIndex]
 				pod.Spec.NodeName = "machine1"
+				pClass, err := GetProcessClass(&pods.Items[firstStorageIndex])
+				Expect(err).NotTo(HaveOccurred())
 
 				cluster.Spec.FaultDomain = fdbtypes.FoundationDBClusterFaultDomain{
 					Key:   "foundationdb.org/kubernetes-cluster",
@@ -3366,7 +3376,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				}
 
 				podClient, _ := internal.NewMockFdbPodClient(cluster, &pod)
-				command, err = internal.GetStartCommand(cluster, newFdbInstance(pod).GetProcessClass(), podClient, 1, 1)
+				command, err = internal.GetStartCommand(cluster, pClass, podClient, 1, 1)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3393,7 +3403,10 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				cluster.Status.RunningVersion = fdbtypes.Versions.WithBinariesFromMainContainer.String()
 				pod := pods.Items[firstStorageIndex]
 				podClient, _ := internal.NewMockFdbPodClient(cluster, &pod)
-				command, err = internal.GetStartCommand(cluster, newFdbInstance(pod).GetProcessClass(), podClient, 1, 1)
+				pClass, err := GetProcessClass(&pods.Items[firstStorageIndex])
+				Expect(err).NotTo(HaveOccurred())
+
+				command, err = internal.GetStartCommand(cluster, pClass, podClient, 1, 1)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3421,7 +3434,9 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				cluster.Status.RunningVersion = fdbtypes.Versions.WithoutBinariesFromMainContainer.String()
 				pod := pods.Items[firstStorageIndex]
 				podClient, _ := internal.NewMockFdbPodClient(cluster, &pod)
-				command, err = internal.GetStartCommand(cluster, newFdbInstance(pod).GetProcessClass(), podClient, 1, 1)
+				pClass, err := GetProcessClass(&pods.Items[firstStorageIndex])
+				Expect(err).NotTo(HaveOccurred())
+				command, err = internal.GetStartCommand(cluster, pClass, podClient, 1, 1)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3444,10 +3459,10 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 		})
 	})
 
-	Describe("ParseInstanceID", func() {
+	Describe("ParseProcessGroupID", func() {
 		Context("with a storage ID", func() {
 			It("can parse the ID", func() {
-				prefix, id, err := ParseInstanceID("storage-12")
+				prefix, id, err := ParseProcessGroupID("storage-12")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(prefix).To(Equal(fdbtypes.ProcessClassStorage))
 				Expect(id).To(Equal(12))
@@ -3456,7 +3471,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 		Context("with a cluster controller ID", func() {
 			It("can parse the ID", func() {
-				prefix, id, err := ParseInstanceID("cluster_controller-3")
+				prefix, id, err := ParseProcessGroupID("cluster_controller-3")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(prefix).To(Equal(fdbtypes.ProcessClassClusterController))
 				Expect(id).To(Equal(3))
@@ -3465,7 +3480,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 		Context("with a custom prefix", func() {
 			It("parses the prefix", func() {
-				prefix, id, err := ParseInstanceID("dc1-storage-12")
+				prefix, id, err := ParseProcessGroupID("dc1-storage-12")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(prefix).To(Equal(fdbtypes.ProcessClass("dc1-storage")))
 				Expect(id).To(Equal(12))
@@ -3474,7 +3489,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 		Context("with no prefix", func() {
 			It("gives a parsing error", func() {
-				_, _, err := ParseInstanceID("6")
+				_, _, err := ParseProcessGroupID("6")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("could not parse instance ID 6"))
 			})
@@ -3482,7 +3497,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 		Context("with no numbers", func() {
 			It("gives a parsing error", func() {
-				_, _, err := ParseInstanceID("storage")
+				_, _, err := ParseProcessGroupID("storage")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("could not parse instance ID storage"))
 			})
@@ -3490,7 +3505,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 		Context("with a text suffix", func() {
 			It("gives a parsing error", func() {
-				_, _, err := ParseInstanceID("storage-bad")
+				_, _, err := ParseProcessGroupID("storage-bad")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("could not parse instance ID storage-bad"))
 			})
@@ -4015,62 +4030,61 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 	})
 
 	Describe("GetPublicIPs", func() {
-		var instance FdbInstance
+		var pod *corev1.Pod
 
 		BeforeEach(func() {
 			err := internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			instance = FdbInstance{}
 		})
 
 		Context("with a default pod", func() {
 			BeforeEach(func() {
-				pod, err := internal.GetPod(cluster, "storage", 1)
+				var err error
+				pod, err = internal.GetPod(cluster, "storage", 1)
 				Expect(err).NotTo(HaveOccurred())
 				pod.Status.PodIP = "1.1.1.1"
 				pod.Status.PodIPs = []corev1.PodIP{
 					{IP: "1.1.1.2"},
 					{IP: "2001:db8::ff00:42:8329"},
 				}
-				instance.Pod = pod
-				instance.Metadata = &pod.ObjectMeta
 			})
 
 			It("should be the public IP from the pod", func() {
-				result := instance.GetPublicIPs()
+				result := GetPublicIPs(pod)
 				Expect(result).To(Equal([]string{"1.1.1.1"}))
 			})
 		})
 
 		Context("with a v6 pod IP family configured", func() {
 			BeforeEach(func() {
-				family := 6
-				cluster.Spec.Routing.PodIPFamily = &family
-				pod, err := internal.GetPod(cluster, "storage", 1)
+				var err error
+				cluster.Spec.Routing.PodIPFamily = pointer.Int(6)
+				pod, err = internal.GetPod(cluster, "storage", 1)
 				Expect(err).NotTo(HaveOccurred())
 				pod.Status.PodIP = "1.1.1.1"
 				pod.Status.PodIPs = []corev1.PodIP{
 					{IP: "1.1.1.2"},
 					{IP: "2001:db8::ff00:42:8329"},
 				}
-				instance.Pod = pod
-				instance.Metadata = &pod.ObjectMeta
 			})
 
 			It("should select the address based on the spec", func() {
-				result := instance.GetPublicIPs()
+				result := GetPublicIPs(pod)
 				Expect(result).To(Equal([]string{"2001:db8::ff00:42:8329"}))
 			})
 
 			Context("with no matching IPs in the Pod IP list", func() {
 				BeforeEach(func() {
-					instance.Pod.Status.PodIPs = []corev1.PodIP{
+					var err error
+					pod, err = internal.GetPod(cluster, "storage", 1)
+					Expect(err).NotTo(HaveOccurred())
+					pod.Status.PodIPs = []corev1.PodIP{
 						{IP: "1.1.1.2"},
 					}
 				})
 
 				It("should be empty", func() {
-					result := instance.GetPublicIPs()
+					result := GetPublicIPs(pod)
 					Expect(result).To(BeEmpty())
 				})
 			})
@@ -4078,34 +4092,26 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 		Context("with a v4 pod IP family configured", func() {
 			BeforeEach(func() {
-				family := 4
-				cluster.Spec.Routing.PodIPFamily = &family
-				pod, err := internal.GetPod(cluster, "storage", 1)
+				var err error
+				cluster.Spec.Routing.PodIPFamily = pointer.Int(4)
+				pod, err = internal.GetPod(cluster, "storage", 1)
 				Expect(err).NotTo(HaveOccurred())
-				pod.Status.PodIP = "1.1.1.1"
+				pod.Status.PodIP = "1.1.1.2"
 				pod.Status.PodIPs = []corev1.PodIP{
 					{IP: "1.1.1.2"},
 					{IP: "2001:db8::ff00:42:8329"},
 				}
-				instance.Pod = pod
-				instance.Metadata = &pod.ObjectMeta
 			})
 
 			It("should select the address based on the spec", func() {
-				result := instance.GetPublicIPs()
+				result := GetPublicIPs(pod)
 				Expect(result).To(Equal([]string{"1.1.1.2"}))
 			})
 		})
 
 		Context("with no pod", func() {
-			BeforeEach(func() {
-				pod, err := internal.GetPod(cluster, "storage", 1)
-				Expect(err).NotTo(HaveOccurred())
-				instance.Metadata = &pod.ObjectMeta
-			})
-
 			It("should be empty", func() {
-				result := instance.GetPublicIPs()
+				result := GetPublicIPs(nil)
 				Expect(result).To(BeEmpty())
 			})
 		})

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -3512,16 +3512,16 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 		})
 	})
 
-	Describe("GetInstanceIDFromProcessID", func() {
+	Describe("GetProcessGroupIDFromProcessID", func() {
 		It("can parse a process ID", func() {
-			Expect(GetInstanceIDFromProcessID("storage-1-1")).To(Equal("storage-1"))
+			Expect(GetProcessGroupIDFromProcessID("storage-1-1")).To(Equal("storage-1"))
 		})
 		It("can parse a process ID with a prefix", func() {
-			Expect(GetInstanceIDFromProcessID("dc1-storage-1-1")).To(Equal("dc1-storage-1"))
+			Expect(GetProcessGroupIDFromProcessID("dc1-storage-1-1")).To(Equal("dc1-storage-1"))
 		})
 
 		It("can handle a process group ID with no process number", func() {
-			Expect(GetInstanceIDFromProcessID("storage-2")).To(Equal("storage-2"))
+			Expect(GetProcessGroupIDFromProcessID("storage-2")).To(Equal("storage-2"))
 		})
 	})
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -3491,7 +3491,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			It("gives a parsing error", func() {
 				_, _, err := ParseProcessGroupID("6")
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("could not parse instance ID 6"))
+				Expect(err.Error()).To(Equal("could not parse process group ID 6"))
 			})
 		})
 
@@ -3499,7 +3499,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			It("gives a parsing error", func() {
 				_, _, err := ParseProcessGroupID("storage")
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("could not parse instance ID storage"))
+				Expect(err.Error()).To(Equal("could not parse process group ID storage"))
 			})
 		})
 
@@ -3507,7 +3507,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			It("gives a parsing error", func() {
 				_, _, err := ParseProcessGroupID("storage-bad")
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("could not parse instance ID storage-bad"))
+				Expect(err.Error()).To(Equal("could not parse process group ID storage-bad"))
 			})
 		})
 	})

--- a/controllers/delete_pods_for_buggification.go
+++ b/controllers/delete_pods_for_buggification.go
@@ -66,7 +66,7 @@ func (d DeletePodsForBuggification) Reconcile(r *FoundationDBClusterReconciler, 
 			continue
 		}
 
-		instanceID := GetInstanceID(pod)
+		instanceID := GetProcessGroupID(pod)
 		_, pendingRemoval := removals[instanceID]
 		if pendingRemoval {
 			continue

--- a/controllers/delete_pods_for_buggification.go
+++ b/controllers/delete_pods_for_buggification.go
@@ -62,10 +62,6 @@ func (d DeletePodsForBuggification) Reconcile(r *FoundationDBClusterReconciler, 
 	}
 
 	for _, pod := range pods {
-		if pod == nil {
-			continue
-		}
-
 		instanceID := GetProcessGroupID(pod)
 		_, pendingRemoval := removals[instanceID]
 		if pendingRemoval {

--- a/controllers/delete_pods_for_buggification.go
+++ b/controllers/delete_pods_for_buggification.go
@@ -37,7 +37,7 @@ type DeletePodsForBuggification struct{}
 // Reconcile runs the reconciler's work.
 func (d DeletePodsForBuggification) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "DeletePodsForBuggification")
-	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}

--- a/controllers/delete_pods_for_buggification.go
+++ b/controllers/delete_pods_for_buggification.go
@@ -23,6 +23,8 @@ package controllers
 import (
 	ctx "context"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
@@ -35,12 +37,12 @@ type DeletePodsForBuggification struct{}
 // Reconcile runs the reconciler's work.
 func (d DeletePodsForBuggification) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "DeletePodsForBuggification")
-	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}
 
-	updates := make([]FdbInstance, 0)
+	updates := make([]*corev1.Pod, 0)
 
 	removals := make(map[string]bool)
 	for _, processGroup := range cluster.Status.ProcessGroups {
@@ -51,27 +53,27 @@ func (d DeletePodsForBuggification) Reconcile(r *FoundationDBClusterReconciler, 
 
 	crashLoopPods := make(map[string]bool, len(cluster.Spec.Buggify.CrashLoop))
 	crashLoopAll := false
-	for _, instanceID := range cluster.Spec.Buggify.CrashLoop {
-		if instanceID == "*" {
+	for _, processGroupID := range cluster.Spec.Buggify.CrashLoop {
+		if processGroupID == "*" {
 			crashLoopAll = true
 		} else {
-			crashLoopPods[instanceID] = true
+			crashLoopPods[processGroupID] = true
 		}
 	}
 
-	for _, instance := range instances {
-		if instance.Pod == nil {
+	for _, pod := range pods {
+		if pod == nil {
 			continue
 		}
 
-		instanceID := instance.GetInstanceID()
+		instanceID := GetInstanceID(pod)
 		_, pendingRemoval := removals[instanceID]
 		if pendingRemoval {
 			continue
 		}
 
 		inCrashLoop := false
-		for _, container := range instance.Pod.Spec.Containers {
+		for _, container := range pod.Spec.Containers {
 			if container.Name == "foundationdb" && len(container.Args) > 0 {
 				inCrashLoop = container.Args[0] == "crash-loop"
 			}
@@ -84,7 +86,7 @@ func (d DeletePodsForBuggification) Reconcile(r *FoundationDBClusterReconciler, 
 				"processGroupID", instanceID,
 				"shouldCrashLoop", shouldCrashLoop,
 				"inCrashLoop", inCrashLoop)
-			updates = append(updates, instance)
+			updates = append(updates, pod)
 		}
 	}
 

--- a/controllers/fdb_process_group.go
+++ b/controllers/fdb_process_group.go
@@ -1,5 +1,5 @@
 /*
- * fdb_instance.go
+ * fdb_process_group.go
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -47,11 +47,11 @@ func ParseProcessGroupID(id string) (fdbtypes.ProcessClass, int, error) {
 	return fdbtypes.ProcessClass(prefix), number, nil
 }
 
-// GetInstanceIDFromProcessID returns the process group ID for the process ID
-func GetInstanceIDFromProcessID(id string) string {
+// GetProcessGroupIDFromProcessID returns the process group ID for the process ID
+func GetProcessGroupIDFromProcessID(id string) string {
 	result := processIDRegex.FindStringSubmatch(id)
 	if result == nil {
-		// In this case we assume that instance ID == process ID
+		// In this case we assume that process group ID == process ID
 		return id
 	}
 
@@ -64,7 +64,7 @@ func GetProcessGroupID(pod *corev1.Pod) string {
 		return ""
 	}
 
-	return internal.GetInstanceIDFromMeta(pod.ObjectMeta)
+	return internal.GetProcessGroupIDFromMeta(pod.ObjectMeta)
 }
 
 // GetProcessClass fetches the process class from a Pod's metadata.

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -44,7 +44,7 @@ func (g GenerateInitialClusterFile) Reconcile(r *FoundationDBClusterReconciler, 
 
 	logger.Info("Generating initial cluster file")
 	r.Recorder.Event(cluster, corev1.EventTypeNormal, "ChangingCoordinators", "Choosing initial coordinators")
-	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, fdbtypes.ProcessClassStorage, "")...)
+	instances, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, fdbtypes.ProcessClassStorage, "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}

--- a/controllers/pod_lifecycle_manager.go
+++ b/controllers/pod_lifecycle_manager.go
@@ -35,10 +35,10 @@ type PodLifecycleManager interface {
 	GetPods(client.Client, *fdbtypes.FoundationDBCluster, ctx.Context, ...client.ListOption) ([]*corev1.Pod, error)
 
 	// CreatePods creates a new instance based on a pod definition
-	CreatePods(client.Client, ctx.Context, *corev1.Pod) error
+	CreatePod(client.Client, ctx.Context, *corev1.Pod) error
 
 	// DeletePods shuts down an instance
-	DeletePods(client.Client, ctx.Context, *corev1.Pod) error
+	DeletePod(client.Client, ctx.Context, *corev1.Pod) error
 
 	// CanDeletePods checks whether it is safe to delete pods.
 	CanDeletePods(AdminClient, ctx.Context, *fdbtypes.FoundationDBCluster) (bool, error)
@@ -93,13 +93,13 @@ func (manager StandardPodLifecycleManager) GetPods(r client.Client, cluster *fdb
 	return resPods, nil
 }
 
-// CreatePods creates a new Pods based on a pod definition
-func (manager StandardPodLifecycleManager) CreatePods(r client.Client, context ctx.Context, pod *corev1.Pod) error {
+// CreatePod creates a new Pod based on a Pod definition
+func (manager StandardPodLifecycleManager) CreatePod(r client.Client, context ctx.Context, pod *corev1.Pod) error {
 	return r.Create(context, pod)
 }
 
-// DeletePods shuts down a Pod
-func (manager StandardPodLifecycleManager) DeletePods(r client.Client, context ctx.Context, pod *corev1.Pod) error {
+// DeletePod shuts down a Pod
+func (manager StandardPodLifecycleManager) DeletePod(r client.Client, context ctx.Context, pod *corev1.Pod) error {
 	return r.Delete(context, pod)
 }
 

--- a/controllers/pod_lifecycle_manager.go
+++ b/controllers/pod_lifecycle_manager.go
@@ -31,14 +31,14 @@ import (
 // PodLifecycleManager provides an abstraction around Pod management to allow
 // using intermediary controllers that will manage the Pod lifecycle.
 type PodLifecycleManager interface {
-	// GetInstances lists the instances in the cluster
-	GetInstances(client.Client, *fdbtypes.FoundationDBCluster, ctx.Context, ...client.ListOption) ([]*corev1.Pod, error)
+	// GetPods lists the instances in the cluster
+	GetPods(client.Client, *fdbtypes.FoundationDBCluster, ctx.Context, ...client.ListOption) ([]*corev1.Pod, error)
 
-	// CreateInstance creates a new instance based on a pod definition
-	CreateInstance(client.Client, ctx.Context, *corev1.Pod) error
+	// CreatePods creates a new instance based on a pod definition
+	CreatePods(client.Client, ctx.Context, *corev1.Pod) error
 
-	// DeleteInstance shuts down an instance
-	DeleteInstance(client.Client, ctx.Context, *corev1.Pod) error
+	// DeletePods shuts down an instance
+	DeletePods(client.Client, ctx.Context, *corev1.Pod) error
 
 	// CanDeletePods checks whether it is safe to delete pods.
 	CanDeletePods(AdminClient, ctx.Context, *fdbtypes.FoundationDBCluster) (bool, error)
@@ -52,21 +52,21 @@ type PodLifecycleManager interface {
 	// UpdateMetadata updates an instance's metadata.
 	UpdateMetadata(client.Client, ctx.Context, *fdbtypes.FoundationDBCluster, *corev1.Pod) error
 
-	// InstanceIsUpdated determines whether an instance is up to date.
+	// PodIsUpdated determines whether an instance is up to date.
 	//
 	// This does not need to check the metadata or the pod spec hash. This only
 	// needs to check aspects of the rollout that are not available in the
 	// instance metadata.
-	InstanceIsUpdated(client.Client, ctx.Context, *fdbtypes.FoundationDBCluster, *corev1.Pod) (bool, error)
+	PodIsUpdated(client.Client, ctx.Context, *fdbtypes.FoundationDBCluster, *corev1.Pod) (bool, error)
 }
 
 // StandardPodLifecycleManager provides an implementation of PodLifecycleManager
 // that directly creates pods.
 type StandardPodLifecycleManager struct{}
 
-// GetInstances returns a list of instances for FDB pods that have been
+// GetPods returns a list of Pods for FDB pods that have been
 // created.
-func (manager StandardPodLifecycleManager) GetInstances(r client.Client, cluster *fdbtypes.FoundationDBCluster, context ctx.Context, options ...client.ListOption) ([]*corev1.Pod, error) {
+func (manager StandardPodLifecycleManager) GetPods(r client.Client, cluster *fdbtypes.FoundationDBCluster, context ctx.Context, options ...client.ListOption) ([]*corev1.Pod, error) {
 	pods := &corev1.PodList{}
 	err := r.List(context, pods, options...)
 	if err != nil {
@@ -93,17 +93,17 @@ func (manager StandardPodLifecycleManager) GetInstances(r client.Client, cluster
 	return resPods, nil
 }
 
-// CreateInstance creates a new instance based on a pod definition
-func (manager StandardPodLifecycleManager) CreateInstance(r client.Client, context ctx.Context, pod *corev1.Pod) error {
+// CreatePods creates a new Pods based on a pod definition
+func (manager StandardPodLifecycleManager) CreatePods(r client.Client, context ctx.Context, pod *corev1.Pod) error {
 	return r.Create(context, pod)
 }
 
-// DeleteInstance shuts down an instance
-func (manager StandardPodLifecycleManager) DeleteInstance(r client.Client, context ctx.Context, pod *corev1.Pod) error {
+// DeletePods shuts down a Pod
+func (manager StandardPodLifecycleManager) DeletePods(r client.Client, context ctx.Context, pod *corev1.Pod) error {
 	return r.Delete(context, pod)
 }
 
-// CanDeletePods checks whether it is safe to delete pods.
+// CanDeletePods checks whether it is safe to delete Pods.
 func (manager StandardPodLifecycleManager) CanDeletePods(adminClient AdminClient, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) (bool, error) {
 	status, err := adminClient.GetStatus()
 	if err != nil {
@@ -113,7 +113,7 @@ func (manager StandardPodLifecycleManager) CanDeletePods(adminClient AdminClient
 	return status.Cluster.FullReplication && status.Client.DatabaseStatus.Available, nil
 }
 
-// UpdatePods updates a list of pods to match the latest specs.
+// UpdatePods updates a list of Pods to match the latest specs.
 func (manager StandardPodLifecycleManager) UpdatePods(r client.Client, context ctx.Context, cluster *fdbtypes.FoundationDBCluster, pods []*corev1.Pod, unsafe bool) error {
 	for _, pod := range pods {
 		err := r.Delete(context, pod)
@@ -135,11 +135,11 @@ func (manager StandardPodLifecycleManager) UpdateMetadata(r client.Client, conte
 	return r.Update(context, pod)
 }
 
-// InstanceIsUpdated determines whether an instance is up to date.
+// PodIsUpdated determines whether a Pod is up to date.
 //
 // This does not need to check the metadata or the pod spec hash. This only
 // needs to check aspects of the rollout that are not available in the
-// instance metadata.
-func (manager StandardPodLifecycleManager) InstanceIsUpdated(client.Client, ctx.Context, *fdbtypes.FoundationDBCluster, *corev1.Pod) (bool, error) {
+// PodIsUpdated metadata.
+func (manager StandardPodLifecycleManager) PodIsUpdated(client.Client, ctx.Context, *fdbtypes.FoundationDBCluster, *corev1.Pod) (bool, error) {
 	return true, nil
 }

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -88,7 +88,7 @@ func removeProcessGroup(r *FoundationDBClusterReconciler, context ctx.Context, c
 	}
 
 	if len(instances) == 1 {
-		err = r.PodLifecycleManager.DeletePods(r, context, instances[0])
+		err = r.PodLifecycleManager.DeletePod(r, context, instances[0])
 
 		if err != nil {
 			return err

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -82,13 +82,13 @@ func (u RemoveProcessGroups) Reconcile(r *FoundationDBClusterReconciler, context
 
 func removeProcessGroup(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster, instanceID string) error {
 	instanceListOptions := internal.GetSinglePodListOptions(cluster, instanceID)
-	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, instanceListOptions...)
+	instances, err := r.PodLifecycleManager.GetPods(r, cluster, context, instanceListOptions...)
 	if err != nil {
 		return err
 	}
 
 	if len(instances) == 1 {
-		err = r.PodLifecycleManager.DeleteInstance(r, context, instances[0])
+		err = r.PodLifecycleManager.DeletePods(r, context, instances[0])
 
 		if err != nil {
 			return err
@@ -133,7 +133,7 @@ func confirmRemoval(r *FoundationDBClusterReconciler, context ctx.Context, clust
 	canBeIncluded := true
 	instanceListOptions := internal.GetSinglePodListOptions(cluster, processGroupID)
 
-	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, instanceListOptions...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, instanceListOptions...)
 	if err != nil {
 		return false, false, err
 	}

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -128,26 +128,26 @@ func removeProcessGroup(r *FoundationDBClusterReconciler, context ctx.Context, c
 	return nil
 }
 
-func confirmRemoval(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster, instanceID string) (bool, bool, error) {
+func confirmRemoval(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster, processGroupID string) (bool, bool, error) {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "RemoveProcessGroups")
 	canBeIncluded := true
-	instanceListOptions := internal.GetSinglePodListOptions(cluster, instanceID)
+	instanceListOptions := internal.GetSinglePodListOptions(cluster, processGroupID)
 
-	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, instanceListOptions...)
+	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, instanceListOptions...)
 	if err != nil {
 		return false, false, err
 	}
 
-	if len(instances) == 1 {
+	if len(pods) == 1 {
 		// If the Pod is already in a terminating state we don't have to care for it
-		if instances[0].Metadata != nil && instances[0].Metadata.DeletionTimestamp == nil {
-			logger.Info("Waiting for instance to get torn down", "processGroupID", instanceID, "pod", instances[0].Metadata.Name)
+		if pods[0] != nil && pods[0].ObjectMeta.DeletionTimestamp == nil {
+			logger.Info("Waiting for instance to get torn down", "processGroupID", processGroupID, "pod", pods[0].Name)
 			return false, false, nil
 		}
 		// Pod is in terminating state so we don't want to block but we also don't want to include it
 		canBeIncluded = false
-	} else if len(instances) > 0 {
-		return false, false, fmt.Errorf("multiple pods found for cluster %s, processGroup %s", cluster.Name, instanceID)
+	} else if len(pods) > 0 {
+		return false, false, fmt.Errorf("multiple pods found for cluster %s, processGroupID %s", cluster.Name, processGroupID)
 	}
 
 	pvcs := &corev1.PersistentVolumeClaimList{}
@@ -158,13 +158,13 @@ func confirmRemoval(r *FoundationDBClusterReconciler, context ctx.Context, clust
 
 	if len(pvcs.Items) == 1 {
 		if pvcs.Items[0].DeletionTimestamp == nil {
-			logger.Info("Waiting for volume claim to get torn down", "processGroupID", instanceID, "pvc", pvcs.Items[0].Name)
+			logger.Info("Waiting for volume claim to get torn down", "processGroupID", processGroupID, "pvc", pvcs.Items[0].Name)
 			return false, canBeIncluded, nil
 		}
 		// PVC is in terminating state so we don't want to block but we also don't want to include it
 		canBeIncluded = false
 	} else if len(pvcs.Items) > 0 {
-		return false, canBeIncluded, fmt.Errorf("multiple PVCs found for cluster %s, processGroup %s", cluster.Name, instanceID)
+		return false, canBeIncluded, fmt.Errorf("multiple PVCs found for cluster %s, processGroupID %s", cluster.Name, processGroupID)
 	}
 
 	services := &corev1.ServiceList{}
@@ -175,13 +175,13 @@ func confirmRemoval(r *FoundationDBClusterReconciler, context ctx.Context, clust
 
 	if len(services.Items) == 1 {
 		if services.Items[0].DeletionTimestamp == nil {
-			logger.Info("Waiting for service to get torn down", "processGroupID", instanceID, "service", services.Items[0].Name)
+			logger.Info("Waiting for service to get torn down", "processGroupID", processGroupID, "service", services.Items[0].Name)
 			return false, canBeIncluded, nil
 		}
 		// service is in terminating state so we don't want to block but we also don't want to include it
 		canBeIncluded = false
 	} else if len(services.Items) > 0 {
-		return false, canBeIncluded, fmt.Errorf("multiple services found for cluster %s, processGroup %s", cluster.Name, instanceID)
+		return false, canBeIncluded, fmt.Errorf("multiple services found for cluster %s, processGroupID %s", cluster.Name, processGroupID)
 	}
 
 	return true, canBeIncluded, nil

--- a/controllers/replace_misconfigured_pods.go
+++ b/controllers/replace_misconfigured_pods.go
@@ -87,7 +87,7 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 	}
 
 	for _, pod := range pods {
-		processGroupStatus := processGroups[GetInstanceID(pod)]
+		processGroupStatus := processGroups[GetProcessGroupID(pod)]
 		needsRemoval, err := instanceNeedsRemoval(cluster, pod, processGroupStatus)
 		if err != nil {
 			return &Requeue{Error: err}
@@ -128,7 +128,7 @@ func instanceNeedsRemovalForPVC(cluster *fdbtypes.FoundationDBCluster, pvc corev
 
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "pvc", pvc.Name, "processGroupID", instanceID, "reconciler", "ReplaceMisconfiguredPods")
 
-	_, idNum, err := ParseInstanceID(instanceID)
+	_, idNum, err := ParseProcessGroupID(instanceID)
 	if err != nil {
 		return false, err
 	}
@@ -159,7 +159,7 @@ func instanceNeedsRemoval(cluster *fdbtypes.FoundationDBCluster, pod *corev1.Pod
 		return false, nil
 	}
 
-	instanceID := GetInstanceID(pod)
+	instanceID := GetProcessGroupID(pod)
 
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", instanceID, "reconciler", "ReplaceMisconfiguredPods")
 
@@ -171,7 +171,7 @@ func instanceNeedsRemoval(cluster *fdbtypes.FoundationDBCluster, pod *corev1.Pod
 		return false, nil
 	}
 
-	_, idNum, err := ParseInstanceID(instanceID)
+	_, idNum, err := ParseProcessGroupID(instanceID)
 	if err != nil {
 		return false, err
 	}

--- a/controllers/replace_misconfigured_pods.go
+++ b/controllers/replace_misconfigured_pods.go
@@ -54,7 +54,7 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 	}
 
 	for _, pvc := range pvcs.Items {
-		instanceID := internal.GetInstanceIDFromMeta(pvc.ObjectMeta)
+		instanceID := internal.GetProcessGroupIDFromMeta(pvc.ObjectMeta)
 		processGroupStatus := processGroups[instanceID]
 		if processGroupStatus == nil {
 			return &Requeue{Error: fmt.Errorf("unknown PVC %s in replace_misconfigured_pods", instanceID)}
@@ -69,7 +69,7 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 			return &Requeue{Error: err}
 		}
 		if needsNewRemoval {
-			instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetSinglePodListOptions(cluster, instanceID)...)
+			instances, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetSinglePodListOptions(cluster, instanceID)...)
 			if err != nil {
 				return &Requeue{Error: err}
 			}
@@ -81,7 +81,7 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 		}
 	}
 
-	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}
@@ -124,7 +124,7 @@ func instanceNeedsRemovalForPVC(cluster *fdbtypes.FoundationDBCluster, pvc corev
 	if !ownedByCluster {
 		return false, nil
 	}
-	instanceID := internal.GetInstanceIDFromMeta(pvc.ObjectMeta)
+	instanceID := internal.GetProcessGroupIDFromMeta(pvc.ObjectMeta)
 
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "pvc", pvc.Name, "processGroupID", instanceID, "reconciler", "ReplaceMisconfiguredPods")
 

--- a/controllers/replace_misconfigured_pods_test.go
+++ b/controllers/replace_misconfigured_pods_test.go
@@ -134,12 +134,17 @@ var _ = Describe("replace_misconfigured_pods", func() {
 		})
 	})
 
-	Context("when the public IP source is removed", func() {
+	When("the public IP source is removed", func() {
 		It("should need a removal", func() {
 			status := &fdbtypes.ProcessGroupStatus{
 				ProcessGroupID: instanceName,
 				Remove:         false,
 			}
+
+			pod.ObjectMeta.Annotations = map[string]string{
+				fdbtypes.PublicIPSourceAnnotation: string(fdbtypes.PublicIPSourceService),
+			}
+
 			ipSource := fdbtypes.PublicIPSourceService
 			cluster.Spec.Routing.PublicIPSource = &ipSource
 

--- a/controllers/replace_misconfigured_pods_test.go
+++ b/controllers/replace_misconfigured_pods_test.go
@@ -48,6 +48,13 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			},
 		}
 		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					fdbtypes.FDBInstanceIDLabel:   instanceName,
+					fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
+				},
+				Annotations: map[string]string{},
+			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{Name: "foundationdb"},
@@ -63,8 +70,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 	Describe("Check instance", func() {
 		Context("when instance has no Pod", func() {
 			It("should not need removal", func() {
-				instance := FdbInstance{}
-				needsRemoval, err := instanceNeedsRemoval(cluster, instance, nil)
+				needsRemoval, err := instanceNeedsRemoval(cluster, nil, nil)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -72,15 +78,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 		Context("when processGroupStatus is missing", func() {
 			It("should return an error", func() {
-				instance := FdbInstance{
-					Metadata: &metav1.ObjectMeta{
-						Labels: map[string]string{
-							fdbtypes.FDBInstanceIDLabel: instanceName,
-						},
-					},
-					Pod: pod,
-				}
-				needsRemoval, err := instanceNeedsRemoval(cluster, instance, nil)
+				needsRemoval, err := instanceNeedsRemoval(cluster, pod, nil)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal(fmt.Sprintf("unknown instance %s in replace_misconfigured_pods", instanceName)))
@@ -89,19 +87,11 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 		Context("when processGroupStatus has remove flag", func() {
 			It("should not need a removal", func() {
-				instance := FdbInstance{
-					Metadata: &metav1.ObjectMeta{
-						Labels: map[string]string{
-							fdbtypes.FDBInstanceIDLabel: instanceName,
-						},
-					},
-					Pod: pod,
-				}
 				status := &fdbtypes.ProcessGroupStatus{
 					ProcessGroupID: instanceName,
 					Remove:         true,
 				}
-				needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+				needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -109,26 +99,17 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 		Context("when instanceID prefix changes", func() {
 			It("should need a removal", func() {
-				instance := FdbInstance{
-					Metadata: &metav1.ObjectMeta{
-						Labels: map[string]string{
-							fdbtypes.FDBInstanceIDLabel:   instanceName,
-							fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-						},
-					},
-					Pod: pod,
-				}
 				status := &fdbtypes.ProcessGroupStatus{
 					ProcessGroupID: instanceName,
 					Remove:         false,
 				}
-				needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+				needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 
 				// Change the instance ID should trigger a removal
 				cluster.Spec.InstanceIDPrefix = "test"
-				needsRemoval, err = instanceNeedsRemoval(cluster, instance, status)
+				needsRemoval, err = instanceNeedsRemoval(cluster, pod, status)
 				Expect(needsRemoval).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -136,27 +117,17 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 		Context("when the public IP source changes", func() {
 			It("should need a removal", func() {
-				instance := FdbInstance{
-					Metadata: &metav1.ObjectMeta{
-						Labels: map[string]string{
-							fdbtypes.FDBInstanceIDLabel:   instanceName,
-							fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-						},
-						Annotations: map[string]string{},
-					},
-					Pod: pod,
-				}
 				status := &fdbtypes.ProcessGroupStatus{
 					ProcessGroupID: instanceName,
 					Remove:         false,
 				}
-				needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+				needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 
 				ipSource := fdbtypes.PublicIPSourceService
 				cluster.Spec.Routing.PublicIPSource = &ipSource
-				needsRemoval, err = instanceNeedsRemoval(cluster, instance, status)
+				needsRemoval, err = instanceNeedsRemoval(cluster, pod, status)
 				Expect(needsRemoval).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -165,18 +136,6 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 	Context("when the public IP source is removed", func() {
 		It("should need a removal", func() {
-			instance := FdbInstance{
-				Metadata: &metav1.ObjectMeta{
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   instanceName,
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-					},
-					Annotations: map[string]string{
-						fdbtypes.PublicIPSourceAnnotation: string(fdbtypes.PublicIPSourceService),
-					},
-				},
-				Pod: pod,
-			}
 			status := &fdbtypes.ProcessGroupStatus{
 				ProcessGroupID: instanceName,
 				Remove:         false,
@@ -184,12 +143,12 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			ipSource := fdbtypes.PublicIPSourceService
 			cluster.Spec.Routing.PublicIPSource = &ipSource
 
-			needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
 			cluster.Spec.Routing.PublicIPSource = nil
-			needsRemoval, err = instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err = instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -197,27 +156,17 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 	Context("when the public IP source is set to default", func() {
 		It("should not need a removal", func() {
-			instance := FdbInstance{
-				Metadata: &metav1.ObjectMeta{
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   instanceName,
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-					},
-					Annotations: map[string]string{},
-				},
-				Pod: pod,
-			}
 			status := &fdbtypes.ProcessGroupStatus{
 				ProcessGroupID: instanceName,
 				Remove:         false,
 			}
-			needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
 			ipSource := fdbtypes.PublicIPSourcePod
 			cluster.Spec.Routing.PublicIPSource = &ipSource
-			needsRemoval, err = instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err = instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -225,26 +174,16 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 	Context("when the storageServersPerPod is changed for a storage class instance", func() {
 		It("should need a removal", func() {
-			instance := FdbInstance{
-				Metadata: &metav1.ObjectMeta{
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   instanceName,
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-					},
-					Annotations: map[string]string{},
-				},
-				Pod: pod,
-			}
 			status := &fdbtypes.ProcessGroupStatus{
 				ProcessGroupID: instanceName,
 				Remove:         false,
 			}
-			needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
 			cluster.Spec.StorageServersPerPod = 2
-			needsRemoval, err = instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err = instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -252,26 +191,24 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 	Context("when the storageServersPerPod is changed for a non storage class instance", func() {
 		It("should not need a removal", func() {
-			instance := FdbInstance{
-				Metadata: &metav1.ObjectMeta{
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   fmt.Sprintf("%s-1337", fdbtypes.ProcessClassLog),
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassLog),
-					},
-					Annotations: map[string]string{},
+			pod.ObjectMeta = metav1.ObjectMeta{
+				Labels: map[string]string{
+					fdbtypes.FDBInstanceIDLabel:   fmt.Sprintf("%s-1337", fdbtypes.ProcessClassLog),
+					fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassLog),
 				},
-				Pod: pod,
+				Annotations: map[string]string{},
 			}
+
 			status := &fdbtypes.ProcessGroupStatus{
 				ProcessGroupID: instanceName,
 				Remove:         false,
 			}
-			needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
 			cluster.Spec.StorageServersPerPod = 2
-			needsRemoval, err = instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err = instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -279,28 +216,18 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 	Context("when the nodeSelector changes", func() {
 		It("should need a removal", func() {
-			instance := FdbInstance{
-				Metadata: &metav1.ObjectMeta{
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   instanceName,
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-					},
-					Annotations: map[string]string{},
-				},
-				Pod: pod,
-			}
 			status := &fdbtypes.ProcessGroupStatus{
 				ProcessGroupID: instanceName,
 				Remove:         false,
 			}
-			needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
 			cluster.Spec.Processes[fdbtypes.ProcessClassGeneral].PodTemplate.Spec.NodeSelector = map[string]string{
 				"dummy": "test",
 			}
-			needsRemoval, err = instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err = instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -308,25 +235,14 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 	Context("when UpdatePodsByReplacement is not set and the PodSpecHash doesn't match", func() {
 		It("should not need a removal", func() {
-			instance := FdbInstance{
-				Metadata: &metav1.ObjectMeta{
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   instanceName,
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-					},
-					Annotations: map[string]string{},
-				},
-				Pod: &corev1.Pod{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{{}},
-					},
-				},
+			pod.Spec = corev1.PodSpec{
+				Containers: []corev1.Container{{}},
 			}
 			status := &fdbtypes.ProcessGroupStatus{
 				ProcessGroupID: instanceName,
 				Remove:         false,
 			}
-			needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -334,19 +250,8 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 	Context("when UpdatePodsByReplacement is set and the PodSpecHash doesn't match", func() {
 		It("should need a removal", func() {
-			instance := FdbInstance{
-				Metadata: &metav1.ObjectMeta{
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   instanceName,
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-					},
-					Annotations: map[string]string{},
-				},
-				Pod: &corev1.Pod{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{{}},
-					},
-				},
+			pod.Spec = corev1.PodSpec{
+				Containers: []corev1.Container{{}},
 			}
 			status := &fdbtypes.ProcessGroupStatus{
 				ProcessGroupID: instanceName,
@@ -356,7 +261,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cluster.Spec.UpdatePodsByReplacement = true
-			needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -396,31 +301,19 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 	Context("when the memory resources are changed", func() {
 		var status *fdbtypes.ProcessGroupStatus
-		var instance FdbInstance
+		var pod *corev1.Pod
 
 		BeforeEach(func() {
 			err := internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{UseFutureDefaults: true})
 			Expect(err).NotTo(HaveOccurred())
-			pod, err := internal.GetPod(cluster, fdbtypes.ProcessClassStorage, 0)
+			pod, err = internal.GetPod(cluster, fdbtypes.ProcessClassStorage, 0)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(err).NotTo(HaveOccurred())
-			instance = FdbInstance{
-				Metadata: &metav1.ObjectMeta{
-					Labels: map[string]string{
-						fdbtypes.FDBInstanceIDLabel:   pod.ObjectMeta.Labels[fdbtypes.FDBInstanceIDLabel],
-						fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-					},
-					Annotations: map[string]string{},
-				},
-				Pod: pod,
-			}
-
 			status = &fdbtypes.ProcessGroupStatus{
 				ProcessGroupID: instanceName,
 				Remove:         false,
 			}
 
-			needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+			needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 			Expect(needsRemoval).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -443,7 +336,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should need a removal", func() {
-					needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+					needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 					Expect(needsRemoval).To(BeTrue())
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -461,7 +354,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should not need a removal", func() {
-					needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+					needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 					Expect(needsRemoval).To(BeFalse())
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -479,7 +372,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should need a removal", func() {
-					needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+					needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 					Expect(needsRemoval).To(BeTrue())
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -497,7 +390,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should not need a removal", func() {
-					needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+					needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 					Expect(needsRemoval).To(BeFalse())
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -518,7 +411,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should need a removal", func() {
-					needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+					needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 					Expect(needsRemoval).To(BeTrue())
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -543,7 +436,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should not need a removal", func() {
-					needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+					needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 					Expect(needsRemoval).To(BeFalse())
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -561,7 +454,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should not need a removal", func() {
-					needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+					needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 					Expect(needsRemoval).To(BeFalse())
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -579,7 +472,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should not need a removal", func() {
-					needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+					needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 					Expect(needsRemoval).To(BeFalse())
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -597,7 +490,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should not need a removal", func() {
-					needsRemoval, err := instanceNeedsRemoval(cluster, instance, status)
+					needsRemoval, err := instanceNeedsRemoval(cluster, pod, status)
 					Expect(needsRemoval).To(BeFalse())
 					Expect(err).NotTo(HaveOccurred())
 				})

--- a/controllers/update_labels.go
+++ b/controllers/update_labels.go
@@ -52,7 +52,7 @@ func (u UpdateLabels) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 			return &Requeue{Error: err}
 		}
 
-		metadata := internal.GetPodMetadata(cluster, processClass, GetInstanceID(pod), "")
+		metadata := internal.GetPodMetadata(cluster, processClass, GetProcessGroupID(pod), "")
 		if metadata.Annotations == nil {
 			metadata.Annotations = make(map[string]string)
 		}

--- a/controllers/update_labels.go
+++ b/controllers/update_labels.go
@@ -37,25 +37,30 @@ type UpdateLabels struct{}
 
 // Reconcile runs the reconciler's work.
 func (u UpdateLabels) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
-	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}
-	for _, instance := range instances {
-		if instance.Pod != nil {
-			processClass := instance.GetProcessClass()
-			instanceID := instance.GetInstanceID()
 
-			metadata := internal.GetPodMetadata(cluster, processClass, instanceID, "")
-			if metadata.Annotations == nil {
-				metadata.Annotations = make(map[string]string)
-			}
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
 
-			if !podMetadataCorrect(metadata, &instance) {
-				err = r.PodLifecycleManager.UpdateMetadata(r, context, cluster, instance)
-				if err != nil {
-					return &Requeue{Error: err}
-				}
+		processClass, err := GetProcessClass(pod)
+		if err != nil {
+			return &Requeue{Error: err}
+		}
+
+		metadata := internal.GetPodMetadata(cluster, processClass, GetInstanceID(pod), "")
+		if metadata.Annotations == nil {
+			metadata.Annotations = make(map[string]string)
+		}
+
+		if !podMetadataCorrect(metadata, pod) {
+			err = r.PodLifecycleManager.UpdateMetadata(r, context, cluster, pod)
+			if err != nil {
+				return &Requeue{Error: err}
 			}
 		}
 	}
@@ -96,15 +101,15 @@ func (u UpdateLabels) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 	return nil
 }
 
-func podMetadataCorrect(metadata metav1.ObjectMeta, instance *FdbInstance) bool {
+func podMetadataCorrect(metadata metav1.ObjectMeta, pod *corev1.Pod) bool {
 	metadataCorrect := true
-	metadata.Annotations[fdbtypes.LastSpecKey] = instance.Metadata.Annotations[fdbtypes.LastSpecKey]
+	metadata.Annotations[fdbtypes.LastSpecKey] = pod.ObjectMeta.Annotations[fdbtypes.LastSpecKey]
 
-	if mergeLabelsInMetadata(instance.Metadata, metadata) {
+	if mergeLabelsInMetadata(&pod.ObjectMeta, metadata) {
 		metadataCorrect = false
 	}
 
-	if mergeAnnotations(instance.Metadata, metadata) {
+	if mergeAnnotations(&pod.ObjectMeta, metadata) {
 		metadataCorrect = false
 	}
 

--- a/controllers/update_labels.go
+++ b/controllers/update_labels.go
@@ -37,7 +37,7 @@ type UpdateLabels struct{}
 
 // Reconcile runs the reconciler's work.
 func (u UpdateLabels) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
-	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}
@@ -72,7 +72,7 @@ func (u UpdateLabels) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 	}
 	for _, pvc := range pvcs.Items {
 		processClass := internal.GetProcessClassFromMeta(pvc.ObjectMeta)
-		instanceID := internal.GetInstanceIDFromMeta(pvc.ObjectMeta)
+		instanceID := internal.GetProcessGroupIDFromMeta(pvc.ObjectMeta)
 
 		metadata := internal.GetPvcMetadata(cluster, processClass, instanceID)
 		if metadata.Annotations == nil {

--- a/controllers/update_labels_test.go
+++ b/controllers/update_labels_test.go
@@ -25,13 +25,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Update labels", func() {
 	type testCase struct {
-		instance     FdbInstance
+		pod          *corev1.Pod
 		metadata     metav1.ObjectMeta
 		expected     bool
 		expectedMeta metav1.ObjectMeta
@@ -39,15 +40,15 @@ var _ = Describe("Update labels", func() {
 
 	DescribeTable("Test metadata correctness",
 		func(tc testCase) {
-			result := podMetadataCorrect(tc.metadata, &tc.instance)
+			result := podMetadataCorrect(tc.metadata, tc.pod)
 			Expect(result).To(Equal(tc.expected))
-			Expect(equality.Semantic.DeepEqual(tc.instance.Metadata.Labels, tc.expectedMeta.Labels)).To(BeTrue())
-			Expect(equality.Semantic.DeepEqual(tc.instance.Metadata.Annotations, tc.expectedMeta.Annotations)).To(BeTrue())
+			Expect(equality.Semantic.DeepEqual(tc.pod.ObjectMeta.Labels, tc.expectedMeta.Labels)).To(BeTrue())
+			Expect(equality.Semantic.DeepEqual(tc.pod.ObjectMeta.Annotations, tc.expectedMeta.Annotations)).To(BeTrue())
 		},
 		Entry("Metadata matches with instance metadata",
 			testCase{
-				instance: FdbInstance{
-					Metadata: &metav1.ObjectMeta{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							fdbtypes.LastSpecKey: "1",
 						},
@@ -68,8 +69,8 @@ var _ = Describe("Update labels", func() {
 		),
 		Entry("Metadata last spec is not matching",
 			testCase{
-				instance: FdbInstance{
-					Metadata: &metav1.ObjectMeta{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							fdbtypes.LastSpecKey: "1",
 						},
@@ -90,8 +91,8 @@ var _ = Describe("Update labels", func() {
 		),
 		Entry("Metadata Annotation is not matching",
 			testCase{
-				instance: FdbInstance{
-					Metadata: &metav1.ObjectMeta{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							fdbtypes.LastSpecKey: "1",
 							"special":            "43",
@@ -115,8 +116,8 @@ var _ = Describe("Update labels", func() {
 		),
 		Entry("Missing annotation on metadata",
 			testCase{
-				instance: FdbInstance{
-					Metadata: &metav1.ObjectMeta{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							fdbtypes.LastSpecKey: "1",
 						},
@@ -139,8 +140,8 @@ var _ = Describe("Update labels", func() {
 		),
 		Entry("Ignore additional annotation",
 			testCase{
-				instance: FdbInstance{
-					Metadata: &metav1.ObjectMeta{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							fdbtypes.LastSpecKey: "1",
 							"controller/X":       "wrong",
@@ -163,8 +164,8 @@ var _ = Describe("Update labels", func() {
 		),
 		Entry("Annotation has wrong value",
 			testCase{
-				instance: FdbInstance{
-					Metadata: &metav1.ObjectMeta{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							fdbtypes.LastSpecKey: "1",
 							"controller/X":       "true",
@@ -188,8 +189,8 @@ var _ = Describe("Update labels", func() {
 		),
 		Entry("Ignore additional label",
 			testCase{
-				instance: FdbInstance{
-					Metadata: &metav1.ObjectMeta{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							fdbtypes.LastSpecKey: "1",
 						},
@@ -216,8 +217,8 @@ var _ = Describe("Update labels", func() {
 		),
 		Entry("Label has wrong value",
 			testCase{
-				instance: FdbInstance{
-					Metadata: &metav1.ObjectMeta{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							fdbtypes.LastSpecKey: "1",
 						},

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -43,7 +43,7 @@ func (u UpdatePodConfig) Reconcile(r *FoundationDBClusterReconciler, context ctx
 		return &Requeue{Error: err}
 	}
 
-	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -50,7 +50,7 @@ func (u UpdatePodConfig) Reconcile(r *FoundationDBClusterReconciler, context ctx
 
 	podProcessGroupMap := make(map[string]*corev1.Pod, len(pods))
 	for _, pod := range pods {
-		processGroupID := GetInstanceID(pod)
+		processGroupID := GetProcessGroupID(pod)
 		if processGroupID == "" {
 			continue
 		}

--- a/controllers/update_pod_config_test.go
+++ b/controllers/update_pod_config_test.go
@@ -36,18 +36,18 @@ var _ = Describe("UpdatePodConfig", func() {
 	var cluster *fdbtypes.FoundationDBCluster
 	var requeue *Requeue
 	var err error
-	var instances []FdbInstance
+	var pods []*corev1.Pod
 
 	BeforeEach(func() {
 		cluster = internal.CreateDefaultCluster()
 		err = setupClusterForTest(cluster)
 		Expect(err).NotTo(HaveOccurred())
 
-		instances, err = clusterReconciler.PodLifecycleManager.GetInstances(clusterReconciler, cluster, context.TODO(), internal.GetSinglePodListOptions(cluster, "storage-1")...)
+		pods, err = clusterReconciler.PodLifecycleManager.GetInstances(clusterReconciler, cluster, context.TODO(), internal.GetSinglePodListOptions(cluster, "storage-1")...)
 		Expect(err).NotTo(HaveOccurred())
 
-		for _, container := range instances[0].Pod.Spec.Containers {
-			instances[0].Pod.Status.ContainerStatuses = append(instances[0].Pod.Status.ContainerStatuses, corev1.ContainerStatus{Ready: true, Name: container.Name})
+		for _, container := range pods[0].Spec.Containers {
+			pods[0].Status.ContainerStatuses = append(pods[0].Status.ContainerStatuses, corev1.ContainerStatus{Ready: true, Name: container.Name})
 		}
 	})
 
@@ -65,7 +65,7 @@ var _ = Describe("UpdatePodConfig", func() {
 
 	When("a Pod is stuck in Pending", func() {
 		BeforeEach(func() {
-			instances[0].Pod.Status.Phase = corev1.PodPending
+			pods[0].Status.Phase = corev1.PodPending
 		})
 
 		It("should not requeue", func() {

--- a/controllers/update_pod_config_test.go
+++ b/controllers/update_pod_config_test.go
@@ -43,7 +43,7 @@ var _ = Describe("UpdatePodConfig", func() {
 		err = setupClusterForTest(cluster)
 		Expect(err).NotTo(HaveOccurred())
 
-		pods, err = clusterReconciler.PodLifecycleManager.GetInstances(clusterReconciler, cluster, context.TODO(), internal.GetSinglePodListOptions(cluster, "storage-1")...)
+		pods, err = clusterReconciler.PodLifecycleManager.GetPods(clusterReconciler, cluster, context.TODO(), internal.GetSinglePodListOptions(cluster, "storage-1")...)
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, container := range pods[0].Spec.Containers {

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -39,7 +39,7 @@ type UpdatePods struct{}
 func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "UpdatePods")
 
-	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -39,16 +39,19 @@ type UpdatePods struct{}
 func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "UpdatePods")
 
-	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}
 
-	updates := make(map[string][]FdbInstance)
-
-	instanceProcessGroupMap := make(map[string]FdbInstance, len(instances))
-	for _, instance := range instances {
-		instanceProcessGroupMap[instance.GetInstanceID()] = instance
+	updates := make(map[string][]*corev1.Pod)
+	podProcessGroupMap := make(map[string]*corev1.Pod, len(pods))
+	for _, pod := range pods {
+		processGroupID := GetInstanceID(pod)
+		if processGroupID == "" {
+			continue
+		}
+		podProcessGroupMap[processGroupID] = pod
 	}
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
@@ -64,14 +67,14 @@ func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 			continue
 		}
 
-		instance, ok := instanceProcessGroupMap[processGroup.ProcessGroupID]
-		if !ok || instance.Pod == nil || instance.Metadata == nil {
+		pod, ok := podProcessGroupMap[processGroup.ProcessGroupID]
+		if !ok || pod == nil {
 			logger.V(1).Info("Could not find Pod for process group ID",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue
 		}
 
-		if instance.Pod.DeletionTimestamp != nil && !cluster.InstanceIsBeingRemoved(processGroup.ProcessGroupID) {
+		if pod.DeletionTimestamp != nil && !cluster.InstanceIsBeingRemoved(processGroup.ProcessGroupID) {
 			return &Requeue{Message: "Cluster has pod that is pending deletion", Delay: podSchedulingDelayDuration}
 		}
 
@@ -80,17 +83,22 @@ func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 			return &Requeue{Error: err}
 		}
 
-		specHash, err := internal.GetPodSpecHash(cluster, instance.GetProcessClass(), idNum, nil)
+		processClass, err := GetProcessClass(pod)
 		if err != nil {
 			return &Requeue{Error: err}
 		}
 
-		if instance.Metadata.Annotations[fdbtypes.LastSpecKey] != specHash {
+		specHash, err := internal.GetPodSpecHash(cluster, processClass, idNum, nil)
+		if err != nil {
+			return &Requeue{Error: err}
+		}
+
+		if pod.ObjectMeta.Annotations[fdbtypes.LastSpecKey] != specHash {
 			logger.Info("Update Pod",
 				"processGroupID", processGroup.ProcessGroupID,
-				"reason", fmt.Sprintf("specHash has changed from %s to %s", specHash, instance.Metadata.Annotations[fdbtypes.LastSpecKey]))
+				"reason", fmt.Sprintf("specHash has changed from %s to %s", specHash, pod.ObjectMeta.Annotations[fdbtypes.LastSpecKey]))
 
-			podClient, message := r.getPodClient(cluster, instance)
+			podClient, message := r.getPodClient(cluster, pod)
 			if podClient == nil {
 				return &Requeue{Message: message, Delay: podSchedulingDelayDuration}
 			}
@@ -106,9 +114,9 @@ func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 			}
 
 			if updates[zone] == nil {
-				updates[zone] = make([]FdbInstance, 0)
+				updates[zone] = make([]*corev1.Pod, 0)
 			}
-			updates[zone] = append(updates[zone], instance)
+			updates[zone] = append(updates[zone], pod)
 		}
 	}
 

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -47,7 +47,7 @@ func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 	updates := make(map[string][]*corev1.Pod)
 	podProcessGroupMap := make(map[string]*corev1.Pod, len(pods))
 	for _, pod := range pods {
-		processGroupID := GetInstanceID(pod)
+		processGroupID := GetProcessGroupID(pod)
 		if processGroupID == "" {
 			continue
 		}
@@ -78,7 +78,7 @@ func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 			return &Requeue{Message: "Cluster has pod that is pending deletion", Delay: podSchedulingDelayDuration}
 		}
 
-		_, idNum, err := ParseInstanceID(processGroup.ProcessGroupID)
+		_, idNum, err := ParseProcessGroupID(processGroup.ProcessGroupID)
 		if err != nil {
 			return &Requeue{Error: err}
 		}

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -39,7 +39,7 @@ type UpdateSidecarVersions struct {
 // Reconcile runs the reconciler's work.
 func (u UpdateSidecarVersions) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "UpdateSidecarVersions")
-	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -39,25 +39,26 @@ type UpdateSidecarVersions struct {
 // Reconcile runs the reconciler's work.
 func (u UpdateSidecarVersions) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "UpdateSidecarVersions")
-	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}
 	upgraded := false
-	for _, instance := range instances {
-		if instance.Pod == nil {
-			return &Requeue{Message: fmt.Sprintf("No pod defined for instance %s", instance.GetInstanceID()), Delay: podSchedulingDelayDuration}
-		}
-
-		image, err := getSidecarImage(cluster, instance)
+	for _, pod := range pods {
+		processClass, err := GetProcessClass(pod)
 		if err != nil {
 			return &Requeue{Error: err}
 		}
 
-		for containerIndex, container := range instance.Pod.Spec.Containers {
+		image, err := internal.GetSidecarImage(cluster, processClass)
+		if err != nil {
+			return &Requeue{Error: err}
+		}
+
+		for containerIndex, container := range pod.Spec.Containers {
 			if container.Name == "foundationdb-kubernetes-sidecar" && container.Image != image {
-				logger.Info("Upgrading sidecar", "processGroupID", instance.GetInstanceID(), "oldImage", container.Image, "newImage", image)
-				err = r.PodLifecycleManager.UpdateImageVersion(r, context, cluster, instance, containerIndex, image)
+				logger.Info("Upgrading sidecar", "processGroupID", GetInstanceID(pod), "oldImage", container.Image, "newImage", image)
+				err = r.PodLifecycleManager.UpdateImageVersion(r, context, cluster, pod, containerIndex, image)
 				if err != nil {
 					return &Requeue{Error: err}
 				}
@@ -71,19 +72,4 @@ func (u UpdateSidecarVersions) Reconcile(r *FoundationDBClusterReconciler, conte
 	}
 
 	return nil
-}
-
-func getSidecarImage(cluster *fdbtypes.FoundationDBCluster, instance FdbInstance) (string, error) {
-	settings := cluster.GetProcessSettings(instance.GetProcessClass())
-
-	image := ""
-	if settings.PodTemplate != nil {
-		for _, container := range settings.PodTemplate.Spec.Containers {
-			if container.Name == "foundationdb-kubernetes-sidecar" && container.Image != "" {
-				image = container.Image
-			}
-		}
-	}
-
-	return internal.GetImage(image, cluster.Spec.SidecarContainer.ImageConfigs, cluster.Spec.Version, settings.GetAllowTagOverride())
 }

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -57,7 +57,7 @@ func (u UpdateSidecarVersions) Reconcile(r *FoundationDBClusterReconciler, conte
 
 		for containerIndex, container := range pod.Spec.Containers {
 			if container.Name == "foundationdb-kubernetes-sidecar" && container.Image != image {
-				logger.Info("Upgrading sidecar", "processGroupID", GetInstanceID(pod), "oldImage", container.Image, "newImage", image)
+				logger.Info("Upgrading sidecar", "processGroupID", GetProcessGroupID(pod), "oldImage", container.Image, "newImage", image)
 				err = r.PodLifecycleManager.UpdateImageVersion(r, context, cluster, pod, containerIndex, image)
 				if err != nil {
 					return &Requeue{Error: err}

--- a/controllers/update_sidecar_versions_test.go
+++ b/controllers/update_sidecar_versions_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func createClusterSpec(sidecarOverrides fdbtypes.ContainerOverrides, processes map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings) *fdbtypes.FoundationDBCluster {
@@ -43,7 +42,7 @@ var _ = Describe("update_sidecar_versions", func() {
 	trueBool := true
 	Context("When fetching the sidecar image", func() {
 		type testCase struct {
-			instance FdbInstance
+			pClass   fdbtypes.ProcessClass
 			cluster  *fdbtypes.FoundationDBCluster
 			hasError bool
 		}
@@ -53,7 +52,7 @@ var _ = Describe("update_sidecar_versions", func() {
 				err := internal.NormalizeClusterSpec(input.cluster, internal.DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				image, err := getSidecarImage(input.cluster, input.instance)
+				image, err := internal.GetSidecarImage(input.cluster, input.pClass)
 				if input.hasError {
 					Expect(err).To(HaveOccurred())
 				} else {
@@ -64,13 +63,7 @@ var _ = Describe("update_sidecar_versions", func() {
 			},
 			Entry("only defaults used",
 				testCase{
-					instance: FdbInstance{
-						Metadata: &metav1.ObjectMeta{
-							Labels: map[string]string{
-								fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-							},
-						},
-					},
+					pClass: fdbtypes.ProcessClassStorage,
 					cluster: createClusterSpec(
 						fdbtypes.ContainerOverrides{},
 						map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{}),
@@ -78,13 +71,7 @@ var _ = Describe("update_sidecar_versions", func() {
 				}, "foundationdb/foundationdb-kubernetes-sidecar:6.2.20-1"),
 			Entry("sidecar override is set",
 				testCase{
-					instance: FdbInstance{
-						Metadata: &metav1.ObjectMeta{
-							Labels: map[string]string{
-								fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-							},
-						},
-					},
+					pClass: fdbtypes.ProcessClassStorage,
 					cluster: createClusterSpec(
 						fdbtypes.ContainerOverrides{ImageConfigs: []fdbtypes.ImageConfig{{BaseImage: "sidecar-override"}}},
 						map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{}),
@@ -92,13 +79,7 @@ var _ = Describe("update_sidecar_versions", func() {
 				}, "sidecar-override:6.2.20-1"),
 			Entry("settings override sidecar",
 				testCase{
-					instance: FdbInstance{
-						Metadata: &metav1.ObjectMeta{
-							Labels: map[string]string{
-								fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-							},
-						},
-					},
+					pClass: fdbtypes.ProcessClassStorage,
 					cluster: createClusterSpec(
 						fdbtypes.ContainerOverrides{ImageConfigs: []fdbtypes.ImageConfig{{BaseImage: "sidecar-override"}}},
 						map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{
@@ -119,13 +100,7 @@ var _ = Describe("update_sidecar_versions", func() {
 				}, "settings-override:6.2.20-1"),
 			Entry("settings override sidecar with tag without override",
 				testCase{
-					instance: FdbInstance{
-						Metadata: &metav1.ObjectMeta{
-							Labels: map[string]string{
-								fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-							},
-						},
-					},
+					pClass: fdbtypes.ProcessClassStorage,
 					cluster: createClusterSpec(
 						fdbtypes.ContainerOverrides{ImageConfigs: []fdbtypes.ImageConfig{{BaseImage: "sidecar-override"}}},
 						map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{
@@ -146,13 +121,7 @@ var _ = Describe("update_sidecar_versions", func() {
 				}, ""),
 			Entry("settings override sidecar with tag with override",
 				testCase{
-					instance: FdbInstance{
-						Metadata: &metav1.ObjectMeta{
-							Labels: map[string]string{
-								fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
-							},
-						},
-					},
+					pClass: fdbtypes.ProcessClassStorage,
 					cluster: createClusterSpec(
 						fdbtypes.ContainerOverrides{ImageConfigs: []fdbtypes.ImageConfig{{BaseImage: "sidecar-override"}}},
 						map[fdbtypes.ProcessClass]fdbtypes.ProcessSettings{

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -625,7 +625,7 @@ func validateProcessGroup(r *FoundationDBClusterReconciler, context ctx.Context,
 			logger.Info("Delete Pod that is stuck in NodeAffinity",
 				"processGroupID", processGroupStatus.ProcessGroupID)
 
-			err = r.PodLifecycleManager.DeletePods(r, context, pod)
+			err = r.PodLifecycleManager.DeletePod(r, context, pod)
 			if err != nil {
 				return needsSidecarConfInConfigMap, err
 			}

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -447,7 +447,7 @@ func validateProcessGroups(r *FoundationDBClusterReconciler, context ctx.Context
 	}
 
 	for _, processGroup := range processGroups {
-		pods, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, processGroup.ProcessClass, processGroup.ProcessGroupID)...)
+		pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, processGroup.ProcessClass, processGroup.ProcessGroupID)...)
 		if err != nil {
 			return processGroups, err
 		}
@@ -558,7 +558,7 @@ func validateProcessGroup(r *FoundationDBClusterReconciler, context ctx.Context,
 
 	incorrectPod := !metadataMatches(pod.ObjectMeta, internal.GetPodMetadata(cluster, processGroupStatus.ProcessClass, processGroupStatus.ProcessGroupID, specHash))
 	if !incorrectPod {
-		updated, err := r.PodLifecycleManager.InstanceIsUpdated(r, context, cluster, pod)
+		updated, err := r.PodLifecycleManager.PodIsUpdated(r, context, cluster, pod)
 		if err != nil {
 			return false, err
 		}
@@ -625,7 +625,7 @@ func validateProcessGroup(r *FoundationDBClusterReconciler, context ctx.Context,
 			logger.Info("Delete Pod that is stuck in NodeAffinity",
 				"processGroupID", processGroupStatus.ProcessGroupID)
 
-			err = r.PodLifecycleManager.DeleteInstance(r, context, pod)
+			err = r.PodLifecycleManager.DeletePods(r, context, pod)
 			if err != nil {
 				return needsSidecarConfInConfigMap, err
 			}

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -46,7 +46,7 @@ var _ = Describe("update_status", func() {
 			err = setupClusterForTest(cluster)
 			Expect(err).NotTo(HaveOccurred())
 
-			pods, err = clusterReconciler.PodLifecycleManager.GetInstances(clusterReconciler, cluster, context.TODO(), internal.GetSinglePodListOptions(cluster, "storage-1")...)
+			pods, err = clusterReconciler.PodLifecycleManager.GetPods(clusterReconciler, cluster, context.TODO(), internal.GetSinglePodListOptions(cluster, "storage-1")...)
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, container := range pods[0].Spec.Containers {

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -395,7 +395,7 @@ func (client *mockFdbPodClient) GetVariableSubstitutions() (map[string]string, e
 		}
 	}
 
-	substitutions["FDB_INSTANCE_ID"] = GetInstanceIDFromMeta(client.Pod.ObjectMeta)
+	substitutions["FDB_INSTANCE_ID"] = GetProcessGroupIDFromMeta(client.Pod.ObjectMeta)
 
 	version, err := fdbtypes.ParseFdbVersion(client.Cluster.Spec.Version)
 	if err != nil {

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"k8s.io/utils/pointer"
 	"net"
 	"strconv"
 
@@ -120,13 +121,12 @@ func GetMinimalPodLabels(cluster *fdbtypes.FoundationDBCluster, processClass fdb
 
 // BuildOwnerReference returns an OwnerReference for the provided input
 func BuildOwnerReference(ownerType metav1.TypeMeta, ownerMetadata metav1.ObjectMeta) []metav1.OwnerReference {
-	var isController = true
 	return []metav1.OwnerReference{{
 		APIVersion: ownerType.APIVersion,
 		Kind:       ownerType.Kind,
 		Name:       ownerMetadata.Name,
 		UID:        ownerMetadata.UID,
-		Controller: &isController,
+		Controller: pointer.Bool(true),
 	}}
 }
 

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -157,3 +157,19 @@ func GetPvcMetadata(cluster *fdbtypes.FoundationDBCluster, processClass fdbtypes
 	}
 	return GetObjectMetadata(cluster, customMetadata, processClass, id)
 }
+
+// GetSidecarImage returns the expected sidecar image for a specific process class
+func GetSidecarImage(cluster *fdbtypes.FoundationDBCluster, pClass fdbtypes.ProcessClass) (string, error) {
+	settings := cluster.GetProcessSettings(pClass)
+
+	image := ""
+	if settings.PodTemplate != nil {
+		for _, container := range settings.PodTemplate.Spec.Containers {
+			if container.Name == "foundationdb-kubernetes-sidecar" && container.Image != "" {
+				image = container.Image
+			}
+		}
+	}
+
+	return GetImage(image, cluster.Spec.SidecarContainer.ImageConfigs, cluster.Spec.Version, settings.GetAllowTagOverride())
+}

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -68,8 +68,8 @@ func GetPublicIPsForPod(pod *corev1.Pod) []string {
 	return []string{pod.Status.PodIP}
 }
 
-// GetInstanceIDFromMeta fetches the instance ID from an object's metadata.
-func GetInstanceIDFromMeta(metadata metav1.ObjectMeta) string {
+// GetProcessGroupIDFromMeta fetches the instance ID from an object's metadata.
+func GetProcessGroupIDFromMeta(metadata metav1.ObjectMeta) string {
 	return metadata.Labels[fdbtypes.FDBInstanceIDLabel]
 }
 

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -4,9 +4,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"k8s.io/utils/pointer"
 	"net"
 	"strconv"
+
+	"k8s.io/utils/pointer"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -2922,4 +2922,94 @@ var _ = Describe("pod_models", func() {
 			)
 		})
 	})
+
+	Describe("getStorageServersPerPodForInstance", func() {
+		Context("when env var is set with 1", func() {
+			It("should return 1", func() {
+				pod := &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Env: []corev1.EnvVar{
+								{
+									Name:  "STORAGE_SERVERS_PER_POD",
+									Value: "1",
+								},
+							},
+						}},
+					},
+				}
+
+				storageServersPerPod, err := GetStorageServersPerPodForPod(pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(storageServersPerPod).To(Equal(1))
+			})
+		})
+
+		Context("when env var is set with 2", func() {
+			It("should return 2", func() {
+				pod := &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Env: []corev1.EnvVar{
+								{
+									Name:  "STORAGE_SERVERS_PER_POD",
+									Value: "2",
+								},
+							},
+						}},
+					},
+				}
+
+				storageServersPerPod, err := GetStorageServersPerPodForPod(pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(storageServersPerPod).To(Equal(2))
+			})
+		})
+
+		Context("when env var is unset", func() {
+			It("should return 1", func() {
+				pod := &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Env: []corev1.EnvVar{},
+						}},
+					},
+				}
+
+				storageServersPerPod, err := GetStorageServersPerPodForPod(pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(storageServersPerPod).To(Equal(1))
+			})
+		})
+
+		Context("when pod is nil", func() {
+			It("should return 1", func() {
+				storageServersPerPod, err := GetStorageServersPerPodForPod(nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(storageServersPerPod).To(Equal(1))
+			})
+		})
+
+		Context("when Pod doesn't contain a Spec", func() {
+			It("should return 1", func() {
+				pod := &corev1.Pod{}
+
+				storageServersPerPod, err := GetStorageServersPerPodForPod(pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(storageServersPerPod).To(Equal(1))
+			})
+		})
+
+		Context("when Pod doesn't contain a containers", func() {
+			It("should return 1", func() {
+				pod := &corev1.Pod{
+					Spec: corev1.PodSpec{},
+				}
+
+				storageServersPerPod, err := GetStorageServersPerPodForPod(pod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(storageServersPerPod).To(Equal(1))
+			})
+		})
+	})
 })


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/681 the change is intended to be a breaking change (which is fine for our `0.*` state) for everyone using our code. The benefit of the refactoring is that we can move more code into our internal package to reduce the public surface.

## Type of change

*Please select one of the options below.*

- Breaking change 

# Discussion

There might be some other places where we can be smarter but I would leave this opt./refactoring for another PR.

# Testing

Unit + locally. Will run some e2e tests later report back.

# Documentation

Nothing to document.

# Follow-up

- https://github.com/FoundationDB/fdb-kubernetes-operator/issues/918