### PR TITLE
Remove the watch namespace flag from the sample deployment.

### DIFF
--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -120,10 +120,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - args:
-        - -watch-namespace
-        - $(WATCH_NAMESPACE)
-        command:
+      - command:
         - /manager
         env:
         - name: WATCH_NAMESPACE

--- a/config/samples/deployment/manager.yaml
+++ b/config/samples/deployment/manager.yaml
@@ -66,9 +66,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - "-watch-namespace"
-        - "$(WATCH_NAMESPACE)"
         image: foundationdb/fdb-kubernetes-operator:v0.51.0
         name: manager
         env:


### PR DESCRIPTION
# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

This removes a flag from our sample deployments that isn't supported in the last stable release. This flag doesn't have any effect in the context where it was being used, because it was being set to the environment variable that is used as the default when the flag is omitted.

Resolves #1081 

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

I considered changing the version of the operator in the deployment to use the latest tag, but we would want to revert that in the future, and I don't think we need this flag in the sample deployment.

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I manually deployed the config in my local environment.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

# Documentation

*Did you update relevant documentation within this repository?*

No.

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.