### PR TITLE
Remove reference to old context package and move context as first parameter

### DIFF
--- a/controllers/add_pods_test.go
+++ b/controllers/add_pods_test.go
@@ -61,7 +61,7 @@ var _ = Describe("add_pods", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = addPods{}.reconcile(clusterReconciler, context.TODO(), cluster)
+		requeue = addPods{}.reconcile(context.TODO(), clusterReconciler, cluster)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -37,7 +37,7 @@ import (
 type addProcessGroups struct{}
 
 // reconcile runs the reconciler's work.
-func (a addProcessGroups) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (a addProcessGroups) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	desiredCountStruct, err := cluster.GetProcessCountsWithDefaults()
 	if err != nil {
 		return &requeue{curError: err}
@@ -101,7 +101,7 @@ func (a addProcessGroups) reconcile(r *FoundationDBClusterReconciler, context ct
 	}
 
 	if hasNewProcessGroups {
-		err = r.Status().Update(context, cluster)
+		err = r.Status().Update(ctx, cluster)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -54,7 +54,7 @@ var _ = Describe("add_process_groups", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = addProcessGroups{}.reconcile(clusterReconciler, context.TODO(), cluster)
+		requeue = addProcessGroups{}.reconcile(context.TODO(), clusterReconciler, cluster)
 		if requeue != nil {
 			Expect(requeue.curError).NotTo(HaveOccurred())
 		}

--- a/controllers/add_pvcs.go
+++ b/controllers/add_pvcs.go
@@ -37,7 +37,7 @@ import (
 type addPVCs struct{}
 
 // reconcile runs the reconciler's work.
-func (a addPVCs) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (a addPVCs) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.Remove {
 			continue
@@ -58,7 +58,7 @@ func (a addPVCs) reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 		}
 		existingPVC := &corev1.PersistentVolumeClaim{}
 
-		err = r.Get(context, client.ObjectKey{Namespace: pvc.Namespace, Name: pvc.Name}, existingPVC)
+		err = r.Get(ctx, client.ObjectKey{Namespace: pvc.Namespace, Name: pvc.Name}, existingPVC)
 		if err != nil {
 			if !k8serrors.IsNotFound(err) {
 				return &requeue{curError: err}
@@ -66,7 +66,7 @@ func (a addPVCs) reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 
 			owner := internal.BuildOwnerReference(cluster.TypeMeta, cluster.ObjectMeta)
 			pvc.ObjectMeta.OwnerReferences = owner
-			err = r.Create(context, pvc)
+			err = r.Create(ctx, pvc)
 
 			if err != nil {
 				return &requeue{curError: err}

--- a/controllers/add_pvcs_test.go
+++ b/controllers/add_pvcs_test.go
@@ -61,7 +61,7 @@ var _ = Describe("add_pvcs", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = addPVCs{}.reconcile(clusterReconciler, context.TODO(), cluster)
+		requeue = addPVCs{}.reconcile(context.TODO(), clusterReconciler, cluster)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -39,14 +39,14 @@ import (
 type addServices struct{}
 
 // reconcile runs the reconciler's work.
-func (a addServices) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (a addServices) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	service := internal.GetHeadlessService(cluster)
 	if service != nil {
 		existingService := &corev1.Service{}
-		err := r.Get(context, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}, existingService)
+		err := r.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}, existingService)
 		if err == nil {
 			// Update the existing service
-			err = updateService(r, context, cluster, existingService, service)
+			err = updateService(r, ctx, cluster, existingService, service)
 			if err != nil {
 				return &requeue{curError: err}
 			}
@@ -56,7 +56,7 @@ func (a addServices) reconcile(r *FoundationDBClusterReconciler, context ctx.Con
 			}
 			owner := internal.BuildOwnerReference(cluster.TypeMeta, cluster.ObjectMeta)
 			service.ObjectMeta.OwnerReferences = owner
-			err = r.Create(context, service)
+			err = r.Create(ctx, service)
 			if err != nil {
 				return &requeue{curError: err}
 			}
@@ -81,16 +81,16 @@ func (a addServices) reconcile(r *FoundationDBClusterReconciler, context ctx.Con
 			}
 
 			existingService := &corev1.Service{}
-			err = r.Get(context, client.ObjectKey{Namespace: cluster.Namespace, Name: serviceName}, existingService)
+			err = r.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: serviceName}, existingService)
 			if err == nil {
 				// Update the existing service
-				err = updateService(r, context, cluster, existingService, service)
+				err = updateService(r, ctx, cluster, existingService, service)
 				if err != nil {
 					return &requeue{curError: err}
 				}
 			} else if k8serrors.IsNotFound(err) {
 				// Create a new service
-				err = r.Create(context, service)
+				err = r.Create(ctx, service)
 
 				if err != nil {
 					return &requeue{curError: err}

--- a/controllers/add_services_test.go
+++ b/controllers/add_services_test.go
@@ -67,7 +67,7 @@ var _ = Describe("add_services", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = addServices{}.reconcile(clusterReconciler, context.TODO(), cluster)
+		requeue = addServices{}.reconcile(context.TODO(), clusterReconciler, cluster)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -21,7 +21,7 @@
 package controllers
 
 import (
-	ctx "context"
+	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -29,8 +29,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	"golang.org/x/net/context"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 	"github.com/go-logr/logr"
@@ -113,7 +111,7 @@ func (r *FoundationDBBackupReconciler) getDatabaseClientProvider() DatabaseClien
 }
 
 // adminClientForBackup provides an admin client for a backup reconciler.
-func (r *FoundationDBBackupReconciler) adminClientForBackup(context ctx.Context, backup *fdbtypes.FoundationDBBackup) (fdbadminclient.AdminClient, error) {
+func (r *FoundationDBBackupReconciler) adminClientForBackup(context context.Context, backup *fdbtypes.FoundationDBBackup) (fdbadminclient.AdminClient, error) {
 	cluster := &fdbtypes.FoundationDBCluster{}
 	err := r.Get(context, types.NamespacedName{Namespace: backup.ObjectMeta.Namespace, Name: backup.Spec.ClusterName}, cluster)
 	if err != nil {
@@ -169,5 +167,5 @@ type backupSubReconciler interface {
 	If reconciliation cannot proceed, this should return a requeue object with a
 	`Message` field.
 	*/
-	reconcile(r *FoundationDBBackupReconciler, context ctx.Context, backup *fdbtypes.FoundationDBBackup) *requeue
+	reconcile(r *FoundationDBBackupReconciler, context context.Context, backup *fdbtypes.FoundationDBBackup) *requeue
 }

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -28,8 +28,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"context"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
-	"golang.org/x/net/context"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -42,7 +42,7 @@ import (
 type bounceProcesses struct{}
 
 // reconcile runs the reconciler's work.
-func (bounceProcesses) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (bounceProcesses) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "bounceProcesses")
 	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
 	if err != nil {
@@ -87,7 +87,7 @@ func (bounceProcesses) reconcile(r *FoundationDBClusterReconciler, context ctx.C
 		addresses = append(addresses, addressMap[process]...)
 
 		processGroupID := podmanager.GetProcessGroupIDFromProcessID(process)
-		pod, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetSinglePodListOptions(cluster, processGroupID)...)
+		pod, err := r.PodLifecycleManager.GetPods(r, cluster, ctx, internal.GetSinglePodListOptions(cluster, processGroupID)...)
 		if err != nil {
 			return &requeue{curError: err}
 		}
@@ -117,7 +117,7 @@ func (bounceProcesses) reconcile(r *FoundationDBClusterReconciler, context ctx.C
 			r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsBounce",
 				"Spec require a bounce of some processes, but killing processes is disabled")
 			cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
-			err = r.Status().Update(context, cluster)
+			err = r.Status().Update(ctx, cluster)
 			if err != nil {
 				logger.Error(err, "Error updating cluster status")
 			}
@@ -129,7 +129,7 @@ func (bounceProcesses) reconcile(r *FoundationDBClusterReconciler, context ctx.C
 			r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsBounce",
 				fmt.Sprintf("Spec require a bounce of some processes, but the cluster has only been up for %f seconds", minimumUptime))
 			cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
-			err = r.Status().Update(context, cluster)
+			err = r.Status().Update(ctx, cluster)
 			if err != nil {
 				logger.Error(err, "Error updating cluster status")
 			}
@@ -191,7 +191,7 @@ func (bounceProcesses) reconcile(r *FoundationDBClusterReconciler, context ctx.C
 
 	if upgrading {
 		cluster.Status.RunningVersion = cluster.Spec.Version
-		err = r.Status().Update(context, cluster)
+		err = r.Status().Update(ctx, cluster)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/bounce_processes_test.go
+++ b/controllers/bounce_processes_test.go
@@ -54,7 +54,7 @@ var _ = Describe("bounceProcesses", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = bounceProcesses{}.reconcile(clusterReconciler, context.TODO(), cluster)
+		requeue = bounceProcesses{}.reconcile(context.TODO(), clusterReconciler, cluster)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -34,7 +34,7 @@ import (
 type changeCoordinators struct{}
 
 // reconcile runs the reconciler's work.
-func (c changeCoordinators) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (c changeCoordinators) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "changeCoordinators")
 	if !cluster.Status.Configured {
 		return nil
@@ -55,7 +55,7 @@ func (c changeCoordinators) reconcile(r *FoundationDBClusterReconciler, context 
 		logger.Info("Updating out-of-date connection string")
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpdatingConnectionString", fmt.Sprintf("Setting connection string to %s", connectionString))
 		cluster.Status.ConnectionString = connectionString
-		err = r.Status().Update(context, cluster)
+		err = r.Status().Update(ctx, cluster)
 
 		if err != nil {
 			return &requeue{curError: err}
@@ -111,7 +111,7 @@ func (c changeCoordinators) reconcile(r *FoundationDBClusterReconciler, context 
 		return &requeue{curError: err}
 	}
 	cluster.Status.ConnectionString = connectionString
-	err = r.Status().Update(context, cluster)
+	err = r.Status().Update(ctx, cluster)
 	if err != nil {
 		return &requeue{curError: err}
 	}

--- a/controllers/check_client_compatibility.go
+++ b/controllers/check_client_compatibility.go
@@ -36,7 +36,7 @@ import (
 type checkClientCompatibility struct{}
 
 // reconcile runs the reconciler's work.
-func (c checkClientCompatibility) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (c checkClientCompatibility) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "checkClientCompatibility")
 	if !cluster.Status.Configured {
 		return nil

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -33,7 +33,7 @@ import (
 type chooseRemovals struct{}
 
 // reconcile runs the reconciler's work.
-func (c chooseRemovals) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (c chooseRemovals) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "chooseRemovals")
 	hasNewRemovals := false
 
@@ -114,7 +114,7 @@ func (c chooseRemovals) reconcile(r *FoundationDBClusterReconciler, context ctx.
 				processGroup.Remove = true
 			}
 		}
-		err := r.Status().Update(context, cluster)
+		err := r.Status().Update(ctx, cluster)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -55,7 +55,7 @@ var _ = Describe("choose_removals", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = chooseRemovals{}.reconcile(clusterReconciler, context.TODO(), cluster)
+		requeue = chooseRemovals{}.reconcile(context.TODO(), clusterReconciler, cluster)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -21,7 +21,7 @@
 package controllers
 
 import (
-	ctx "context"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -38,8 +38,6 @@ import (
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	"golang.org/x/net/context"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podclient"
@@ -153,7 +151,7 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 		cluster.Spec = *(normalizedSpec.DeepCopy())
 		clusterLog.Info("Attempting to run sub-reconciler", "subReconciler", fmt.Sprintf("%T", subReconciler))
 
-		requeue := subReconciler.reconcile(r, ctx, cluster)
+		requeue := subReconciler.reconcile(ctx, r, cluster)
 		if requeue == nil {
 			continue
 		}
@@ -183,21 +181,21 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 
 // SetupWithManager prepares a reconciler for use.
 func (r *FoundationDBClusterReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int, selector metav1.LabelSelector, watchedObjects ...client.Object) error {
-	err := mgr.GetFieldIndexer().IndexField(ctx.Background(), &corev1.Pod{}, "metadata.name", func(o client.Object) []string {
+	err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, "metadata.name", func(o client.Object) []string {
 		return []string{o.(*corev1.Pod).Name}
 	})
 	if err != nil {
 		return err
 	}
 
-	err = mgr.GetFieldIndexer().IndexField(ctx.Background(), &corev1.Service{}, "metadata.name", func(o client.Object) []string {
+	err = mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Service{}, "metadata.name", func(o client.Object) []string {
 		return []string{o.(*corev1.Service).Name}
 	})
 	if err != nil {
 		return err
 	}
 
-	err = mgr.GetFieldIndexer().IndexField(ctx.Background(), &corev1.PersistentVolumeClaim{}, "metadata.name", func(o client.Object) []string {
+	err = mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.PersistentVolumeClaim{}, "metadata.name", func(o client.Object) []string {
 		return []string{o.(*corev1.PersistentVolumeClaim).Name}
 	})
 	if err != nil {
@@ -346,7 +344,7 @@ func (r *FoundationDBClusterReconciler) takeLock(cluster *fdbtypes.FoundationDBC
 }
 
 // clearPendingRemovalsFromSpec removes the pending removals from the cluster spec.
-func (r *FoundationDBClusterReconciler) clearPendingRemovalsFromSpec(context ctx.Context, cluster *fdbtypes.FoundationDBCluster) error {
+func (r *FoundationDBClusterReconciler) clearPendingRemovalsFromSpec(context context.Context, cluster *fdbtypes.FoundationDBCluster) error {
 	modifiedCluster := cluster.DeepCopy()
 	modifiedCluster.Spec.PendingRemovals = nil
 	return r.Update(context, modifiedCluster)
@@ -368,7 +366,7 @@ type clusterSubReconciler interface {
 	If reconciliation cannot proceed, this should return a requeue object with
 	a `Message` field.
 	*/
-	reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue
+	reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue
 }
 
 // localityInfo captures information about a process for the purposes of

--- a/controllers/delete_pods_for_buggification.go
+++ b/controllers/delete_pods_for_buggification.go
@@ -35,9 +35,9 @@ import (
 type deletePodsForBuggification struct{}
 
 // reconcile runs the reconciler's work.
-func (d deletePodsForBuggification) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (d deletePodsForBuggification) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "deletePodsForBuggification")
-	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, ctx, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &requeue{curError: err}
 	}
@@ -91,7 +91,7 @@ func (d deletePodsForBuggification) reconcile(r *FoundationDBClusterReconciler, 
 		logger.Info("Deleting pods", "count", len(updates))
 		r.Recorder.Event(cluster, "Normal", "UpdatingPods", "Recreating pods for buggification")
 
-		err = r.PodLifecycleManager.UpdatePods(r, context, cluster, updates, true)
+		err = r.PodLifecycleManager.UpdatePods(r, ctx, cluster, updates, true)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/delete_pods_for_buggification_test.go
+++ b/controllers/delete_pods_for_buggification_test.go
@@ -61,7 +61,7 @@ var _ = Describe("delete_pods_for_buggification", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = deletePodsForBuggification{}.reconcile(clusterReconciler, context.TODO(), cluster)
+		requeue = deletePodsForBuggification{}.reconcile(context.TODO(), clusterReconciler, cluster)
 		if requeue != nil {
 			Expect(requeue.curError).NotTo(HaveOccurred())
 		}

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -41,7 +41,7 @@ var missingProcessThreshold = 0.8
 type excludeProcesses struct{}
 
 // reconcile runs the reconciler's work.
-func (e excludeProcesses) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (e excludeProcesses) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
 	if err != nil {
 		return &requeue{curError: err}

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -36,7 +36,7 @@ import (
 type generateInitialClusterFile struct{}
 
 // reconcile runs the reconciler's work.
-func (g generateInitialClusterFile) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (g generateInitialClusterFile) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "generateInitialClusterFile")
 	if cluster.Status.ConnectionString != "" {
 		return nil
@@ -44,7 +44,7 @@ func (g generateInitialClusterFile) reconcile(r *FoundationDBClusterReconciler, 
 
 	logger.Info("Generating initial cluster file")
 	r.Recorder.Event(cluster, corev1.EventTypeNormal, "ChangingCoordinators", "Choosing initial coordinators")
-	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, fdbtypes.ProcessClassStorage, "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, ctx, internal.GetPodListOptions(cluster, fdbtypes.ProcessClassStorage, "")...)
 	if err != nil {
 		return &requeue{curError: err}
 	}
@@ -103,7 +103,7 @@ func (g generateInitialClusterFile) reconcile(r *FoundationDBClusterReconciler, 
 
 	cluster.Status.ConnectionString = connectionString.String()
 
-	err = r.Status().Update(context, cluster)
+	err = r.Status().Update(ctx, cluster)
 	if err != nil {
 		return &requeue{curError: err}
 	}

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -37,7 +37,7 @@ import (
 type removeProcessGroups struct{}
 
 // reconcile runs the reconciler's work.
-func (u removeProcessGroups) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (u removeProcessGroups) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	remainingMap, err := r.getRemainingMap(cluster)
 	if err != nil {
 		return &requeue{curError: err}
@@ -77,8 +77,8 @@ func (u removeProcessGroups) reconcile(r *FoundationDBClusterReconciler, context
 		}
 	}
 
-	removedProcessGroups := r.removeProcessGroups(context, cluster, processGroupsToRemove)
-	err = includeProcessGroup(r, context, cluster, removedProcessGroups)
+	removedProcessGroups := r.removeProcessGroups(ctx, cluster, processGroupsToRemove)
+	err = includeProcessGroup(r, ctx, cluster, removedProcessGroups)
 	if err != nil {
 		return &requeue{curError: err}
 	}

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -52,7 +52,7 @@ var _ = Describe("remove_process_groups", func() {
 	})
 
 	JustBeforeEach(func() {
-		result = removeProcessGroups{}.reconcile(clusterReconciler, context.TODO(), cluster)
+		result = removeProcessGroups{}.reconcile(context.TODO(), clusterReconciler, cluster)
 	})
 
 	When("trying to remove a coordinator", func() {

--- a/controllers/remove_services.go
+++ b/controllers/remove_services.go
@@ -36,13 +36,13 @@ import (
 type removeServices struct{}
 
 // reconcile runs the reconciler's work.
-func (u removeServices) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (u removeServices) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	if internal.GetHeadlessService(cluster) != nil {
 		return nil
 	}
 
 	existingService := &corev1.Service{}
-	err := r.Get(context, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}, existingService)
+	err := r.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}, existingService)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
@@ -50,7 +50,7 @@ func (u removeServices) reconcile(r *FoundationDBClusterReconciler, context ctx.
 		return &requeue{curError: err}
 	}
 
-	err = r.Delete(context, existingService)
+	err = r.Delete(ctx, existingService)
 	if err != nil {
 		return &requeue{curError: err}
 	}

--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -32,7 +32,7 @@ import (
 type replaceFailedProcessGroups struct{}
 
 // reconcile runs the reconciler's work.
-func (c replaceFailedProcessGroups) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (c replaceFailedProcessGroups) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	adminClient, err := r.DatabaseClientProvider.GetAdminClient(cluster, r)
 	if err != nil {
 		return &requeue{curError: err}
@@ -40,7 +40,7 @@ func (c replaceFailedProcessGroups) reconcile(r *FoundationDBClusterReconciler, 
 	defer adminClient.Close()
 
 	if replacements.ReplaceFailedProcessGroups(log, cluster, adminClient) {
-		err := r.Status().Update(context, cluster)
+		err := r.Status().Update(ctx, cluster)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/replace_misconfigured_process_groups.go
+++ b/controllers/replace_misconfigured_process_groups.go
@@ -36,16 +36,16 @@ import (
 type replaceMisconfiguredProcessGroups struct{}
 
 // reconcile runs the reconciler's work.
-func (c replaceMisconfiguredProcessGroups) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (c replaceMisconfiguredProcessGroups) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "replaceMisconfiguredProcessGroups")
 
 	pvcs := &corev1.PersistentVolumeClaimList{}
-	err := r.List(context, pvcs, internal.GetPodListOptions(cluster, "", "")...)
+	err := r.List(ctx, pvcs, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &requeue{curError: err}
 	}
 
-	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, ctx, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &requeue{curError: err}
 	}
@@ -56,7 +56,7 @@ func (c replaceMisconfiguredProcessGroups) reconcile(r *FoundationDBClusterRecon
 	}
 
 	if hasReplacements {
-		err = r.Status().Update(context, cluster)
+		err = r.Status().Update(ctx, cluster)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -21,6 +21,7 @@
 package controllers
 
 import (
+	"context"
 	ctx "context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,8 +30,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	"golang.org/x/net/context"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 	"github.com/go-logr/logr"
@@ -146,5 +145,5 @@ type restoreSubReconciler interface {
 	If reconciliation cannot proceed, this should return a `requeue` object with
 	a `Message` field.
 	*/
-	reconcile(r *FoundationDBRestoreReconciler, context ctx.Context, restore *fdbtypes.FoundationDBRestore) *requeue
+	reconcile(r *FoundationDBRestoreReconciler, context context.Context, restore *fdbtypes.FoundationDBRestore) *requeue
 }

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -25,8 +25,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"context"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/types"
 )
 

--- a/controllers/update_config_map.go
+++ b/controllers/update_config_map.go
@@ -39,17 +39,17 @@ import (
 type updateConfigMap struct{}
 
 // reconcile runs the reconciler's work.
-func (u updateConfigMap) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (u updateConfigMap) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	configMap, err := internal.GetConfigMap(cluster)
 	if err != nil {
 		return &requeue{curError: err}
 	}
 	logger := log.WithValues("namespace", configMap.Namespace, "cluster", cluster.Name, "name", configMap.Name, "reconciler", "UpdateConfigMap")
 	existing := &corev1.ConfigMap{}
-	err = r.Get(context, types.NamespacedName{Namespace: configMap.Namespace, Name: configMap.Name}, existing)
+	err = r.Get(ctx, types.NamespacedName{Namespace: configMap.Namespace, Name: configMap.Name}, existing)
 	if err != nil && k8serrors.IsNotFound(err) {
 		logger.Info("Creating config map")
-		err = r.Create(context, configMap)
+		err = r.Create(ctx, configMap)
 		if err != nil {
 			return &requeue{curError: err}
 		}
@@ -72,7 +72,7 @@ func (u updateConfigMap) reconcile(r *FoundationDBClusterReconciler, context ctx
 		logger.Info("Updating config map")
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpdatingConfigMap", "")
 		existing.Data = configMap.Data
-		err = r.Update(context, existing)
+		err = r.Update(ctx, existing)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -35,7 +35,7 @@ import (
 type updateDatabaseConfiguration struct{}
 
 // reconcile runs the reconciler's work.
-func (u updateDatabaseConfiguration) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (u updateDatabaseConfiguration) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updateDatabaseConfiguration")
 	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
 
@@ -90,7 +90,7 @@ func (u updateDatabaseConfiguration) reconcile(r *FoundationDBClusterReconciler,
 			r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsConfigurationChange",
 				fmt.Sprintf("Spec require configuration change to `%s`, but configuration changes are disabled", configurationString))
 			cluster.Status.Generations.NeedsConfigurationChange = cluster.ObjectMeta.Generation
-			err = r.Status().Update(context, cluster)
+			err = r.Status().Update(ctx, cluster)
 			if err != nil {
 				logger.Error(err, "Error updating cluster status")
 			}
@@ -115,7 +115,7 @@ func (u updateDatabaseConfiguration) reconcile(r *FoundationDBClusterReconciler,
 		}
 		if initialConfig {
 			cluster.Status.Configured = true
-			err = r.Status().Update(context, cluster)
+			err = r.Status().Update(ctx, cluster)
 			if err != nil {
 				return &requeue{curError: err}
 			}

--- a/controllers/update_labels.go
+++ b/controllers/update_labels.go
@@ -34,16 +34,16 @@ import (
 type updateLabels struct{}
 
 // reconcile runs the reconciler's work.
-func (updateLabels) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (updateLabels) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updateLabels")
-	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, ctx, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &requeue{curError: err}
 	}
 	podMap := internal.CreatePodMap(cluster, pods)
 
 	pvcs := &corev1.PersistentVolumeClaimList{}
-	err = r.List(context, pvcs, internal.GetPodListOptions(cluster, "", "")...)
+	err = r.List(ctx, pvcs, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &requeue{curError: err}
 	}
@@ -64,7 +64,7 @@ func (updateLabels) reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 			}
 
 			if !metadataCorrect(metadata, &pod.ObjectMeta) {
-				err = r.PodLifecycleManager.UpdateMetadata(r, context, cluster, pod)
+				err = r.PodLifecycleManager.UpdateMetadata(r, ctx, cluster, pod)
 				if err != nil {
 					return &requeue{curError: err}
 				}
@@ -87,7 +87,7 @@ func (updateLabels) reconcile(r *FoundationDBClusterReconciler, context ctx.Cont
 		}
 
 		if !metadataCorrect(metadata, &pvc.ObjectMeta) {
-			err = r.Update(context, &pvc)
+			err = r.Update(ctx, &pvc)
 			if err != nil {
 				return &requeue{curError: err}
 			}

--- a/controllers/update_lock_configuration.go
+++ b/controllers/update_lock_configuration.go
@@ -31,7 +31,7 @@ import (
 type updateLockConfiguration struct{}
 
 // reconcile runs the reconciler's work.
-func (updateLockConfiguration) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (updateLockConfiguration) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	if len(cluster.Spec.LockOptions.DenyList) == 0 || !cluster.ShouldUseLocks() || !cluster.Status.Configured {
 		return nil
 	}

--- a/controllers/update_lock_configuration_test.go
+++ b/controllers/update_lock_configuration_test.go
@@ -59,7 +59,7 @@ var _ = Describe("update_lock_configuration", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = updateLockConfiguration{}.reconcile(clusterReconciler, context.TODO(), cluster)
+		requeue = updateLockConfiguration{}.reconcile(context.TODO(), clusterReconciler, cluster)
 		if requeue != nil {
 			Expect(requeue.curError).NotTo(HaveOccurred())
 		}

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -37,14 +37,14 @@ import (
 type updatePodConfig struct{}
 
 // reconcile runs the reconciler's work.
-func (updatePodConfig) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (updatePodConfig) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updatePodConfig")
 	configMap, err := internal.GetConfigMap(cluster)
 	if err != nil {
 		return &requeue{curError: err}
 	}
 
-	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, ctx, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &requeue{curError: err}
 	}
@@ -115,7 +115,7 @@ func (updatePodConfig) reconcile(r *FoundationDBClusterReconciler, context ctx.C
 			}
 
 			pod.ObjectMeta.Annotations[fdbtypes.OutdatedConfigMapKey] = fmt.Sprintf("%d", time.Now().Unix())
-			err = r.PodLifecycleManager.UpdateMetadata(r, context, cluster, pod)
+			err = r.PodLifecycleManager.UpdateMetadata(r, ctx, cluster, pod)
 			if err != nil {
 				allSynced = false
 				curLogger.Error(err, "Update Pod ConfigMap annotation")
@@ -126,7 +126,7 @@ func (updatePodConfig) reconcile(r *FoundationDBClusterReconciler, context ctx.C
 
 		pod.ObjectMeta.Annotations[fdbtypes.LastConfigMapKey] = configMapHash
 		delete(pod.ObjectMeta.Annotations, fdbtypes.OutdatedConfigMapKey)
-		err = r.PodLifecycleManager.UpdateMetadata(r, context, cluster, pod)
+		err = r.PodLifecycleManager.UpdateMetadata(r, ctx, cluster, pod)
 		if err != nil {
 			allSynced = false
 			curLogger.Error(err, "Update Pod metadata")
@@ -138,7 +138,7 @@ func (updatePodConfig) reconcile(r *FoundationDBClusterReconciler, context ctx.C
 	}
 
 	if hasUpdate {
-		err = r.Status().Update(context, cluster)
+		err = r.Status().Update(ctx, cluster)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/update_pod_config_test.go
+++ b/controllers/update_pod_config_test.go
@@ -52,7 +52,7 @@ var _ = Describe("updatePodConfig", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = updatePodConfig{}.reconcile(clusterReconciler, context.TODO(), cluster)
+		requeue = updatePodConfig{}.reconcile(context.TODO(), clusterReconciler, cluster)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -21,12 +21,11 @@
 package controllers
 
 import (
-	ctx "context"
+	"context"
 	"fmt"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
 	"github.com/go-logr/logr"
-	"golang.org/x/net/context"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
 
@@ -43,10 +42,10 @@ import (
 type updatePods struct{}
 
 // reconcile runs the reconciler's work.
-func (updatePods) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updatePods")
 
-	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, ctx, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &requeue{curError: err}
 	}
@@ -136,7 +135,7 @@ func (updatePods) reconcile(r *FoundationDBClusterReconciler, context ctx.Contex
 			r.Recorder.Event(cluster, corev1.EventTypeNormal,
 				"NeedsPodsDeletion", "Spec require deleting some pods, but deleting pods is disabled")
 			cluster.Status.Generations.NeedsPodDeletion = cluster.ObjectMeta.Generation
-			err = r.Status().Update(context, cluster)
+			err = r.Status().Update(ctx, cluster)
 			if err != nil {
 				logger.Error(err, "Error updating cluster status")
 			}
@@ -154,7 +153,7 @@ func (updatePods) reconcile(r *FoundationDBClusterReconciler, context ctx.Contex
 		return nil
 	}
 
-	return deletePodsForUpdates(context, r, cluster, adminClient, updates, logger)
+	return deletePodsForUpdates(ctx, r, cluster, adminClient, updates, logger)
 }
 
 func getPodsToDelete(deletionMode fdbtypes.DeletionMode, updates map[string][]*corev1.Pod) (string, []*corev1.Pod, error) {

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -38,9 +38,9 @@ import (
 type updateSidecarVersions struct{}
 
 // reconcile runs the reconciler's work.
-func (updateSidecarVersions) reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (updateSidecarVersions) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updateSidecarVersions")
-	pods, err := r.PodLifecycleManager.GetPods(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
+	pods, err := r.PodLifecycleManager.GetPods(r, cluster, ctx, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &requeue{curError: err}
 	}
@@ -80,7 +80,7 @@ func (updateSidecarVersions) reconcile(r *FoundationDBClusterReconciler, context
 		for containerIndex, container := range pod.Spec.Containers {
 			if container.Name == "foundationdb-kubernetes-sidecar" && container.Image != image {
 				logger.Info("Upgrading sidecar", "processGroupID", podmanager.GetProcessGroupID(cluster, pod), "oldImage", container.Image, "newImage", image)
-				err = r.PodLifecycleManager.UpdateImageVersion(r, context, cluster, pod, containerIndex, image)
+				err = r.PodLifecycleManager.UpdateImageVersion(r, ctx, cluster, pod, containerIndex, image)
 				if err != nil {
 					return &requeue{curError: err}
 				}

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -448,7 +448,7 @@ var _ = Describe("update_status", func() {
 		JustBeforeEach(func() {
 			err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			requeue = updateStatus{}.reconcile(clusterReconciler, context.TODO(), cluster)
+			requeue = updateStatus{}.reconcile(context.TODO(), clusterReconciler, cluster)
 			if requeue != nil {
 				Expect(requeue.curError).NotTo(HaveOccurred())
 			}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
-	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -25,10 +25,11 @@ import (
 	"strings"
 	"time"
 
+	"context"
+
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/kubectl-fdb/cmd/deprecation.go
+++ b/kubectl-fdb/cmd/deprecation.go
@@ -21,15 +21,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
-
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"


### PR DESCRIPTION
# Description

Remove the references to the old context package: https://pkg.go.dev/golang.org/x/net/context and move the context to be the first parameter from the referenced docs:

```
Do not store Contexts inside a struct type; instead, pass a Context explicitly to each function that needs it. The Context should be the first parameter, typically named ctx:
```

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)
# Discussion

*Are there any design details that you would like to discuss further?*

# Testing

Local + unit.

# Documentation

*Did you update relevant documentation within this repository?*

-

# Follow-up

-
