### PR TITLE
Pass configured logger into fdbclient

### DIFF
--- a/config/development/debug_logs.yaml
+++ b/config/development/debug_logs.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          args:
+            - --zap-log-level=debug

--- a/config/development/kustomization.yaml
+++ b/config/development/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 patchesStrategicMerge:
 - test_certs.yaml
 - backup_credentials.yaml
+- debug_logs.yaml
 
 resources:
 - ../deployment

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -175,7 +175,7 @@ func StartManager(
 		clusterReconciler.Client = mgr.GetClient()
 		clusterReconciler.Recorder = mgr.GetEventRecorderFor("foundationdbcluster-controller")
 		clusterReconciler.DeprecationOptions = operatorOpts.DeprecationOptions
-		clusterReconciler.DatabaseClientProvider = fdbclient.NewDatabaseClientProvider()
+		clusterReconciler.DatabaseClientProvider = fdbclient.NewDatabaseClientProvider(logger)
 		clusterReconciler.Log = logr.WithName("controllers").WithName("FoundationDBCluster")
 
 		if err := clusterReconciler.SetupWithManager(mgr, operatorOpts.MaxConcurrentReconciles, *labelSelector, watchedObjects...); err != nil {
@@ -191,7 +191,7 @@ func StartManager(
 	if backupReconciler != nil {
 		backupReconciler.Client = mgr.GetClient()
 		backupReconciler.Recorder = mgr.GetEventRecorderFor("foundationdbbackup-controller")
-		backupReconciler.DatabaseClientProvider = fdbclient.NewDatabaseClientProvider()
+		backupReconciler.DatabaseClientProvider = fdbclient.NewDatabaseClientProvider(logger)
 		backupReconciler.Log = logr.WithName("controllers").WithName("FoundationDBBackup")
 
 		if err := backupReconciler.SetupWithManager(mgr, operatorOpts.MaxConcurrentReconciles, *labelSelector); err != nil {
@@ -203,7 +203,7 @@ func StartManager(
 	if restoreReconciler != nil {
 		restoreReconciler.Client = mgr.GetClient()
 		restoreReconciler.Recorder = mgr.GetEventRecorderFor("foundationdbrestore-controller")
-		restoreReconciler.DatabaseClientProvider = fdbclient.NewDatabaseClientProvider()
+		restoreReconciler.DatabaseClientProvider = fdbclient.NewDatabaseClientProvider(logger)
 		restoreReconciler.Log = logr.WithName("controllers").WithName("FoundationDBRestore")
 
 		if err := restoreReconciler.SetupWithManager(mgr, operatorOpts.MaxConcurrentReconciles, *labelSelector); err != nil {


### PR DESCRIPTION
# Description

This removes the creation of a new (not configured) logger in the fdbclient package instead we pass down the configured logger from our setup method. Now the status printout is correctly identified as debug log:

```
{"level":"info","ts":1647165605.8607554,"logger":"fdbclient","msg":"Fetch status from FDB","namespace":"default","cluster":"test-cluster"}
{"level":"debug","ts":1647165605.8626332,"logger":"controller-runtime.manager.events","msg":"Normal","object":{"kind":"FoundationDBCluster","namespace":"default","name":"test-cluster","uid":"876e80a3-d0ac-4174-9b8b-0f101401e9d4","apiVersion":"apps.foundationdb.org/v1beta2","resourceVersion":"662619"},"reason":"RemovingProcesses","message":"Removing pods: []"}
{"level":"debug","ts":1647165606.1626394,"logger":"fdbclient","msg":"Retrieved JSON status","raw":"{\"client\": ... 
```

Before all logs where handled as `info` and printed our irrespective of their actual level. This will reduce the noise for the `info` level.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

# Discussion

-

# Testing

Local.

# Documentation

-

# Follow-up

https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1112
