### PR TITLE
Check if processes are excluded before run exclude command in CanSafelyRemove

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1996,17 +1996,13 @@ func ParseProcessAddressesFromCmdline(cmdline string) ([]ProcessAddress, error) 
 // String gets the string representation of an address.
 func (address ProcessAddress) String() string {
 	if address.Port == 0 {
-		return address.IPAddress.String()
+		return address.MachineAddress()
 	}
 
 	var sb strings.Builder
 	// We have to do this since we are creating a template file for the processes.
 	// The template file will contain variables like POD_IP which is not a valid net.IP :)
-	if address.StringAddress == "" {
-		sb.WriteString(net.JoinHostPort(address.IPAddress.String(), strconv.Itoa(address.Port)))
-	} else {
-		sb.WriteString(net.JoinHostPort(address.StringAddress, strconv.Itoa(address.Port)))
-	}
+	sb.WriteString(net.JoinHostPort(address.MachineAddress(), strconv.Itoa(address.Port)))
 
 	flags := address.SortedFlags()
 
@@ -2021,13 +2017,22 @@ func (address ProcessAddress) String() string {
 	return sb.String()
 }
 
-// StringWithoutFlags gets the string representation of an address without flags.
-func (address ProcessAddress) StringWithoutFlags() string {
-	if address.Port == 0 {
+// MachineAddress returns the machine address, this is the address without any ports.
+func (address ProcessAddress) MachineAddress() string {
+	if address.StringAddress == "" {
 		return address.IPAddress.String()
 	}
 
-	return net.JoinHostPort(address.IPAddress.String(), strconv.Itoa(address.Port))
+	return address.StringAddress
+}
+
+// StringWithoutFlags gets the string representation of an address without flags.
+func (address ProcessAddress) StringWithoutFlags() string {
+	if address.Port == 0 {
+		return address.MachineAddress()
+	}
+
+	return net.JoinHostPort(address.MachineAddress(), strconv.Itoa(address.Port))
 }
 
 // GetFullAddress gets the full public address we should use for a process.

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -364,12 +364,12 @@ func getRemainingAndExcludedFromStatus(status *fdbtypes.FoundationDBStatus, addr
 
 			excludeCheckAddr = append(excludeCheckAddr, addr)
 		}
-	} else {
-		excludeCheckAddr = addresses
-		remaining = make([]fdbtypes.ProcessAddress, 0, len(excludeCheckAddr))
+
+		return excludeCheckAddr, remaining
 	}
 
-	return excludeCheckAddr, remaining
+	// All addresses are excluded
+	return addresses, nil
 }
 
 // CanSafelyRemove checks whether it is safe to remove processes from the


### PR DESCRIPTION
# Description

This change adds support for only checking with the `exclude` command for already excluded addresses if they are fully excluded and if they can be removed from the cluster. Before this change it could happen that we invoked the `CanSafelyRemove` method before an address was excluded in the exclude sub reconciler (which has some additional age checks). In order to be more restrictive and be safer I added a check to only run the exclude command for processes that are marked as excluded in the cluster status.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

# Testing

local testing and I will add some more unit tests.

# Documentation

-

# Follow-up

I will create a design doc for some ideas how to improve the exclusion handling in the operator.
