### PR TITLE
Add support for env variables in custom parameters

### DIFF
--- a/internal/monitor_conf.go
+++ b/internal/monitor_conf.go
@@ -255,6 +255,18 @@ func GetMonitorProcessConfiguration(cluster *fdbtypes.FoundationDBCluster, proce
 		}
 		for _, argument := range podSettings.CustomParameters {
 			sanitizedArgument := "--" + equalPattern.ReplaceAllString(argument, "=")
+			parts := strings.Split(sanitizedArgument, "=")
+			if len(parts) == 2 {
+				// We found a env variable here, we will replace that variable with the according value
+				if strings.HasPrefix(parts[1], "$") {
+					configuration.Arguments = append(configuration.Arguments, monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+						{Value: fmt.Sprintf("%s=", parts[0])},
+						{ArgumentType: monitorapi.EnvironmentArgumentType, Source: parts[1][1:]},
+					}})
+					continue
+				}
+			}
+
 			configuration.Arguments = append(configuration.Arguments, monitorapi.Argument{Value: sanitizedArgument})
 		}
 	}

--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -536,7 +536,7 @@ var _ = Describe("pod_models", func() {
 					}}}
 				})
 
-				It("should fill in the process number", func() {
+				It("should fill in the placeholder", func() {
 					podClient, err := NewMockFdbPodClient(cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
 					command, err = GetStartCommand(cluster, processClass, podClient, 2, 3)
@@ -594,7 +594,7 @@ var _ = Describe("pod_models", func() {
 					}}}
 				})
 
-				It("should fill in the process number", func() {
+				It("should fill in the placeholder", func() {
 					podClient, err := NewMockFdbPodClient(cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
 					command, err = GetStartCommand(cluster, processClass, podClient, 1, 1)


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1016

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)
- 
# Discussion

-

# Testing

Unit + local

# Documentation

We should document in another PR that only env variables that are provided as `substitutes` will work.

# Follow-up

-
