### PR TITLE
Fix the handling of missing processes in status for safe removes

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -333,6 +333,7 @@ func (client *cliAdminClient) GetExclusions() ([]fdbtypes.ProcessAddress, error)
 // The second list contains all addresses that are part of the input list and are not marked as excluded in the cluster, those addresses are not safe to remove.
 func getRemainingAndExcludedFromStatus(status *fdbtypes.FoundationDBStatus, addresses []fdbtypes.ProcessAddress) ([]fdbtypes.ProcessAddress, []fdbtypes.ProcessAddress) {
 	notExcluded := map[string]fdbtypes.None{}
+	visitedAddresses := map[string]fdbtypes.None{}
 	for _, addr := range addresses {
 		notExcluded[addr.MachineAddress()] = fdbtypes.None{}
 	}
@@ -343,6 +344,8 @@ func getRemainingAndExcludedFromStatus(status *fdbtypes.FoundationDBStatus, addr
 			continue
 		}
 
+		// Add to the visited processes
+		visitedAddresses[process.Address.MachineAddress()] = fdbtypes.None{}
 		if !process.Excluded {
 			continue
 		}
@@ -356,8 +359,11 @@ func getRemainingAndExcludedFromStatus(status *fdbtypes.FoundationDBStatus, addr
 		remaining = make([]fdbtypes.ProcessAddress, 0, len(notExcluded))
 
 		for _, addr := range addresses {
-			// Those addresses are not excluded, so it's not safe to remove them
-			if _, ok := notExcluded[addr.MachineAddress()]; ok {
+			// Those addresses are not excluded, so it's not safe to start the exclude command to check
+			// if they are fully excluded. If we didn't visit that address (absent in the cluster status) we assume
+			// it's safe to run the exclude command against it.
+			_, visited := visitedAddresses[addr.MachineAddress()]
+			if _, ok := notExcluded[addr.MachineAddress()]; ok && visited {
 				remaining = append(remaining, addr)
 				continue
 			}

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -156,6 +156,7 @@ var _ = Describe("admin_client_test", func() {
 		addr2 := fdbtypes.NewProcessAddress(net.ParseIP("127.0.0.2"), "", 0, nil)
 		addr3 := fdbtypes.NewProcessAddress(net.ParseIP("127.0.0.3"), "", 0, nil)
 		addr4 := fdbtypes.NewProcessAddress(net.ParseIP("127.0.0.4"), "", 0, nil)
+		addr5 := fdbtypes.NewProcessAddress(net.ParseIP("127.0.0.5"), "", 0, nil)
 
 		DescribeTable("fetching the excluded and ramining processes from the status",
 			func(status *fdbtypes.FoundationDBStatus, addresses []fdbtypes.ProcessAddress, expectedExcluded []fdbtypes.ProcessAddress, expectedRemaining []fdbtypes.ProcessAddress) {
@@ -264,6 +265,31 @@ var _ = Describe("admin_client_test", func() {
 				[]fdbtypes.ProcessAddress{addr1, addr2, addr3, addr4},
 				[]fdbtypes.ProcessAddress{addr1, addr4},
 				[]fdbtypes.ProcessAddress{addr2, addr3},
+			),
+			Entry("when a process is missing",
+				&fdbtypes.FoundationDBStatus{
+					Cluster: fdbtypes.FoundationDBStatusClusterInfo{
+						Processes: map[string]fdbtypes.FoundationDBStatusProcessInfo{
+							"1": {
+								Address:  addr1,
+								Excluded: true,
+							},
+							"2": {
+								Address: addr2,
+							},
+							"3": {
+								Address: addr3,
+							},
+							"4": {
+								Address:  addr4,
+								Excluded: true,
+							},
+						},
+					},
+				},
+				[]fdbtypes.ProcessAddress{addr5},
+				[]fdbtypes.ProcessAddress{addr5},
+				[]fdbtypes.ProcessAddress{},
 			),
 		)
 	})


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1071

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

In the new code was a race condition, when a Pod was deleted and the process was absent from the cluster status we added it to the `notExcludedAddresses` instead we should add missing processes to the `markedAsExcluded` to ensure that those processes data are replicated. This leaves a small risk that a Pod changes it's address and then the process get's excluded even when the operator didn't trigger the exclusion but I think that risk is fairly small and still better than the previous behaviour were we always excluded all processes when we called the `CanSafelyRemove` method.

# Testing

Unit tests + e2e test run.

# Documentation

I create an issue to better document the exclusion process in the operator.

# Follow-up

-
