### PR TITLE
Move the remove services set to after we remove process groups.

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -151,8 +151,8 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 		changeCoordinators{},
 		bounceProcesses{},
 		updatePods{},
-		removeServices{},
 		removeProcessGroups{},
+		removeServices{},
 		updateStatus{},
 	}
 


### PR DESCRIPTION
# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

This is working around an issue when disabling DNS names, where we were removing the headless service before the replacement transaction processes were able to come up, leaving them stuck indefinitely.

Fixes #1226 

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

*Are there any design details that you would like to discuss further?*

This is relying on indirect properties, and the ordering of steps, in order to determine whether the DNS names are required. I don't know if we want to rely on that, or if we want to have a more explicit signal. However, designing that signal would be more complex, and I wanted to get a fix in quickly.

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I ran a manual test.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

We should validate that this fixes the issues we've observed in the new integration tests.

## Documentation

*Did you update relevant documentation within this repository?*

No.

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.
