### PR TITLE
Update go version to 1.17.8

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17.6
+          go-version: 1.17.8
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.17.6
+        go-version: 1.17.8
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17.6
+          go-version: 1.17.8
       - name: Release binaries
         run: make release
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.17.6 as builder
+FROM docker.io/library/golang:1.17.8 as builder
 
 # Install FDB this version is only required to compile the fdb operator
 ARG FDB_VERSION=6.3.23

--- a/distrolesss.dockerfile
+++ b/distrolesss.dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.17.6 as builder
+FROM docker.io/library/golang:1.17.8 as builder
 
 # Install FDB this version is only required to compile the fdb operator
 ARG FDB_VERSION=6.3.23


### PR DESCRIPTION
# Description

Updates go to the latest 1.17 version with some security patches.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Locally + unit

## Documentation

-

## Follow-up

-
