### PR TITLE
Extend the timeout for connections to the sidecar.

### DIFF
--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -176,7 +176,7 @@ func (client *realFdbPodClient) makeRequest(method string, path string) (string,
 	switch method {
 	case http.MethodGet:
 		// We assume that a get request should be relative fast.
-		retryClient.HTTPClient.Timeout = 2 * time.Second
+		retryClient.HTTPClient.Timeout = 5 * time.Second
 		resp, err = retryClient.Get(url)
 	case http.MethodPost:
 		// A post request could take a little bit longer since we copy sometimes files.


### PR DESCRIPTION
# Description

This extends the timeout for GET requests to the sidecar in response to observations of longer request times.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

Having a single hard-coded timeout is rigid, and we may find other scenarios where the new value is not desireable, so I thought about making this more configurable. I wanted to err on the side of getting this fixed quickly rather than introducing new configuration items, and the issue should be moot when we transition to the new unified image.

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I ran manual tests in a real environment.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

# Documentation

*Did you update relevant documentation within this repository?*

No.

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No

*Does this introduce new defaults that we should re-evaluate in the future?*

No