### PR TITLE
Add support for is present and fix a bug in is_present

### DIFF
--- a/api/v1beta2/foundationdb_version.go
+++ b/api/v1beta2/foundationdb_version.go
@@ -195,6 +195,11 @@ func (version Version) IsReleaseCandidate() bool {
 	return version.ReleaseCandidate > 0
 }
 
+// SupportsIsPresent returns true if the sidecar of this version supports the is_present endpoint
+func (version Version) SupportsIsPresent() bool {
+	return version.IsAtLeast(Versions.SupportsIsPresent)
+}
+
 // Versions provides a shorthand for known versions.
 // This is only to be used in testing.
 var Versions = struct {
@@ -202,6 +207,7 @@ var Versions = struct {
 	NextPatchVersion,
 	MinimumVersion,
 	SupportsRocksDBV1,
+	SupportsIsPresent,
 	Default Version
 }{
 	Default:           Version{Major: 6, Minor: 2, Patch: 20},
@@ -209,4 +215,5 @@ var Versions = struct {
 	NextMajorVersion:  Version{Major: 7, Minor: 0, Patch: 0},
 	MinimumVersion:    Version{Major: 6, Minor: 2, Patch: 20},
 	SupportsRocksDBV1: Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 4},
+	SupportsIsPresent: Version{Major: 7, Minor: 1, Patch: 4},
 }


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1205 in addition to that this PR fixes a bug in the `is_present` method.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Discussion

Before this change we never checked the response of the `check_hash` call in the `is_present`, that means the operator thought the file would be there even if the sidecar returned a `404`.

## Testing

Unit + local testing with a own build sidecar.

## Documentation

-

## Follow-up

-