### PR TITLE
For versions that support grv and commit use grv and commit proxy count if defined

### DIFF
--- a/api/v1beta2/foundationdb_database_configuration.go
+++ b/api/v1beta2/foundationdb_database_configuration.go
@@ -307,6 +307,7 @@ func (configuration *DatabaseConfiguration) GetRoleCountsWithDefaults(version Ve
 			counts.LogRouters = -1
 		}
 	}
+
 	return *counts
 }
 
@@ -552,7 +553,7 @@ func (configuration DatabaseConfiguration) getRegionPriorities() map[string]int 
 // to 0
 func (configuration DatabaseConfiguration) AreSeparatedProxiesConfigured() bool {
 	counts := configuration.RoleCounts
-	return counts.Proxies == 0 && (counts.GrvProxies > 0 || counts.CommitProxies > 0)
+	return counts.GrvProxies > 0 || counts.CommitProxies > 0
 }
 
 // GetProxiesString returns a string that contains the correct fdbcli

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -182,10 +182,7 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2
 
 	podName, processGroupID := GetProcessGroupID(cluster, processClass, idNum)
 
-	versionString := cluster.Status.RunningVersion
-	if versionString == "" {
-		versionString = cluster.Spec.Version
-	}
+	versionString := cluster.GetRunningVersion()
 
 	image, err := GetImage(mainContainer.Image, cluster.Spec.MainContainer.ImageConfigs, versionString)
 	if err != nil {


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1179 this change makes upgrades easier since all three proxies can be defined before upgrading and after the upgrade the more precise definition (grv and commit) of proxies will be used.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Local + unit test

## Documentation

I'll add that in a separate PR to document the upgrade process in general.

## Follow-up

-
