### PR TITLE
Don't use sort just compare the length and the content

### DIFF
--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -22,7 +22,6 @@ package controllers
 
 import (
 	"context"
-	"sort"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 
@@ -92,14 +91,15 @@ var _ = Describe("add_process_groups", func() {
 					storageProcesses = append(storageProcesses, processGroup.ProcessGroupID)
 				}
 			}
-			sort.Strings(storageProcesses)
-			Expect(storageProcesses).To(Equal([]string{
+			expectedStorageProcesses := []string{
 				"storage-1",
 				"storage-2",
 				"storage-3",
 				"storage-4",
 				"storage-5",
-			}))
+			}
+			Expect(len(storageProcesses)).To(BeNumerically("==", len(expectedStorageProcesses)))
+			Expect(storageProcesses).To(ContainElements(expectedStorageProcesses))
 		})
 
 		It("should not change the log or stateless processes", func() {
@@ -125,14 +125,15 @@ var _ = Describe("add_process_groups", func() {
 					storageProcesses = append(storageProcesses, processGroup.ProcessGroupID)
 				}
 			}
-			sort.Strings(storageProcesses)
-			Expect(storageProcesses).To(Equal([]string{
+			expectedStorageProcesses := []string{
 				"old-prefix-storage-4",
 				"storage-1",
 				"storage-2",
 				"storage-3",
 				"storage-5",
-			}))
+			}
+			Expect(len(storageProcesses)).To(BeNumerically("==", len(expectedStorageProcesses)))
+			Expect(storageProcesses).To(ContainElements(expectedStorageProcesses))
 		})
 
 		It("should not change the log or stateless processes", func() {
@@ -157,15 +158,16 @@ var _ = Describe("add_process_groups", func() {
 					storageProcesses = append(storageProcesses, processGroup.ProcessGroupID)
 				}
 			}
-			sort.Strings(storageProcesses)
-			Expect(storageProcesses).To(Equal([]string{
+			expectedStorageProcesses := []string{
 				"storage-1",
 				"storage-2",
 				"storage-3",
 				"storage-4",
 				"storage-5",
 				"storage-6",
-			}))
+			}
+			Expect(len(storageProcesses)).To(BeNumerically("==", len(expectedStorageProcesses)))
+			Expect(storageProcesses).To(ContainElements(expectedStorageProcesses))
 		})
 
 		It("should not change the log or stateless processes", func() {
@@ -189,15 +191,16 @@ var _ = Describe("add_process_groups", func() {
 						storageProcesses = append(storageProcesses, processGroup.ProcessGroupID)
 					}
 				}
-				sort.Strings(storageProcesses)
-				Expect(storageProcesses).To(Equal([]string{
+				expectedStorageProcesses := []string{
 					"storage-1",
 					"storage-2",
 					"storage-3",
 					"storage-4",
 					"storage-5",
 					"storage-7",
-				}))
+				}
+				Expect(len(storageProcesses)).To(BeNumerically("==", len(expectedStorageProcesses)))
+				Expect(storageProcesses).To(ContainElements(expectedStorageProcesses))
 			})
 		})
 	})

--- a/controllers/add_pvcs_test.go
+++ b/controllers/add_pvcs_test.go
@@ -99,7 +99,6 @@ var _ = Describe("add_pvcs", func() {
 			Expect(lastPVC.Name).To(Equal("operator-test-1-storage-9-data"))
 			Expect(lastPVC.Labels[fdbtypes.FDBProcessGroupIDLabel]).To(Equal("storage-9"))
 			Expect(lastPVC.Labels[fdbtypes.FDBProcessClassLabel]).To(Equal("storage"))
-
 			Expect(lastPVC.OwnerReferences).To(Equal(internal.BuildOwnerReference(cluster.TypeMeta, cluster.ObjectMeta)))
 		})
 

--- a/controllers/bounce_processes_test.go
+++ b/controllers/bounce_processes_test.go
@@ -23,7 +23,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
@@ -154,8 +153,8 @@ var _ = Describe("bounceProcesses", func() {
 					addresses = append(addresses, fmt.Sprintf("%s:4501", address), fmt.Sprintf("%s:4503", address))
 				}
 			}
-			sort.Strings(adminClient.KilledAddresses)
-			Expect(adminClient.KilledAddresses).To(Equal(addresses))
+			Expect(len(adminClient.KilledAddresses)).To(BeNumerically("==", len(addresses)))
+			Expect(adminClient.KilledAddresses).To(ContainElements(addresses))
 		})
 	})
 
