### PR TITLE
Don't log missing PVC for stateless processes

### DIFF
--- a/controllers/update_labels.go
+++ b/controllers/update_labels.go
@@ -74,6 +74,11 @@ func (updateLabels) reconcile(ctx ctx.Context, r *FoundationDBClusterReconciler,
 				"processGroupID", processGroup.ProcessGroupID)
 		}
 
+		// We can skip all stateless processes because they won't have a PVC attached.
+		if !processGroup.ProcessClass.IsStateful() {
+			continue
+		}
+
 		pvc, ok := pvcMap[processGroup.ProcessGroupID]
 		if !ok || pod == nil {
 			logger.V(1).Info("Could not find PVC for process group ID",


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1037

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

-

# Testing

local

# Documentation

-

# Follow-up

-
