### PR TITLE
Add timestamp for remove and exclude

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -486,13 +486,13 @@ type ProcessGroupStatus struct {
 	// Remove defines if the process group is marked for removal.
 	Remove bool `json:"remove,omitempty"`
 	// RemoveTimestamp if not empty defines when the process group was marked for removal.
-	RemoveTimestamp metav1.Time `json:"removeTimestamp,omitempty"`
+	RemoveTimestamp *metav1.Time `json:"removeTimestamp,omitempty"`
 	// Excluded defines if the process group has been fully excluded.
 	// This is only used within the reconciliation process, and should not be considered authoritative.
 	Excluded bool `json:"excluded,omitempty"`
 	// ExcludedTimestamp defines when the process group has been fully excluded.
 	// This is only used within the reconciliation process, and should not be considered authoritative.
-	ExcludedTimestamp metav1.Time `json:"excludedTimestamp,omitempty"`
+	ExcludedTimestamp *metav1.Time `json:"excludedTimestamp,omitempty"`
 	// ExclusionSkipped determines if exclusion has been skipped for a process, which will allow the process group to be removed without exclusion.
 	ExclusionSkipped bool `json:"exclusionSkipped,omitempty"`
 	// ProcessGroupConditions represents a list of degraded conditions that the process group is in.
@@ -501,24 +501,24 @@ type ProcessGroupStatus struct {
 
 // IsExcluded returns if a process group is excluded
 func (processGroupStatus *ProcessGroupStatus) IsExcluded() bool {
-	return processGroupStatus.Excluded || !processGroupStatus.ExcludedTimestamp.IsZero() || processGroupStatus.ExclusionSkipped
+	return processGroupStatus.Excluded || (processGroupStatus.ExcludedTimestamp != nil && !processGroupStatus.ExcludedTimestamp.IsZero()) || processGroupStatus.ExclusionSkipped
 }
 
 // SetExclude marks a process group as excluded
 func (processGroupStatus *ProcessGroupStatus) SetExclude() {
 	processGroupStatus.Excluded = true
-	processGroupStatus.ExcludedTimestamp = metav1.Time{Time: time.Now()}
+	processGroupStatus.ExcludedTimestamp = &metav1.Time{Time: time.Now()}
 }
 
 // IsRemoved returns if a process group is marked for removal
 func (processGroupStatus *ProcessGroupStatus) IsRemoved() bool {
-	return processGroupStatus.Remove || !processGroupStatus.RemoveTimestamp.IsZero()
+	return processGroupStatus.Remove || (processGroupStatus.RemoveTimestamp != nil && !processGroupStatus.RemoveTimestamp.IsZero())
 }
 
 // SetRemove marks a process group for removal
 func (processGroupStatus *ProcessGroupStatus) SetRemove() {
 	processGroupStatus.Remove = true
-	processGroupStatus.RemoveTimestamp = metav1.Time{Time: time.Now()}
+	processGroupStatus.RemoveTimestamp = &metav1.Time{Time: time.Now()}
 }
 
 // NeedsReplacement checks if the ProcessGroupStatus has conditions so that it should be removed

--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -517,8 +517,8 @@ func (processGroupStatus *ProcessGroupStatus) IsMarkedForRemoval() bool {
 	return processGroupStatus.Remove || (processGroupStatus.RemovalTimestamp != nil && !processGroupStatus.RemovalTimestamp.IsZero())
 }
 
-// SetRemove marks a process group for removal
-func (processGroupStatus *ProcessGroupStatus) SetRemove() {
+// MarkForRemoval marks a process group for removal
+func (processGroupStatus *ProcessGroupStatus) MarkForRemoval() {
 	processGroupStatus.Remove = true
 	processGroupStatus.RemovalTimestamp = &metav1.Time{Time: time.Now()}
 }
@@ -656,7 +656,7 @@ func MarkProcessGroupForRemoval(processGroups []*ProcessGroupStatus, processGrou
 			processGroup.Addresses = append(processGroup.Addresses, address)
 		}
 
-		processGroup.SetRemove()
+		processGroup.MarkForRemoval()
 		return true, nil
 	}
 
@@ -668,7 +668,7 @@ func MarkProcessGroupForRemoval(processGroups []*ProcessGroupStatus, processGrou
 	}
 
 	processGroup := NewProcessGroupStatus(processGroupID, processClass, addresses)
-	processGroup.SetRemove()
+	processGroup.MarkForRemoval()
 
 	return false, processGroup
 }

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -2607,7 +2607,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			cluster = createCluster()
 			cluster.Spec.ProcessCounts.Storage = 2
-			cluster.Status.ProcessGroups[0].Remove = true
+			cluster.Status.ProcessGroups[0].SetRemove()
 			result, err = cluster.CheckReconciliation(log)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeFalse())
@@ -2618,7 +2618,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			cluster = createCluster()
 			cluster.Spec.ProcessCounts.Storage = 2
-			cluster.Status.ProcessGroups[0].Remove = true
+			cluster.Status.ProcessGroups[0].SetRemove()
 			cluster.Status.ProcessGroups[0].UpdateCondition(ResourcesTerminating, true, nil, "")
 			result, err = cluster.CheckReconciliation(log)
 			Expect(err).NotTo(HaveOccurred())
@@ -2630,8 +2630,8 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			cluster = createCluster()
 			cluster.Spec.ProcessCounts.Storage = 2
-			cluster.Status.ProcessGroups[0].Remove = true
-			cluster.Status.ProcessGroups[0].Excluded = true
+			cluster.Status.ProcessGroups[0].SetRemove()
+			cluster.Status.ProcessGroups[0].SetExclude()
 			cluster.Status.ProcessGroups[0].UpdateCondition(IncorrectCommandLine, true, nil, "")
 			cluster.Status.ProcessGroups[0].UpdateCondition(ResourcesTerminating, true, nil, "")
 			result, err = cluster.CheckReconciliation(log)

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -2607,7 +2607,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			cluster = createCluster()
 			cluster.Spec.ProcessCounts.Storage = 2
-			cluster.Status.ProcessGroups[0].SetRemove()
+			cluster.Status.ProcessGroups[0].MarkForRemoval()
 			result, err = cluster.CheckReconciliation(log)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeFalse())
@@ -2618,7 +2618,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			cluster = createCluster()
 			cluster.Spec.ProcessCounts.Storage = 2
-			cluster.Status.ProcessGroups[0].SetRemove()
+			cluster.Status.ProcessGroups[0].MarkForRemoval()
 			cluster.Status.ProcessGroups[0].UpdateCondition(ResourcesTerminating, true, nil, "")
 			result, err = cluster.CheckReconciliation(log)
 			Expect(err).NotTo(HaveOccurred())
