### PR TITLE
Only replace on changed node selector if pod spec hash has changed

### DIFF
--- a/internal/replacements/suite_test.go
+++ b/internal/replacements/suite_test.go
@@ -1,0 +1,13 @@
+package replacements
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Replacements Suite")
+}


### PR DESCRIPTION
# Description

This is a fix for https://github.com/FoundationDB/fdb-kubernetes-operator/issues/950.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Discussion

This will trigger a replacement if any part of the pod template spec is changed if there is a [PodNodeSelector](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podnodeselector). Which isn't ideal but is better than the previous behavior of the pods being replaced endlessly.

# Testing

I ran unit tests and manually deployed the operator and cluster in a namespace with a PodNodeSelector.

