### PR TITLE
Run specs in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ GOLANGCI_LINT_PKG=github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
 GOLANGCI_LINT=$(GOBIN)/golangci-lint
 BUILD_DEPS?=
 BUILDER?="docker"
+GINKGO_PARALLEL=8
 
 define godep
 BUILD_DEPS+=$(1)
@@ -82,17 +83,14 @@ clean:
 clean-deps:
 	@rm $(CONTROLLER_GEN) $(KUSTOMIZE) $(KUBEBUILDER) $(GOLANGCI_LINT)
 
-# Run tests
-test:
-ifneq "$(SKIP_TEST)" "1"
-	go test ${go_test_flags} ./... -coverprofile cover.out
-endif
-
 test_if_changed: cover.out
 
+# Run tests
 cover.out: ${GO_ALL} ${MANIFESTS}
+
+test:
 ifneq "$(SKIP_TEST)" "1"
-	go test ${go_test_flags} ./... -coverprofile cover.out -tags test
+	go test ${go_test_flags} ./... -coverprofile cover.out --ginkgo.parallel.total $(GINKGO_PARALLEL)
 endif
 
 # Build manager binary


### PR DESCRIPTION
# Description

Run Ginkgo specs in parallel (not the individual tests):

```bash
time go test -count=1 ./...
?       github.com/FoundationDB/fdb-kubernetes-operator [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1     0.351s
ok      github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2     0.532s
?       github.com/FoundationDB/fdb-kubernetes-operator/cmd/po-docgen   [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/controllers     90.306s
ok      github.com/FoundationDB/fdb-kubernetes-operator/fdbclient       1.325s
ok      github.com/FoundationDB/fdb-kubernetes-operator/internal        0.964s
ok      github.com/FoundationDB/fdb-kubernetes-operator/internal/removals       0.634s
ok      github.com/FoundationDB/fdb-kubernetes-operator/internal/replacements   1.584s
?       github.com/FoundationDB/fdb-kubernetes-operator/kubectl-fdb     [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/kubectl-fdb/cmd 0.605s
ok      github.com/FoundationDB/fdb-kubernetes-operator/mock-kubernetes-client/client   1.214s
?       github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient      [no test files]
?       github.com/FoundationDB/fdb-kubernetes-operator/pkg/podclient   [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager  0.907s
?       github.com/FoundationDB/fdb-kubernetes-operator/setup   [no test files]
gotest -count=1 ./...  119.18s user 6.71s system 134% cpu 1:33.82 total
```

```bash
test -count=1 ./... --ginkgo.parallel.total 8
?       github.com/FoundationDB/fdb-kubernetes-operator [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1     0.609s
ok      github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2     0.355s
?       github.com/FoundationDB/fdb-kubernetes-operator/cmd/po-docgen   [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/controllers     5.447s
ok      github.com/FoundationDB/fdb-kubernetes-operator/fdbclient       1.035s
ok      github.com/FoundationDB/fdb-kubernetes-operator/internal        0.623s
ok      github.com/FoundationDB/fdb-kubernetes-operator/internal/removals       0.902s
ok      github.com/FoundationDB/fdb-kubernetes-operator/internal/replacements   0.785s
?       github.com/FoundationDB/fdb-kubernetes-operator/kubectl-fdb     [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/kubectl-fdb/cmd 0.434s
ok      github.com/FoundationDB/fdb-kubernetes-operator/mock-kubernetes-client/client   0.677s
?       github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient      [no test files]
?       github.com/FoundationDB/fdb-kubernetes-operator/pkg/podclient   [no test files]
ok      github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager  0.900s
?       github.com/FoundationDB/fdb-kubernetes-operator/setup   [no test files]
go test -count=1 ./... --ginkgo.parallel.total 8  22.74s user 4.98s system 323% cpu 8.558 total
```

On my local machine I got a nice improvement from ~90s runtime to ~8s.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

# Discussion

-

# Testing

Locally.

# Documentation

Here is some additional background for ginkgo parallel: https://onsi.github.io/ginkgo/#spec-parallelization

# Follow-up

-
