### PR TITLE
manager: add new cli flag `-watch-namespace`

### DIFF
--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -122,6 +122,9 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-watch-namespace"
+        - "$(WATCH_NAMESPACE)"
         env:
         - name: FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY
           value: /usr/bin/fdb

--- a/config/samples/deployment/manager.yaml
+++ b/config/samples/deployment/manager.yaml
@@ -83,6 +83,9 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-watch-namespace"
+        - "$(WATCH_NAMESPACE)"
         image: foundationdb/fdb-kubernetes-operator:v0.51.0
         name: manager
         env:

--- a/docs/manual/customization.md
+++ b/docs/manual/customization.md
@@ -255,7 +255,7 @@ To run the controller in single-namespace mode, you will need to configure the f
 
 * A service account for the controller
 * The serviceAccountName field in the controller's pod spec
-* A `WATCH_NAMESPACE` environment variable defined in the controller's pod spec or in the arguments of the st
+* A `WATCH_NAMESPACE` environment variable defined in the controller's pod spec or in the arguments of the container command
 * A Role that grants access to the necessary permissions to all of the resources that the controller manages. See the [sample role](https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/samples/deployment/rbac_role.yaml) for the list of those permissions.
 * A RoleBinding that binds that role to the service account for the controller
 

--- a/docs/manual/customization.md
+++ b/docs/manual/customization.md
@@ -247,7 +247,7 @@ Our [sample deployment](https://raw.githubusercontent.com/foundationdb/fdb-kuber
 
 ### Single-Namespace Mode
 
-To use single-namespace mode, set the `WATCH_NAMESPACE` environment variable or the command-line option `-watch-namespace` for the controller to be the namespace where your FDB clusters will run. It does not have to be the same namespace where the operator is running, though this is generally the simplest way to configure it. When you are running in single-namespace mode, the controller will ignore any clusters you try to create in namespaces other than the one you give it. If both options are defined, the environment variable will take precedence.
+To use single-namespace mode, set the `WATCH_NAMESPACE` environment variable or the command-line option `-watch-namespace` for the controller to be the namespace where your FDB clusters will run. It does not have to be the same namespace where the operator is running, though this is generally the simplest way to configure it. When you are running in single-namespace mode, the controller will ignore any clusters you try to create in namespaces other than the one you give it. If both options are defined, the command line argument will be used.
 
 The advantage of single-namespace mode is that it allows owners of different namespaces to run the operator themselves without needing access to other namespaces that may be managed by other tenants. The only cluster-level configuration it requires is the installation of the CRD. The disadvantage of single-namespace mode is that if you are running multiple namespaces for a single team, each namespace will need its own installation of the controller, which can make it more operationally challenging.
 
@@ -276,7 +276,7 @@ To run the controller in global mode, you will need to configure the following t
 
 You can build this kind of configuration easily from the sample deployment by changing the following things:
 
-* Delete the configuration for the `WATCH_NAMESPACE` variable or remove the command line option `-watch-namespace`.
+* Delete the configuration for the `WATCH_NAMESPACE` variable and remove the `-watch-namespace` option from the manager's container start command
 * Change the Roles to ClusterRoles
 * Change the RoleBindings to ClusterRoleBindings
 

--- a/docs/manual/customization.md
+++ b/docs/manual/customization.md
@@ -247,7 +247,7 @@ Our [sample deployment](https://raw.githubusercontent.com/foundationdb/fdb-kuber
 
 ### Single-Namespace Mode
 
-To use single-namespace mode, set the `WATCH_NAMESPACE` environment variable for the controller to be the namespace where your FDB clusters will run. It does not have to be the same namespace where the operator is running, though this is generally the simplest way to configure it. When you are running in single-namespace mode, the controller will ignore any clusters you try to create in namespaces other than the one you give it.
+To use single-namespace mode, set the `WATCH_NAMESPACE` environment variable or the command-line option `-watch-namespace` for the controller to be the namespace where your FDB clusters will run. It does not have to be the same namespace where the operator is running, though this is generally the simplest way to configure it. When you are running in single-namespace mode, the controller will ignore any clusters you try to create in namespaces other than the one you give it. If both options are defined, the environment variable will take precedence.
 
 The advantage of single-namespace mode is that it allows owners of different namespaces to run the operator themselves without needing access to other namespaces that may be managed by other tenants. The only cluster-level configuration it requires is the installation of the CRD. The disadvantage of single-namespace mode is that if you are running multiple namespaces for a single team, each namespace will need its own installation of the controller, which can make it more operationally challenging.
 
@@ -255,7 +255,7 @@ To run the controller in single-namespace mode, you will need to configure the f
 
 * A service account for the controller
 * The serviceAccountName field in the controller's pod spec
-* A `WATCH_NAMESPACE` environment variable defined in the controller's pod spec
+* A `WATCH_NAMESPACE` environment variable defined in the controller's pod spec or in the arguments of the st
 * A Role that grants access to the necessary permissions to all of the resources that the controller manages. See the [sample role](https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/samples/deployment/rbac_role.yaml) for the list of those permissions.
 * A RoleBinding that binds that role to the service account for the controller
 
@@ -263,7 +263,7 @@ The sample deployment provides all of this configuration.
 
 ### Global Mode
 
-To use global mode, omit the `WATCH_NAMESPACE` environment variable for the controller. When you are running in global mode, the controller will watch for changes to FDB clusters in all namespaces, and will manage them all through a single instance of the controller.
+To use global mode, omit the `WATCH_NAMESPACE` environment variable or the `-watch-namespace` command line flag for the controller. When you are running in global mode, the controller will watch for changes to FDB clusters in all namespaces, and will manage them all through a single instance of the controller.
 
 The advantage of global mode is that you can easily add new namespaces without needing to run a new instance of the controller, which limits the per-namespace operational load. The disadvantage of global mode is that it requires the controller to have extensive access to all namespaces in the Kubernetes cluster. In a multi-tenant environment, this means the controller would have to be managed by the team that is adminstering your Kubernetes environment, which may create its own operational concerns.
 
@@ -276,7 +276,7 @@ To run the controller in global mode, you will need to configure the following t
 
 You can build this kind of configuration easily from the sample deployment by changing the following things:
 
-* Delete the configuration for the `WATCH_NAMESPACE` variable
+* Delete the configuration for the `WATCH_NAMESPACE` variable or remove the command line option `-watch-namespace`.
 * Change the Roles to ClusterRoles
 * Change the RoleBindings to ClusterRoleBindings
 

--- a/docs/manual/customization.md
+++ b/docs/manual/customization.md
@@ -263,7 +263,7 @@ The sample deployment provides all of this configuration.
 
 ### Global Mode
 
-To use global mode, omit the `WATCH_NAMESPACE` environment variable or the `-watch-namespace` command line flag for the controller. When you are running in global mode, the controller will watch for changes to FDB clusters in all namespaces, and will manage them all through a single instance of the controller.
+To use global mode, omit the `WATCH_NAMESPACE` environment variable and the `-watch-namespace` command line flag for the controller. When you are running in global mode, the controller will watch for changes to FDB clusters in all namespaces, and will manage them all through a single instance of the controller.
 
 The advantage of global mode is that you can easily add new namespaces without needing to run a new instance of the controller, which limits the per-namespace operational load. The disadvantage of global mode is that it requires the controller to have extensive access to all namespaces in the Kubernetes cluster. In a multi-tenant environment, this means the controller would have to be managed by the team that is adminstering your Kubernetes environment, which may create its own operational concerns.
 

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -68,6 +68,7 @@ type Options struct {
 	CompressOldFiles        bool
 	PrintVersion            bool
 	LabelSelector           string
+	WatchNamespace          string
 }
 
 // BindFlags will parse the given flagset for the operator option flags
@@ -91,6 +92,7 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&o.CompressOldFiles, "compress", false, "Defines whether the rotated log files should be compressed using gzip or not.")
 	fs.BoolVar(&o.PrintVersion, "version", false, "Prints the version of the operator and exits.")
 	fs.StringVar(&o.LabelSelector, "label-selector", "", "Defines a label-selector that will be used to select resources.")
+	fs.StringVar(&o.WatchNamespace, "watch-namespace", "", "Defines which namespace the operator should watch")
 }
 
 // StartManager will start the FoundationDB operator manager.
