### PR TITLE
Delay the requeue after the update Pods method deleted Pods

### DIFF
--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -197,7 +197,7 @@ func deletePodsForUpdates(context context.Context, r *FoundationDBClusterReconci
 		return &requeue{curError: err}
 	}
 	if !ready {
-		return &requeue{message: "Reconciliation requires deleting pods, but deletion is not currently safe", delay: podSchedulingDelayDuration}
+		return &requeue{message: "Reconciliation requires deleting pods, but deletion is currently not safe", delay: podSchedulingDelayDuration}
 	}
 
 	// Only lock the cluster if we are not running in the delete "All" mode.
@@ -217,5 +217,5 @@ func deletePodsForUpdates(context context.Context, r *FoundationDBClusterReconci
 		return &requeue{curError: err}
 	}
 
-	return &requeue{message: "Pods need to be recreated"}
+	return &requeue{message: "Pods need to be recreated", delayedRequeue: true}
 }


### PR DESCRIPTION
# Description

If we don't delay the requeue the operator can never delete process groups that are fully excluded. 

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

-

# Testing

Local + unit

# Documentation

-

# Follow-up

-
