### PR TITLE
Download FDB assets from GitHub rather than the FDB website.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go
       - name: Get dependencies
-        run: curl --fail "https://github.com/apple/foundationdb/releases/download/${{ matrix.fdbver }}/foundationdb-clients_${{ matrix.fdbver }}-1_amd64.deb" -o fdb.deb
+        run: curl -L --fail "https://github.com/apple/foundationdb/releases/download/${{ matrix.fdbver }}/foundationdb-clients_${{ matrix.fdbver }}-1_amd64.deb" -o fdb.deb
       - name: Install dependencies
         run: sudo dpkg -i fdb.deb
       - name: Run golangci-lint
@@ -67,7 +67,7 @@ jobs:
         os=$(go env GOOS)
         arch=$(go env GOARCH)
         curl --fail -L "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VER}/kubebuilder_${KUBEBUILDER_VER}_${os}_${arch}.tar.gz" -o kubebuilder.tar.gz
-        curl --fail "https://github.com/apple/foundationdb/releases/download/${{ matrix.fdbver }}/foundationdb-clients_${{ matrix.fdbver }}-1_amd64.deb" -o fdb.deb
+        curl --fail -L "https://github.com/apple/foundationdb/releases/download/${{ matrix.fdbver }}/foundationdb-clients_${{ matrix.fdbver }}-1_amd64.deb" -o fdb.deb
         curl -Lo kind https://kind.sigs.k8s.io/dl/${KIND_VER}/kind-linux-amd64
         curl -Lo yq.tar.gz https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz
     - name: Install dependencies

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go
       - name: Get dependencies
-        run: curl --fail "https://www.foundationdb.org/downloads/${{ matrix.fdbver }}/ubuntu/installers/foundationdb-clients_${{ matrix.fdbver }}-1_amd64.deb" -o fdb.deb
+        run: curl --fail "https://github.com/apple/foundationdb/releases/download/${{ matrix.fdbver }}/foundationdb-clients_${{ matrix.fdbver }}-1_amd64.deb" -o fdb.deb
       - name: Install dependencies
         run: sudo dpkg -i fdb.deb
       - name: Run golangci-lint
@@ -67,7 +67,7 @@ jobs:
         os=$(go env GOOS)
         arch=$(go env GOARCH)
         curl --fail -L "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VER}/kubebuilder_${KUBEBUILDER_VER}_${os}_${arch}.tar.gz" -o kubebuilder.tar.gz
-        curl --fail "https://www.foundationdb.org/downloads/${{ matrix.fdbver }}/ubuntu/installers/foundationdb-clients_${{ matrix.fdbver }}-1_amd64.deb" -o fdb.deb
+        curl --fail "https://github.com/apple/foundationdb/releases/download/${{ matrix.fdbver }}/foundationdb-clients_${{ matrix.fdbver }}-1_amd64.deb" -o fdb.deb
         curl -Lo kind https://kind.sigs.k8s.io/dl/${KIND_VER}/kind-linux-amd64
         curl -Lo yq.tar.gz https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz
     - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,12 +55,12 @@ jobs:
         run: |
           go get -v -t -d ./...
           if [[ "${RUNNER_OS}" == "macOS" ]];then
-              curl --fail "https://github.com/apple/foundationdb/releases/download/FoundationDB-${FDB_VER}.pkg" -o fdb.pkg
+              curl --fail -L "https://github.com/apple/foundationdb/releases/download/FoundationDB-${FDB_VER}.pkg" -o fdb.pkg
               sudo installer -allowUntrusted -verbose -pkg ./fdb.pkg -target /
               # required later for calculating the sha256
               brew install coreutils
           else
-              curl --fail "hhttps://github.com/apple/foundationdb/releases/download/${FDB_VER}/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
+              curl --fail -L "https://github.com/apple/foundationdb/releases/download/${FDB_VER}/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
               sudo dpkg -i fdb.deb
           fi
       # - name: Get FDB client (windows-only)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,19 +55,19 @@ jobs:
         run: |
           go get -v -t -d ./...
           if [[ "${RUNNER_OS}" == "macOS" ]];then
-              curl --fail "https://www.foundationdb.org/downloads/${FDB_VER}/macOS/installers/FoundationDB-${FDB_VER}.pkg" -o fdb.pkg
+              curl --fail "https://github.com/apple/foundationdb/releases/download/FoundationDB-${FDB_VER}.pkg" -o fdb.pkg
               sudo installer -allowUntrusted -verbose -pkg ./fdb.pkg -target /
               # required later for calculating the sha256
               brew install coreutils
           else
-              curl --fail "https://www.foundationdb.org/downloads/${FDB_VER}/ubuntu/installers/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
+              curl --fail "hhttps://github.com/apple/foundationdb/releases/download/${FDB_VER}/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
               sudo dpkg -i fdb.deb
           fi
       # - name: Get FDB client (windows-only)
       #   if: runner.os == 'Windows'
       #   shell: powershell
       #   run: |
