### PR TITLE
Fix handling of custom parameters with substitution variables.

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -260,7 +260,7 @@ func (r *FoundationDBClusterReconciler) updatePodDynamicConf(cluster *fdbtypes.F
 
 	imageType := internal.GetImageType(pod)
 	if imageType == internal.FDBImageTypeUnified {
-		config, err := internal.GetMonitorProcessConfiguration(cluster, processClass, serversPerPod, imageType)
+		config, err := internal.GetMonitorProcessConfiguration(cluster, processClass, serversPerPod, imageType, nil)
 		if err != nil {
 			return false, err
 		}

--- a/internal/configmap_helper.go
+++ b/internal/configmap_helper.go
@@ -81,7 +81,7 @@ func GetConfigMap(cluster *v1beta1.FoundationDBCluster) (*corev1.ConfigMap, erro
 		if _, useUnifiedImage := imageTypes[FDBImageTypeUnified]; useUnifiedImage {
 			if processClass == v1beta1.ProcessClassStorage {
 				for _, serversPerPod := range storageServersPerDisk {
-					config, err := GetMonitorProcessConfiguration(cluster, processClass, serversPerPod, FDBImageTypeUnified)
+					config, err := GetMonitorProcessConfiguration(cluster, processClass, serversPerPod, FDBImageTypeUnified, nil)
 					if err != nil {
 						return nil, err
 					}
@@ -93,7 +93,7 @@ func GetConfigMap(cluster *v1beta1.FoundationDBCluster) (*corev1.ConfigMap, erro
 					data[filename] = string(jsonData)
 				}
 			} else {
-				config, err := GetMonitorProcessConfiguration(cluster, processClass, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, processClass, 1, FDBImageTypeUnified, nil)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/configmap_helper_test.go
+++ b/internal/configmap_helper_test.go
@@ -94,7 +94,7 @@ var _ = Describe("configmap_helper", func() {
 				config := monitorapi.ProcessConfiguration{}
 				err = json.Unmarshal([]byte(jsonData), &config)
 				Expect(err).NotTo(HaveOccurred())
-				expectedConfig, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				expectedConfig, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config).To(Equal(expectedConfig))
 			})
@@ -166,7 +166,7 @@ var _ = Describe("configmap_helper", func() {
 					config := monitorapi.ProcessConfiguration{}
 					err = json.Unmarshal([]byte(jsonData), &config)
 					Expect(err).NotTo(HaveOccurred())
-					expectedConfig, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+					expectedConfig, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(config).To(Equal(expectedConfig))
 
@@ -175,7 +175,7 @@ var _ = Describe("configmap_helper", func() {
 					config = monitorapi.ProcessConfiguration{}
 					err = json.Unmarshal([]byte(jsonData), &config)
 					Expect(err).NotTo(HaveOccurred())
-					expectedConfig, err = GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 2, FDBImageTypeUnified)
+					expectedConfig, err = GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 2, FDBImageTypeUnified, nil)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(config).To(Equal(expectedConfig))
 				})

--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -54,7 +54,7 @@ var _ = Describe("pod_models", func() {
 			It("generates conf with an no processes", func() {
 				Expect(cluster).NotTo(BeNil())
 				cluster.Status.ConnectionString = ""
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.RunServers).NotTo(BeNil())
 				Expect(*config.RunServers).To(BeFalse())
@@ -64,7 +64,7 @@ var _ = Describe("pod_models", func() {
 
 		When("running a storage instance", func() {
 			It("generates the conf", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Version).To(Equal(fdbtypes.Versions.Default.String()))
 				Expect(config.BinaryPath).To(BeEmpty())
@@ -100,7 +100,7 @@ var _ = Describe("pod_models", func() {
 
 		When("running a log instance", func() {
 			It("generates the conf", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassLog, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassLog, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Version).To(Equal(fdbtypes.Versions.Default.String()))
 				Expect(config.BinaryPath).To(BeEmpty())
@@ -113,7 +113,7 @@ var _ = Describe("pod_models", func() {
 
 		When("using the split image type", func() {
 			It("generates the conf", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeSplit)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeSplit, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Version).To(Equal(fdbtypes.Versions.Default.String()))
 				Expect(config.BinaryPath).To(BeEmpty())
@@ -149,7 +149,7 @@ var _ = Describe("pod_models", func() {
 
 		When("running multiple processes", func() {
 			It("adds a process ID argument", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 2, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 2, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(config.Arguments[7]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
@@ -165,7 +165,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("includes the process number in the data directory", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 2, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 2, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments[6]).To(Equal(monitorapi.Argument{
 					ArgumentType: monitorapi.ConcatenateArgumentType,
@@ -184,7 +184,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("does not have a listen address", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
@@ -204,7 +204,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("adds a separate listen address", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
@@ -227,7 +227,7 @@ var _ = Describe("pod_models", func() {
 				})
 
 				It("does not have a listen address", func() {
-					config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+					config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 					Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
@@ -248,7 +248,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("includes the TLS flag in the address", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
@@ -269,7 +269,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("includes both addresses", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
@@ -294,7 +294,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("includes both addresses", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
@@ -320,7 +320,7 @@ var _ = Describe("pod_models", func() {
 				})
 
 				It("includes the custom parameters", func() {
-					config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+					config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 					Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{Value: "--knob_disable_posix_kernel_aio=1"}))
@@ -343,7 +343,7 @@ var _ = Describe("pod_models", func() {
 				})
 
 				It("includes the custom parameters for that class", func() {
-					config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+					config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 					Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{Value: "--knob_test=test1"}))
@@ -360,7 +360,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("uses the variable as the zone ID", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 
@@ -377,7 +377,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("includes the verification rules", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{Value: "--tls_verify_peers=S.CN=foundationdb.org"}))
@@ -390,7 +390,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("includes the log group", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(config.Arguments[5]).To(Equal(monitorapi.Argument{Value: "--loggroup=test-fdb-cluster"}))
@@ -403,7 +403,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("adds an argument for the data center", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{Value: "--locality_dcid=dc01"}))
@@ -416,7 +416,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("adds an argument for the data hall", func() {
-				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config, err := GetMonitorProcessConfiguration(cluster, fdbtypes.ProcessClassStorage, 1, FDBImageTypeUnified, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{Value: "--locality_data_hall=dh01"}))
@@ -457,6 +457,34 @@ var _ = Describe("pod_models", func() {
 					fmt.Sprintf("--public_address=%s:4501", address),
 					"--seed_cluster_file=/var/dynamic-conf/fdb.cluster",
 				}, " ")))
+			})
+
+			Context("with custom parameters with substitutions", func() {
+				It("should substitute the variables in the custom parameters", func() {
+					settings := cluster.Spec.Processes["general"]
+					settings.CustomParameters = []string{"locality_disk_id=$FDB_INSTANCE_ID"}
+					cluster.Spec.Processes["general"] = settings
+
+					podClient, err := NewMockFdbPodClient(cluster, pod)
+					Expect(err).NotTo(HaveOccurred())
+					command, err = GetStartCommand(cluster, processClass, podClient, 1, 1)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(command).To(Equal(strings.Join([]string{
+						"/usr/bin/fdbserver",
+						"--class=storage",
+						"--cluster_file=/var/fdb/data/fdb.cluster",
+						"--datadir=/var/fdb/data",
+						fmt.Sprintf("--locality_disk_id=%s", processGroupID),
+						fmt.Sprintf("--locality_instance_id=%s", processGroupID),
+						fmt.Sprintf("--locality_machineid=%s-%s", cluster.Name, processGroupID),
+						fmt.Sprintf("--locality_zoneid=%s-%s", cluster.Name, processGroupID),
+						"--logdir=/var/log/fdb-trace-logs",
+						"--loggroup=" + cluster.Name,
+						fmt.Sprintf("--public_address=%s:4501", address),
+						"--seed_cluster_file=/var/dynamic-conf/fdb.cluster",
+					}, " ")))
+				})
 			})
 		})
 


### PR DESCRIPTION
# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

This fixes the handling of custom parameters with substitution variables.

Fixes #1016 

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

This will only work in old image with the separate sidecar image; it won't work with the unified image. I think that supporting it properly in the new image will require a more complex solution with structured custom parameters, but I wanted to get a fix in for the regression on this feature in the old image.

@johscheuer took a different approach in #1017, but closed that PR without merging it. One difference in the approaches is that this PR will also support custom parameters that have a substitution variable embedded partway through the value, like `locality_custom_id=process-$FDB_INSTANCE_ID`. 

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I added unit tests, and did manual tests in my dev environment.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

# Documentation

*Did you update relevant documentation within this repository?*

No.

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

We should find a way to make this more structured.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.