### PR TITLE
Ensure we only iterate over process groups

### DIFF
--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -59,10 +59,7 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 		return &Requeue{Error: err}
 	}
 
-	podMap := make(map[string]*corev1.Pod, len(pods))
-	for _, pod := range pods {
-		podMap[GetProcessGroupID(cluster, pod)] = pod
-	}
+	podMap := internal.CreatePodMap(cluster, pods)
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		_, podExists := podMap[processGroup.ProcessGroupID]

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -125,7 +125,7 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 		UpdateLockConfiguration{},
 		UpdateConfigMap{},
 		CheckClientCompatibility{},
-		ReplaceMisconfiguredPods{},
+		ReplaceMisconfiguredProcessGroups{},
 		ReplaceFailedPods{},
 		DeletePodsForBuggification{},
 		AddProcessGroups{},

--- a/controllers/delete_pods_for_buggification.go
+++ b/controllers/delete_pods_for_buggification.go
@@ -42,14 +42,8 @@ func (d DeletePodsForBuggification) Reconcile(r *FoundationDBClusterReconciler, 
 		return &Requeue{Error: err}
 	}
 
+	podMap := internal.CreatePodMap(cluster, pods)
 	updates := make([]*corev1.Pod, 0)
-
-	removals := make(map[string]bool)
-	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.Remove {
-			removals[processGroup.ProcessGroupID] = true
-		}
-	}
 
 	crashLoopPods := make(map[string]bool, len(cluster.Spec.Buggify.CrashLoop))
 	crashLoopAll := false
@@ -61,10 +55,17 @@ func (d DeletePodsForBuggification) Reconcile(r *FoundationDBClusterReconciler, 
 		}
 	}
 
