### PR TITLE
Remove CGO setting for building the plugin

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,8 +3,6 @@ before:
     - go mod tidy
 builds:
   - id: kubectl-fdb
-    env:
-      - CGO_ENABLED=0
     goos:
       - linux
       - windows


### PR DESCRIPTION
# Description

Remove the CGO env for the plugin, there is no need to build it without CGO.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)r

## Discussion

-

## Testing

Locally.

## Documentation

-

## Follow-up

-
