### PR TITLE
Make use of goreleaser for plugin

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Install dependencies
         run: sudo dpkg -i fdb.deb
       - name: Run golangci-lint
-        run: |
-          make fmt lint
+        run: make fmt lint
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -49,6 +48,10 @@ jobs:
         go-version: 1.17.6
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Fetch all tags
+      run: git fetch --force --tags
     - uses: actions/cache@v2
       with:
         path: ~/go/pkg/mod

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,63 +31,23 @@ jobs:
           draft: false
           prerelease: false
   release-plugin:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macOS-latest
+    runs-on: ubuntu-latest
     needs: create-release
     steps:
-      - uses: actions/checkout@v2
-      - name: Set package name
-        id: set_package_name
-        run: echo ::set-output name=package_name::kubectl-fdb-${{ needs.create-release.outputs.tag }}-$(echo ${RUNNER_OS} | tr [:upper:] [:lower:])
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch all tags
+        run: git fetch --force --tags
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
           go-version: 1.17.6
-      - name: Get FDB client
-        if: runner.os != 'Windows'
-        env:
-          FDB_VER: "6.2.29"
-        run: |
-          go get -v -t -d ./...
-          if [[ "${RUNNER_OS}" == "macOS" ]];then
-              curl --fail -L "https://github.com/apple/foundationdb/releases/download/${FDB_VER}/FoundationDB-${FDB_VER}.pkg" -o fdb.pkg
-              sudo installer -allowUntrusted -verbose -pkg ./fdb.pkg -target /
-              # required later for calculating the sha256
-              brew install coreutils
-          else
-              curl --fail -L "https://github.com/apple/foundationdb/releases/download/${FDB_VER}/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
-              sudo dpkg -i fdb.deb
-          fi
-      - name: Build
-        run: TAG=${{ needs.create-release.outputs.tag }} make plugin package
-      - name: Test binary
-        run: ./bin/kubectl-fdb version --client-only
-      - name: Create sha256 for assert
-        run: |
-          cp ./bin/kubectl-fdb ${{ steps.set_package_name.outputs.package_name }}
-          sha256sum ${{ steps.set_package_name.outputs.package_name }} > ./bin/${{ steps.set_package_name.outputs.package_name }}.sha256
-      - name: Upload Release asset
-        uses: actions/upload-release-asset@v1
+      - name: Release binaries
+        run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./bin/kubectl-fdb
-          asset_name: ${{ steps.set_package_name.outputs.package_name }}
-          asset_content_type: application/octet-stream
-      - name: Upload sha256 for asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./bin/${{ steps.set_package_name.outputs.package_name }}.sha256
-          asset_name: ${{ steps.set_package_name.outputs.package_name }}.sha256
-          asset_content_type: text/plain
   push_images:
     name: Push Docker images
     needs: create-release

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ config/default/manager_image_patch.yaml-e
 
 # General temp directory
 tmp/
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,36 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - id: kubectl-fdb
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    main: ./kubectl-fdb
+    binary: kubectl-fdb
+    ldflags:
+      - -s -w -X github.com/FoundationDB/fdb-kubernetes-operator/kubectl-fdb/cmd.pluginVersion={{.Version}}
+    goarch:
+      - amd64
+      - arm64
+archives:
+  - id: kubectl-fdb
+    builds:
+    - kubectl-fdb
+    format: binary
+    name_template: "{{ .Binary }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+# TODO(johscheuer): evaluate if we want to use this feature
+changelog:
+  skip: true

--- a/kubectl-fdb/Readme.md
+++ b/kubectl-fdb/Readme.md
@@ -9,9 +9,10 @@ Install from release:
 
 ```bash
 pushd $TMPDIR
-OS=macos
+OS=$(uname)
+ARCH="x86_64"
 VERSION="$(curl -s "https://api.github.com/repos/FoundationDB/fdb-kubernetes-operator/releases/latest" | jq -r '.tag_name')"
-curl -sLo kubectl-fdb "https://github.com/FoundationDB/fdb-kubernetes-operator/releases/download/${VERSION}/kubectl-fdb-${VERSION}-${OS}"
+curl -sLo kubectl-fdb "https://github.com/FoundationDB/fdb-kubernetes-operator/releases/download/${VERSION}/kubectl-fdb_${VERSION}_${OS}_${ARCH}"
 chmod +x kubectl-fdb
 sudo mv ./kubectl-fdb /usr/local/bin
 popd
@@ -22,7 +23,7 @@ In order to install the latest version from the source code run:
 ```bash
 make plugin
 # move the binary into your path
-export PATH="$PATH:$(pwd)/bin" 
+export PATH="${PATH}:$(pwd)/dist/kubectl-fdb_$(go env GOHOSTOS)_$(go env GOARCH)"
 ```
 
 ## Usage


### PR DESCRIPTION
# Description

Make use of go releaser (https://goreleaser.com/).

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/721

This simplifies the release process for the plugin and adds builds for Windows and arm64.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

Example release: https://github.com/johscheuer/fdb-kubernetes-operator/releases/tag/v1.0.3

## Testing

Locally + sample pipeline.

## Documentation

Adjusted.

## Follow-up

-