### PR TITLE
Deprecate enforce full replication

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1106,6 +1106,7 @@ type FoundationDBClusterAutomationOptions struct {
 	// if the cluster is fully replicated. If the cluster is not fully replicated the Operator won't
 	// delete any Pods that are marked for removal.
 	// Defaults to true.
+	// Deprecated: Will be enforced by default in 1.0.0 without disabling.
 	EnforceFullReplicationForDeletion *bool `json:"enforceFullReplicationForDeletion,omitempty"`
 }
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -190,7 +190,7 @@ FoundationDBClusterAutomationOptions provides flags for enabling or disabling op
 | deletePods | DeletePods defines whether the operator is allowed to delete pods in order to recreate them. | *bool | false |
 | replacements | Replacements contains options for automatically replacing failed processes. | [AutomaticReplacementOptions](#automaticreplacementoptions) | false |
 | ignorePendingPodsDuration | IgnorePendingPodsDuration defines how long a Pod has to be in the Pending Phase before ignore it during reconciliation. This prevents Pod that are stuck in Pending to block further reconciliation. | time.Duration | false |
-| enforceFullReplicationForDeletion | EnforceFullReplicationForDeletion defines if the operator is only allowed to delete Pods if the cluster is fully replicated. If the cluster is not fully replicated the Operator won't delete any Pods that are marked for removal. Defaults to true. | *bool | false |
+| enforceFullReplicationForDeletion | EnforceFullReplicationForDeletion defines if the operator is only allowed to delete Pods if the cluster is fully replicated. If the cluster is not fully replicated the Operator won't delete any Pods that are marked for removal. Defaults to true. **Deprecated: Will be enforced by default in 1.0.0 without disabling.** | *bool | false |
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/940 to remove the setting in 1.0 and not allow to deactivate it.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

-

# Testing

-

# Documentation

-

# Follow-up

-