-	for _, pod := range pods {
-		instanceID := GetProcessGroupID(cluster, pod)
-		_, pendingRemoval := removals[instanceID]
-		if pendingRemoval {
+	for _, processGroup := range cluster.Status.ProcessGroups {
+		if processGroup.Remove {
+			logger.V(1).Info("Ignore removed Pod",
+				"processGroupID", processGroup.ProcessGroupID)
+			continue
+		}
+
+		pod, ok := podMap[processGroup.ProcessGroupID]
+		if !ok || pod == nil {
+			logger.V(1).Info("Could not find Pod for process group ID",
+				"processGroupID", processGroup.ProcessGroupID)
 			continue
 		}
 
@@ -75,11 +76,11 @@ func (d DeletePodsForBuggification) Reconcile(r *FoundationDBClusterReconciler, 
 			}
 		}
 
-		shouldCrashLoop := crashLoopAll || crashLoopPods[instanceID]
+		shouldCrashLoop := crashLoopAll || crashLoopPods[processGroup.ProcessGroupID]
 
 		if shouldCrashLoop != inCrashLoop {
 			logger.Info("Deleting pod for buggification",
-				"processGroupID", instanceID,
+				"processGroupID", processGroup.ProcessGroupID,
 				"shouldCrashLoop", shouldCrashLoop,
 				"inCrashLoop", inCrashLoop)
 			updates = append(updates, pod)

--- a/controllers/delete_pods_for_buggification.go
+++ b/controllers/delete_pods_for_buggification.go
@@ -57,7 +57,7 @@ func (d DeletePodsForBuggification) Reconcile(r *FoundationDBClusterReconciler, 
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.Remove {
-			logger.V(1).Info("Ignore removed Pod",
+			logger.V(1).Info("Ignore process group marked for removal",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue
 		}

--- a/controllers/replace_misconfigured_process_groups.go
+++ b/controllers/replace_misconfigured_process_groups.go
@@ -72,11 +72,9 @@ func (c ReplaceMisconfiguredProcessGroups) Reconcile(r *FoundationDBClusterRecon
 				return &Requeue{Error: err}
 			}
 
-			if needsPVCRemoval {
-				if hasPod {
-					processGroup.Remove = true
-					hasNewRemovals = true
-				}
+			if needsPVCRemoval && hasPod {
+				processGroup.Remove = true
+				hasNewRemovals = true
 				continue
 			}
 		} else {

--- a/controllers/replace_misconfigured_process_groups.go
+++ b/controllers/replace_misconfigured_process_groups.go
@@ -1,5 +1,5 @@
 /*
- * replace_misconfigured_pods.go
+ * replace_misconfigured_process_groups.go
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -34,18 +34,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// ReplaceMisconfiguredPods identifies processes that need to be replaced in
+// ReplaceMisconfiguredProcessGroups identifies processes that need to be replaced in
 // order to bring up new processes with different configuration.
-type ReplaceMisconfiguredPods struct{}
+type ReplaceMisconfiguredProcessGroups struct{}
 
 // Reconcile runs the reconciler's work.
-func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
+func (c ReplaceMisconfiguredProcessGroups) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "ReplaceMisconfiguredProcessGroups")
 	hasNewRemovals := false
-
-	processGroups := make(map[string]*fdbtypes.ProcessGroupStatus)
-	for _, processGroup := range cluster.Status.ProcessGroups {
-		processGroups[processGroup.ProcessGroupID] = processGroup
-	}
 
 	pvcs := &corev1.PersistentVolumeClaimList{}
 	err := r.List(context, pvcs, internal.GetPodListOptions(cluster, "", "")...)
@@ -53,48 +49,54 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 		return &Requeue{Error: err}
 	}
 
-	for _, pvc := range pvcs.Items {
-		instanceID := internal.GetProcessGroupIDFromMeta(cluster, pvc.ObjectMeta)
-		processGroupStatus := processGroups[instanceID]
-		if processGroupStatus == nil {
-			return &Requeue{Error: fmt.Errorf("unknown PVC %s in replace_misconfigured_pods", instanceID)}
-		}
-
-		if processGroupStatus.Remove {
-			continue
-		}
-
-		needsNewRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
-		if err != nil {
-			return &Requeue{Error: err}
-		}
-		if needsNewRemoval {
-			instances, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetSinglePodListOptions(cluster, instanceID)...)
-			if err != nil {
-				return &Requeue{Error: err}
-			}
-
-			if len(instances) > 0 {
-				processGroupStatus.Remove = true
-				hasNewRemovals = true
-			}
-		}
-	}
+	pvcMap := internal.CreatePVCMap(cluster, pvcs)
 
 	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}
 
-	for _, pod := range pods {
-		processGroupStatus := processGroups[GetProcessGroupID(cluster, pod)]
-		needsRemoval, err := instanceNeedsRemoval(cluster, pod, processGroupStatus)
+	podMap := internal.CreatePodMap(cluster, pods)
+
+	for _, processGroup := range cluster.Status.ProcessGroups {
+		if processGroup.Remove {
+			continue
+		}
+
+		pvc, hasPVC := pvcMap[processGroup.ProcessGroupID]
+		pod, hasPod := podMap[processGroup.ProcessGroupID]
+
+		if hasPVC {
+			needsPVCRemoval, err := instanceNeedsRemovalForPVC(cluster, pvc)
+			if err != nil {
+				return &Requeue{Error: err}
+			}
+
+			if needsPVCRemoval {
+				if hasPod {
+					processGroup.Remove = true
+					hasNewRemovals = true
+				}
+				continue
+			}
+		} else {
+			logger.V(1).Info("Could not find PVC for process group ID",
+				"processGroupID", processGroup.ProcessGroupID)
+		}
+
+		if !hasPod || pod == nil {
+			logger.V(1).Info("Could not find Pod for process group ID",
+				"processGroupID", processGroup.ProcessGroupID)
+			continue
+		}
+
+		needsRemoval, err := instanceNeedsRemoval(cluster, pod, processGroup)
 		if err != nil {
 			return &Requeue{Error: err}
 		}
 
 		if needsRemoval {
-			processGroupStatus.Remove = true
+			processGroup.Remove = true
 			hasNewRemovals = true
 		}
 	}
@@ -113,7 +115,7 @@ func (c ReplaceMisconfiguredPods) Reconcile(r *FoundationDBClusterReconciler, co
 
 func instanceNeedsRemovalForPVC(cluster *fdbtypes.FoundationDBCluster, pvc corev1.PersistentVolumeClaim) (bool, error) {
 	instanceID := internal.GetProcessGroupIDFromMeta(cluster, pvc.ObjectMeta)
-	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "pvc", pvc.Name, "processGroupID", instanceID, "reconciler", "ReplaceMisconfiguredPods")
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "pvc", pvc.Name, "processGroupID", instanceID, "reconciler", "ReplaceMisconfiguredProcessGroups")
 
 	ownedByCluster := !cluster.ShouldFilterOnOwnerReferences()
 	if !ownedByCluster {
@@ -153,6 +155,7 @@ func instanceNeedsRemovalForPVC(cluster *fdbtypes.FoundationDBCluster, pvc corev
 			"reason", fmt.Sprintf("PVC name has changed from %s to %s", desiredPVC.Name, pvc.Name))
 		return true, nil
 	}
+
 	return false, nil
 }
 
@@ -163,7 +166,7 @@ func instanceNeedsRemoval(cluster *fdbtypes.FoundationDBCluster, pod *corev1.Pod
 
 	processGroupID := GetProcessGroupID(cluster, pod)
 
-	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", processGroupID, "reconciler", "ReplaceMisconfiguredPods")
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", processGroupID, "reconciler", "ReplaceMisconfiguredProcessGroups")
 
 	if processGroupStatus == nil {
 		return false, fmt.Errorf("unknown instance %s in replace_misconfigured_pods", processGroupID)

--- a/controllers/replace_misconfigured_process_groups_test.go
+++ b/controllers/replace_misconfigured_process_groups_test.go
@@ -1,5 +1,5 @@
 /*
- * replace_misconfigured_pods.go
+ * replace_misconfigured_process_groups.go
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/controllers/update_labels.go
+++ b/controllers/update_labels.go
@@ -22,10 +22,8 @@ package controllers
 
 import (
 	ctx "context"
-	"reflect"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
@@ -37,60 +35,58 @@ type UpdateLabels struct{}
 
 // Reconcile runs the reconciler's work.
 func (u UpdateLabels) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "UpdateLabels")
 	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}
-
-	for _, pod := range pods {
-		if pod == nil {
-			continue
-		}
-
-		processClass, err := GetProcessClass(cluster, pod)
-		if err != nil {
-			return &Requeue{Error: err}
-		}
-
-		metadata := internal.GetPodMetadata(cluster, processClass, GetProcessGroupID(cluster, pod), "")
-		if metadata.Annotations == nil {
-			metadata.Annotations = make(map[string]string)
-		}
-
-		if !podMetadataCorrect(metadata, pod) {
-			err = r.PodLifecycleManager.UpdateMetadata(r, context, cluster, pod)
-			if err != nil {
-				return &Requeue{Error: err}
-			}
-		}
-	}
+	podMap := internal.CreatePodMap(cluster, pods)
 
 	pvcs := &corev1.PersistentVolumeClaimList{}
 	err = r.List(context, pvcs, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
 	}
-	for _, pvc := range pvcs.Items {
-		processClass := internal.GetProcessClassFromMeta(cluster, pvc.ObjectMeta)
-		instanceID := internal.GetProcessGroupIDFromMeta(cluster, pvc.ObjectMeta)
+	pvcMap := internal.CreatePVCMap(cluster, pvcs)
 
-		metadata := internal.GetPvcMetadata(cluster, processClass, instanceID)
+	for _, processGroup := range cluster.Status.ProcessGroups {
+		if processGroup.Remove {
+			logger.V(1).Info("Ignore removed Pod",
+				"processGroupID", processGroup.ProcessGroupID)
+			continue
+		}
+
+		pod, ok := podMap[processGroup.ProcessGroupID]
+		if ok {
+			metadata := internal.GetPodMetadata(cluster, processGroup.ProcessClass, processGroup.ProcessGroupID, "")
+			if metadata.Annotations == nil {
+				metadata.Annotations = make(map[string]string, 1)
+			}
+
+			if !metadataCorrect(metadata, &pod.ObjectMeta) {
+				err = r.PodLifecycleManager.UpdateMetadata(r, context, cluster, pod)
+				if err != nil {
+					return &Requeue{Error: err}
+				}
+			}
+		} else {
+			logger.V(1).Info("Could not find Pod for process group ID",
+				"processGroupID", processGroup.ProcessGroupID)
+		}
+
+		pvc, ok := pvcMap[processGroup.ProcessGroupID]
+		if !ok || pod == nil {
+			logger.V(1).Info("Could not find PVC for process group ID",
+				"processGroupID", processGroup.ProcessGroupID)
+			continue
+		}
+
+		metadata := internal.GetPvcMetadata(cluster, processGroup.ProcessClass, processGroup.ProcessGroupID)
 		if metadata.Annotations == nil {
 			metadata.Annotations = make(map[string]string, 1)
 		}
-		metadata.Annotations[fdbtypes.LastSpecKey] = pvc.ObjectMeta.Annotations[fdbtypes.LastSpecKey]
 
-		metadataCorrect := true
-		if !reflect.DeepEqual(pvc.ObjectMeta.Labels, metadata.Labels) {
-			pvc.Labels = metadata.Labels
-			metadataCorrect = false
-		}
-
-		if mergeAnnotations(&pvc.ObjectMeta, metadata) {
-			metadataCorrect = false
-		}
-
-		if !metadataCorrect {
+		if !metadataCorrect(metadata, &pvc.ObjectMeta) {
 			err = r.Update(context, &pvc)
 			if err != nil {
 				return &Requeue{Error: err}
@@ -101,15 +97,15 @@ func (u UpdateLabels) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 	return nil
 }
 
-func podMetadataCorrect(metadata metav1.ObjectMeta, pod *corev1.Pod) bool {
+func metadataCorrect(desiredMetadata metav1.ObjectMeta, currentMetadata *metav1.ObjectMeta) bool {
 	metadataCorrect := true
-	metadata.Annotations[fdbtypes.LastSpecKey] = pod.ObjectMeta.Annotations[fdbtypes.LastSpecKey]
+	desiredMetadata.Annotations[fdbtypes.LastSpecKey] = currentMetadata.Annotations[fdbtypes.LastSpecKey]
 
-	if mergeLabelsInMetadata(&pod.ObjectMeta, metadata) {
+	if mergeLabelsInMetadata(currentMetadata, desiredMetadata) {
 		metadataCorrect = false
 	}
 
-	if mergeAnnotations(&pod.ObjectMeta, metadata) {
+	if mergeAnnotations(currentMetadata, desiredMetadata) {
 		metadataCorrect = false
 	}
 

--- a/controllers/update_labels.go
+++ b/controllers/update_labels.go
@@ -51,7 +51,7 @@ func (u UpdateLabels) Reconcile(r *FoundationDBClusterReconciler, context ctx.Co
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.Remove {
-			logger.V(1).Info("Ignore removed Pod",
+			logger.V(1).Info("Ignore process group marked for removal",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue
 		}

--- a/controllers/update_labels_test.go
+++ b/controllers/update_labels_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Update labels", func() {
 
 	DescribeTable("Test metadata correctness",
 		func(tc testCase) {
-			result := podMetadataCorrect(tc.metadata, tc.pod)
+			result := metadataCorrect(tc.metadata, &tc.pod.ObjectMeta)
 			Expect(result).To(Equal(tc.expected))
 			Expect(equality.Semantic.DeepEqual(tc.pod.ObjectMeta.Labels, tc.expectedMeta.Labels)).To(BeTrue())
 			Expect(equality.Semantic.DeepEqual(tc.pod.ObjectMeta.Annotations, tc.expectedMeta.Annotations)).To(BeTrue())

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -55,6 +55,11 @@ func (u UpdatePodConfig) Reconcile(r *FoundationDBClusterReconciler, context ctx
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		curLogger := logger.WithValues("processGroupID", processGroup.ProcessGroupID)
 
+		if processGroup.Remove {
+			curLogger.V(1).Info("Ignore process group marked for removal")
+			continue
+		}
+
 		if cluster.SkipProcessGroup(processGroup) {
 			curLogger.Info("Process group has pending Pod, will be skipped")
 			continue

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -24,8 +24,6 @@ import (
 	ctx "context"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
@@ -48,14 +46,7 @@ func (u UpdatePodConfig) Reconcile(r *FoundationDBClusterReconciler, context ctx
 		return &Requeue{Error: err}
 	}
 
-	podProcessGroupMap := make(map[string]*corev1.Pod, len(pods))
-	for _, pod := range pods {
-		processGroupID := GetProcessGroupID(cluster, pod)
-		if processGroupID == "" {
-			continue
-		}
-		podProcessGroupMap[processGroupID] = pod
-	}
+	podMap := internal.CreatePodMap(cluster, pods)
 
 	allSynced := true
 	hasUpdate := false
@@ -69,7 +60,7 @@ func (u UpdatePodConfig) Reconcile(r *FoundationDBClusterReconciler, context ctx
 			continue
 		}
 
-		pod, ok := podProcessGroupMap[processGroup.ProcessGroupID]
+		pod, ok := podMap[processGroup.ProcessGroupID]
 		if !ok || pod == nil {
 			curLogger.Info("Could not find Pod for process group")
 			// TODO (johscheuer): we should requeue if that happens.

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -45,14 +45,7 @@ func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 	}
 
 	updates := make(map[string][]*corev1.Pod)
-	podProcessGroupMap := make(map[string]*corev1.Pod, len(pods))
-	for _, pod := range pods {
-		processGroupID := GetProcessGroupID(cluster, pod)
-		if processGroupID == "" {
-			continue
-		}
-		podProcessGroupMap[processGroupID] = pod
-	}
+	podMap := internal.CreatePodMap(cluster, pods)
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.Remove {
@@ -67,7 +60,7 @@ func (u UpdatePods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 			continue
 		}
 
-		pod, ok := podProcessGroupMap[processGroup.ProcessGroupID]
+		pod, ok := podMap[processGroup.ProcessGroupID]
 		if !ok || pod == nil {
 			logger.V(1).Info("Could not find Pod for process group ID",
 				"processGroupID", processGroup.ProcessGroupID)

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -47,6 +47,12 @@ func (u UpdateSidecarVersions) Reconcile(r *FoundationDBClusterReconciler, conte
 
 	podMap := internal.CreatePodMap(cluster, pods)
 	for _, processGroup := range cluster.Status.ProcessGroups {
+		if processGroup.Remove {
+			logger.V(1).Info("Ignore process group marked for removal",
+				"processGroupID", processGroup.ProcessGroupID)
+			continue
+		}
+
 		pod, ok := podMap[processGroup.ProcessGroupID]
 		if !ok || pod == nil {
 			logger.V(1).Info("Could not find Pod for process group ID",

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -44,7 +44,16 @@ func (u UpdateSidecarVersions) Reconcile(r *FoundationDBClusterReconciler, conte
 		return &Requeue{Error: err}
 	}
 	upgraded := false
-	for _, pod := range pods {
+
+	podMap := internal.CreatePodMap(cluster, pods)
+	for _, processGroup := range cluster.Status.ProcessGroups {
+		pod, ok := podMap[processGroup.ProcessGroupID]
+		if !ok || pod == nil {
+			logger.V(1).Info("Could not find Pod for process group ID",
+				"processGroupID", processGroup.ProcessGroupID)
+			continue
+		}
+
 		processClass, err := GetProcessClass(cluster, pod)
 		if err != nil {
 			return &Requeue{Error: err}

--- a/docs/manual/technical_design.md
+++ b/docs/manual/technical_design.md
@@ -88,7 +88,7 @@ The cluster reconciler runs the following subreconcilers:
 1. UpdateLockConfiguration
 1. UpdateConfigMap
 1. CheckClientCompatibility
-1. ReplaceMisconfiguredPods
+1. ReplaceMisconfiguredProcessGroups
 1. ReplaceFailedPods
 1. DeletePodsForBuggification
 1. AddProcessGroups
@@ -135,9 +135,9 @@ The `CheckClientCompatibility` subreconciler is used during upgrades to ensure t
 
 You can skip this check by setting the `ignoreUpgradabilityChecks` flag in the cluster spec.
 
-### ReplaceMisconfiguredPods
+### ReplaceMisconfiguredProcessGroups
 
-The `ReplaceMisconfiguredPods` subreconciler checks for process groups that need to be replaced in order to safely bring them up on a new configuration. The core action this subreconciler takes is setting the `remove` field on the `ProcessGroup` in the cluster status. Later subreconcilers will do the work for handling the replacement, whether processes are marked for replacement through this subreconciler or another mechanism.
+The `ReplaceMisconfiguredProcessGroups` subreconciler checks for process groups that need to be replaced in order to safely bring them up on a new configuration. The core action this subreconciler takes is setting the `remove` field on the `ProcessGroup` in the cluster status. Later subreconcilers will do the work for handling the replacement, whether processes are marked for replacement through this subreconciler or another mechanism.
 
 See the [Replacements and Deletions](replacements_and_deletions.md) document for more details on when we do these replacements.
 

--- a/internal/configmap_helper.go
+++ b/internal/configmap_helper.go
@@ -1,3 +1,23 @@
+/*
+ * configmap_helper.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package internal
 
 import (

--- a/internal/deprecations_test.go
+++ b/internal/deprecations_test.go
@@ -1,3 +1,23 @@
+/*
+ * deprecations_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package internal
 
 import (

--- a/internal/log.go
+++ b/internal/log.go
@@ -1,3 +1,23 @@
+/*
+ * log.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package internal
 
 import logf "sigs.k8s.io/controller-runtime/pkg/log"

--- a/internal/monitor_conf.go
+++ b/internal/monitor_conf.go
@@ -1,3 +1,23 @@
+/*
+ * monitor_conf.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package internal
 
 import (

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -1,3 +1,24 @@
+/*
+ * pod_helper.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package internal
 
 import (
@@ -191,4 +212,18 @@ func GetSidecarImage(cluster *fdbtypes.FoundationDBCluster, pClass fdbtypes.Proc
 	}
 
 	return GetImage(image, cluster.Spec.SidecarContainer.ImageConfigs, cluster.Spec.Version, settings.GetAllowTagOverride())
+}
+
+// CreatePodMap creates a map with the process group ID as a key and the according Pod as a value
+func CreatePodMap(cluster *fdbtypes.FoundationDBCluster, pods []*corev1.Pod) map[string]*corev1.Pod {
+	podProcessGroupMap := make(map[string]*corev1.Pod, len(pods))
+	for _, pod := range pods {
+		processGroupID := GetProcessGroupIDFromMeta(cluster, pod.ObjectMeta)
+		if processGroupID == "" {
+			continue
+		}
+		podProcessGroupMap[processGroupID] = pod
+	}
+
+	return podProcessGroupMap
 }

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-
 package internal
 
 import (

--- a/internal/pvc_helper.go
+++ b/internal/pvc_helper.go
@@ -1,5 +1,5 @@
 /*
- * service_helper.go
+ * pvc_helper.go
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -18,26 +18,25 @@
  * limitations under the License.
  */
 
+
 package internal
 
 import (
-	"github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
-	v1 "k8s.io/api/core/v1"
+	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 )
 
-// GetHeadlessService builds a headless service for a FoundationDB cluster.
-func GetHeadlessService(cluster *v1beta1.FoundationDBCluster) *v1.Service {
-	headless := cluster.Spec.Routing.HeadlessService
-	if headless == nil || !*headless {
-		return nil
+// CreatePVCMap creates a map with the process group ID as a key and the according PVC as a value
+func CreatePVCMap(cluster *fdbtypes.FoundationDBCluster, pvcs *corev1.PersistentVolumeClaimList) map[string]corev1.PersistentVolumeClaim {
+	pvcMap := make(map[string]corev1.PersistentVolumeClaim, len(pvcs.Items))
+	for _, pvc := range pvcs.Items {
+		processGroupID := GetProcessGroupIDFromMeta(cluster, pvc.ObjectMeta)
+		if processGroupID == "" {
+			continue
+		}
+
+		pvcMap[processGroupID] = pvc
 	}
 
-	service := &v1.Service{
-		ObjectMeta: GetObjectMetadata(cluster, nil, "", ""),
-	}
-	service.ObjectMeta.Name = cluster.ObjectMeta.Name
-	service.Spec.ClusterIP = "None"
-	service.Spec.Selector = cluster.Spec.LabelConfig.MatchLabels
-
-	return service
+	return pvcMap
 }

--- a/internal/pvc_helper.go
+++ b/internal/pvc_helper.go
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-
 package internal
 
 import (

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -1,3 +1,24 @@
+/*
+ * test_helper.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package internal
 
 import (

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-
 package internal
 
 import (


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/918 (Ensure in reconcilers that we iterate over ProcessGroups not Instances/Pods )

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Discussion

- 

# Testing

Unit + local 

# Documentation

Adjusted.

# Follow-up

-