### PR TITLE
Specify the complete registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM foundationdb/foundationdb:6.2.30 as fdb62
-FROM foundationdb/foundationdb:6.1.13 as fdb61
-FROM foundationdb/foundationdb:6.3.10 as fdb63
+FROM docker.io/foundationdb/foundationdb:6.2.30 as fdb62
+FROM docker.io/foundationdb/foundationdb:6.1.13 as fdb61
+FROM docker.io/foundationdb/foundationdb:6.3.10 as fdb63
 
 # Build the manager binary
-FROM golang:1.16.8 as builder
+FROM docker.io/library/golang:1.16.8 as builder
 
 # Install FDB
 ARG FDB_VERSION=6.2.30


### PR DESCRIPTION
# Description

Specify the complete registry to allow builds with container runtimes/builders other than `docker`.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

Docker has hardcoded that search path but we should make it explicit to make it easier for other tools to use the Dockerfile.

# Testing

local.

# Documentation

-

# Follow-up

-
