### PR TITLE
Update go bindings for operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/FoundationDB/fdb-kubernetes-operator
 go 1.17
 
 require (
-	github.com/apple/foundationdb/bindings/go v0.0.0-20190724023245-90ba203c166c
-	github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20211117195619-01c37a053a62
+	github.com/apple/foundationdb/bindings/go v0.0.0-20220513200452-e6fa4d7422d2
+	github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20220513200452-e6fa4d7422d2
 	github.com/fatih/color v1.10.0
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.5
@@ -98,6 +98,7 @@ require (
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,10 +59,10 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
-github.com/apple/foundationdb/bindings/go v0.0.0-20190724023245-90ba203c166c h1:+NyJPOJEmyYbbN8YyfGWk2XJMMLyrBJI8UY5s8dWMPI=
-github.com/apple/foundationdb/bindings/go v0.0.0-20190724023245-90ba203c166c/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=
-github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20211117195619-01c37a053a62 h1:qZCIRm+CYoFtyiWPchNBaKELEvb83XZ5FuHM0SGEKyE=
-github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20211117195619-01c37a053a62/go.mod h1:LgBm9afX7nbQnDQa6bOXluKRnXypEDni36EJExtih80=
+github.com/apple/foundationdb/bindings/go v0.0.0-20220513200452-e6fa4d7422d2 h1:uURaQ56I7ydPCn+epTnZ2b1bGhKpHYYVn/Ybd6ToCH8=
+github.com/apple/foundationdb/bindings/go v0.0.0-20220513200452-e6fa4d7422d2/go.mod h1:w63jdZTFCtvdjsUj5yrdKgjxaAD5uXQX6hJ7EaiLFRs=
+github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20220513200452-e6fa4d7422d2 h1:qQW+EDheBFF09sjMwEJu7cc6LBQKnsbIVTgj9i12lws=
+github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20220513200452-e6fa4d7422d2/go.mod h1:LgBm9afX7nbQnDQa6bOXluKRnXypEDni36EJExtih80=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
# Description

Updates the go bindings to [7.1.5](https://github.com/apple/foundationdb/tree/7.1.5)

## Type of change

*Please select one of the options below.*

- Other (Version update)

## Discussion

-

## Testing

Unit + local

## Documentation

-

## Follow-up

-