@@ -146,7 +148,10 @@ func StartManager(
 
 	namespace := os.Getenv("WATCH_NAMESPACE")
 	if namespace != "" {
+		setupLog.Info("WATCH_NAMESPACE env variable will be deprecated.\nPlease use the command line option -watch-namespace instead")
 		options.Namespace = namespace
+	} else if operatorOpts.WatchNamespace != "" {
+		options.Namespace = operatorOpts.WatchNamespace
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -92,7 +92,7 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&o.CompressOldFiles, "compress", false, "Defines whether the rotated log files should be compressed using gzip or not.")
 	fs.BoolVar(&o.PrintVersion, "version", false, "Prints the version of the operator and exits.")
 	fs.StringVar(&o.LabelSelector, "label-selector", "", "Defines a label-selector that will be used to select resources.")
-	fs.StringVar(&o.WatchNamespace, "watch-namespace", "", "Defines which namespace the operator should watch")
+	fs.StringVar(&o.WatchNamespace, "watch-namespace", os.Getenv("WATCH_NAMESPACE"), "Defines which namespace the operator should watch")
 }
 
 // StartManager will start the FoundationDB operator manager.
@@ -146,12 +146,11 @@ func StartManager(
 		Port:               9443,
 	}
 
-	namespace := os.Getenv("WATCH_NAMESPACE")
-	if namespace != "" {
-		setupLog.Info("WATCH_NAMESPACE env variable will be deprecated.\nPlease use the command line option -watch-namespace instead")
-		options.Namespace = namespace
-	} else if operatorOpts.WatchNamespace != "" {
+	if operatorOpts.WatchNamespace != "" {
 		options.Namespace = operatorOpts.WatchNamespace
+		setupLog.Info("Operator starting in single namespace mode", "namespace", options.Namespace)
+	} else {
+		setupLog.Info("Operator starting in Global mode")
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)


### PR DESCRIPTION
# Description

Add new cli flag `-watch-namespace` with same functionality as the `WATCH_NAMESPACE` env variable. For compatibility, I let the env var take precedence if set. 

Addresses issue: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/659


## Type of change

*Please select one of the options below.*
- New feature (non-breaking change which adds functionality)

