### PR TITLE
Make exclusions not block in sub reconciler

### DIFF
--- a/controllers/admin_client_mock_test.go
+++ b/controllers/admin_client_mock_test.go
@@ -1,0 +1,180 @@
+/*
+ * admin_client_mock_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2020-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+)
+
+var _ = Describe("mock_client", func() {
+	When("checking if it's safe to delete a process group", func() {
+		type testCase struct {
+			cluster    *fdbtypes.FoundationDBCluster
+			removals   []fdbtypes.ProcessAddress
+			exclusions []fdbtypes.ProcessAddress
+			remaining  []fdbtypes.ProcessAddress
+		}
+
+		DescribeTable("should return the correct image",
+			func(input testCase) {
+				admin, err := newMockAdminClient(input.cluster, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = admin.ExcludeProcesses(input.exclusions)
+				Expect(err).NotTo(HaveOccurred())
+
+				remaining, err := admin.CanSafelyRemove(input.removals)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(remaining).To(ContainElements(input.remaining))
+				Expect(len(remaining)).To(Equal(len(input.remaining)))
+			},
+			Entry("Empty list of removals",
+				testCase{
+					cluster:    &fdbtypes.FoundationDBCluster{},
+					removals:   []fdbtypes.ProcessAddress{},
+					exclusions: []fdbtypes.ProcessAddress{},
+					remaining:  []fdbtypes.ProcessAddress{},
+				}),
+			Entry("Process group that skips exclusion",
+				testCase{
+					cluster: &fdbtypes.FoundationDBCluster{
+						Status: fdbtypes.FoundationDBClusterStatus{
+							ProcessGroups: []*fdbtypes.ProcessGroupStatus{
+								{
+									Addresses: []string{
+										"1.1.1.1:4500",
+									},
+									ExclusionSkipped: true,
+								},
+								{
+									Addresses: []string{
+										"1.1.1.2:4500",
+									},
+								},
+							},
+						},
+					},
+					removals: []fdbtypes.ProcessAddress{
+						{
+							IPAddress: net.ParseIP("1.1.1.1"),
+							Port:      4500,
+						},
+						{
+							IPAddress: net.ParseIP("1.1.1.2"),
+							Port:      4500,
+						},
+					},
+					exclusions: []fdbtypes.ProcessAddress{},
+					remaining: []fdbtypes.ProcessAddress{
+						{
+							IPAddress: net.ParseIP("1.1.1.2"),
+							Port:      4500,
+						},
+					},
+				}),
+			Entry("Process group that is excluded by the client",
+				testCase{
+					cluster: &fdbtypes.FoundationDBCluster{
+						Status: fdbtypes.FoundationDBClusterStatus{
+							ProcessGroups: []*fdbtypes.ProcessGroupStatus{
+								{
+									Addresses: []string{
+										"1.1.1.1:4500",
+									},
+								},
+								{
+									Addresses: []string{
+										"1.1.1.2:4500",
+									},
+								},
+							},
+						},
+					},
+					removals: []fdbtypes.ProcessAddress{
+						{
+							IPAddress: net.ParseIP("1.1.1.1"),
+							Port:      4500,
+						},
+						{
+							IPAddress: net.ParseIP("1.1.1.2"),
+							Port:      4500,
+						},
+					},
+					exclusions: []fdbtypes.ProcessAddress{
+						{
+							IPAddress: net.ParseIP("1.1.1.1"),
+							Port:      4500,
+						},
+					},
+					remaining: []fdbtypes.ProcessAddress{
+						{
+							IPAddress: net.ParseIP("1.1.1.2"),
+							Port:      4500,
+						},
+					},
+				}),
+			Entry("Process group that is excluded in the cluster status",
+				testCase{
+					cluster: &fdbtypes.FoundationDBCluster{
+						Status: fdbtypes.FoundationDBClusterStatus{
+							ProcessGroups: []*fdbtypes.ProcessGroupStatus{
+								{
+									Addresses: []string{
+										"1.1.1.1:4500",
+									},
+									Excluded: true,
+								},
+								{
+									Addresses: []string{
+										"1.1.1.2:4500",
+									},
+								},
+							},
+						},
+					},
+					removals: []fdbtypes.ProcessAddress{
+						{
+							IPAddress: net.ParseIP("1.1.1.1"),
+							Port:      4500,
+						},
+						{
+							IPAddress: net.ParseIP("1.1.1.2"),
+							Port:      4500,
+						},
+					},
+					exclusions: []fdbtypes.ProcessAddress{},
+					remaining: []fdbtypes.ProcessAddress{
+						{
+							IPAddress: net.ParseIP("1.1.1.2"),
+							Port:      4500,
+						},
+					},
+				}),
+		)
+	})
+})

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -992,11 +992,12 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			JustBeforeEach(func() {
 				generations, err := reloadClusterGenerations(cluster)
 				Expect(err).NotTo(HaveOccurred())
+				// Since we delay the requeue we are able to choose new
+				// coordinators.
 				Expect(generations).To(Equal(fdbtypes.ClusterGenerationStatus{
-					Reconciled:             originalVersion,
-					NeedsCoordinatorChange: originalVersion + 1,
-					NeedsShrink:            originalVersion + 1,
-					HasUnhealthyProcess:    originalVersion + 1,
+					Reconciled:          originalVersion,
+					NeedsShrink:         originalVersion + 1,
+					HasUnhealthyProcess: originalVersion + 1,
 				}))
 			})
 
@@ -1687,16 +1688,21 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				})
 
 				It("should replace the process group", func() {
-					adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+					pods := &corev1.PodList{}
+					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 					Expect(err).NotTo(HaveOccurred())
 
-					replacements := make(map[string]bool, len(originalPods.Items))
+					originalNames := make([]string, 0, len(originalPods.Items))
 					for _, pod := range originalPods.Items {
-						replacements[pod.Status.PodIP] = true
+						originalNames = append(originalNames, pod.Name)
 					}
 
-					Expect(adminClient.ReincludedAddresses).To(Equal(replacements))
-					Expect(adminClient.ExcludedAddresses).To(BeNil())
+					currentNames := make([]string, 0, len(originalPods.Items))
+					for _, pod := range pods.Items {
+						currentNames = append(currentNames, pod.Name)
+					}
+
+					Expect(currentNames).NotTo(ContainElements(originalNames))
 				})
 			})
 
@@ -1780,16 +1786,21 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			})
 
 			It("should replace the old processes", func() {
-				adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+				pods := &corev1.PodList{}
+				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 				Expect(err).NotTo(HaveOccurred())
 
-				replacements := make(map[string]bool, len(originalPods.Items))
+				originalNames := make([]string, 0, len(originalPods.Items))
 				for _, pod := range originalPods.Items {
-					replacements[pod.Status.PodIP] = true
+					originalNames = append(originalNames, pod.Name)
 				}
 
-				Expect(adminClient.ReincludedAddresses).To(Equal(replacements))
-				Expect(adminClient.ExcludedAddresses).To(BeNil())
+				currentNames := make([]string, 0, len(originalPods.Items))
+				for _, pod := range pods.Items {
+					currentNames = append(currentNames, pod.Name)
+				}
+
+				Expect(currentNames).NotTo(ContainElements(originalNames))
 			})
 		})
 
@@ -1916,16 +1927,21 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			})
 
 			It("should replace the old processes", func() {
-				adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+				pods := &corev1.PodList{}
+				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 				Expect(err).NotTo(HaveOccurred())
 
-				replacements := make(map[string]bool, len(originalPods.Items))
+				originalNames := make([]string, 0, len(originalPods.Items))
 				for _, pod := range originalPods.Items {
-					replacements[pod.Status.PodIP] = true
+					originalNames = append(originalNames, pod.Name)
 				}
 
-				Expect(adminClient.ReincludedAddresses).To(Equal(replacements))
-				Expect(adminClient.ExcludedAddresses).To(BeNil())
+				currentNames := make([]string, 0, len(originalPods.Items))
+				for _, pod := range pods.Items {
+					currentNames = append(currentNames, pod.Name)
+				}
+
+				Expect(currentNames).NotTo(ContainElements(originalNames))
 			})
 		})
 
@@ -2333,16 +2349,21 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			})
 
 			It("should replace the process groups", func() {
-				adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+				pods := &corev1.PodList{}
+				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 				Expect(err).NotTo(HaveOccurred())
 
-				replacements := make(map[string]bool, len(originalPods.Items))
+				originalNames := make([]string, 0, len(originalPods.Items))
 				for _, pod := range originalPods.Items {
-					replacements[pod.Status.PodIP] = true
+					originalNames = append(originalNames, pod.Name)
 				}
 
-				Expect(adminClient.ReincludedAddresses).To(Equal(replacements))
-				Expect(adminClient.ExcludedAddresses).To(BeNil())
+				currentNames := make([]string, 0, len(originalPods.Items))
+				for _, pod := range pods.Items {
+					currentNames = append(currentNames, pod.Name)
+				}
+
+				Expect(currentNames).NotTo(ContainElements(originalNames))
 			})
 
 			It("should generate process group IDs with the new prefix", func() {
@@ -2365,16 +2386,21 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			})
 
 			It("should replace the process groups", func() {
-				adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+				pods := &corev1.PodList{}
+				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 				Expect(err).NotTo(HaveOccurred())
 
-				replacements := make(map[string]bool, len(originalPods.Items))
+				originalNames := make([]string, 0, len(originalPods.Items))
 				for _, pod := range originalPods.Items {
-					replacements[pod.Status.PodIP] = true
+					originalNames = append(originalNames, pod.Name)
 				}
 
-				Expect(adminClient.ReincludedAddresses).To(Equal(replacements))
-				Expect(adminClient.ExcludedAddresses).To(BeNil())
+				currentNames := make([]string, 0, len(originalPods.Items))
+				for _, pod := range pods.Items {
+					currentNames = append(currentNames, pod.Name)
+				}
+
+				Expect(currentNames).NotTo(ContainElements(originalNames))
 			})
 
 			It("should generate process group IDs with the new prefix", func() {

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -87,6 +87,10 @@ var _ = Describe("remove_process_groups", func() {
 			marked, processGroup := fdbtypes.MarkProcessGroupForRemoval(cluster.Status.ProcessGroups, removedProcessGroup.ProcessGroupID, removedProcessGroup.ProcessClass, removedProcessGroup.Addresses[0])
 			Expect(marked).To(BeTrue())
 			Expect(processGroup).To(BeNil())
+			// Exclude the process group
+			adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
+			adminClient.ExcludedAddresses = removedProcessGroup.Addresses
 		})
 
 		When("using the default setting of EnforceFullReplicationForDeletion", func() {

--- a/internal/error_helper.go
+++ b/internal/error_helper.go
@@ -23,12 +23,26 @@ package internal
 import (
 	"errors"
 	"net"
+	"strings"
 )
 
 // IsNetworkError returns true if the network is a network error net.Error
 func IsNetworkError(err error) bool {
 	for err != nil {
 		if _, ok := err.(net.Error); ok {
+			return true
+		}
+
+		err = errors.Unwrap(err)
+	}
+
+	return false
+}
+
+// IsTimeoutError returns true if the observed error was a timeout error
+func IsTimeoutError(err error) bool {
+	for err != nil {
+		if strings.Contains(err.Error(), "Specified timeout reached") {
 			return true
 		}
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/971

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Discussion

Moving forward allows the operator to actually change coordinators if required or do any other operator and is not blocked on a single replacement/exclusion. Since the operator will only replace process groups that are excluded (or we skip the exclusion) it's safe to move forwards.

# Testing

Unit + local

# Documentation

-

# Follow-up

None
