### PR TITLE
Support container builds for amd64 platform on Apple M1 (#1065)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ ifneq "$(FDB_WEBSITE)" ""
 	img_build_args := $(img_build_args) --build-arg FDB_WEBSITE=$(FDB_WEBSITE)
 endif
 
+# Support overriding the default build platform
+ifneq "$(BUILD_PLATFORM)" ""
+	img_build_args := $(img_build_args) --platform $(BUILD_PLATFORM)
+endif
+
 # TAG is used to define the version in the kubectl-fdb plugin.
 # If not defined we use the current git hash.
 ifndef TAG

--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ To get this controller running in a local Kubernetes cluster:
    `$GOPATH/src/github.com/foundationdb`.
 3. Run `config/test-certs/generate_secrets.bash` to set up a secret with
    self-signed test certs.
-4. Run `make rebuild-operator` to install the operator.
+4. Run `make rebuild-operator` to install the operator. By default, the
+   docker image is built for the platform where this command is executed.
+   To override the platform, for example, to build amd64 image on Apple M1,
+   you can set the BUILD_PLATFORM env variable
+   `BUILD_PLATFORM="linux/amd64" make rebuild-operator`.
 5. Run `kubectl apply -k ./config/tests/base`
    to create a new FoundationDB cluster with the operator.
 


### PR DESCRIPTION
# Description

Support container builds for amd64 platform on Apple M1 (#1065)

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

I have retained the default behavior of building the image for the platform where we run `make rebuild-operator`. This can optionally be overridden by setting the environment variable `BUILD_PLATFORM="linux/amd64" make rebuild-operator`.

# Testing

Tested manually by building amd64 image on Apple M1

# Documentation

Updated README