### PR TITLE
If a Pod gets deleted during an upgrade recreate it with the new version

### DIFF
--- a/api/v1beta2/foundationdb_constants.go
+++ b/api/v1beta2/foundationdb_constants.go
@@ -1,0 +1,32 @@
+/*
+ * foundationdb_constants.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1beta2
+
+const (
+	// SidecarContainer is the name of the sidecar container
+	SidecarContainer string = "foundationdb-kubernetes-sidecar"
+	// MainContainer is the name of main container that runs FoundationDB
+	MainContainer string = "foundationdb"
+	// InitContainer is the name of the init container
+	InitContainer string = "foundationdb-kubernetes-init"
+	// SidecarDefaultImage is the name of the default sidecar and init container
+	SidecarDefaultImage string = "foundationdb/foundationdb-kubernetes-sidecar"
+)

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -79,7 +79,7 @@ func (a addPods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler
 			continue
 		}
 
-		idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
+		idNum, err := podmanager.GetProcessGroupIDNumber(processGroup.ProcessGroupID)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -79,7 +79,7 @@ func (a addPods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler
 			continue
 		}
 
-		_, idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
+		idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -48,7 +48,7 @@ func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterR
 	processGroupIDs := make(map[fdbv1beta2.ProcessClass]map[int]bool)
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		processGroupID := processGroup.ProcessGroupID
-		num, err := podmanager.ParseProcessGroupID(processGroupID)
+		num, err := podmanager.GetProcessGroupIDNumber(processGroupID)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -48,7 +48,7 @@ func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterR
 	processGroupIDs := make(map[fdbv1beta2.ProcessClass]map[int]bool)
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		processGroupID := processGroup.ProcessGroupID
-		_, num, err := podmanager.ParseProcessGroupID(processGroupID)
+		num, err := podmanager.ParseProcessGroupID(processGroupID)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/add_pvcs.go
+++ b/controllers/add_pvcs.go
@@ -44,7 +44,7 @@ func (a addPVCs) reconcile(ctx context.Context, r *FoundationDBClusterReconciler
 			continue
 		}
 
-		_, idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
+		idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/add_pvcs.go
+++ b/controllers/add_pvcs.go
@@ -44,7 +44,7 @@ func (a addPVCs) reconcile(ctx context.Context, r *FoundationDBClusterReconciler
 			continue
 		}
 
-		idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
+		idNum, err := podmanager.GetProcessGroupIDNumber(processGroup.ProcessGroupID)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -71,7 +71,7 @@ func (a addServices) reconcile(ctx context.Context, r *FoundationDBClusterReconc
 				continue
 			}
 
-			_, idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
+			idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
 			if err != nil {
 				return &requeue{curError: err}
 			}

--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -71,7 +71,7 @@ func (a addServices) reconcile(ctx context.Context, r *FoundationDBClusterReconc
 				continue
 			}
 
-			idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
+			_, idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
 			if err != nil {
 				return &requeue{curError: err}
 			}

--- a/controllers/admin_client_mock.go
+++ b/controllers/admin_client_mock.go
@@ -210,7 +210,7 @@ func (client *mockAdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, erro
 				CommandLine:   command,
 				Excluded:      excluded,
 				Locality:      locality,
-				Version:       client.Cluster.Status.RunningVersion,
+				Version:       client.Cluster.GetRunningVersion(),
 				UptimeSeconds: 60000,
 				Roles:         fdbRoles,
 			}
@@ -231,7 +231,7 @@ func (client *mockAdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, erro
 				Address:       fullAddress,
 				ProcessClass:  processGroup.ProcessClass,
 				Locality:      locality,
-				Version:       client.Cluster.Status.RunningVersion,
+				Version:       client.Cluster.GetRunningVersion(),
 				UptimeSeconds: 60000,
 			}
 

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -67,6 +67,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 
 	processesToBounce := fdbv1beta2.FilterByConditions(cluster.Status.ProcessGroups, map[fdbv1beta2.ProcessGroupConditionType]bool{
 		fdbv1beta2.IncorrectCommandLine: true,
+		fdbv1beta2.IncorrectPodSpec:     false,
 	}, true)
 
 	addresses := make([]fdbv1beta2.ProcessAddress, 0, len(processesToBounce))

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -67,7 +67,6 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 
 	processesToBounce := fdbv1beta2.FilterByConditions(cluster.Status.ProcessGroups, map[fdbv1beta2.ProcessGroupConditionType]bool{
 		fdbv1beta2.IncorrectCommandLine: true,
-		fdbv1beta2.IncorrectPodSpec:     false,
 	}, true)
 
 	addresses := make([]fdbv1beta2.ProcessAddress, 0, len(processesToBounce))
@@ -110,7 +109,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		return &requeue{message: "Waiting for config map to sync to all pods"}
 	}
 
-	upgrading := cluster.Status.RunningVersion != cluster.Spec.Version
+	upgrading := cluster.IsBeingUpgraded()
 
 	if len(addresses) > 0 {
 		if !pointer.BoolDeref(cluster.Spec.AutomationOptions.KillProcesses, true) {

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1298,7 +1298,7 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, item := range pods.Items {
-					id, err := podmanager.ParseProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
+					id, err := podmanager.GetProcessGroupIDNumber(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
 					Expect(err).NotTo(HaveOccurred())
 
 					hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(cluster, item.Labels), id, nil)
@@ -1437,7 +1437,7 @@ var _ = Describe("cluster_controller", func() {
 					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 					Expect(err).NotTo(HaveOccurred())
 					for _, item := range pods.Items {
-						id, err := podmanager.ParseProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
+						id, err := podmanager.GetProcessGroupIDNumber(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
 						Expect(err).NotTo(HaveOccurred())
 
 						hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(cluster, item.Labels), id, nil)
@@ -1545,7 +1545,7 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, item := range pods.Items {
-					id, err := podmanager.ParseProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
+					id, err := podmanager.GetProcessGroupIDNumber(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
 					Expect(err).NotTo(HaveOccurred())
 
 					hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(cluster, item.Labels), id, nil)

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1298,7 +1298,7 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, item := range pods.Items {
-					_, id, err := podmanager.ParseProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
+					id, err := podmanager.ParseProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
 					Expect(err).NotTo(HaveOccurred())
 
 					hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(cluster, item.Labels), id, nil)
@@ -1437,7 +1437,7 @@ var _ = Describe("cluster_controller", func() {
 					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 					Expect(err).NotTo(HaveOccurred())
 					for _, item := range pods.Items {
-						_, id, err := podmanager.ParseProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
+						id, err := podmanager.ParseProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
 						Expect(err).NotTo(HaveOccurred())
 
 						hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(cluster, item.Labels), id, nil)
@@ -1545,7 +1545,7 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, item := range pods.Items {
-					_, id, err := podmanager.ParseProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
+					id, err := podmanager.ParseProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
 					Expect(err).NotTo(HaveOccurred())
 
 					hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(cluster, item.Labels), id, nil)
@@ -3162,72 +3162,6 @@ var _ = Describe("cluster_controller", func() {
 					"locality_dcid = dc01",
 				}, "\n")))
 			})
-		})
-	})
-
-	Describe("ParseProcessGroupID", func() {
-		Context("with a storage ID", func() {
-			It("can parse the ID", func() {
-				prefix, id, err := podmanager.ParseProcessGroupID("storage-12")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(prefix).To(Equal(fdbv1beta2.ProcessClassStorage))
-				Expect(id).To(Equal(12))
-			})
-		})
-
-		Context("with a cluster controller ID", func() {
-			It("can parse the ID", func() {
-				prefix, id, err := podmanager.ParseProcessGroupID("cluster_controller-3")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(prefix).To(Equal(fdbv1beta2.ProcessClassClusterController))
-				Expect(id).To(Equal(3))
-			})
-		})
-
-		Context("with a custom prefix", func() {
-			It("parses the prefix", func() {
-				prefix, id, err := podmanager.ParseProcessGroupID("dc1-storage-12")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(prefix).To(Equal(fdbv1beta2.ProcessClass("dc1-storage")))
-				Expect(id).To(Equal(12))
-			})
-		})
-
-		Context("with no prefix", func() {
-			It("gives a parsing error", func() {
-				_, _, err := podmanager.ParseProcessGroupID("6")
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("could not parse process group ID 6"))
-			})
-		})
-
-		Context("with no numbers", func() {
-			It("gives a parsing error", func() {
-				_, _, err := podmanager.ParseProcessGroupID("storage")
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("could not parse process group ID storage"))
-			})
-		})
-
-		Context("with a text suffix", func() {
-			It("gives a parsing error", func() {
-				_, _, err := podmanager.ParseProcessGroupID("storage-bad")
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("could not parse process group ID storage-bad"))
-			})
-		})
-	})
-
-	Describe("GetProcessGroupIDFromProcessID", func() {
-		It("can parse a process ID", func() {
-			Expect(podmanager.GetProcessGroupIDFromProcessID("storage-1-1")).To(Equal("storage-1"))
-		})
-		It("can parse a process ID with a prefix", func() {
-			Expect(podmanager.GetProcessGroupIDFromProcessID("dc1-storage-1-1")).To(Equal("dc1-storage-1"))
-		})
-
-		It("can handle a process group ID with no process number", func() {
-			Expect(podmanager.GetProcessGroupIDFromProcessID("storage-2")).To(Equal("storage-2"))
 		})
 	})
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -3051,7 +3051,6 @@ var _ = Describe("cluster_controller", func() {
 		Context("with a version that can use binaries from the main container", func() {
 			BeforeEach(func() {
 				cluster.Spec.Version = fdbv1beta2.Versions.Default.String()
-				cluster.Status.RunningVersion = fdbv1beta2.Versions.Default.String()
 				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
 				Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -42,12 +42,6 @@ const (
 	podSchedulingDelayDuration = 15 * time.Second
 )
 
-// metadataMatches determines if the current metadata on an object matches the
-// metadata specified by the cluster spec.
-func metadataMatches(currentMetadata metav1.ObjectMeta, desiredMetadata metav1.ObjectMeta) bool {
-	return containsAll(currentMetadata.Labels, desiredMetadata.Labels) && containsAll(currentMetadata.Annotations, desiredMetadata.Annotations)
-}
-
 // mergeLabels merges the the labels specified by the operator into
 // on object's metadata.
 //

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -43,7 +43,6 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 	if cluster.IsBeingUpgraded() {
 		return nil
 	}
-
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updatePods")
 
 	pods, err := r.PodLifecycleManager.GetPods(ctx, r, cluster, internal.GetPodListOptions(cluster, "", "")...)

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -39,6 +39,11 @@ type updatePods struct{}
 
 // reconcile runs the reconciler's work.
 func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+	// During an upgrade we don't want to recreate all Pods before we run the new version in the cluster.
+	if cluster.IsBeingUpgraded() {
+		return nil
+	}
+
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updatePods")
 
 	pods, err := r.PodLifecycleManager.GetPods(ctx, r, cluster, internal.GetPodListOptions(cluster, "", "")...)

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -83,7 +83,7 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 			return &requeue{message: "Cluster has pod that is pending deletion", delay: podSchedulingDelayDuration, delayedRequeue: true}
 		}
 
-		idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
+		idNum, err := podmanager.GetProcessGroupIDNumber(processGroup.ProcessGroupID)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -84,7 +84,7 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 			return &requeue{message: "Cluster has pod that is pending deletion", delay: podSchedulingDelayDuration, delayedRequeue: true}
 		}
 
-		_, idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
+		idNum, err := podmanager.ParseProcessGroupID(processGroup.ProcessGroupID)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -503,6 +503,12 @@ func validateProcessGroup(ctx context.Context, r *FoundationDBClusterReconciler,
 		return nil
 	}
 
+	// During an upgrade we only validate if the sidecar image of the Pod was updated to the new sidecar.
+	// We will ignore any further changes made to the Pod Spec that the same time.
+	// The reason behind this is that once we change the version in the cluster spec the GetPodSpec method will return the spec with the new image.
+	// This would lead to a case were the operator can't update the Pods, since we are waiting for the version upgrade, and the restart of cluster
+	// would be blocked by all process groups not having the "correct" Pod spec.
+	// This implies that we can't run Pod spec updates until the upgrade is done.
 	correctPodSpec, err := internal.PodHasCorrectSpec(cluster, processGroupStatus.ProcessClass, processGroupStatus.ProcessGroupID, *pod)
 	if err != nil {
 		return err

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -525,7 +525,7 @@ func validateProcessGroup(ctx context.Context, r *FoundationDBClusterReconciler,
 	if err != nil {
 		return err
 	}
-	idNum, err := podmanager.ParseProcessGroupID(processGroupStatus.ProcessGroupID)
+	idNum, err := podmanager.GetProcessGroupIDNumber(processGroupStatus.ProcessGroupID)
 	if err != nil {
 		return err
 	}

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -303,18 +303,18 @@ func PodHasCorrectSpec(cluster *fdbv1beta2.FoundationDBCluster, pClass fdbv1beta
 		return false, err
 	}
 
-	if cluster.IsBeingUpgraded() {
-		// When a cluster is upgraded we only want to validate that the sidecar is matching to ensure the new binary is
-		// available.
-		desiredSpec, err := GetPodSpec(cluster, pClass, idNum)
-		if err != nil {
-			return false, err
-		}
+	// When a cluster is upgraded we only want to validate that the sidecar is matching to ensure the new binary is
+	// available.
+	desiredSpec, err := GetPodSpec(cluster, pClass, idNum)
+	if err != nil {
+		return false, err
+	}
 
+	if cluster.IsBeingUpgraded() {
 		return GetSidecarImageFromPodSpec(desiredSpec) == GetSidecarImageFromPodSpec(&pod.Spec), nil
 	}
 
-	specHash, err := GetPodSpecHash(cluster, pClass, idNum, nil)
+	specHash, err := GetPodSpecHash(cluster, pClass, idNum, desiredSpec)
 	if err != nil {
 		return false, err
 	}

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -37,17 +37,6 @@ import (
 
 var processClassSanitizationPattern = regexp.MustCompile("[^a-z0-9-]")
 
-const (
-	// SidecarContainer is the name of the sidecar container
-	SidecarContainer string = "foundationdb-kubernetes-sidecar"
-	// MainContainer is the name of main container that runs FoundationDB
-	MainContainer string = "foundationdb"
-	// InitContainer is the name of the init container
-	InitContainer string = "foundationdb-kubernetes-init"
-	// SidecarDefaultImage is the name of the default sidecar and init container
-	SidecarDefaultImage string = "foundationdb/foundationdb-kubernetes-sidecar"
-)
-
 // GetProcessGroupID generates an ID for a process group.
 //
 // This will return the pod name and the processGroupID ID.
@@ -165,9 +154,9 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2
 	var initContainer *corev1.Container
 
 	for index, container := range podSpec.Containers {
-		if container.Name == MainContainer {
+		if container.Name == fdbv1beta2.MainContainer {
 			mainContainer = &podSpec.Containers[index]
-		} else if container.Name == SidecarContainer {
+		} else if container.Name == fdbv1beta2.SidecarContainer {
 			sidecarContainer = &podSpec.Containers[index]
 		}
 	}
@@ -184,7 +173,7 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2
 		initContainer = &corev1.Container{}
 	} else {
 		for index, container := range podSpec.InitContainers {
-			if container.Name == InitContainer {
+			if container.Name == fdbv1beta2.InitContainer {
 				initContainer = &podSpec.InitContainers[index]
 			}
 		}
@@ -557,7 +546,7 @@ func configureSidecarContainer(container *corev1.Container, initMode bool, proce
 	if len(imageConfigs) > 0 {
 		overrides.ImageConfigs = imageConfigs
 	} else {
-		overrides.ImageConfigs = []fdbv1beta2.ImageConfig{{BaseImage: SidecarDefaultImage, TagSuffix: "-1"}}
+		overrides.ImageConfigs = []fdbv1beta2.ImageConfig{{BaseImage: fdbv1beta2.SidecarDefaultImage, TagSuffix: "-1"}}
 	}
 
 	if overrides.EnableTLS && !initMode {
@@ -802,20 +791,20 @@ func GetBackupDeployment(backup *fdbv1beta2.FoundationDBBackup) (*appsv1.Deploym
 	var initContainer *corev1.Container
 
 	for index, container := range podTemplate.Spec.Containers {
-		if container.Name == MainContainer {
+		if container.Name == fdbv1beta2.MainContainer {
 			mainContainer = &podTemplate.Spec.Containers[index]
 		}
 	}
 
 	for index, container := range podTemplate.Spec.InitContainers {
-		if container.Name == InitContainer {
+		if container.Name == fdbv1beta2.InitContainer {
 			initContainer = &podTemplate.Spec.InitContainers[index]
 		}
 	}
 
 	if mainContainer == nil {
 		containers := []corev1.Container{
-			{Name: MainContainer},
+			{Name: fdbv1beta2.MainContainer},
 		}
 		containers = append(containers, podTemplate.Spec.Containers...)
 		mainContainer = &containers[0]
@@ -872,7 +861,7 @@ func GetBackupDeployment(backup *fdbv1beta2.FoundationDBBackup) (*appsv1.Deploym
 	}
 
 	if initContainer == nil {
-		podTemplate.Spec.InitContainers = append(podTemplate.Spec.InitContainers, corev1.Container{Name: InitContainer})
+		podTemplate.Spec.InitContainers = append(podTemplate.Spec.InitContainers, corev1.Container{Name: fdbv1beta2.InitContainer})
 		initContainer = &podTemplate.Spec.InitContainers[0]
 	}
 

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -185,9 +185,7 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2
 
 	podName, processGroupID := GetProcessGroupID(cluster, processClass, idNum)
 
-	versionString := cluster.GetRunningVersion()
-
-	image, err := GetImage(mainContainer.Image, cluster.Spec.MainContainer.ImageConfigs, versionString, false)
+	image, err := GetImage(mainContainer.Image, cluster.Spec.MainContainer.ImageConfigs, cluster.Spec.Version, false)
 	if err != nil {
 		return nil, err
 	}
@@ -271,12 +269,7 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2
 	}
 
 	if useUnifiedImages {
-		sidecarVersionString := cluster.Status.RunningVersion
-		if sidecarVersionString == "" {
-			sidecarVersionString = cluster.Spec.Version
-		}
-
-		sidecarImage, err := GetImage(sidecarContainer.Image, cluster.Spec.MainContainer.ImageConfigs, sidecarVersionString, false)
+		sidecarImage, err := GetImage(sidecarContainer.Image, cluster.Spec.MainContainer.ImageConfigs, cluster.Spec.Version, false)
 		if err != nil {
 			return nil, err
 		}
@@ -285,7 +278,7 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2
 		sidecarContainer.Args = []string{
 			"--mode", "sidecar",
 			"--output-dir", "/var/fdb/shared-binaries",
-			"--main-container-version", versionString,
+			"--main-container-version", cluster.Spec.Version,
 			"--copy-binary", "fdbserver",
 			"--copy-binary", "fdbcli",
 			"--log-path", "/var/log/fdb-trace-logs/monitor.log",
@@ -452,7 +445,7 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2
 // configureSidecarContainerForCluster sets up a sidecar container for a sidecar
 // in the FDB cluster.
 func configureSidecarContainerForCluster(cluster *fdbv1beta2.FoundationDBCluster, podName string, container *corev1.Container, initMode bool, processGroupID string) error {
-	return configureSidecarContainer(container, initMode, processGroupID, podName, cluster.GetRunningVersion(), cluster, cluster.Spec.SidecarContainer.ImageConfigs, false)
+	return configureSidecarContainer(container, initMode, processGroupID, podName, cluster.Spec.Version, cluster, cluster.Spec.SidecarContainer.ImageConfigs, false)
 }
 
 // configureSidecarContainerForBackup sets up a sidecar container for the init

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -262,7 +262,7 @@ var _ = Describe("pod_models", func() {
 
 			It("should have the sidecar container", func() {
 				sidecarContainer := spec.Containers[1]
-				Expect(sidecarContainer.Name).To(Equal(SidecarContainer))
+				Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainer))
 				Expect(sidecarContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
 				Expect(sidecarContainer.Args).To(Equal([]string{
 					"--copy-file",
@@ -387,13 +387,13 @@ var _ = Describe("pod_models", func() {
 
 				It("should have a livenessProbe for the sidecar", func() {
 					sidecarContainer := spec.Containers[1]
-					Expect(sidecarContainer.Name).To(Equal(SidecarContainer))
+					Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainer))
 					Expect(sidecarContainer.LivenessProbe).NotTo(BeNil())
 				})
 
 				It("should not have a livenessProbe for the init container", func() {
 					sidecarContainer := spec.InitContainers[0]
-					Expect(sidecarContainer.Name).To(Equal(InitContainer))
+					Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.InitContainer))
 					Expect(sidecarContainer.LivenessProbe).To(BeNil())
 				})
 			})
@@ -408,13 +408,13 @@ var _ = Describe("pod_models", func() {
 
 				It("should not have a readinessProbe for the sidecar", func() {
 					sidecarContainer := spec.Containers[1]
-					Expect(sidecarContainer.Name).To(Equal(SidecarContainer))
+					Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainer))
 					Expect(sidecarContainer.ReadinessProbe).To(BeNil())
 				})
 
 				It("should not have a readinessProbe for the init container", func() {
 					sidecarContainer := spec.InitContainers[0]
-					Expect(sidecarContainer.Name).To(Equal(InitContainer))
+					Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.InitContainer))
 					Expect(sidecarContainer.ReadinessProbe).To(BeNil())
 				})
 			})
@@ -429,13 +429,13 @@ var _ = Describe("pod_models", func() {
 
 				It("should have a readinessProbe for the sidecar", func() {
 					sidecarContainer := spec.Containers[1]
-					Expect(sidecarContainer.Name).To(Equal(SidecarContainer))
+					Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainer))
 					Expect(sidecarContainer.ReadinessProbe).NotTo(BeNil())
 				})
 
 				It("should not have a readinessProbe for the init container", func() {
 					sidecarContainer := spec.InitContainers[0]
-					Expect(sidecarContainer.Name).To(Equal(InitContainer))
+					Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.InitContainer))
 					Expect(sidecarContainer.ReadinessProbe).To(BeNil())
 				})
 			})
@@ -465,7 +465,7 @@ var _ = Describe("pod_models", func() {
 
 				It("should have the main foundationdb container", func() {
 					mainContainer := spec.Containers[0]
-					Expect(mainContainer.Name).To(Equal(MainContainer))
+					Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainer))
 					Expect(mainContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes:%s", cluster.Spec.Version)))
 					Expect(mainContainer.Command).To(BeNil())
 					Expect(mainContainer.Args).To(Equal([]string{
@@ -1667,10 +1667,10 @@ var _ = Describe("pod_models", func() {
 							Image: "test/foundationdb-kubernetes-sidecar:dummy",
 						}},
 						Containers: []corev1.Container{{
-							Name:  MainContainer,
+							Name:  fdbv1beta2.MainContainer,
 							Image: "test/foundationdb:dummy",
 						}, {
-							Name:  SidecarContainer,
+							Name:  fdbv1beta2.SidecarContainer,
 							Image: "test/foundationdb-kubernetes-sidecar:dummy",
 						}},
 					},
@@ -3189,11 +3189,11 @@ var _ = Describe("pod_models", func() {
 			&corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name:  MainContainer,
+						Name:  fdbv1beta2.MainContainer,
 						Image: "main",
 					},
 					{
-						Name:  SidecarContainer,
+						Name:  fdbv1beta2.SidecarContainer,
 						Image: "sidecar",
 					},
 				},
@@ -3202,7 +3202,7 @@ var _ = Describe("pod_models", func() {
 			&corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name:  MainContainer,
+						Name:  fdbv1beta2.MainContainer,
 						Image: "main",
 					},
 				},
@@ -3230,12 +3230,12 @@ var _ = Describe("pod_models", func() {
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Name:  MainContainer,
+									Name:  fdbv1beta2.MainContainer,
 									Image: "main",
 								},
 								{
-									Name:  SidecarContainer,
-									Image: fmt.Sprintf("%s:%s-1", SidecarDefaultImage, cluster.Spec.Version),
+									Name:  fdbv1beta2.SidecarContainer,
+									Image: fmt.Sprintf("%s:%s-1", fdbv1beta2.SidecarDefaultImage, cluster.Spec.Version),
 								},
 							},
 						},
@@ -3256,12 +3256,12 @@ var _ = Describe("pod_models", func() {
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Name:  MainContainer,
+									Name:  fdbv1beta2.MainContainer,
 									Image: "main",
 								},
 								{
-									Name:  SidecarContainer,
-									Image: fmt.Sprintf("%s:%s-1", SidecarDefaultImage, cluster.Status.RunningVersion),
+									Name:  fdbv1beta2.SidecarContainer,
+									Image: fmt.Sprintf("%s:%s-1", fdbv1beta2.SidecarDefaultImage, cluster.Status.RunningVersion),
 								},
 							},
 						},
@@ -3279,16 +3279,3 @@ var _ = Describe("pod_models", func() {
 		})
 	})
 })
-
-/*
-
-add tests:
-
-
-	specHash, err := GetPodSpecHash(cluster, class, idNum, nil)
-	if err != nil {
-		return false, err
-	}
-
-	return MetadataMatches(pod.ObjectMeta, GetPodMetadata(cluster, class, id, specHash)), nil
-*/

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -106,7 +106,7 @@ func processGroupNeedsRemovalForPVC(cluster *fdbv1beta2.FoundationDBCluster, pvc
 		return false, nil
 	}
 
