### PR TITLE
Prevents the cluster creation from getting deadlocked when it cannot connect to the database before the processes have a cluster file.

### DIFF
--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -82,7 +82,16 @@ func (updateStatus) reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 
 		databaseStatus, err = adminClient.GetStatus()
 		if err != nil {
-			return &requeue{curError: err}
+			if cluster.Status.Configured {
+				return &requeue{curError: err}
+			}
+			databaseStatus = &fdbtypes.FoundationDBStatus{
+				Cluster: fdbtypes.FoundationDBStatusClusterInfo{
+					Layers: fdbtypes.FoundationDBStatusLayerInfo{
+						Error: "configurationMissing",
+					},
+				},
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description

This addresses a failure mode I've observed in cluster creation where an error in reconciliation at a certain phase will call cause the cluster to have a connection string in the FoundationDBCluster resource, but not in the config map or any of the pods.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

We may want to be more resilient to failures to get the database status in general, rather than narrowly targeting this at cases where the database has not been configured.

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I had a live case of this problem in my test environment, and I verified that the fix allowed cluster creation to move forward.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

# Documentation

*Did you update relevant documentation within this repository?*

No.

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.