### PR TITLE
Add flag to ignore removals

### DIFF
--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -307,11 +307,11 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, clusterName st
 	}
 
 	if ignoreRemovals && len(removedProcessGroups) > 0 {
-		printStatement(cmd, fmt.Sprintf("ignored %d process groups marked for removal", len(removedProcessGroups)), warnMessage)
+		printStatement(cmd, fmt.Sprintf("Ignored %d process groups marked for removal", len(removedProcessGroups)), warnMessage)
 	}
 
 	if ignoredConditions > 0 {
-		printStatement(cmd, fmt.Sprintf("ignored %d conditions", ignoredConditions), warnMessage)
+		printStatement(cmd, fmt.Sprintf("Ignored %d conditions", ignoredConditions), warnMessage)
 	}
 
 	if !processGroupIssue {

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -144,6 +144,10 @@ kubectl fdb analyze --auto-fix sample-cluster-1
 
 # Analyze the cluster "sample-cluster-1" in the current namespace and ignore the IncorrectCommandLine and IncorrectPodSpec condition
 kubectl fdb analyze cluster --ignore-condition=IncorrectCommandLine --ignore-condition=IncorrectPodSpec sample-cluster-1
+
+# Per default the plugin will print out how many process groups are marked for removal instead of printing out each process group.
+# This can be disabled by using the ignore-removals flag to print out the details about process groups that are marked for removal.
+kubectl fdb analyze cluster --ignore-removals=false sample-cluster-1
 `,
 	}
 	cmd.SetOut(o.Out)

--- a/kubectl-fdb/cmd/analyze_test.go
+++ b/kubectl-fdb/cmd/analyze_test.go
@@ -415,7 +415,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 							},
 						},
 					}, &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}),
-					ExpectedErrMsg: "⚠ ignored 1 process groups marked for removal",
+					ExpectedErrMsg: "⚠ Ignored 1 process groups marked for removal",
 					ExpectedStdoutMsg: `Checking cluster: test/test
 ✔ Cluster is available
 ✔ Cluster is fully replicated
@@ -473,7 +473,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
 					}, nil),
-					ExpectedErrMsg: fmt.Sprintf("✖ ProcessGroup: instance-1 has the following condition: MissingProcesses since %s\n⚠ ignored 1 conditions", time.Unix(time.Now().Unix(), 0).String()),
+					ExpectedErrMsg: fmt.Sprintf("✖ ProcessGroup: instance-1 has the following condition: MissingProcesses since %s\n⚠ Ignored 1 conditions", time.Unix(time.Now().Unix(), 0).String()),
 					ExpectedStdoutMsg: `Checking cluster: test/test
 ✔ Cluster is available
 ✔ Cluster is fully replicated


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1068

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

The flag will be enabled by default and the result looks like this:

```bash
$ ./dist/kubectl-fdb_darwin_amd64/kubectl-fdb analyze test-cluster
Checking cluster: default/test-cluster
✔ Cluster is available
✔ Cluster is fully replicated
✔ Cluster is reconciled
⚠ ignored 1 process groups marked for removal
✔ ProcessGroups are all in ready condition
✔ Pods are all running and available
```

## Testing

Local + unit

## Documentation

Added in code.

## Follow-up

-
