### PR TITLE
Don't requeue in generate initial cluster file when no error occurs

### DIFF
--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -99,5 +99,8 @@ func (g GenerateInitialClusterFile) Reconcile(r *FoundationDBClusterReconciler, 
 	cluster.Status.ConnectionString = connectionString.String()
 
 	err = r.Status().Update(context, cluster)
-	return &Requeue{Error: err}
+	if err != nil {
+		return &Requeue{Error: err}
+	}
+	return nil
 }


### PR DESCRIPTION
# Description

Fixes #838. Checked all the other occurrences and didn't find anything similar

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)


# Discussion

Not needed

# Testing

Not needed

# Documentation
Not needed

# Follow-up

Not needed