### PR TITLE
Use default retry policy

### DIFF
--- a/controllers/bounce_processes_test.go
+++ b/controllers/bounce_processes_test.go
@@ -93,8 +93,9 @@ var _ = Describe("BounceProcesses", func() {
 					addresses = append(addresses, fmt.Sprintf("%s:4501", address))
 				}
 			}
-			sort.Strings(adminClient.KilledAddresses)
-			Expect(adminClient.KilledAddresses).To(Equal(addresses))
+
+			Expect(len(adminClient.KilledAddresses)).To(Equal(len(addresses)))
+			Expect(adminClient.KilledAddresses).To(ContainElements(addresses))
 		})
 	})
 

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -21,7 +21,6 @@
 package internal
 
 import (
-	"context"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -166,14 +165,6 @@ func (client *realFdbPodClient) makeRequest(method string, path string) (string,
 	retryClient.RetryWaitMax = 1 * time.Second
 	// Prevent logging
 	retryClient.Logger = nil
-	retryClient.CheckRetry = func(c context.Context, resp *http.Response, err error) (bool, error) {
-		if c.Err() != nil && err != nil && resp != nil && resp.StatusCode >= http.StatusBadRequest {
-			return true, nil
-		}
-
-		// All other go to default policy
-		return retryablehttp.DefaultRetryPolicy(c, resp, err)
-	}
 
 	if client.useTLS {
 		retryClient.HTTPClient.Transport = &http.Transport{TLSClientConfig: client.tlsConfig}

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -95,7 +95,7 @@ func NewFdbPodClient(cluster *fdbtypes.FoundationDBCluster, pod *corev1.Pod) (Fd
 	}
 	for _, container := range pod.Status.ContainerStatuses {
 		if container.Name == "foundationdb-kubernetes-sidecar" && !container.Ready {
-			return nil, fmt.Errorf("Waiting for pod %s/%s/%s to be ready", cluster.Namespace, cluster.Name, pod.Name)
+			return nil, fmt.Errorf("waiting for pod %s/%s/%s to be ready", cluster.Namespace, cluster.Name, pod.Name)
 		}
 	}
 
@@ -199,25 +199,17 @@ func (client *realFdbPodClient) makeRequest(method string, path string) (string,
 		return "", err
 	}
 
-	if resp.StatusCode >= http.StatusBadRequest {
-		return "", failedResponse{response: resp, body: bodyText}
-	}
-
 	return bodyText, nil
 }
 
 // IsPresent checks whether a file in the sidecar is present.
 func (client *realFdbPodClient) IsPresent(filename string) (bool, error) {
 	_, err := client.makeRequest("GET", fmt.Sprintf("check_hash/%s", filename))
-	if err == nil {
-		return true, err
+	if err != nil {
+		return false, err
 	}
 
-	response, isResponse := err.(failedResponse)
-	if isResponse && response.response.StatusCode == 404 {
-		return false, nil
-	}
-	return false, err
+	return true, nil
 }
 
 // CheckHash checks whether a file in the sidecar has the expected contents.
@@ -363,7 +355,7 @@ func (client *mockFdbPodClient) GetVariableSubstitutions() (map[string]string, e
 	if ipString != "" {
 		ip := net.ParseIP(ipString)
 		if ip == nil {
-			return nil, fmt.Errorf("Failed to parse IP from pod: %s", ipString)
+			return nil, fmt.Errorf("failed to parse IP from pod: %s", ipString)
 		}
 
 		if ip.To4() == nil {
@@ -407,17 +399,6 @@ func (client *mockFdbPodClient) GetVariableSubstitutions() (map[string]string, e
 	}
 
 	return substitutions, nil
-}
-
-// failedResponse is an error thrown when a request to the sidecar fails.
-type failedResponse struct {
-	response *http.Response
-	body     string
-}
-
-// Error generates an error message.
-func (response failedResponse) Error() string {
-	return fmt.Sprintf("HTTP request failed. Status=%d; response=%s", response.response.StatusCode, response.body)
 }
 
 // podHasSidecarTLS determines whether a pod currently has TLS enabled for the

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -165,6 +165,7 @@ func (client *realFdbPodClient) makeRequest(method string, path string) (string,
 	retryClient.RetryWaitMax = 1 * time.Second
 	// Prevent logging
 	retryClient.Logger = nil
+	retryClient.CheckRetry = retryablehttp.ErrorPropagatedRetryPolicy
 
 	if client.useTLS {
 		retryClient.HTTPClient.Transport = &http.Transport{TLSClientConfig: client.tlsConfig}


### PR DESCRIPTION
# Description

Make use of the default retry policy instead of a custom one (https://pkg.go.dev/github.com/hashicorp/go-retryablehttp#DefaultRetryPolicy)

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

I'm not sure why we added the custom logic but looking at the sidecar I don't think that the custom check has any benefits.

# Testing

Unit + local.

# Documentation

None.

# Follow-up

-
