### PR TITLE
Delay requeue for terminating Pod in update pods

### DIFF
--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -76,7 +76,7 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 		}
 
 		if shouldRequeueDueToTerminatingPod(pod, cluster, processGroup.ProcessGroupID) {
-			return &requeue{message: "Cluster has pod that is pending deletion", delay: podSchedulingDelayDuration}
+			return &requeue{message: "Cluster has pod that is pending deletion", delay: podSchedulingDelayDuration, delayedRequeue: true}
 		}
 
 		_, idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)


### PR DESCRIPTION
# Description

Adding a delay to the requeue if a Pod is in the terminating state. We already do this for the deletion step but we didn't added this for the terminating check: https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/controllers/update_pods.go#L237

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

Otherwise this might block any ongoing replacements for no reason.

## Testing

Local + unit test.

## Documentation

-

## Follow-up

-
