### PR TITLE
Remove the usage of go get and unused dep

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,18 +12,18 @@
 - Documentation
 - Other
 
-# Discussion
+## Discussion
 
 *Are there any design details that you would like to discuss further?*
 
-# Testing
+## Testing
 
 *Please describe the tests that you ran to verify your changes. Unit tests?
 Manual testing?*
 
 *Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*
 
-# Documentation
+## Documentation
 
 *Did you update relevant documentation within this repository?*
 
@@ -33,7 +33,7 @@ Manual testing?*
 
 *If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*
 
-# Follow-up
+## Follow-up
 
 *Are there any follow-up issues that we should pursue in the future?*
 

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,6 @@ CONTROLLER_GEN_PKG?=sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 KUSTOMIZE_PKG?=sigs.k8s.io/kustomize/kustomize/v3@v3.9.4
 KUSTOMIZE=$(GOBIN)/kustomize
-YQ_PKG?=github.com/mikefarah/yq/v4@v4.13.5
-YQ=$(GOBIN)/yq
 GOLANGCI_LINT_PKG=github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
 GOLANGCI_LINT=$(GOBIN)/golangci-lint
 BUILD_DEPS?=
@@ -43,7 +41,7 @@ BUILD_DEPS+=$(1)
 $($2):
 	(export TMP_DIR=$$$$(mktemp -d) ;\
 	cd $$$$TMP_DIR ;\
-	go get $$($2_PKG) ;\
+	go install $$($2_PKG) ;\
 	cd - ;\
 	rm -rf $$$$TMP_DIR )
 $(1): $$($2)
@@ -52,7 +50,6 @@ endef
 $(eval $(call godep,controller-gen,CONTROLLER_GEN))
 $(eval $(call godep,golangci-lint,GOLANGCI_LINT))
 $(eval $(call godep,kustomize,KUSTOMIZE))
-$(eval $(call godep,yq,YQ))
 
 GO_SRC=$(shell find . -name "*.go" -not -name "zz_generated.*.go")
 GENERATED_GO=api/v1beta2/zz_generated.deepcopy.go

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 ![GitHub](https://img.shields.io/github/license/FoundationDB/fdb-kubernetes-operator)
 [![CI for main branch](https://github.com/FoundationDB/fdb-kubernetes-operator/actions/workflows/pull_request.yml/badge.svg)](https://github.com/FoundationDB/fdb-kubernetes-operator/actions/workflows/pull_request.yml)
 
-This project provides an operator for managing FoundationDB
-clusters on Kubernetes.
+This project provides an operator for managing FoundationDB clusters on Kubernetes.
 
 ## Running the Operator
 
@@ -26,10 +25,10 @@ kubectl apply -f https://raw.githubusercontent.com/foundationdb/fdb-kubernetes-o
 ```
 
 You can see logs from the operator by running
-`kubectl logs -f -l app=fdb-kubernetes-operator-controller-manager --container=manager`. To determine whether the reconciliation has completed, you can run `kubectl get foundationdbcluster my-cluster`. This will show the latest generation of the
+`kubectl logs -f -l app=fdb-kubernetes-operator-controller-manager --container=manager`. To determine whether the reconciliation has completed, you can run `kubectl get foundationdbcluster test-cluster`. This will show the latest generation of the
 spec and the last reconciled generation of the spec. Once reconciliation has completed, these values will be the same.
 
-Once the reconciliation is complete, you can run `kubectl exec -it my-cluster-log-1 -- fdbcli` to open up a CLI on your cluster.
+Once the reconciliation is complete, you can run `kubectl exec -it test-cluster-log-1 -- fdbcli` to open up a CLI on your cluster.
 
 You can also browse the [sample directory](config/samples) for more examples of different resource configurations.
 
@@ -37,36 +36,31 @@ For more information about using the operator, including detailed discussion of 
 
 For more information on version compatibility, see our [compatibility guide](docs/compatibility.md).
 
-For more information on the fields you can define on the cluster resource, see
-the [API documentation](docs/cluster_spec.md).
+For more information on the fields you can define on the cluster resource, see the [API documentation](docs/cluster_spec.md).
 
 ## Local Development
 
 ### Environment Set-up
 
-1. Install GO on your machine, see the [Getting Started](https://golang.org/doc/install) guide for more information.
-2. Install KubeBuilder and its dependencies on your machine, see [The KubeBuilder Book](https://book.kubebuilder.io/quick-start.html) for more information (currently version `2.3.2` is used).
-3. Set your $GOPATH, e.x. `/Users/me/Code/go`.
-4. Install [kustomize](https://github.com/kubernetes-sigs/kustomize).
-5. Install the [foundationDB client package](https://www.foundationdb.org/download).
+1. Install Go on your machine, see the [Getting Started](https://golang.org/doc/install) guide for more information.
+1. Install the required dependencies with `make deps`.
+1. Install the [foundationDB client package](https://www.foundationdb.org/download).
 
 ### Running Locally
 
 To get this controller running in a local Kubernetes cluster:
 
-1. Change your current directory to $GOPATH/src/github.com using the
-   command `cd $GOPATH/src/github.com` and run `mkdir foundationdb`
-   to create the directory `foundationdb`.
-2. CD into the newly created directory and clone this github repo inside
-   `$GOPATH/src/github.com/foundationdb`.
-3. Run `config/test-certs/generate_secrets.bash` to set up a secret with
+1. The assumption is that you have local Kubernetes cluster running.
+   Depending on what solution you use some of the following steps might differ.
+1. Clone this repository onto your local machine.
+1. Run `config/test-certs/generate_secrets.bash` to set up a secret with
    self-signed test certs.
-4. Run `make rebuild-operator` to install the operator. By default, the
-   docker image is built for the platform where this command is executed.
-   To override the platform, for example, to build amd64 image on Apple M1,
-   you can set the BUILD_PLATFORM env variable
+1. Run `make rebuild-operator` to install the operator. By default, the
+   container image is built for the platform where this command is executed.
+   To override the platform, for example, to build an amd64 image on Apple M1,
+   you can set the `BUILD_PLATFORM` env variable
    `BUILD_PLATFORM="linux/amd64" make rebuild-operator`.
-5. Run `kubectl apply -k ./config/tests/base`
+1. Run `kubectl apply -k ./config/tests/base`
    to create a new FoundationDB cluster with the operator.
 
 ### Running locally with nerdctl


### PR DESCRIPTION
# Description

Remove the `go get` command to install our dependencies and update our documentation

## Type of change

*Please select one of the options below.*

- Documentation

# Discussion

-

# Testing

Locally tested `make deps`

# Documentation

-

# Follow-up

-
