### PR TITLE
role count fix

### DIFF
--- a/api/v1beta2/foundationdb_database_configuration.go
+++ b/api/v1beta2/foundationdb_database_configuration.go
@@ -199,11 +199,12 @@ func (configuration DatabaseConfiguration) NormalizeConfiguration() DatabaseConf
 // NormalizeConfigurationWithSeparatedProxies ensures a standardized
 // format and defaults when comparing database configuration in the
 // cluster spec with database configuration in the cluster status,
-// taking into account and if the current running version of FDB
-// supports them and if we need them configured.
+// taking into account if the current running version of FDB supports
+// them and if we need them configured.
 //
-// This will fill in defaults of -1 for some fields that have a default of 0,
-// and will ensure that the region configuration is ordered consistently.
+// This will fill in defaults of -1 for some fields that have a default
+// of 0, and will ensure that the region configuration is ordered
+// consistently.
 func (configuration DatabaseConfiguration) NormalizeConfigurationWithSeparatedProxies(version string, areSeparatedProxiesConfigured bool) DatabaseConfiguration {
 	result := configuration.NormalizeConfiguration()
 

--- a/api/v1beta2/foundationdb_database_configuration.go
+++ b/api/v1beta2/foundationdb_database_configuration.go
@@ -537,7 +537,7 @@ func (configuration DatabaseConfiguration) getRegionPriorities() map[string]int 
 // to 0
 func (configuration DatabaseConfiguration) AreSeparatedProxiesConfigured() bool {
 	counts := configuration.RoleCounts
-	return counts.Proxies == 0 && (counts.GrvProxies > 0 && counts.CommitProxies > 0)
+	return counts.Proxies == 0 && (counts.GrvProxies > 0 || counts.CommitProxies > 0)
 }
 
 // GetProxiesString returns a string that contains the correct fdbcli

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1060,12 +1060,11 @@ func (cluster *FoundationDBCluster) GetProcessCountsWithDefaults() (ProcessCount
 			return *processCounts, err
 		}
 
-		if fdbVersion.HasSeparatedProxies() {
+		if fdbVersion.HasSeparatedProxies() && cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured() {
 			primaryStatelessCount += cluster.calculateProcessCountFromRole(roleCounts.GrvProxies, processCounts.GrvProxy)
 			primaryStatelessCount += cluster.calculateProcessCountFromRole(roleCounts.CommitProxies, processCounts.CommitProxy)
 		} else {
 			primaryStatelessCount += cluster.calculateProcessCountFromRole(roleCounts.Proxies, processCounts.Proxy)
-
 		}
 
 		processCounts.Stateless = cluster.calculateProcessCount(true,
@@ -1468,10 +1467,17 @@ func (config ImageConfig) Image() string {
 // DesiredDatabaseConfiguration builds the database configuration for the
 // cluster based on its spec.
 func (cluster *FoundationDBCluster) DesiredDatabaseConfiguration() DatabaseConfiguration {
-	configuration := cluster.Spec.DatabaseConfiguration.NormalizeConfiguration()
-
+	configuration := cluster.Spec.DatabaseConfiguration.NormalizeConfiguration(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())
 	configuration.RoleCounts = cluster.GetRoleCountsWithDefaults()
 	configuration.RoleCounts.Storage = 0
+
+	if cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured() {
+		configuration.RoleCounts.Proxies = 0
+	} else {
+		configuration.RoleCounts.GrvProxies = 0
+		configuration.RoleCounts.CommitProxies = 0
+	}
+
 	if configuration.StorageEngine == StorageEngineSSD {
 		configuration.StorageEngine = StorageEngineSSD2
 	}

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1467,7 +1467,7 @@ func (config ImageConfig) Image() string {
 // DesiredDatabaseConfiguration builds the database configuration for the
 // cluster based on its spec.
 func (cluster *FoundationDBCluster) DesiredDatabaseConfiguration() DatabaseConfiguration {
-	configuration := cluster.Spec.DatabaseConfiguration.NormalizeConfiguration(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())
+	configuration := cluster.Spec.DatabaseConfiguration.NormalizeConfigurationWithSeparatedProxies(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())
 	configuration.RoleCounts = cluster.GetRoleCountsWithDefaults()
 	configuration.RoleCounts.Storage = 0
 

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -2467,7 +2467,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			It("should set the correct value (-1) for log routers", func() {
 				spec := DatabaseConfiguration{}
 				spec.RemoteLogs = 9
-				normalized := spec.NormalizeConfiguration(version, false)
+				normalized := spec.NormalizeConfigurationWithSeparatedProxies(version, false)
 				Expect(normalized.LogRouters).To(Equal(-1))
 				Expect(normalized.RemoteLogs).To(Equal(9))
 			})
@@ -2515,7 +2515,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 						},
 					},
 				}
-				normalized := spec.NormalizeConfiguration(version, false)
+				normalized := spec.NormalizeConfigurationWithSeparatedProxies(version, false)
 				Expect(normalized.Regions).To(Equal([]Region{
 					{
 						DataCenters: []DataCenter{
@@ -2599,7 +2599,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 						},
 					},
 				}
-				normalized := spec.NormalizeConfiguration(version, false)
+				normalized := spec.NormalizeConfigurationWithSeparatedProxies(version, false)
 				Expect(normalized.Regions).To(Equal([]Region{
 					{
 						DataCenters: []DataCenter{

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -803,7 +803,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}
 			})
 
-			It("should be parsed correctly", func() {
+			It("should be parsed correctly when proxies are set", func() {
 				Expect(cluster.DesiredDatabaseConfiguration()).To(Equal(DatabaseConfiguration{
 					RedundancyMode: RedundancyModeDouble,
 					StorageEngine:  StorageEngineSSD2,
@@ -838,9 +838,85 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 					},
 				}))
 			})
+
+			It("should be parsed correctly when no proxies are set", func() {
+				cluster.Spec.DatabaseConfiguration.RoleCounts.Proxies = 0
+				Expect(cluster.DesiredDatabaseConfiguration()).To(Equal(DatabaseConfiguration{
+					RedundancyMode: RedundancyModeDouble,
+					StorageEngine:  StorageEngineSSD2,
+					UsableRegions:  1,
+					RoleCounts: RoleCounts{
+						Logs:          4,
+						Proxies:       3,
+						CommitProxies: 0,
+						GrvProxies:    0,
+						Resolvers:     1,
+						LogRouters:    -1,
+						RemoteLogs:    -1,
+					},
+				}))
+			})
+
+			It("should be parsed correctly when only grv_proxies are set", func() {
+				cluster.Spec.DatabaseConfiguration.RoleCounts.Proxies = 0
+				cluster.Spec.DatabaseConfiguration.RoleCounts.GrvProxies = 4
+				Expect(cluster.DesiredDatabaseConfiguration()).To(Equal(DatabaseConfiguration{
+					RedundancyMode: RedundancyModeDouble,
+					StorageEngine:  StorageEngineSSD2,
+					UsableRegions:  1,
+					RoleCounts: RoleCounts{
+						Logs:          4,
+						Proxies:       0,
+						CommitProxies: 2,
+						GrvProxies:    4,
+						Resolvers:     1,
+						LogRouters:    -1,
+						RemoteLogs:    -1,
+					},
+				}))
+			})
+
+			It("should be parsed correctly when only grv_proxies are set", func() {
+				cluster.Spec.DatabaseConfiguration.RoleCounts.Proxies = 0
+				cluster.Spec.DatabaseConfiguration.RoleCounts.CommitProxies = 4
+				Expect(cluster.DesiredDatabaseConfiguration()).To(Equal(DatabaseConfiguration{
+					RedundancyMode: RedundancyModeDouble,
+					StorageEngine:  StorageEngineSSD2,
+					UsableRegions:  1,
+					RoleCounts: RoleCounts{
+						Logs:          4,
+						Proxies:       0,
+						CommitProxies: 4,
+						GrvProxies:    1,
+						Resolvers:     1,
+						LogRouters:    -1,
+						RemoteLogs:    -1,
+					},
+				}))
+			})
+
+			It("should be parsed correctly when both grv_proxies/commit_proxies are set", func() {
+				cluster.Spec.DatabaseConfiguration.RoleCounts.Proxies = 0
+				cluster.Spec.DatabaseConfiguration.RoleCounts.CommitProxies = 4
+				cluster.Spec.DatabaseConfiguration.RoleCounts.GrvProxies = 4
+				Expect(cluster.DesiredDatabaseConfiguration()).To(Equal(DatabaseConfiguration{
+					RedundancyMode: RedundancyModeDouble,
+					StorageEngine:  StorageEngineSSD2,
+					UsableRegions:  1,
+					RoleCounts: RoleCounts{
+						Logs:          4,
+						Proxies:       0,
+						CommitProxies: 4,
+						GrvProxies:    4,
+						Resolvers:     1,
+						LogRouters:    -1,
+						RemoteLogs:    -1,
+					},
+				}))
+			})
 		})
 
-		When("the version supports grv and commit proxies", func() {
+		When("the version does not support grv and commit proxies", func() {
 			BeforeEach(func() {
 				cluster = &FoundationDBCluster{
 					ObjectMeta: metav1.ObjectMeta{

--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -91,8 +91,8 @@ var _ = Describe("admin_client_test", func() {
 						RoleCounts: fdbv1beta2.RoleCounts{
 							Logs:          3,
 							Proxies:       3,
-							CommitProxies: 2,
-							GrvProxies:    1,
+							CommitProxies: 0,
+							GrvProxies:    0,
 							Resolvers:     1,
 							LogRouters:    -1,
 							RemoteLogs:    -1,

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -65,7 +65,7 @@ func (u updateDatabaseConfiguration) reconcile(ctx context.Context, r *Foundatio
 		return nil
 	}
 
-	currentConfiguration = status.Cluster.DatabaseConfiguration.NormalizeConfiguration(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())
+	currentConfiguration = status.Cluster.DatabaseConfiguration.NormalizeConfigurationWithSeparatedProxies(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())
 	cluster.ClearMissingVersionFlags(&currentConfiguration)
 	needsChange = initialConfig || !reflect.DeepEqual(desiredConfiguration, currentConfiguration)
 

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -65,7 +65,7 @@ func (u updateDatabaseConfiguration) reconcile(ctx context.Context, r *Foundatio
 		return nil
 	}
 
-	currentConfiguration = status.Cluster.DatabaseConfiguration.NormalizeConfiguration()
+	currentConfiguration = status.Cluster.DatabaseConfiguration.NormalizeConfiguration(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())
 	cluster.ClearMissingVersionFlags(&currentConfiguration)
 	needsChange = initialConfig || !reflect.DeepEqual(desiredConfiguration, currentConfiguration)
 

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -104,7 +104,7 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	}
 
 	status.HasListenIPsForAllPods = cluster.NeedsExplicitListenAddress()
-	status.DatabaseConfiguration = databaseStatus.Cluster.DatabaseConfiguration.NormalizeConfiguration(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())
+	status.DatabaseConfiguration = databaseStatus.Cluster.DatabaseConfiguration.NormalizeConfigurationWithSeparatedProxies(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())
 	cluster.ClearMissingVersionFlags(&status.DatabaseConfiguration)
 	status.Configured = cluster.Status.Configured || (databaseStatus.Client.DatabaseStatus.Available && databaseStatus.Cluster.Layers.Error != "configurationMissing")
 

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -104,7 +104,7 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	}
 
 	status.HasListenIPsForAllPods = cluster.NeedsExplicitListenAddress()
-	status.DatabaseConfiguration = databaseStatus.Cluster.DatabaseConfiguration.NormalizeConfiguration()
+	status.DatabaseConfiguration = databaseStatus.Cluster.DatabaseConfiguration.NormalizeConfiguration(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())
 	cluster.ClearMissingVersionFlags(&status.DatabaseConfiguration)
 	status.Configured = cluster.Status.Configured || (databaseStatus.Client.DatabaseStatus.Available && databaseStatus.Cluster.Layers.Error != "configurationMissing")
 


### PR DESCRIPTION
# Description

Fixes  #1150 #1151. 
If proxies are set to 0, then grv_proxies/commit_proxies will be used in the configure string correctly and vice versa. Defaults have been set for all cases and added some extra logic in normalization of the status to account for that so that reconciliation completes.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Testing
Unit tests and local dev environment.
