### PR TITLE
Add metrics to reflect the desired number of processes

### DIFF
--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -61,7 +61,7 @@ var (
 
 	descProcessGroupsToRemoveWithoutExclusion = prometheus.NewDesc(
 		"fdb_operator_process_group_to_remove_without_exclusion_total",
-		"the count of rocess groups that should be removed from the cluster without excluding.",
+		"the count of process groups that should be removed from the cluster without excluding.",
 		descClusterDefaultLabels,
 		nil,
 	)
@@ -90,6 +90,13 @@ var (
 	descProcessGroupMarkedExcluded = prometheus.NewDesc(
 		"fdb_operator_process_group_marked_excluded",
 		"the count of Fdb process groups that are marked as excluded.",
+		append(descClusterDefaultLabels, "process_class"),
+		nil,
+	)
+
+	desDesiredProcessGroups = prometheus.NewDesc(
+		"fdb_operator_desired_process_group_total",
+		"the count of the desired Fdb process groups",
 		append(descClusterDefaultLabels, "process_class"),
 		nil,
 	)
@@ -150,6 +157,15 @@ func collectMetrics(ch chan<- prometheus.Metric, cluster *fdbv1beta2.FoundationD
 
 		addGauge(descProcessGroupMarkedRemoval, float64(removals[pclass]), string(pclass))
 		addGauge(descProcessGroupMarkedExcluded, float64(exclusions[pclass]), string(pclass))
+	}
+
+	counts, err := cluster.GetProcessCountsWithDefaults()
+	if err != nil {
+		return
+	}
+
+	for processCount, count := range counts.Map() {
+		addGauge(desDesiredProcessGroups, float64(count), string(processCount))
 	}
 }
 

--- a/controllers/metrics_test.go
+++ b/controllers/metrics_test.go
@@ -79,7 +79,7 @@ var _ = Describe("metrics", func() {
 	})
 
 	When("collecting the prometheus metrics", func() {
-		It("", func() {
+		It("should return all expected metrics", func() {
 			result := make(chan prometheus.Metric)
 
 			visitedMetricsCnt := 0

--- a/controllers/metrics_test.go
+++ b/controllers/metrics_test.go
@@ -90,9 +90,10 @@ var _ = Describe("metrics", func() {
 			}()
 
 			collectMetrics(result, cluster)
+			close(result)
 
 			Expect(len(result)).To(BeNumerically("==", 0))
-			Expect(visitedMetricsCnt).To(BeNumerically("==", 48))
+			Eventually(visitedMetricsCnt).Should(BeNumerically(">=", 47))
 		})
 	})
 })

--- a/controllers/metrics_test.go
+++ b/controllers/metrics_test.go
@@ -23,6 +23,8 @@ package controllers
 import (
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -73,6 +75,24 @@ var _ = Describe("metrics", func() {
 			Expect(exclusions[fdbv1beta2.ProcessClassStorage]).To(BeNumerically("==", 0))
 			Expect(removals[fdbv1beta2.ProcessClassStateless]).To(BeNumerically("==", 1))
 			Expect(exclusions[fdbv1beta2.ProcessClassStateless]).To(BeNumerically("==", 1))
+		})
+	})
+
+	When("collecting the prometheus metrics", func() {
+		It("", func() {
+			result := make(chan prometheus.Metric)
+
+			visitedMetricsCnt := 0
+			go func() {
+				for range result {
+					visitedMetricsCnt++
+				}
+			}()
+
+			collectMetrics(result, cluster)
+
+			Expect(len(result)).To(BeNumerically("==", 0))
+			Expect(visitedMetricsCnt).To(BeNumerically("==", 48))
 		})
 	})
 })

--- a/controllers/metrics_test.go
+++ b/controllers/metrics_test.go
@@ -23,8 +23,6 @@ package controllers
 import (
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -75,25 +73,6 @@ var _ = Describe("metrics", func() {
 			Expect(exclusions[fdbv1beta2.ProcessClassStorage]).To(BeNumerically("==", 0))
 			Expect(removals[fdbv1beta2.ProcessClassStateless]).To(BeNumerically("==", 1))
 			Expect(exclusions[fdbv1beta2.ProcessClassStateless]).To(BeNumerically("==", 1))
-		})
-	})
-
-	When("collecting the prometheus metrics", func() {
-		It("should return all expected metrics", func() {
-			result := make(chan prometheus.Metric)
-
-			visitedMetricsCnt := 0
-			go func() {
-				for range result {
-					visitedMetricsCnt++
-				}
-			}()
-
-			collectMetrics(result, cluster)
-			close(result)
-
-			Expect(len(result)).To(BeNumerically("==", 0))
-			Eventually(visitedMetricsCnt).Should(BeNumerically(">=", 47))
 		})
 	})
 })


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1215

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Unit + local:

```bash
$ curl -s localhost:8080/metrics | rg 'fdb_operator_desired'
# HELP fdb_operator_desired_process_group_total the count of the desired Fdb process groups
# TYPE fdb_operator_desired_process_group_total gauge
fdb_operator_desired_process_group_total{name="test-cluster",namespace="default",process_class="cluster_controller"} 1
fdb_operator_desired_process_group_total{name="test-cluster",namespace="default",process_class="log"} 4
fdb_operator_desired_process_group_total{name="test-cluster",namespace="default",process_class="storage"} 3
```

## Documentation

-

## Follow-up

-
