### PR TITLE
Ensure we delete all resources when a process group is in resource terminating state

### DIFF
--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -338,7 +338,7 @@ func (r *FoundationDBClusterReconciler) removeProcessGroups(ctx context.Context,
 	for _, id := range processGroups {
 		err := removeProcessGroup(ctx, r, cluster, id)
 		if err != nil {
-			logger.Error(err, "Error during remove procress group", "processGroupID", id)
+			logger.Error(err, "Error during remove process group", "processGroupID", id)
 			continue
 		}
 	}
@@ -349,7 +349,7 @@ func (r *FoundationDBClusterReconciler) removeProcessGroups(ctx context.Context,
 	for _, id := range processGroups {
 		removed, include, err := confirmRemoval(ctx, r, cluster, id)
 		if err != nil {
-			logger.Error(err, "Error during confirm procress group removal", "processGroupID", id)
+			logger.Error(err, "Error during confirm process group removal", "processGroupID", id)
 			continue
 		}
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1144

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Local + unit test.

## Documentation

-

## Follow-up

-
