### PR TITLE
Add more conditions for automatic replacement

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -61,7 +61,7 @@ type FoundationDBClusterList struct {
 	Items           []FoundationDBCluster `json:"items"`
 }
 
-var conditionsThatNeedReplacement = []ProcessGroupConditionType{MissingProcesses, PodFailing}
+var conditionsThatNeedReplacement = []ProcessGroupConditionType{MissingProcesses, PodFailing, MissingPod, MissingPVC, MissingService, PodPending}
 
 func init() {
 	SchemeBuilder.Register(&FoundationDBCluster{}, &FoundationDBClusterList{})

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -4094,6 +4094,54 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			})
 		})
 
+		When("process group is in the missing Pod state", func() {
+			BeforeEach(func() {
+				processGroup.UpdateCondition(MissingPod, true, nil, "")
+				processGroup.ProcessGroupConditions[0].Timestamp = oldTimestamp
+			})
+
+			It("should need replacement", func() {
+				Expect(needsReplacement).To(BeTrue())
+				Expect(timestamp).To(Equal(oldTimestamp))
+			})
+		})
+
+		When("process group is in the missing PVC state", func() {
+			BeforeEach(func() {
+				processGroup.UpdateCondition(MissingPVC, true, nil, "")
+				processGroup.ProcessGroupConditions[0].Timestamp = oldTimestamp
+			})
+
+			It("should need replacement", func() {
+				Expect(needsReplacement).To(BeTrue())
+				Expect(timestamp).To(Equal(oldTimestamp))
+			})
+		})
+
+		When("process group is in the missing Service state", func() {
+			BeforeEach(func() {
+				processGroup.UpdateCondition(MissingService, true, nil, "")
+				processGroup.ProcessGroupConditions[0].Timestamp = oldTimestamp
+			})
+
+			It("should need replacement", func() {
+				Expect(needsReplacement).To(BeTrue())
+				Expect(timestamp).To(Equal(oldTimestamp))
+			})
+		})
+
+		When("process group is in the Pod pending state", func() {
+			BeforeEach(func() {
+				processGroup.UpdateCondition(PodPending, true, nil, "")
+				processGroup.ProcessGroupConditions[0].Timestamp = oldTimestamp
+			})
+
+			It("should need replacement", func() {
+				Expect(needsReplacement).To(BeTrue())
+				Expect(timestamp).To(Equal(oldTimestamp))
+			})
+		})
+
 		Context("with a process group that had the wrong command line", func() {
 			BeforeEach(func() {
 				processGroup.UpdateCondition(IncorrectCommandLine, true, nil, "")

--- a/docs/manual/replacements_and_deletions.md
+++ b/docs/manual/replacements_and_deletions.md
@@ -39,6 +39,10 @@ The following conditions are currently eligible for replacement:
 
 * `MissingProcesses`: This indicates that a process is not reporting to the database.
 * `PodFailing`: This indicates that one of the containers is not ready.
+* `MissingPod`: This indicates a process group that doesn't have a Pod assigned.
+* `MissingPVC`: This indicates that a process group that doesn't have a PVC assigned.
+* `MissingService`: This indicates that a process group that doesn't have a Service assigned.
+* `PodPending`: This indicates that a process group where the pod is in a pending state.
 
 ## Enforce Full Replication
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1213

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

This should catch the case where a Pod is deleted (or in a deleted state) but the process is still running.

## Testing

Unit testing.

## Documentation

-

## Follow-up

-