@@ -2630,7 +2630,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			cluster = createCluster()
 			cluster.Spec.ProcessCounts.Storage = 2
-			cluster.Status.ProcessGroups[0].SetRemove()
+			cluster.Status.ProcessGroups[0].MarkForRemoval()
 			cluster.Status.ProcessGroups[0].SetExclude()
 			cluster.Status.ProcessGroups[0].UpdateCondition(IncorrectCommandLine, true, nil, "")
 			cluster.Status.ProcessGroups[0].UpdateCondition(ResourcesTerminating, true, nil, "")

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1512,12 +1512,12 @@ func (in *ProcessGroupStatus) DeepCopyInto(out *ProcessGroupStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.RemoveTimestamp != nil {
-		in, out := &in.RemoveTimestamp, &out.RemoveTimestamp
+	if in.RemovalTimestamp != nil {
+		in, out := &in.RemovalTimestamp, &out.RemovalTimestamp
 		*out = (*in).DeepCopy()
 	}
-	if in.ExcludedTimestamp != nil {
-		in, out := &in.ExcludedTimestamp, &out.ExcludedTimestamp
+	if in.ExclusionTimestamp != nil {
+		in, out := &in.ExclusionTimestamp, &out.ExclusionTimestamp
 		*out = (*in).DeepCopy()
 	}
 	if in.ProcessGroupConditions != nil {

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1512,8 +1512,14 @@ func (in *ProcessGroupStatus) DeepCopyInto(out *ProcessGroupStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	in.RemoveTimestamp.DeepCopyInto(&out.RemoveTimestamp)
-	in.ExcludedTimestamp.DeepCopyInto(&out.ExcludedTimestamp)
+	if in.RemoveTimestamp != nil {
+		in, out := &in.RemoveTimestamp, &out.RemoveTimestamp
+		*out = (*in).DeepCopy()
+	}
+	if in.ExcludedTimestamp != nil {
+		in, out := &in.ExcludedTimestamp, &out.ExcludedTimestamp
+		*out = (*in).DeepCopy()
+	}
 	if in.ProcessGroupConditions != nil {
 		in, out := &in.ProcessGroupConditions, &out.ProcessGroupConditions
 		*out = make([]*ProcessGroupCondition, len(*in))

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1512,6 +1512,8 @@ func (in *ProcessGroupStatus) DeepCopyInto(out *ProcessGroupStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	in.RemoveTimestamp.DeepCopyInto(&out.RemoveTimestamp)
+	in.ExcludedTimestamp.DeepCopyInto(&out.ExcludedTimestamp)
 	if in.ProcessGroupConditions != nil {
 		in, out := &in.ProcessGroupConditions, &out.ProcessGroupConditions
 		*out = make([]*ProcessGroupCondition, len(*in))

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -9195,11 +9195,11 @@ spec:
                         type: array
                       excluded:
                         type: boolean
-                      excludedTimestamp:
-                        format: date-time
-                        type: string
                       exclusionSkipped:
                         type: boolean
+                      exclusionTimestamp:
+                        format: date-time
+                        type: string
                       processClass:
                         type: string
                       processGroupConditions:
@@ -9214,11 +9214,11 @@ spec:
                         type: array
                       processGroupID:
                         type: string
-                      remove:
-                        type: boolean
-                      removeTimestamp:
+                      removalTimestamp:
                         format: date-time
                         type: string
+                      remove:
+                        type: boolean
                     type: object
                   type: array
                 requiredAddresses:

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -9195,6 +9195,9 @@ spec:
                         type: array
                       excluded:
                         type: boolean
+                      excludedTimestamp:
+                        format: date-time
+                        type: string
                       exclusionSkipped:
                         type: boolean
                       processClass:
@@ -9213,6 +9216,9 @@ spec:
                         type: string
                       remove:
                         type: boolean
+                      removeTimestamp:
+                        format: date-time
+                        type: string
                     type: object
                   type: array
                 requiredAddresses:

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -65,7 +65,7 @@ func (a addPods) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cl
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		_, podExists := podMap[processGroup.ProcessGroupID]
-		if !podExists && !processGroup.Remove {
+		if !podExists && !processGroup.IsRemoved() {
 			_, idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
 			if err != nil {
 				return &requeue{curError: err}

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -65,7 +65,7 @@ func (a addPods) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cl
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		_, podExists := podMap[processGroup.ProcessGroupID]
-		if !podExists && !processGroup.IsRemoved() {
+		if !podExists && !processGroup.IsMarkedForRemoval() {
 			_, idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
 			if err != nil {
 				return &requeue{curError: err}

--- a/controllers/add_pods_test.go
+++ b/controllers/add_pods_test.go
@@ -104,7 +104,7 @@ var _ = Describe("add_pods", func() {
 
 		Context("when the process group is being removed", func() {
 			BeforeEach(func() {
-				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].SetRemove()
+				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].MarkForRemoval()
 			})
 
 			It("should not requeue", func() {

--- a/controllers/add_pods_test.go
+++ b/controllers/add_pods_test.go
@@ -104,7 +104,7 @@ var _ = Describe("add_pods", func() {
 
 		Context("when the process group is being removed", func() {
 			BeforeEach(func() {
-				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].Remove = true
+				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].SetRemove()
 			})
 
 			It("should not requeue", func() {

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -60,7 +60,7 @@ func (a addProcessGroups) reconcile(ctx ctx.Context, r *FoundationDBClusterRecon
 
 		processGroupIDs[class][num] = true
 
-		if !processGroup.IsRemoved() {
+		if !processGroup.IsMarkedForRemoval() {
 			processCounts[class]++
 		}
 	}

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -60,7 +60,7 @@ func (a addProcessGroups) reconcile(ctx ctx.Context, r *FoundationDBClusterRecon
 
 		processGroupIDs[class][num] = true
 
-		if !processGroup.Remove {
+		if !processGroup.IsRemoved() {
 			processCounts[class]++
 		}
 	}

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -79,7 +79,7 @@ var _ = Describe("add_process_groups", func() {
 		BeforeEach(func() {
 			for _, processGroup := range cluster.Status.ProcessGroups {
 				if processGroup.ProcessGroupID == "storage-4" {
-					processGroup.Remove = true
+					processGroup.SetRemove()
 				}
 			}
 		})
@@ -113,7 +113,7 @@ var _ = Describe("add_process_groups", func() {
 			for _, processGroup := range cluster.Status.ProcessGroups {
 				if processGroup.ProcessGroupID == "storage-4" {
 					processGroup.ProcessGroupID = "old-prefix-storage-4"
-					processGroup.Remove = true
+					processGroup.SetRemove()
 				}
 			}
 		})

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -79,7 +79,7 @@ var _ = Describe("add_process_groups", func() {
 		BeforeEach(func() {
 			for _, processGroup := range cluster.Status.ProcessGroups {
 				if processGroup.ProcessGroupID == "storage-4" {
-					processGroup.SetRemove()
+					processGroup.MarkForRemoval()
 				}
 			}
 		})
@@ -113,7 +113,7 @@ var _ = Describe("add_process_groups", func() {
 			for _, processGroup := range cluster.Status.ProcessGroups {
 				if processGroup.ProcessGroupID == "storage-4" {
 					processGroup.ProcessGroupID = "old-prefix-storage-4"
-					processGroup.SetRemove()
+					processGroup.MarkForRemoval()
 				}
 			}
 		})

--- a/controllers/add_pvcs.go
+++ b/controllers/add_pvcs.go
@@ -39,7 +39,7 @@ type addPVCs struct{}
 // reconcile runs the reconciler's work.
 func (a addPVCs) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.Remove {
+		if processGroup.IsRemoved() {
 			continue
 		}
 

--- a/controllers/add_pvcs.go
+++ b/controllers/add_pvcs.go
@@ -39,7 +39,7 @@ type addPVCs struct{}
 // reconcile runs the reconciler's work.
 func (a addPVCs) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.IsRemoved() {
+		if processGroup.IsMarkedForRemoval() {
 			continue
 		}
 

--- a/controllers/add_pvcs_test.go
+++ b/controllers/add_pvcs_test.go
@@ -104,7 +104,7 @@ var _ = Describe("add_pvcs", func() {
 
 		Context("when the process group is being removed", func() {
 			BeforeEach(func() {
-				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].SetRemove()
+				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].MarkForRemoval()
 			})
 
 			It("should not requeue", func() {

--- a/controllers/add_pvcs_test.go
+++ b/controllers/add_pvcs_test.go
@@ -104,7 +104,7 @@ var _ = Describe("add_pvcs", func() {
 
 		Context("when the process group is being removed", func() {
 			BeforeEach(func() {
-				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].Remove = true
+				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].SetRemove()
 			})
 
 			It("should not requeue", func() {

--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -65,7 +65,7 @@ func (a addServices) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler
 
 	if *cluster.Spec.Routing.PublicIPSource == fdbtypes.PublicIPSourceService {
 		for _, processGroup := range cluster.Status.ProcessGroups {
-			if processGroup.IsRemoved() {
+			if processGroup.IsMarkedForRemoval() {
 				continue
 			}
 

--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -65,7 +65,7 @@ func (a addServices) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler
 
 	if *cluster.Spec.Routing.PublicIPSource == fdbtypes.PublicIPSourceService {
 		for _, processGroup := range cluster.Status.ProcessGroups {
-			if processGroup.Remove {
+			if processGroup.IsRemoved() {
 				continue
 			}
 

--- a/controllers/add_services_test.go
+++ b/controllers/add_services_test.go
@@ -154,7 +154,7 @@ var _ = Describe("add_services", func() {
 
 		Context("when the process group is being removed", func() {
 			BeforeEach(func() {
-				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].SetRemove()
+				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].MarkForRemoval()
 			})
 
 			It("should not requeue", func() {

--- a/controllers/add_services_test.go
+++ b/controllers/add_services_test.go
@@ -154,14 +154,14 @@ var _ = Describe("add_services", func() {
 
 		Context("when the process group is being removed", func() {
 			BeforeEach(func() {
-				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].Remove = true
+				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].SetRemove()
 			})
 
 			It("should not requeue", func() {
 				Expect(requeue).To(BeNil())
 			})
 
-			It("should not create any pods", func() {
+			It("should not create any services", func() {
 				Expect(newServices.Items).To(HaveLen(len(initialServices.Items)))
 			})
 		})

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -39,7 +39,7 @@ func (c chooseRemovals) reconcile(ctx ctx.Context, r *FoundationDBClusterReconci
 
 	var removals = make(map[string]bool)
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.IsRemoved() {
+		if processGroup.IsMarkedForRemoval() {
 			removals[processGroup.ProcessGroupID] = true
 		}
 	}
@@ -73,7 +73,7 @@ func (c chooseRemovals) reconcile(ctx ctx.Context, r *FoundationDBClusterReconci
 		processClassLocality := make([]localityInfo, 0, currentCounts[processClass])
 
 		for _, processGroup := range cluster.Status.ProcessGroupsByProcessClass(processClass) {
-			if processGroup.IsRemoved() {
+			if processGroup.IsMarkedForRemoval() {
 				removedCount--
 			} else {
 				locality, present := localityMap[processGroup.ProcessGroupID]

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -111,7 +111,7 @@ func (c chooseRemovals) reconcile(ctx ctx.Context, r *FoundationDBClusterReconci
 	if hasNewRemovals {
 		for _, processGroup := range cluster.Status.ProcessGroups {
 			if !remainingProcessMap[processGroup.ProcessGroupID] {
-				processGroup.SetRemove()
+				processGroup.MarkForRemoval()
 			}
 		}
 		err := r.Status().Update(ctx, cluster)

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -39,7 +39,7 @@ func (c chooseRemovals) reconcile(ctx ctx.Context, r *FoundationDBClusterReconci
 
 	var removals = make(map[string]bool)
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.Remove {
+		if processGroup.IsRemoved() {
 			removals[processGroup.ProcessGroupID] = true
 		}
 	}
@@ -73,7 +73,7 @@ func (c chooseRemovals) reconcile(ctx ctx.Context, r *FoundationDBClusterReconci
 		processClassLocality := make([]localityInfo, 0, currentCounts[processClass])
 
 		for _, processGroup := range cluster.Status.ProcessGroupsByProcessClass(processClass) {
-			if processGroup.Remove {
+			if processGroup.IsRemoved() {
 				removedCount--
 			} else {
 				locality, present := localityMap[processGroup.ProcessGroupID]
@@ -111,7 +111,7 @@ func (c chooseRemovals) reconcile(ctx ctx.Context, r *FoundationDBClusterReconci
 	if hasNewRemovals {
 		for _, processGroup := range cluster.Status.ProcessGroups {
 			if !remainingProcessMap[processGroup.ProcessGroupID] {
-				processGroup.Remove = true
+				processGroup.SetRemove()
 			}
 		}
 		err := r.Status().Update(ctx, cluster)

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -96,7 +96,7 @@ var _ = Describe("choose_removals", func() {
 			BeforeEach(func() {
 				processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-3]
 				Expect(processGroup.ProcessGroupID).To(Equal("storage-2"))
-				processGroup.SetRemove()
+				processGroup.MarkForRemoval()
 				err = clusterReconciler.Status().Update(context.TODO(), cluster)
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -62,7 +62,7 @@ var _ = Describe("choose_removals", func() {
 
 		removals = nil
 		for _, processGroup := range cluster.Status.ProcessGroups {
-			if processGroup.Remove {
+			if processGroup.IsRemoved() {
 				removals = append(removals, processGroup.ProcessGroupID)
 			}
 		}
@@ -96,7 +96,7 @@ var _ = Describe("choose_removals", func() {
 			BeforeEach(func() {
 				processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-3]
 				Expect(processGroup.ProcessGroupID).To(Equal("storage-2"))
-				processGroup.Remove = true
+				processGroup.SetRemove()
 				err = clusterReconciler.Status().Update(context.TODO(), cluster)
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -62,7 +62,7 @@ var _ = Describe("choose_removals", func() {
 
 		removals = nil
 		for _, processGroup := range cluster.Status.ProcessGroups {
-			if processGroup.IsRemoved() {
+			if processGroup.IsMarkedForRemoval() {
 				removals = append(removals, processGroup.ProcessGroupID)
 			}
 		}

--- a/controllers/delete_pods_for_buggification.go
+++ b/controllers/delete_pods_for_buggification.go
@@ -56,7 +56,7 @@ func (d deletePodsForBuggification) reconcile(ctx ctx.Context, r *FoundationDBCl
 	}
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.IsRemoved() {
+		if processGroup.IsMarkedForRemoval() {
 			logger.V(1).Info("Ignore process group marked for removal",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue

--- a/controllers/delete_pods_for_buggification.go
+++ b/controllers/delete_pods_for_buggification.go
@@ -56,7 +56,7 @@ func (d deletePodsForBuggification) reconcile(ctx ctx.Context, r *FoundationDBCl
 	}
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.Remove {
+		if processGroup.IsRemoved() {
 			logger.V(1).Info("Ignore process group marked for removal",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -50,7 +50,7 @@ func (e excludeProcesses) reconcile(ctx ctx.Context, r *FoundationDBClusterRecon
 
 	removalCount := 0
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.IsRemoved() {
+		if processGroup.IsMarkedForRemoval() {
 			removalCount++
 		}
 	}
@@ -70,7 +70,7 @@ func (e excludeProcesses) reconcile(ctx ctx.Context, r *FoundationDBClusterRecon
 
 		for _, processGroup := range cluster.Status.ProcessGroups {
 			for _, address := range processGroup.Addresses {
-				if processGroup.IsRemoved() && !processGroup.ExclusionSkipped && !currentExclusionMap[address] {
+				if processGroup.IsMarkedForRemoval() && !processGroup.ExclusionSkipped && !currentExclusionMap[address] {
 					addresses = append(addresses, fdbtypes.ProcessAddress{IPAddress: net.ParseIP(address)})
 					processClassesToExclude[processGroup.ProcessClass] = fdbtypes.None{}
 				}
@@ -126,7 +126,7 @@ func canExcludeNewProcesses(cluster *fdbtypes.FoundationDBCluster, processClass 
 	validProcesses := make([]string, 0)
 
 	for _, processGroupStatus := range cluster.Status.ProcessGroups {
-		if processGroupStatus.IsRemoved() || processGroupStatus.ProcessClass != processClass {
+		if processGroupStatus.IsMarkedForRemoval() || processGroupStatus.ProcessClass != processClass {
 			continue
 		}
 

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -50,7 +50,7 @@ func (e excludeProcesses) reconcile(ctx ctx.Context, r *FoundationDBClusterRecon
 
 	removalCount := 0
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.Remove {
+		if processGroup.IsRemoved() {
 			removalCount++
 		}
 	}
@@ -70,7 +70,7 @@ func (e excludeProcesses) reconcile(ctx ctx.Context, r *FoundationDBClusterRecon
 
 		for _, processGroup := range cluster.Status.ProcessGroups {
 			for _, address := range processGroup.Addresses {
-				if processGroup.Remove && !processGroup.ExclusionSkipped && !currentExclusionMap[address] {
+				if processGroup.IsRemoved() && !processGroup.ExclusionSkipped && !currentExclusionMap[address] {
 					addresses = append(addresses, fdbtypes.ProcessAddress{IPAddress: net.ParseIP(address)})
 					processClassesToExclude[processGroup.ProcessClass] = fdbtypes.None{}
 				}
@@ -126,7 +126,7 @@ func canExcludeNewProcesses(cluster *fdbtypes.FoundationDBCluster, processClass 
 	validProcesses := make([]string, 0)
 
 	for _, processGroupStatus := range cluster.Status.ProcessGroups {
-		if processGroupStatus.Remove || processGroupStatus.ProcessClass != processClass {
+		if processGroupStatus.IsRemoved() || processGroupStatus.ProcessClass != processClass {
 			continue
 		}
 

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -181,11 +181,11 @@ func getProcessGroupMetrics(cluster *fdbtypes.FoundationDBCluster) (map[fdbtypes
 			exclusions[processGroup.ProcessClass] = 0
 		}
 
-		if processGroup.Remove {
+		if processGroup.IsRemoved() {
 			removals[processGroup.ProcessClass]++
 		}
 
-		if processGroup.Excluded {
+		if processGroup.IsExcluded() {
 			exclusions[processGroup.ProcessClass]++
 		}
 

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -181,7 +181,7 @@ func getProcessGroupMetrics(cluster *fdbtypes.FoundationDBCluster) (map[fdbtypes
 			exclusions[processGroup.ProcessClass] = 0
 		}
 
-		if processGroup.IsRemoved() {
+		if processGroup.IsMarkedForRemoval() {
 			removals[processGroup.ProcessClass]++
 		}
 

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -206,7 +206,7 @@ func includeProcessGroup(r *FoundationDBClusterReconciler, context ctx.Context, 
 
 	processGroups := make([]*fdbtypes.ProcessGroupStatus, 0, len(cluster.Status.ProcessGroups))
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.IsRemoved() && removedProcessGroups[processGroup.ProcessGroupID] {
+		if processGroup.IsMarkedForRemoval() && removedProcessGroups[processGroup.ProcessGroupID] {
 			for _, pAddr := range processGroup.Addresses {
 				addresses = append(addresses, fdbtypes.ProcessAddress{IPAddress: net.ParseIP(pAddr)})
 			}
@@ -253,7 +253,7 @@ func (r *FoundationDBClusterReconciler) getRemainingMap(cluster *fdbtypes.Founda
 
 	addresses := make([]fdbtypes.ProcessAddress, 0, len(cluster.Status.ProcessGroups))
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if !processGroup.IsRemoved() || processGroup.ExclusionSkipped {
+		if !processGroup.IsMarkedForRemoval() || processGroup.ExclusionSkipped {
 			continue
 		}
 
@@ -297,7 +297,7 @@ func (r *FoundationDBClusterReconciler) getProcessGroupsToRemove(cluster *fdbtyp
 	processGroupsToRemove := make([]string, 0, len(cluster.Status.ProcessGroups))
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if !processGroup.IsRemoved() {
+		if !processGroup.IsMarkedForRemoval() {
 			continue
 		}
 

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -301,7 +301,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 func getRemovedProcessGroupIDs(cluster *fdbtypes.FoundationDBCluster) []string {
 	results := make([]string, 0)
 	for _, processGroupStatus := range cluster.Status.ProcessGroups {
-		if processGroupStatus.IsRemoved() {
+		if processGroupStatus.IsMarkedForRemoval() {
 			results = append(results, processGroupStatus.ProcessGroupID)
 		}
 	}

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -131,7 +131,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 		Context("with another in-flight exclusion", func() {
 			BeforeEach(func() {
 				processGroup := fdbtypes.FindProcessGroupByID(cluster.Status.ProcessGroups, "storage-3")
-				processGroup.Remove = true
+				processGroup.SetRemove()
 			})
 
 			It("should return false", func() {
@@ -176,8 +176,8 @@ var _ = Describe("replace_failed_process_groups", func() {
 		Context("with another complete exclusion", func() {
 			BeforeEach(func() {
 				processGroup := fdbtypes.FindProcessGroupByID(cluster.Status.ProcessGroups, "storage-3")
-				processGroup.Remove = true
-				processGroup.Excluded = true
+				processGroup.SetRemove()
+				processGroup.SetExclude()
 			})
 
 			It("should return true", func() {
@@ -301,7 +301,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 func getRemovedProcessGroupIDs(cluster *fdbtypes.FoundationDBCluster) []string {
 	results := make([]string, 0)
 	for _, processGroupStatus := range cluster.Status.ProcessGroups {
-		if processGroupStatus.Remove {
+		if processGroupStatus.IsRemoved() {
 			results = append(results, processGroupStatus.ProcessGroupID)
 		}
 	}

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -131,7 +131,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 		Context("with another in-flight exclusion", func() {
 			BeforeEach(func() {
 				processGroup := fdbtypes.FindProcessGroupByID(cluster.Status.ProcessGroups, "storage-3")
-				processGroup.SetRemove()
+				processGroup.MarkForRemoval()
 			})
 
 			It("should return false", func() {
@@ -176,7 +176,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 		Context("with another complete exclusion", func() {
 			BeforeEach(func() {
 				processGroup := fdbtypes.FindProcessGroupByID(cluster.Status.ProcessGroups, "storage-3")
-				processGroup.SetRemove()
+				processGroup.MarkForRemoval()
 				processGroup.SetExclude()
 			})
 

--- a/controllers/update_labels.go
+++ b/controllers/update_labels.go
@@ -50,7 +50,7 @@ func (updateLabels) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler,
 	pvcMap := internal.CreatePVCMap(cluster, pvcs)
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.IsRemoved() {
+		if processGroup.IsMarkedForRemoval() {
 			logger.V(1).Info("Ignore process group marked for removal",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue

--- a/controllers/update_labels.go
+++ b/controllers/update_labels.go
@@ -50,7 +50,7 @@ func (updateLabels) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler,
 	pvcMap := internal.CreatePVCMap(cluster, pvcs)
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.Remove {
+		if processGroup.IsRemoved() {
 			logger.V(1).Info("Ignore process group marked for removal",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -58,7 +58,7 @@ func (updatePodConfig) reconcile(ctx ctx.Context, r *FoundationDBClusterReconcil
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		curLogger := logger.WithValues("processGroupID", processGroup.ProcessGroupID)
 
-		if processGroup.Remove {
+		if processGroup.IsRemoved() {
 			curLogger.V(1).Info("Ignore process group marked for removal")
 			continue
 		}

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -58,7 +58,7 @@ func (updatePodConfig) reconcile(ctx ctx.Context, r *FoundationDBClusterReconcil
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		curLogger := logger.WithValues("processGroupID", processGroup.ProcessGroupID)
 
-		if processGroup.IsRemoved() {
+		if processGroup.IsMarkedForRemoval() {
 			curLogger.V(1).Info("Ignore process group marked for removal")
 			continue
 		}

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -54,7 +54,7 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 	podMap := internal.CreatePodMap(cluster, pods)
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.Remove {
+		if processGroup.IsRemoved() {
 			logger.V(1).Info("Ignore removed Pod",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -54,7 +54,7 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 	podMap := internal.CreatePodMap(cluster, pods)
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.IsRemoved() {
+		if processGroup.IsMarkedForRemoval() {
 			logger.V(1).Info("Ignore removed Pod",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -48,7 +48,7 @@ func (updateSidecarVersions) reconcile(ctx ctx.Context, r *FoundationDBClusterRe
 
 	podMap := internal.CreatePodMap(cluster, pods)
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.Remove {
+		if processGroup.IsRemoved() {
 			logger.V(1).Info("Ignore process group marked for removal",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -48,7 +48,7 @@ func (updateSidecarVersions) reconcile(ctx ctx.Context, r *FoundationDBClusterRe
 
 	podMap := internal.CreatePodMap(cluster, pods)
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.IsRemoved() {
+		if processGroup.IsMarkedForRemoval() {
 			logger.V(1).Info("Ignore process group marked for removal",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -495,10 +495,10 @@ func validateProcessGroups(r *FoundationDBClusterReconciler, context ctx.Context
 
 		pod := pods[0]
 
-		processGroup.AddAddresses(podmanager.GetPublicIPs(pod), processGroup.Remove || !status.Health.Available)
+		processGroup.AddAddresses(podmanager.GetPublicIPs(pod), processGroup.IsRemoved() || !status.Health.Available)
 		processCount := 1
 
-		if processGroup.Remove && pod.ObjectMeta.DeletionTimestamp != nil {
+		if processGroup.IsRemoved() && pod.ObjectMeta.DeletionTimestamp != nil {
 			processGroup.UpdateCondition(fdbtypes.ResourcesTerminating, true, processGroups, processGroup.ProcessGroupID)
 			continue
 		}
@@ -528,7 +528,7 @@ func validateProcessGroups(r *FoundationDBClusterReconciler, context ctx.Context
 		}
 
 		if isBeingRemoved {
-			processGroup.Remove = true
+			processGroup.SetRemove()
 			// Check if we should skip exclusion for the process group
 			_, ok := processGroupsWithoutExclusion[processGroup.ProcessGroupID]
 			processGroup.ExclusionSkipped = ok

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -495,10 +495,10 @@ func validateProcessGroups(r *FoundationDBClusterReconciler, context ctx.Context
 
 		pod := pods[0]
 
-		processGroup.AddAddresses(podmanager.GetPublicIPs(pod), processGroup.IsRemoved() || !status.Health.Available)
+		processGroup.AddAddresses(podmanager.GetPublicIPs(pod), processGroup.IsMarkedForRemoval() || !status.Health.Available)
 		processCount := 1
 
-		if processGroup.IsRemoved() && pod.ObjectMeta.DeletionTimestamp != nil {
+		if processGroup.IsMarkedForRemoval() && pod.ObjectMeta.DeletionTimestamp != nil {
 			processGroup.UpdateCondition(fdbtypes.ResourcesTerminating, true, processGroups, processGroup.ProcessGroupID)
 			continue
 		}

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -528,7 +528,7 @@ func validateProcessGroups(r *FoundationDBClusterReconciler, context ctx.Context
 		}
 
 		if isBeingRemoved {
-			processGroup.SetRemove()
+			processGroup.MarkForRemoval()
 			// Check if we should skip exclusion for the process group
 			_, ok := processGroupsWithoutExclusion[processGroup.ProcessGroupID]
 			processGroup.ExclusionSkipped = ok

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -237,13 +237,13 @@ var _ = Describe("update_status", func() {
 				removalCount := 0
 				for _, processGroup := range processGroupStatus {
 					if processGroup.ProcessGroupID == removedProcessGroup {
-						Expect(processGroup.IsRemoved()).To(BeTrue())
+						Expect(processGroup.IsMarkedForRemoval()).To(BeTrue())
 						Expect(processGroup.ExclusionSkipped).To(BeFalse())
 						removalCount++
 						continue
 					}
 
-					Expect(processGroup.IsRemoved()).To(BeFalse())
+					Expect(processGroup.IsMarkedForRemoval()).To(BeFalse())
 				}
 
 				Expect(removalCount).To(BeNumerically("==", 1))
@@ -268,13 +268,13 @@ var _ = Describe("update_status", func() {
 				removalCount := 0
 				for _, processGroup := range processGroupStatus {
 					if processGroup.ProcessGroupID == removedProcessGroup {
-						Expect(processGroup.IsRemoved()).To(BeTrue())
+						Expect(processGroup.IsMarkedForRemoval()).To(BeTrue())
 						Expect(processGroup.ExclusionSkipped).To(BeFalse())
 						removalCount++
 						continue
 					}
 
-					Expect(processGroup.IsRemoved()).To(BeFalse())
+					Expect(processGroup.IsMarkedForRemoval()).To(BeFalse())
 				}
 
 				Expect(removalCount).To(BeNumerically("==", 1))
@@ -299,13 +299,13 @@ var _ = Describe("update_status", func() {
 				removalCount := 0
 				for _, processGroup := range processGroupStatus {
 					if processGroup.ProcessGroupID == removedProcessGroup {
-						Expect(processGroup.IsRemoved()).To(BeTrue())
+						Expect(processGroup.IsMarkedForRemoval()).To(BeTrue())
 						Expect(processGroup.ExclusionSkipped).To(BeTrue())
 						removalCount++
 						continue
 					}
 
-					Expect(processGroup.IsRemoved()).To(BeFalse())
+					Expect(processGroup.IsMarkedForRemoval()).To(BeFalse())
 				}
 
 				Expect(removalCount).To(BeNumerically("==", 1))
@@ -330,13 +330,13 @@ var _ = Describe("update_status", func() {
 				removalCount := 0
 				for _, processGroup := range processGroupStatus {
 					if processGroup.ProcessGroupID == removedProcessGroup {
-						Expect(processGroup.IsRemoved()).To(BeTrue())
+						Expect(processGroup.IsMarkedForRemoval()).To(BeTrue())
 						Expect(processGroup.ExclusionSkipped).To(BeTrue())
 						removalCount++
 						continue
 					}
 
-					Expect(processGroup.IsRemoved()).To(BeFalse())
+					Expect(processGroup.IsMarkedForRemoval()).To(BeFalse())
 				}
 
 				Expect(removalCount).To(BeNumerically("==", 1))
@@ -418,7 +418,7 @@ var _ = Describe("update_status", func() {
 						continue
 					}
 
-					Expect(processGroup.IsRemoved()).To(BeFalse())
+					Expect(processGroup.IsMarkedForRemoval()).To(BeFalse())
 				}
 
 				Expect(pendingCount).To(BeNumerically("==", 1))

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -237,13 +237,13 @@ var _ = Describe("update_status", func() {
 				removalCount := 0
 				for _, processGroup := range processGroupStatus {
 					if processGroup.ProcessGroupID == removedProcessGroup {
-						Expect(processGroup.Remove).To(BeTrue())
+						Expect(processGroup.IsRemoved()).To(BeTrue())
 						Expect(processGroup.ExclusionSkipped).To(BeFalse())
 						removalCount++
 						continue
 					}
 
-					Expect(processGroup.Remove).To(BeFalse())
+					Expect(processGroup.IsRemoved()).To(BeFalse())
 				}
 
 				Expect(removalCount).To(BeNumerically("==", 1))
@@ -268,13 +268,13 @@ var _ = Describe("update_status", func() {
 				removalCount := 0
 				for _, processGroup := range processGroupStatus {
 					if processGroup.ProcessGroupID == removedProcessGroup {
-						Expect(processGroup.Remove).To(BeTrue())
+						Expect(processGroup.IsRemoved()).To(BeTrue())
 						Expect(processGroup.ExclusionSkipped).To(BeFalse())
 						removalCount++
 						continue
 					}
 
-					Expect(processGroup.Remove).To(BeFalse())
+					Expect(processGroup.IsRemoved()).To(BeFalse())
 				}
 
 				Expect(removalCount).To(BeNumerically("==", 1))
@@ -299,13 +299,13 @@ var _ = Describe("update_status", func() {
 				removalCount := 0
 				for _, processGroup := range processGroupStatus {
 					if processGroup.ProcessGroupID == removedProcessGroup {
-						Expect(processGroup.Remove).To(BeTrue())
+						Expect(processGroup.IsRemoved()).To(BeTrue())
 						Expect(processGroup.ExclusionSkipped).To(BeTrue())
 						removalCount++
 						continue
 					}
 
-					Expect(processGroup.Remove).To(BeFalse())
+					Expect(processGroup.IsRemoved()).To(BeFalse())
 				}
 
 				Expect(removalCount).To(BeNumerically("==", 1))
@@ -330,13 +330,13 @@ var _ = Describe("update_status", func() {
 				removalCount := 0
 				for _, processGroup := range processGroupStatus {
 					if processGroup.ProcessGroupID == removedProcessGroup {
-						Expect(processGroup.Remove).To(BeTrue())
+						Expect(processGroup.IsRemoved()).To(BeTrue())
 						Expect(processGroup.ExclusionSkipped).To(BeTrue())
 						removalCount++
 						continue
 					}
 
-					Expect(processGroup.Remove).To(BeFalse())
+					Expect(processGroup.IsRemoved()).To(BeFalse())
 				}
 
 				Expect(removalCount).To(BeNumerically("==", 1))
@@ -418,7 +418,7 @@ var _ = Describe("update_status", func() {
 						continue
 					}
 
-					Expect(processGroup.Remove).To(BeFalse())
+					Expect(processGroup.IsRemoved()).To(BeFalse())
 				}
 
 				Expect(pendingCount).To(BeNumerically("==", 1))

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -452,7 +452,9 @@ ProcessGroupStatus represents a the status of a ProcessGroup.
 | processClass | ProcessClass represents the class the process group has. | ProcessClass | false |
 | addresses | Addresses represents the list of addresses the process group has been known to have. | []string | false |
 | remove | Remove defines if the process group is marked for removal. | bool | false |
+| removeTimestamp | RemoveTimestamp if not empty defines when the process group was marked for removal. | metav1.Time | false |
 | excluded | Excluded defines if the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | bool | false |
+| excludedTimestamp | ExcludedTimestamp defines when the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | metav1.Time | false |
 | exclusionSkipped | ExclusionSkipped determines if exclusion has been skipped for a process, which will allow the process group to be removed without exclusion. | bool | false |
 | processGroupConditions | ProcessGroupConditions represents a list of degraded conditions that the process group is in. | []*[ProcessGroupCondition](#processgroupcondition) | false |
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -451,10 +451,10 @@ ProcessGroupStatus represents a the status of a ProcessGroup.
 | processGroupID | ProcessGroupID represents the ID of the process group | string | false |
 | processClass | ProcessClass represents the class the process group has. | ProcessClass | false |
 | addresses | Addresses represents the list of addresses the process group has been known to have. | []string | false |
-| remove | Remove defines if the process group is marked for removal. | bool | false |
-| removeTimestamp | RemoveTimestamp if not empty defines when the process group was marked for removal. | *metav1.Time | false |
-| excluded | Excluded defines if the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | bool | false |
-| excludedTimestamp | ExcludedTimestamp defines when the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | *metav1.Time | false |
+| remove | Remove defines if the process group is marked for removal. **Deprecated: Use RemovalTimestamp instead.** | bool | false |
+| removalTimestamp | RemoveTimestamp if not empty defines when the process group was marked for removal. | *metav1.Time | false |
+| excluded | Excluded defines if the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. **Deprecated: Use ExclusionTimestamp instead.** | bool | false |
+| exclusionTimestamp | ExcludedTimestamp defines when the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | *metav1.Time | false |
 | exclusionSkipped | ExclusionSkipped determines if exclusion has been skipped for a process, which will allow the process group to be removed without exclusion. | bool | false |
 | processGroupConditions | ProcessGroupConditions represents a list of degraded conditions that the process group is in. | []*[ProcessGroupCondition](#processgroupcondition) | false |
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -452,9 +452,9 @@ ProcessGroupStatus represents a the status of a ProcessGroup.
 | processClass | ProcessClass represents the class the process group has. | ProcessClass | false |
 | addresses | Addresses represents the list of addresses the process group has been known to have. | []string | false |
 | remove | Remove defines if the process group is marked for removal. | bool | false |
-| removeTimestamp | RemoveTimestamp if not empty defines when the process group was marked for removal. | metav1.Time | false |
+| removeTimestamp | RemoveTimestamp if not empty defines when the process group was marked for removal. | *metav1.Time | false |
 | excluded | Excluded defines if the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | bool | false |
-| excludedTimestamp | ExcludedTimestamp defines when the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | metav1.Time | false |
+| excludedTimestamp | ExcludedTimestamp defines when the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | *metav1.Time | false |
 | exclusionSkipped | ExclusionSkipped determines if exclusion has been skipped for a process, which will allow the process group to be removed without exclusion. | bool | false |
 | processGroupConditions | ProcessGroupConditions represents a list of degraded conditions that the process group is in. | []*[ProcessGroupCondition](#processgroupcondition) | false |
 

--- a/internal/replacements/replace_failed_process_groups.go
+++ b/internal/replacements/replace_failed_process_groups.go
@@ -94,7 +94,7 @@ func ReplaceFailedProcessGroups(log logr.Logger, cluster *fdbtypes.FoundationDBC
 				"processGroupID", processGroupStatus.ProcessGroupID,
 				"reason", fmt.Sprintf("automatic replacement detected failure time: %s", time.Unix(missingTime, 0).UTC().String()))
 
-			processGroupStatus.SetRemove()
+			processGroupStatus.MarkForRemoval()
 			hasReplacement = true
 			maxReplacements--
 		}

--- a/internal/replacements/replace_failed_process_groups.go
+++ b/internal/replacements/replace_failed_process_groups.go
@@ -36,7 +36,7 @@ func getMaxReplacements(cluster *fdbtypes.FoundationDBCluster, maxReplacements i
 	// not fully excluded.
 	removalCount := 0
 	for _, processGroupStatus := range cluster.Status.ProcessGroups {
-		if processGroupStatus.IsRemoved() && !processGroupStatus.IsExcluded() {
+		if processGroupStatus.IsMarkedForRemoval() && !processGroupStatus.IsExcluded() {
 			// If we already have a removal in-flight, we should not try
 			// replacing more failed process groups.
 			removalCount++

--- a/internal/replacements/replace_failed_process_groups.go
+++ b/internal/replacements/replace_failed_process_groups.go
@@ -36,7 +36,7 @@ func getMaxReplacements(cluster *fdbtypes.FoundationDBCluster, maxReplacements i
 	// not fully excluded.
 	removalCount := 0
 	for _, processGroupStatus := range cluster.Status.ProcessGroups {
-		if processGroupStatus.Remove && (!processGroupStatus.Excluded || processGroupStatus.ExclusionSkipped) {
+		if processGroupStatus.IsRemoved() && !processGroupStatus.IsExcluded() {
 			// If we already have a removal in-flight, we should not try
 			// replacing more failed process groups.
 			removalCount++
@@ -94,7 +94,7 @@ func ReplaceFailedProcessGroups(log logr.Logger, cluster *fdbtypes.FoundationDBC
 				"processGroupID", processGroupStatus.ProcessGroupID,
 				"reason", fmt.Sprintf("automatic replacement detected failure time: %s", time.Unix(missingTime, 0).UTC().String()))
 
-			processGroupStatus.Remove = true
+			processGroupStatus.SetRemove()
 			hasReplacement = true
 			maxReplacements--
 		}

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -43,7 +43,7 @@ func ReplaceMisconfiguredProcessGroups(log logr.Logger, cluster *fdbtypes.Founda
 			break
 		}
 
-		if processGroup.Remove {
+		if processGroup.IsRemoved() {
 			continue
 		}
 
@@ -57,7 +57,7 @@ func ReplaceMisconfiguredProcessGroups(log logr.Logger, cluster *fdbtypes.Founda
 			}
 
 			if needsPVCRemoval && hasPod {
-				processGroup.Remove = true
+				processGroup.SetRemove()
 				hasReplacements = true
 				maxReplacements--
 				continue
@@ -79,7 +79,7 @@ func ReplaceMisconfiguredProcessGroups(log logr.Logger, cluster *fdbtypes.Founda
 		}
 
 		if needsRemoval {
-			processGroup.Remove = true
+			processGroup.SetRemove()
 			hasReplacements = true
 			maxReplacements--
 		}
@@ -147,7 +147,7 @@ func processGroupNeedsRemoval(cluster *fdbtypes.FoundationDBCluster, pod *corev1
 		return false, fmt.Errorf("unknown process group %s in replace_misconfigured_pods", processGroupID)
 	}
 
-	if processGroupStatus.Remove {
+	if processGroupStatus.IsRemoved() {
 		return false, nil
 	}
 

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -43,7 +43,7 @@ func ReplaceMisconfiguredProcessGroups(log logr.Logger, cluster *fdbtypes.Founda
 			break
 		}
 
-		if processGroup.IsRemoved() {
+		if processGroup.IsMarkedForRemoval() {
 			continue
 		}
 
@@ -147,7 +147,7 @@ func processGroupNeedsRemoval(cluster *fdbtypes.FoundationDBCluster, pod *corev1
 		return false, fmt.Errorf("unknown process group %s in replace_misconfigured_pods", processGroupID)
 	}
 
-	if processGroupStatus.IsRemoved() {
+	if processGroupStatus.IsMarkedForRemoval() {
 		return false, nil
 	}
 

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -57,7 +57,7 @@ func ReplaceMisconfiguredProcessGroups(log logr.Logger, cluster *fdbtypes.Founda
 			}
 
 			if needsPVCRemoval && hasPod {
-				processGroup.SetRemove()
+				processGroup.MarkForRemoval()
 				hasReplacements = true
 				maxReplacements--
 				continue
@@ -79,7 +79,7 @@ func ReplaceMisconfiguredProcessGroups(log logr.Logger, cluster *fdbtypes.Founda
 		}
 
 		if needsRemoval {
-			processGroup.SetRemove()
+			processGroup.MarkForRemoval()
 			hasReplacements = true
 			maxReplacements--
 		}

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -582,7 +582,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 				cntReplacements := 0
 				for _, pGroup := range cluster.Status.ProcessGroups {
-					if !pGroup.IsRemoved() {
+					if !pGroup.IsMarkedForRemoval() {
 						continue
 					}
 
@@ -605,7 +605,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 				cntReplacements := 0
 				for _, pGroup := range cluster.Status.ProcessGroups {
-					if !pGroup.IsRemoved() {
+					if !pGroup.IsMarkedForRemoval() {
 						continue
 					}
 
@@ -624,7 +624,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 				cntReplacements := 0
 				for _, pGroup := range cluster.Status.ProcessGroups {
-					if !pGroup.IsRemoved() {
+					if !pGroup.IsMarkedForRemoval() {
 						continue
 					}
 

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -582,7 +582,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 				cntReplacements := 0
 				for _, pGroup := range cluster.Status.ProcessGroups {
-					if !pGroup.Remove {
+					if !pGroup.IsRemoved() {
 						continue
 					}
 
@@ -605,7 +605,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 				cntReplacements := 0
 				for _, pGroup := range cluster.Status.ProcessGroups {
-					if !pGroup.Remove {
+					if !pGroup.IsRemoved() {
 						continue
 					}
 
@@ -624,7 +624,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 				cntReplacements := 0
 				for _, pGroup := range cluster.Status.ProcessGroups {
-					if !pGroup.Remove {
+					if !pGroup.IsRemoved() {
 						continue
 					}
 

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -218,7 +218,7 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, clusterName st
 
 		// Skip if the processGroup should be removed
 		// or should we check for how long they are marked as removed e.g. stuck in removal?
-		if processGroup.IsRemoved() {
+		if processGroup.IsMarkedForRemoval() {
 			statement := fmt.Sprintf("ProcessGroup: %s is marked for removal, excluded state: %t", processGroup.ProcessGroupID, processGroup.IsExcluded())
 			printStatement(cmd, statement, true)
 			continue

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -218,8 +218,8 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, clusterName st
 
 		// Skip if the processGroup should be removed
 		// or should we check for how long they are marked as removed e.g. stuck in removal?
-		if processGroup.Remove {
-			statement := fmt.Sprintf("ProcessGroup: %s is marked for removal, excluded state: %t", processGroup.ProcessGroupID, processGroup.Excluded)
+		if processGroup.IsRemoved() {
+			statement := fmt.Sprintf("ProcessGroup: %s is marked for removal, excluded state: %t", processGroup.ProcessGroupID, processGroup.IsExcluded())
 			printStatement(cmd, statement, true)
 			continue
 		}


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/982

This allows to see when a process group was removed or excluded without looking into the logs.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

I added this as an addition and in another release we can drop the support for the boolean flags.

# Testing

Unit + local testing:

```yaml
 - addresses:
    - 10.42.0.118
    processClass: storage
    processGroupID: storage-3
    remove: true
    removeTimestamp: "2021-11-26T17:52:41Z"
```

# Documentation

I can update the operation manual with the new variable.

# Follow-up

-