@@ -178,9 +177,8 @@ var _ = Describe("bounceProcesses", func() {
 					addresses = append(addresses, fmt.Sprintf("%s:4501", address))
 				}
 			}
-			sort.Strings(addresses)
-			sort.Strings(adminClient.KilledAddresses)
-			Expect(adminClient.KilledAddresses).To(Equal(addresses))
+			Expect(len(adminClient.KilledAddresses)).To(BeNumerically("==", len(addresses)))
+			Expect(adminClient.KilledAddresses).To(ContainElements(addresses))
 		})
 
 		It("should update the running version in the status", func() {
@@ -247,9 +245,8 @@ var _ = Describe("bounceProcesses", func() {
 						}
 					}
 					addresses = append(addresses, "1.2.3.4:4501")
-					sort.Strings(addresses)
-					sort.Strings(adminClient.KilledAddresses)
-					Expect(adminClient.KilledAddresses).To(Equal(addresses))
+					Expect(len(adminClient.KilledAddresses)).To(BeNumerically("==", len(addresses)))
+					Expect(adminClient.KilledAddresses).To(ContainElements(addresses))
 				})
 			})
 
@@ -286,9 +283,8 @@ var _ = Describe("bounceProcesses", func() {
 							addresses = append(addresses, fmt.Sprintf("%s:4501", address))
 						}
 					}
-					sort.Strings(addresses)
-					sort.Strings(adminClient.KilledAddresses)
-					Expect(adminClient.KilledAddresses).To(Equal(addresses))
+					Expect(len(adminClient.KilledAddresses)).To(BeNumerically("==", len(addresses)))
+					Expect(adminClient.KilledAddresses).To(ContainElements(addresses))
 				})
 
 				It("should not submit pending upgrade information", func() {

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -320,12 +320,6 @@ func (r *FoundationDBClusterReconciler) clearPendingRemovalsFromSpec(context ctx
 	return r.Update(context, modifiedCluster)
 }
 
-func sortPodsByName(pods *corev1.PodList) {
-	sort.Slice(pods.Items, func(i, j int) bool {
-		return pods.Items[i].ObjectMeta.Name < pods.Items[j].ObjectMeta.Name
-	})
-}
-
 var connectionStringNameRegex, _ = regexp.Compile("[^A-Za-z0-9_]")
 
 // clusterSubReconciler describes a class that does part of the work of

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -84,6 +84,12 @@ func getListOptions(cluster *fdbtypes.FoundationDBCluster) []client.ListOption {
 	}
 }
 
+func sortPodsByName(pods *corev1.PodList) {
+	sort.Slice(pods.Items, func(i, j int) bool {
+		return pods.Items[i].ObjectMeta.Name < pods.Items[j].ObjectMeta.Name
+	})
+}
+
 var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 	var cluster *fdbtypes.FoundationDBCluster
 	var fakeConnectionString string
@@ -1087,13 +1093,8 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 						addresses = append(addresses, cluster.GetFullAddress(pod.Status.PodIP, 1).String())
 					}
 
-					sort.Slice(adminClient.KilledAddresses, func(i, j int) bool {
-						return strings.Compare(adminClient.KilledAddresses[i], adminClient.KilledAddresses[j]) < 0
-					})
-					sort.Slice(addresses, func(i, j int) bool {
-						return strings.Compare(addresses[i], addresses[j]) < 0
-					})
-					Expect(adminClient.KilledAddresses).To(Equal(addresses))
+					Expect(len(adminClient.KilledAddresses)).To(BeNumerically("==", len(addresses)))
+					Expect(adminClient.KilledAddresses).To(ContainElements(addresses))
 				})
 
 				It("should update the config map", func() {
@@ -1179,13 +1180,8 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 						}
 					}
 
-					sort.Slice(adminClient.KilledAddresses, func(i, j int) bool {
-						return strings.Compare(adminClient.KilledAddresses[i], adminClient.KilledAddresses[j]) < 0
-					})
-					sort.Slice(addresses, func(i, j int) bool {
-						return strings.Compare(addresses[i], addresses[j]) < 0
-					})
-					Expect(adminClient.KilledAddresses).To(Equal(addresses))
+					Expect(len(adminClient.KilledAddresses)).To(BeNumerically("==", len(addresses)))
+					Expect(adminClient.KilledAddresses).To(ContainElements(addresses))
 				})
 			})
 		})


### PR DESCRIPTION
# Description

Instead of using the `sort` and sometimes forgetting to invoke it we should just compare the length of both slices and then the content with gomega.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

-

# Testing

Unit

# Documentation

-

# Follow-up

-
