### PR TITLE
Add slim image

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -105,7 +105,6 @@ jobs:
         make test
   build_images:
     if: github.ref != 'refs/heads/main'
-    needs: build
     name: Push Docker images
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -105,7 +105,7 @@ jobs:
         make test
   build_images:
     if: github.ref != 'refs/heads/main'
-    name: Push Docker images
+    name: Build Docker images
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -105,7 +105,7 @@ jobs:
         # Run the actual tests
         make test
   push_images:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     needs: build
     name: Push Docker images
     runs-on: ubuntu-latest
@@ -118,9 +118,18 @@ jobs:
           - image: fdb-kubernetes-operator
             context: ./
             name: foundationdb/fdb-kubernetes-operator
+            tagSuffix: ""
+            file: ./Dockerfile
+          - image: fdb-kubernetes-operator
+            context: ./
+            name: foundationdb/fdb-kubernetes-operator
+            tagSuffix: -distrolesss
+            file: ./distrolesss.dockerfile
           - image: fdb-data-loader
             context: ./sample-apps/data-loader
             name: foundationdb/fdb-data-loader
+            tagSuffix: ""
+            file: ./foundationdb/fdb-data-loader/Dockerfile
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -137,4 +146,5 @@ jobs:
           build-args: TAG=${GITHUB_SHA}
           push: true
           context: ${{ matrix.context }}
