### PR TITLE
Enable CGO for kubectl plugin build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,8 @@ before:
     - go mod tidy
 builds:
   - id: kubectl-fdb
+    env:
+      - CGO_ENABLED=1
     goos:
       - linux
       - windows


### PR DESCRIPTION
# Description

Enable CGO explicitly for kubectl plugin builder.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

-

## Documentation

-

## Follow-up

-