-      #     Invoke-WebRequest -OutFile fdb.msi -Uri https://www.foundationdb.org/downloads/6.2.28/windows/installers/foundationdb-6.2.28-x64.msi
+      #     Invoke-WebRequest -OutFile fdb.msi -Uri hhttps://github.com/apple/foundationdb/releases/download/6.2.28/foundationdb-6.2.28-x64.msi
       #     msiexec /i "fdb.msi"
       #     go get -v -t -d ./...
       - name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,18 +7,18 @@ FROM docker.io/library/golang:1.16.11 as builder
 
 # Install FDB
 ARG FDB_VERSION=6.2.30
-ARG FDB_WEBSITE=https://www.foundationdb.org
+ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 ARG TAG="latest"
 
 RUN set -eux && \
-	curl --fail ${FDB_WEBSITE}/downloads/${FDB_VERSION}/ubuntu/installers/foundationdb-clients_${FDB_VERSION}-1_amd64.deb -o fdb.deb && \
+	curl --fail -L ${FDB_WEBSITE}/${FDB_VERSION}/foundationdb-clients_${FDB_VERSION}-1_amd64.deb -o fdb.deb && \
 	dpkg -i fdb.deb && rm fdb.deb && \
-	curl --fail $FDB_WEBSITE/downloads/$FDB_VERSION/linux/fdb_$FDB_VERSION.tar.gz -o fdb_$FDB_VERSION.tar.gz && \
-	tar -xzf fdb_$FDB_VERSION.tar.gz --strip-components=1 && \
-	rm fdb_$FDB_VERSION.tar.gz && \
-	chmod u+x fdbbackup fdbcli fdbdr fdbmonitor fdbrestore fdbserver backup_agent dr_agent && \
 	mkdir -p /usr/bin/fdb/${FDB_VERSION%.*} && \
-	mv fdbbackup fdbcli fdbdr fdbmonitor fdbrestore fdbserver backup_agent dr_agent /usr/bin/fdb/${FDB_VERSION%.*} && \
+	for binary in fdbbackup fdbcli; do \
+		download_path=/usr/bin/fdb/${FDB_VERSION%.*}/$binary && \
+		curl --fail -L ${FDB_WEBSITE}/${FDB_VERSION}/$binary.x86_64 -o $download_path && \
+		chmod u+x $download_path; \
+	done && \
 	mkdir -p /usr/lib/fdb
 
 # TODO: Remove the behavior of copying binaries from the FDB images as part of the 1.0 release of the operator.

--- a/docs/backup_spec.md
+++ b/docs/backup_spec.md
@@ -38,7 +38,7 @@ BlobStoreConfiguration describes the blob store configuration.
 | backupName | The name for the backup. If empty defaults to .metadata.name. | string | false |
 | accountName | The account name to use with the backup destination. | string | true |
 | bucket | The backup bucket to write to. The default is \"fdb-backups\". | string | false |
-| urlParameters | Additional URL parameters passed to the blobstore URL. | []string | false |
+| urlParameters | Additional URL parameters passed to the blobstore URL. | []URLParamater | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -311,7 +311,7 @@ FoundationDBClusterStatus defines the observed state of FoundationDBCluster
 | pendingRemovals | PendingRemovals defines the processes that are pending removal. This maps the process group ID to its removal state. **Deprecated: Use ProcessGroups instead.** | map[string][PendingRemovalState](#pendingremovalstate) | false |
 | needsSidecarConfInConfigMap | NeedsSidecarConfInConfigMap determines whether we need to include the sidecar conf in the config map even when the latest version should not require it. | bool | false |
 | storageServersPerDisk | StorageServersPerDisk defines the storageServersPerPod observed in the cluster. If there are more than one value in the slice the reconcile phase is not finished. | []int | false |
-| imageTypes | ImageTypes defines the kinds of images that are in use in the cluster. If there is more than one value in the slice the reconcile phase is not finished. | []string | false |
+| imageTypes | ImageTypes defines the kinds of images that are in use in the cluster. If there is more than one value in the slice the reconcile phase is not finished. | []ImageType | false |
 | processGroups | ProcessGroups contain information about a process group. This information is used in multiple places to trigger the according action. | []*[ProcessGroupStatus](#processgroupstatus) | false |
 | locks | Locks contains information about the locking system. | [LockSystemStatus](#locksystemstatus) | false |
 


### PR DESCRIPTION
# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

This moves the download source for FDB assets to GitHub rather than the FDB website. This is necessary in the short term while the website is under maintenance, but I think we can continue to use GitHub as the source of these assets in the long term. 

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

No.

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I ran a local build of the operator with the new dockerfile.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

We'll need to make sure that the GitHub actions work with the new locations, and we should probably cut a patch release to make sure that process works and get a fully supported release on the 0.49 code.

# Documentation

*Did you update relevant documentation within this repository?*

N/A

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.