### PR TITLE
bump the sample operatior to 0.49.2

### DIFF
--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -129,7 +129,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: foundationdb/fdb-kubernetes-operator:v0.49.2
+        image: foundationdb/fdb-kubernetes-operator:v0.50.0
         name: manager
         ports:
         - containerPort: 8080

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -129,7 +129,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: foundationdb/fdb-kubernetes-operator:v0.49.0
+        image: foundationdb/fdb-kubernetes-operator:v0.49.2
         name: manager
         ports:
         - containerPort: 8080

--- a/helm/fdb-operator/values.yaml
+++ b/helm/fdb-operator/values.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   repository: foundationdb/fdb-kubernetes-operator
-  tag: v0.49.0
+  tag: v0.50.0
   pullPolicy: IfNotPresent
 
 initContainers:


### PR DESCRIPTION


# Description
0.49.0 doesn't exist so bumping the version to 0.49.2
https://hub.docker.com/r/foundationdb/fdb-kubernetes-operator/tags?page=1&name=49

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Testing

`docker pull foundationdb/fdb-kubernetes-operator:v0.49.2`

# Documentation

*Did you update relevant documentation within this repository?*
no updates required
*If this change is adding new functionality, do we need to describe it in our user manual?*
its not
*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*
it's not
*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*
it's not
# Follow-up

*Are there any follow-up issues that we should pursue in the future?*
it'd be nice to make sure image tags in sample deployments are valid
