### PR TITLE
Add missing go pkg to copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY setup/ setup/
 COPY fdbclient/ fdbclient/
 COPY internal/ internal/
 COPY pkg/ pkg/
+COPY mock-kubernetes-client/ mock-kubernetes-client/
 
 # Build
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on make manager


### PR DESCRIPTION
# Description

I don' see a harm here since we only copy the files into the build container. On the other hand we remove the surprises for user that want to change something in the Dockerfile or if they want to run tests in the (build) container.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

-

# Testing

Local.

# Documentation

-

# Follow-up

Wee might consider in the future to load everything into the container and work with a `.dockerignore` file .