-          tags: ${{ matrix.name }}:latest
+          tags: ${{ matrix.name }}:latest${{ matrix.tag }}
+          file: ${{ matrix.file }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,6 @@ name: Integration checks
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
 
@@ -87,10 +86,6 @@ jobs:
         ./scripts/setup_kind_local_registry.sh ${{ matrix.kubever }}
         tar xvfz yq.tar.gz
         sudo mv ./yq_linux_amd64 /usr/bin/yq
-    - name: Check for uncommitted changes
-      run: |
-        make clean all 
-        git diff --exit-code
     - name: Run tests
       # Currently the default runner has 2 vCPU:
       # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
@@ -104,6 +99,10 @@ jobs:
         kubectl apply -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
         # Run the actual tests
         make test
+    - name: Check for uncommitted changes
+      run: |
+        make clean all
+        git diff --exit-code
   push_images:
     if: github.ref == 'refs/heads/main'
     needs: build
@@ -114,13 +113,14 @@ jobs:
         image:
           - fdb-kubernetes-operator
           - fdb-data-loader
+          - fdb-kubernetes-operator-distroless
         include:
           - image: fdb-kubernetes-operator
             context: ./
             name: foundationdb/fdb-kubernetes-operator
             tagSuffix: ""
             file: ./Dockerfile
-          - image: fdb-kubernetes-operator
+          - image: fdb-kubernetes-operator-distroless
             context: ./
             name: foundationdb/fdb-kubernetes-operator
             tagSuffix: -distrolesss
@@ -146,5 +146,5 @@ jobs:
           build-args: TAG=${GITHUB_SHA}
           push: true
           context: ${{ matrix.context }}
-          tags: ${{ matrix.name }}:latest${{ matrix.tag }}
+          tags: ${{ matrix.name }}:latest${{ matrix.tagSuffix }}
           file: ${{ matrix.file }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -103,6 +103,51 @@ jobs:
       run: |
         make clean all
         git diff --exit-code
+  build_images:
+    if: github.ref != 'refs/heads/main'
+    needs: build
+    name: Push Docker images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - fdb-kubernetes-operator
+          - fdb-data-loader
+          - fdb-kubernetes-operator-distroless
+        include:
+          - image: fdb-kubernetes-operator
+            context: ./
+            name: foundationdb/fdb-kubernetes-operator
+            tagSuffix: ""
+            file: ./Dockerfile
+          - image: fdb-kubernetes-operator-distroless
+            context: ./
+            name: foundationdb/fdb-kubernetes-operator
+            tagSuffix: -distrolesss
+            file: ./distrolesss.dockerfile
+          - image: fdb-data-loader
+            context: ./sample-apps/data-loader
+            name: foundationdb/fdb-data-loader
+            tagSuffix: ""
+            file: ./foundationdb/fdb-data-loader/Dockerfile
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push to registry
+        uses: docker/build-push-action@v2
+        with:
+          build-args: TAG=${GITHUB_SHA}
+          push: false
+          context: ${{ matrix.context }}
+          tags: ${{ matrix.name }}:latest${{ matrix.tagSuffix }}
+          file: ${{ matrix.file }}
   push_images:
     if: github.ref == 'refs/heads/main'
     needs: build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -86,6 +86,10 @@ jobs:
         ./scripts/setup_kind_local_registry.sh ${{ matrix.kubever }}
         tar xvfz yq.tar.gz
         sudo mv ./yq_linux_amd64 /usr/bin/yq
+    - name: Check for uncommitted changes
+      run: |
+        make clean all
+        git diff --exit-code
     - name: Run tests
       # Currently the default runner has 2 vCPU:
       # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
@@ -99,10 +103,6 @@ jobs:
         kubectl apply -f https://raw.githubusercontent.com/FoundationDB/fdb-kubernetes-operator/master/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
         # Run the actual tests
         make test
-    - name: Check for uncommitted changes
-      run: |
-        make clean all
-        git diff --exit-code
   build_images:
     if: github.ref != 'refs/heads/main'
     needs: build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -128,7 +128,7 @@ jobs:
             context: ./sample-apps/data-loader
             name: foundationdb/fdb-data-loader
             tagSuffix: ""
-            file: ./foundationdb/fdb-data-loader/Dockerfile
+            file: ./sample-apps/data-loader/Dockerfile
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -168,7 +168,7 @@ jobs:
             context: ./sample-apps/data-loader
             name: foundationdb/fdb-data-loader
             tagSuffix: ""
-            file: ./foundationdb/fdb-data-loader/Dockerfile
+            file: ./sample-apps/data-loader/Dockerfile
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -134,11 +134,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push to registry
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -134,7 +134,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Build and push to registry
+      - name: Build image
         uses: docker/build-push-action@v2
         with:
           build-args: TAG=${GITHUB_SHA}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Create Release
 on:
   push:
     tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   create-release:
@@ -97,13 +97,23 @@ jobs:
         image:
           - fdb-kubernetes-operator
           - fdb-data-loader
+          - fdb-kubernetes-operator-distroless
         include:
           - image: fdb-kubernetes-operator
             context: ./
             name: foundationdb/fdb-kubernetes-operator
+            tagSuffix: ""
+            file: ./Dockerfile
+          - image: fdb-kubernetes-operator-distroless
+            context: ./
+            name: foundationdb/fdb-kubernetes-operator
+            tagSuffix: -distrolesss
+            file: ./distrolesss.dockerfile
           - image: fdb-data-loader
             context: ./sample-apps/data-loader
             name: foundationdb/fdb-data-loader
+            tagSuffix: ""
+            file: ./foundationdb/fdb-data-loader/Dockerfile
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -123,4 +133,5 @@ jobs:
           build-args: TAG=${{ steps.get_tag.outputs.TAG }}
           push: true
           context: ${{ matrix.context }}
-          tags: ${{ matrix.name }}:${{ steps.get_tag.outputs.TAG }}
+          tags: ${{ matrix.name }}:${{ steps.get_tag.outputs.TAG }}${{ matrix.tagSuffix }}
+          file: ${{ matrix.file }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,7 +113,7 @@ jobs:
             context: ./sample-apps/data-loader
             name: foundationdb/fdb-data-loader
             tagSuffix: ""
-            file: ./foundationdb/fdb-data-loader/Dockerfile
+            file: ./sample-apps/data-loader/Dockerfile
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN groupadd --gid 4059 fdb && \
 	mkdir -p /var/log/fdb && \
 	touch /var/log/fdb/.keep
 
-FROM docker.io/ubuntu:22.04
+FROM docker.io/debian:bullseye
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN groupadd --gid 4059 fdb && \
 	mkdir -p /var/log/fdb && \
 	touch /var/log/fdb/.keep
 
-FROM docker.io/centos:centos8
+FROM docker.io/ubuntu:22.04
 
 WORKDIR /
 

--- a/distrolesss.dockerfile
+++ b/distrolesss.dockerfile
@@ -1,4 +1,5 @@
 FROM docker.io/foundationdb/foundationdb:6.2.30 as fdb62
+FROM docker.io/foundationdb/foundationdb:6.1.13 as fdb61
 FROM docker.io/foundationdb/foundationdb:6.3.22 as fdb63
 
 # Build the manager binary
@@ -24,6 +25,10 @@ RUN set -eux && \
 
 # Copy 6.2 binaries
 COPY --from=fdb62 /usr/bin/fdb* /usr/bin/fdb/6.2/
+
+# Copy 6.1 binaries
+COPY --from=fdb61 /usr/bin/fdb* /usr/bin/fdb/6.1/
+COPY --from=fdb61 /usr/lib/libfdb_c.so /usr/lib/fdb/libfdb_c_6.1.so
 
 # Copy 6.3 binaries
 COPY --from=fdb63 /usr/bin/fdb* /usr/bin/fdb/6.3/
@@ -60,7 +65,7 @@ RUN groupadd --gid 4059 fdb && \
 	mkdir -p /var/log/fdb && \
 	touch /var/log/fdb/.keep
 
-FROM docker.io/centos:centos8
+FROM gcr.io/distroless/base
 
 WORKDIR /
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1067 IO also fixed a bug that the latest image was not published anymore when we changed from `master` to `main`.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

This adds a new slim image (which was the default previously) and the new default image will have centos8 as base image that allows people easier to debug any issues.

# Testing

I currently have some tests running in GitHub and I ensured that the new image runs with centos8

# Documentation

-

# Follow-up

-
