### PR TITLE
Changes to support coordinator changes when using DNS names

### DIFF
--- a/config/development/images.yaml
+++ b/config/development/images.yaml
@@ -5,6 +5,39 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+        # Install client libraries for unreleased versions of FDB
+        - name: foundationdb-kubernetes-init-7-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.0-rc2-1
+          args:
+            - "--copy-binary"
+            - "fdbcli"
+            - "--copy-binary"
+            - "fdbbackup"
+            - "--copy-binary"
+            - "fdbrestore"
+            - "--output-dir"
+            - "/var/output-files/7.1.0-rc2"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
+        # Install this library in a special location to force the operator to
+        # use it as the primary library.
+        - name: foundationdb-kubernetes-init-7-1-primary
+          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.0-rc2-1
+          args:
+            - "--copy-library"
+            - "7.1"
+            - "--output-dir"
+            - "/var/output-files/primary"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
       containers:
         - name: manager
           imagePullPolicy: IfNotPresent
+          env:
+            - name: LD_LIBRARY_PATH
+              value: /usr/bin/fdb/primary/lib

--- a/config/tests/dns/client.yaml
+++ b/config/tests/dns/client.yaml
@@ -17,7 +17,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: foundationdb-kubernetes-init-7-1
-          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.0-rc1-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.0-rc2-1
           imagePullPolicy: IfNotPresent
           args:
             - "--copy-file"

--- a/config/tests/dns/client.yaml
+++ b/config/tests/dns/client.yaml
@@ -17,7 +17,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: foundationdb-kubernetes-init-7-1
-          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.0-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.0-rc1-1
           imagePullPolicy: IfNotPresent
           args:
             - "--copy-file"
@@ -34,10 +34,8 @@ spec:
               mountPath: /var/output-files
       containers:
         - name: client
-          image: foundationdb/foundationdb-sample-go-app:latest
+          image: foundationdb/foundationdb-sample-python-app:latest
           imagePullPolicy: IfNotPresent
-          command:
-            - /go/bin/fdb-demo-golang
           env:
             - name: FDB_CLUSTER_FILE
               value: /var/dynamic-conf/fdb.cluster
@@ -87,4 +85,4 @@ spec:
   type: LoadBalancer
   ports:
     - port: 9562
-      targetPort: 8080
+      targetPort: 5000

--- a/config/tests/dns/dns.yaml
+++ b/config/tests/dns/dns.yaml
@@ -1,6 +1,6 @@
 - op: add
   path: "/spec/version"
-  value: 7.1.0-rc1
+  value: 7.1.0-rc2
 - op: add
   path: "/spec/routing/useDNSInClusterFile"
   value: true

--- a/config/tests/dns/dns.yaml
+++ b/config/tests/dns/dns.yaml
@@ -1,6 +1,6 @@
 - op: add
   path: "/spec/version"
-  value: 7.1.0
+  value: 7.1.0-rc1
 - op: add
   path: "/spec/routing/useDNSInClusterFile"
   value: true

--- a/config/tests/dns/kustomization.yaml
+++ b/config/tests/dns/kustomization.yaml
@@ -10,7 +10,7 @@ patchesJson6902:
 - path: dns.yaml
   target:
     group: apps.foundationdb.org
-    version: v1beta1
+    version: v1beta2
     kind: FoundationDBCluster
     name: test-cluster
 resources:

--- a/config/tests/tls/kustomization.yaml
+++ b/config/tests/tls/kustomization.yaml
@@ -5,6 +5,6 @@ patchesJson6902:
 - path: tls.yaml
   target:
     group: apps.foundationdb.org
-    version: v1beta1
+    version: v1beta2
     kind: FoundationDBCluster
     name: test-cluster

--- a/config/tests/unified_image/kustomization.yaml
+++ b/config/tests/unified_image/kustomization.yaml
@@ -8,6 +8,6 @@ patchesJson6902:
 - path: images.yaml
   target:
     group: apps.foundationdb.org
-    version: v1beta1
+    version: v1beta2
     kind: FoundationDBCluster
     name: test-cluster


### PR DESCRIPTION
# Description

This changes the way we handle unknown environment variables when evaluating the monitor conf, to handle cases where we want the monitor conf to reference environment variables that haven't been defined on all the pods yet. This comes up in the conversion process for DNS names, because we add a new environment variable to pass the DNS name into the locality config.

This also adds a release candidate version of FDB for use in the DNS name testing, and updates some test cases that were using older builds of the CRD.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Discussion

*Are there any design details that you would like to discuss further?*

The change to the handling of unspecified environment variables may be too broad, and may make it harder to detect problems where we haven't defined environment variables properly. However, the DNS conversion case shows where it can be helpful, and shows that we can safely add new environment variables and reference them in the monitor conf.

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I tested this manually in my local environment, and updated the unit tests to more accurately reflect how the environment variables get rolled out in real environments.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

# Documentation

*Did you update relevant documentation within this repository?*

No.

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.