### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug Report
+description: Report a bug encountered while operating the FDB Kubernetes operator
+labels: bug
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner.
+        For security related issues please contact privately fdb-oss-security@group.apple.com.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How can we reproduce it (as minimally and precisely as possible)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?
+
+  - type: textarea
+    id: fdbOperatorVersion
+    attributes:
+      label: FDB Kubernetes operator
+      value: |
+        <details>
+
+        ```console
+        $ kubectl fdb version
+        # paste output here
+        ```
+
+        </details>
+    validations:
+      required: true
+
+  - type: textarea
+    id: kubeVersion
+    attributes:
+      label: Kubernetes version
+      value: |
+        <details>
+
+        ```console
+        $ kubectl version
+        # paste output here
+        ```
+
+        </details>
+    validations:
+      required: true
+
+  - type: textarea
+    id: cloudProvider
+    attributes:
+      label: Cloud provider
+      value: |
+        <details>
+
+        </details>
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support Request
+    url: https://forums.foundationdb.org/c/using-foundationdb/kubernetes-operator
+    about: Support request or question relating to FDB Kubernetes operator
+  - name: Security Report
+    url: https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/CONTRIBUTING.md#security-issues
+    about: Reports about security issues for the FDB Kubernetes operator.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,14 @@
+name: Enhancement Tracking Issue
+description: Provide supporting details for a feature in development
+labels: enhancement
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added/changed?
+      description: |
+        Check if the requested feature has already a design document in https://github.com/FoundationDB/fdb-kubernetes-operator/tree/main/docs/design.
+        For larger changes consider to create and file a PR with design document and the details about the changes.
+        Please also add some additional context and let us know why this feature is required and should be implemented.
+    validations:
+      required: true


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/735

## Type of change

*Please select one of the options below.*

- Documentation

# Discussion

I think those two templates are a good start and we can add more templates if we identify the need for it.

# Testing

-

# Documentation

-

# Follow-up

-