### PR TITLE
Recreating pods that are not fully excluded.

### DIFF
--- a/docs/manual/technical_design.md
+++ b/docs/manual/technical_design.md
@@ -171,7 +171,7 @@ The `AddPVCs` subreconciler creates any PVCs that are required for the cluster. 
 
 ### AddPods
 
-The `AddPods` subreconciler creates any pods that are required for the cluster. Every process group will have one pod created for it. If a process group is flagged for removal, we will not create a pod for it.
+The `AddPods` subreconciler creates any pods that are required for the cluster. Every process group will have one pod created for it. If a process group is flagged for removal and a previous run of `RemoveProcessGroups` has determined (by submitting the `exclude` command to FoundationDB) that it has in fact been fully excluded from the FoundationDB cluster, we will not create a pod for it. However, if we do not know for certain that the process group is fully excluded from FoundationDB, we will bring it back up even if it is flagged for removal - this is to handle a case where a storage node crashes (or is accidentally stopped) while it is draining.
 
 ### GenerateInitialClusterFile
 


### PR DESCRIPTION
# Description

This fixes #970, which is an issue that can happen when some nodes crash (or are accidentally deleted, as happened in our case) while a cluster is in the process of being scaled down. If one or more of the nodes that crashed had been marked for removal but weren't fully drained before they crashed, we need to bring them back up again so that they can be drained before actually being shut down cleanly.

## Type of change

Bug fix (non-breaking change which fixes an issue).

# Discussion

This implementation of the fix relies on a previous run of the `removeProcessGroups` subreconciler having called `SetExcluded()` on process groups that FDB has confirmed to be fully excluded from the cluster (and saved that status to Kubernetes).

# Testing

- Unit tests (including new tests in `controllers/add_pods_test.go`)
- Initiating a scale-down in a dev FDB cluster and then deleting all the pods, and verifying that all the original storage pods get recreated so that they can be drained before they are actually excluded

# Documentation

Updated the "AddPods" section in `docs/manual/technical_design.md`.

# Follow-up

When #990 has been implemented (and we have upgraded FDB to version 7), we could simply query for the current exclusion status rather than relying on the previous run of the `removeProcessGroups` subreconciler having used the `exclude` command to determine which process groups are actually fully excluded.