### PR TITLE
Add plugin command to get the configuration string

### DIFF
--- a/kubectl-fdb/cmd/configuration.go
+++ b/kubectl-fdb/cmd/configuration.go
@@ -1,0 +1,113 @@
+/*
+ * configuration.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newConfigurationCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newFDBOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "configuration",
+		Short: "Get the configuration string based on the database configuration of the cluster spec.",
+		Long:  "Get the configuration string based on the database configuration of the cluster spec.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			failOver, err := cmd.Flags().GetBool("fail-over")
+			if err != nil {
+				return err
+			}
+
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = fdbtypes.AddToScheme(scheme)
+
+			config, err := o.configFlags.ToRESTConfig()
+			if err != nil {
+				return err
+			}
+
+			kubeClient, err := client.New(config, client.Options{Scheme: scheme})
+			if err != nil {
+				return err
+			}
+
+			namespace, err := getNamespace(*o.configFlags.Namespace)
+			if err != nil {
+				return err
+			}
+
+			for _, clusterName := range args {
+				configuration, err := getConfigurationString(kubeClient, clusterName, namespace, failOver)
+				if err != nil {
+					return err
+				}
+
+				cmd.Println(configuration)
+			}
+
+			return nil
+		},
+		Example: `
+This command will give you the configuration string used to configure the cluster.
+You can use "fdbcli configure <cmd output>" to configure that cluster or make changes to that configuration once.
+If you manually change that configuration keep in mind that the operator will revert it to the desired state.
+
+# Get the configuration string from cluster c1
+kubectl fdb get configuration c1
+
+# Get the configuration string from cluster c1 in the namespace default
+kubectl fdb -n default get configuration c1
+
+# Get the configuration string from cluster c1 and change the priority for an HA cluster
+kubectl fdb get configuration --fail-over c1
+`,
+	}
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
+	cmd.SetIn(o.In)
+
+	cmd.Flags().Bool("fail-over", false, "defines if the configuration should be changed to issue a fail over")
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// printConfiguration
+func getConfigurationString(kubeClient client.Client, clusterName string, namespace string, failOver bool) (string, error) {
+	cluster, err := loadCluster(kubeClient, namespace, clusterName)
+	if err != nil {
+		return "", err
+	}
+
+	config := cluster.Spec.DatabaseConfiguration
+	if failOver {
+		config = config.FailOver()
+	}
+
+	return config.GetConfigurationString()
+}

--- a/kubectl-fdb/cmd/configuration_test.go
+++ b/kubectl-fdb/cmd/configuration_test.go
@@ -1,0 +1,162 @@
+/*
+ * configuration_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("[plugin] configuration command", func() {
+	When("getting the configuration string", func() {
+		When("using a single region cluster", func() {
+			var cluster *fdbtypes.FoundationDBCluster
+
+			BeforeEach(func() {
+				cluster = &fdbtypes.FoundationDBCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Spec: fdbtypes.FoundationDBClusterSpec{
+						DatabaseConfiguration: fdbtypes.DatabaseConfiguration{
+							Regions: []fdbtypes.Region{
+								{
+									DataCenters: []fdbtypes.DataCenter{
+										{
+											ID:       "test",
+											Priority: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("should return the configuration string", func() {
+				scheme := runtime.NewScheme()
+				_ = clientgoscheme.AddToScheme(scheme)
+				_ = fdbtypes.AddToScheme(scheme)
+				kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cluster).Build()
+
+				configuration, err := getConfigurationString(kubeClient, "test", "test", false)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(configuration).To(Equal("  usable_regions=0 logs=0 proxies=0 resolvers=0 log_routers=0 remote_logs=0 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"test\\\",\\\"priority\\\":1}]}]"))
+			})
+
+			It("should return the same configuration string with failover", func() {
+				scheme := runtime.NewScheme()
+				_ = clientgoscheme.AddToScheme(scheme)
+				_ = fdbtypes.AddToScheme(scheme)
+				kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cluster).Build()
+
+				configuration, err := getConfigurationString(kubeClient, "test", "test", true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(configuration).To(Equal("  usable_regions=0 logs=0 proxies=0 resolvers=0 log_routers=0 remote_logs=0 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"test\\\",\\\"priority\\\":1}]}]"))
+			})
+		})
+
+		When("using a multi region cluster", func() {
+			var cluster *fdbtypes.FoundationDBCluster
+
+			BeforeEach(func() {
+				cluster = &fdbtypes.FoundationDBCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Spec: fdbtypes.FoundationDBClusterSpec{
+						DatabaseConfiguration: fdbtypes.DatabaseConfiguration{
+							Regions: []fdbtypes.Region{
+								{
+									DataCenters: []fdbtypes.DataCenter{
+										{
+											ID:       "primary",
+											Priority: 1,
+										},
+										{
+											ID:        "primary-sat",
+											Priority:  1,
+											Satellite: 1,
+										},
+										{
+											ID:        "remote-sat",
+											Priority:  0,
+											Satellite: 1,
+										},
+									},
+								},
+								{
+									DataCenters: []fdbtypes.DataCenter{
+										{
+											ID:       "remote",
+											Priority: 0,
+										},
+										{
+											ID:        "remote-sat",
+											Priority:  1,
+											Satellite: 1,
+										},
+										{
+											ID:        "primary-sat",
+											Priority:  0,
+											Satellite: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+			})
+
+			It("should return the configuration string", func() {
+				scheme := runtime.NewScheme()
+				_ = clientgoscheme.AddToScheme(scheme)
+				_ = fdbtypes.AddToScheme(scheme)
+				kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cluster).Build()
+
+				configuration, err := getConfigurationString(kubeClient, "test", "test", false)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(configuration).To(Equal("  usable_regions=0 logs=0 proxies=0 resolvers=0 log_routers=0 remote_logs=0 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"satellite\\\":1}]},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\"},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"satellite\\\":1}]}]"))
+			})
+
+			It("should return the configuration string with the modified priority", func() {
+				scheme := runtime.NewScheme()
+				_ = clientgoscheme.AddToScheme(scheme)
+				_ = fdbtypes.AddToScheme(scheme)
+				kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cluster).Build()
+
+				configuration, err := getConfigurationString(kubeClient, "test", "test", true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(configuration).To(Equal("  usable_regions=0 logs=0 proxies=0 resolvers=0 log_routers=0 remote_logs=0 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\"},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"satellite\\\":1}]},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"satellite\\\":1}]}]"))
+			})
+		})
+	})
+})

--- a/kubectl-fdb/cmd/get.go
+++ b/kubectl-fdb/cmd/get.go
@@ -1,0 +1,55 @@
+/*
+ * get.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/spf13/cobra"
+)
+
+func newGetCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newFDBOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Subcommand to get resources from a given cluster",
+		Long:  "Subcommand to get resources from a given cluster",
+		RunE: func(c *cobra.Command, args []string) error {
+			return c.Help()
+		},
+		Example: `
+# Get the configuration string from cluster c1
+kubectl fdb get configuration c1
+
+# Get the configuration string from cluster c1 in the namespace default
+kubectl fdb -n default get configuration c1
+`,
+	}
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
+	cmd.SetIn(o.In)
+
+	cmd.AddCommand(newConfigurationCmd(streams))
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -81,6 +81,7 @@ func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
 		newAnalyzeCmd(streams),
 		newDeprecationCmd(streams),
 		newFixCoordinatorIPsCmd(streams),
+		newGetCmd(streams),
 	)
 
 	return cmd


### PR DESCRIPTION
# Description

Add a plugin command that returns the configuration string based on the cluster spec e.g.:

```bash
$ /bin/kubectl-fdb get configuration --fail-over test
triple ssd-2 usable_regions=1 logs=3 proxies=3 resolvers=1 log_routers=-1 remote_logs=-1 log_version:=5 regions=[{\"datacenters\":[{\"id\":\"test\",\"priority\":1}]}]
```

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

-

# Testing

Unit and local.

# Documentation

Added in the command.

# Follow-up

The next step would be a fail-over command to change the cluster spec and make the operator fail-over the cluster.