-	idNum, err := internal.ParseProcessGroupID(processGroupID)
+	idNum, err := internal.GetProcessGroupIDNumber(processGroupID)
 	if err != nil {
 		return false, err
 	}
@@ -151,7 +151,7 @@ func processGroupNeedsRemoval(cluster *fdbv1beta2.FoundationDBCluster, pod *core
 		return false, nil
 	}
 
-	idNum, err := internal.ParseProcessGroupID(processGroupID)
+	idNum, err := internal.GetProcessGroupIDNumber(processGroupID)
 	if err != nil {
 		return false, err
 	}

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -202,7 +202,8 @@ func processGroupNeedsRemoval(cluster *fdbv1beta2.FoundationDBCluster, pod *core
 		}
 	}
 
-	if cluster.NeedsReplacement(processGroupStatus) {
+	// Only replace process groups when we are not doing an upgrade.
+	if cluster.NeedsReplacement(processGroupStatus) && !cluster.IsBeingUpgraded() {
 		specHash, err := internal.GetPodSpecHash(cluster, processClass, idNum, nil)
 		if err != nil {
 			return false, err

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -106,7 +106,7 @@ func processGroupNeedsRemovalForPVC(cluster *fdbv1beta2.FoundationDBCluster, pvc
 		return false, nil
 	}
 
-	_, idNum, err := internal.ParseProcessGroupID(processGroupID)
+	idNum, err := internal.ParseProcessGroupID(processGroupID)
 	if err != nil {
 		return false, err
 	}
@@ -151,7 +151,7 @@ func processGroupNeedsRemoval(cluster *fdbv1beta2.FoundationDBCluster, pod *core
 		return false, nil
 	}
 
-	_, idNum, err := internal.ParseProcessGroupID(processGroupID)
+	idNum, err := internal.ParseProcessGroupID(processGroupID)
 	if err != nil {
 		return false, err
 	}

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -295,7 +295,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			It("should not need a removal", func() {
 				processClass := internal.GetProcessClassFromMeta(cluster, pod.ObjectMeta)
 				processGroupID := internal.GetProcessGroupIDFromMeta(cluster, pod.ObjectMeta)
-				_, idNum, err := internal.ParseProcessGroupID(processGroupID)
+				idNum, err := internal.ParseProcessGroupID(processGroupID)
 				Expect(err).NotTo(HaveOccurred())
 				pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey], err = internal.GetPodSpecHash(cluster, processClass, idNum, nil)
 				Expect(err).NotTo(HaveOccurred())

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -295,7 +295,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			It("should not need a removal", func() {
 				processClass := internal.GetProcessClassFromMeta(cluster, pod.ObjectMeta)
 				processGroupID := internal.GetProcessGroupIDFromMeta(cluster, pod.ObjectMeta)
-				idNum, err := internal.ParseProcessGroupID(processGroupID)
+				idNum, err := internal.GetProcessGroupIDNumber(processGroupID)
 				Expect(err).NotTo(HaveOccurred())
 				pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey], err = internal.GetPodSpecHash(cluster, processClass, idNum, nil)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/podmanager/fdb_process_group.go
+++ b/pkg/podmanager/fdb_process_group.go
@@ -34,8 +34,14 @@ import (
 var processIDRegex = regexp.MustCompile(`^([\w-]+-\d)-\d$`)
 
 // ParseProcessGroupID extracts the components of a process group ID.
-func ParseProcessGroupID(id string) (int, error) {
+// Deprecated: This method is deprecated and shouldn't be used. The signature is misleading and the return values should be (string, int ,error).
+func ParseProcessGroupID(id string) (fdbv1beta2.ProcessClass, int, error) {
 	return internal.ParseProcessGroupID(id)
+}
+
+// GetProcessGroupIDNumber extracts the process group ID number from the process group ID string.
+func GetProcessGroupIDNumber(id string) (int, error) {
+	return internal.GetProcessGroupIDNumber(id)
 }
 
 // GetProcessGroupIDFromProcessID returns the process group ID for the process ID

--- a/pkg/podmanager/fdb_process_group.go
+++ b/pkg/podmanager/fdb_process_group.go
@@ -34,7 +34,7 @@ import (
 var processIDRegex = regexp.MustCompile(`^([\w-]+-\d)-\d$`)
 
 // ParseProcessGroupID extracts the components of a process group ID.
-func ParseProcessGroupID(id string) (fdbv1beta2.ProcessClass, int, error) {
+func ParseProcessGroupID(id string) (int, error) {
 	return internal.ParseProcessGroupID(id)
 }
 

--- a/pkg/podmanager/fdb_process_group_test.go
+++ b/pkg/podmanager/fdb_process_group_test.go
@@ -29,7 +29,7 @@ var _ = Describe("fdb_process_group", func() {
 	When("parsing the process group ID", func() {
 		Context("with a storage ID", func() {
 			It("can parse the ID", func() {
-				id, err := ParseProcessGroupID("storage-12")
+				_, id, err := ParseProcessGroupID("storage-12")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(id).To(Equal(12))
 			})
@@ -37,7 +37,7 @@ var _ = Describe("fdb_process_group", func() {
 
 		Context("with a cluster controller ID", func() {
 			It("can parse the ID", func() {
-				id, err := ParseProcessGroupID("cluster_controller-3")
+				_, id, err := ParseProcessGroupID("cluster_controller-3")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(id).To(Equal(3))
 			})
@@ -45,7 +45,7 @@ var _ = Describe("fdb_process_group", func() {
 
 		Context("with a custom prefix", func() {
 			It("parses the prefix", func() {
-				id, err := ParseProcessGroupID("dc1-storage-12")
+				_, id, err := ParseProcessGroupID("dc1-storage-12")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(id).To(Equal(12))
 			})
@@ -53,7 +53,7 @@ var _ = Describe("fdb_process_group", func() {
 
 		Context("with no prefix", func() {
 			It("gives a parsing error", func() {
-				_, err := ParseProcessGroupID("6")
+				_, _, err := ParseProcessGroupID("6")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("could not parse process group ID 6"))
 			})
@@ -61,7 +61,7 @@ var _ = Describe("fdb_process_group", func() {
 
 		Context("with no numbers", func() {
 			It("gives a parsing error", func() {
-				_, err := ParseProcessGroupID("storage")
+				_, _, err := ParseProcessGroupID("storage")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("could not parse process group ID storage"))
 			})
@@ -69,7 +69,57 @@ var _ = Describe("fdb_process_group", func() {
 
 		Context("with a text suffix", func() {
 			It("gives a parsing error", func() {
-				_, err := ParseProcessGroupID("storage-bad")
+				_, _, err := ParseProcessGroupID("storage-bad")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("could not parse process group ID storage-bad"))
+			})
+		})
+	})
+
+	When("parsing the process group ID number", func() {
+		Context("with a storage ID", func() {
+			It("can parse the ID", func() {
+				id, err := GetProcessGroupIDNumber("storage-12")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(id).To(Equal(12))
+			})
+		})
+
+		Context("with a cluster controller ID", func() {
+			It("can parse the ID", func() {
+				id, err := GetProcessGroupIDNumber("cluster_controller-3")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(id).To(Equal(3))
+			})
+		})
+
+		Context("with a custom prefix", func() {
+			It("parses the prefix", func() {
+				id, err := GetProcessGroupIDNumber("dc1-storage-12")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(id).To(Equal(12))
+			})
+		})
+
+		Context("with no prefix", func() {
+			It("gives a parsing error", func() {
+				_, err := GetProcessGroupIDNumber("6")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("could not parse process group ID 6"))
+			})
+		})
+
+		Context("with no numbers", func() {
+			It("gives a parsing error", func() {
+				_, err := GetProcessGroupIDNumber("storage")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("could not parse process group ID storage"))
+			})
+		})
+
+		Context("with a text suffix", func() {
+			It("gives a parsing error", func() {
+				_, err := GetProcessGroupIDNumber("storage-bad")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("could not parse process group ID storage-bad"))
 			})

--- a/pkg/podmanager/fdb_process_group_test.go
+++ b/pkg/podmanager/fdb_process_group_test.go
@@ -1,0 +1,91 @@
+/*
+ * fdb_process_group_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2020-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package podmanager
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("fdb_process_group", func() {
+	When("parsing the process group ID", func() {
+		Context("with a storage ID", func() {
+			It("can parse the ID", func() {
+				id, err := ParseProcessGroupID("storage-12")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(id).To(Equal(12))
+			})
+		})
+
+		Context("with a cluster controller ID", func() {
+			It("can parse the ID", func() {
+				id, err := ParseProcessGroupID("cluster_controller-3")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(id).To(Equal(3))
+			})
+		})
+
+		Context("with a custom prefix", func() {
+			It("parses the prefix", func() {
+				id, err := ParseProcessGroupID("dc1-storage-12")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(id).To(Equal(12))
+			})
+		})
+
+		Context("with no prefix", func() {
+			It("gives a parsing error", func() {
+				_, err := ParseProcessGroupID("6")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("could not parse process group ID 6"))
+			})
+		})
+
+		Context("with no numbers", func() {
+			It("gives a parsing error", func() {
+				_, err := ParseProcessGroupID("storage")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("could not parse process group ID storage"))
+			})
+		})
+
+		Context("with a text suffix", func() {
+			It("gives a parsing error", func() {
+				_, err := ParseProcessGroupID("storage-bad")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("could not parse process group ID storage-bad"))
+			})
+		})
+	})
+
+	When("getting the process ID from the process group ID", func() {
+		It("can parse a process ID", func() {
+			Expect(GetProcessGroupIDFromProcessID("storage-1-1")).To(Equal("storage-1"))
+		})
+		It("can parse a process ID with a prefix", func() {
+			Expect(GetProcessGroupIDFromProcessID("dc1-storage-1-1")).To(Equal("dc1-storage-1"))
+		})
+
+		It("can handle a process group ID with no process number", func() {
+			Expect(GetProcessGroupIDFromProcessID("storage-2")).To(Equal("storage-2"))
+		})
+	})
+})


### PR DESCRIPTION
# Description

fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1178

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

Like discussed in the issue we will recreate Pods that are deleted during an upgrade.

## Testing

Unit testing, local test and e2e test.

## Documentation

Will be updated.

## Follow-up

-
