### PR TITLE
Revert to an older FDB version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM docker.io/library/golang:1.17.8 as builder
 
 # Install FDB this version is only required to compile the fdb operator
-ARG FDB_VERSION=7.1.5
+ARG FDB_VERSION=6.2.29
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 ARG TAG="latest"
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -28,6 +28,8 @@ published for each major version.
 | 0.x              | 0.51.1              | v1beta1                  | 6.1.12+                | 1.15.0+                       |
 | 1.x              | -                   | v1beta1,v1beta2          | 6.2.20+                | 1.19.0+                       |
 
+Note that the base operator image only supports a single version of FoundationDB. For more information about using different versions of FoundationDB, see the [Operator Customization](/docs/manual/operator_customization.md) guide in the user manual.
+
 ## Preparing for a Major Release
 
 Before you upgrade to a new major version, you should first update the operator

--- a/docs/fdb_release_prep.md
+++ b/docs/fdb_release_prep.md
@@ -1,4 +1,6 @@
-# Preparing for New Releases of FoundationDB
+# Managing Supported FDB Versions
+
+## Preparing for New Releases of FoundationDB
 
 When a new major or minor release of FoundationDB is coming up, we should take steps to ensure that the operator supports that release. This document captures some common things to look for.
 
@@ -12,3 +14,12 @@ Once the new version has a full public release, we should update the operator co
 
 1. Update the manager config to load binaries from the new release. You can do this by adding another init container in our YAML config. You can find existing init containers by looking for container names like `foundationdb-kubernetes-init-X-Y` and use those as a reference.
 1. Modify the base test config to use the new version, and create a cluster with that test config.
+
+## Dropping Support for Old Versions
+
+During a major release of the operator, we will often want to drop support for older versions of FoundationDB, as a way of paying down technical debt and making it easier for us to rely on newer features in FoundationDB. In general, the minimum range we want to support is all patches for the latest stable minor release of FoundationDB, and at least one patch for the previous minor release of FoundationDB. We may support a wider range based on the community's needs. As part of the major release process, we should create an issue on dropping support for older versions, to capture the work required and the discussion on what versions we will support going forward. Once we have selected the oldest version of FoundationDB we will support, we should update the following configuration:
+
+1. The API version set in `main.go` should match the oldest minor version we will support.
+2. The version of the Go binding set in `go.mod` should match the oldest version we will support.
+3. The version of the FoundationDB client package installed in the `Dockerfile` should match the oldest version we will support.
+4. The supported FoundationDB versions in the [compatibility](compatibility.md) document should be updated to reflect the supported versions for the new operator release.

--- a/docs/manual/customization.md
+++ b/docs/manual/customization.md
@@ -1,4 +1,4 @@
-# Customization
+# Customizing Your Deployments
 
 This document covers some of the options the operator provides for customizing your FoundationDB deployment.
 
@@ -440,4 +440,4 @@ For more information on how the interaction between the operator and these image
 
 ## Next
 
-You can continue on to the [next section](replacements_and_deletions.md) or go back to the [table of contents](index.md).
+You can continue on to the [next section](operator_customization.md) or go back to the [table of contents](index.md).

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -12,7 +12,8 @@ For more information on that area, see the [Kubernetes documentation](https://ku
 1. [Resources Managed by the Operator](resources.md)
 1. [Lifecycle Operations](operations.md)
 1. [Scaling](scaling.md)
-1. [Customization](customization.md)
+1. [Customizing Your Deployments](customization.md)
+1. [Customizing the Operator](operator_customization.md).
 1. [Replacements and Deletions](replacements_and_deletions.md)
 1. [Controlling Fault Domains](fault_domains.md)
 1. [Running with TLS](tls.md)

--- a/docs/manual/operator_customization.md
+++ b/docs/manual/operator_customization.md
@@ -1,0 +1,75 @@
+# Operator Customization
+
+This document provides more information on how to customize the way the operator runs based on the needs of your infrastructure.
+
+## Details on FoundationDB Version Compatibility
+
+Out of the box, the operator only supports a single minor version of FoundationDB, matching the oldest FoundationDB version listed for that operator version in the [compatibility guide](/docs/compatibility.md). This constraint comes from the FoundationDB client library, which must match the protocol version of the servers that it connects to. To connect to newer versions of FoundationDB, you must install a [multi-version client library](https://apple.github.io/foundationdb/api-general.html#multi-version-client-api). The operator supports using init containers to provide additional client libraries independently of the libraries shipped in the basic operator docker image. We have an example of this configuration in our [example deployment configuration](https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/config/samples/deployment.yaml#L176). This example is updated regularly to include binaries and client libraries for all supported versions of FoundationDB.
+
+If you need to customize this, to support pre-releases or custom builds, you can use this example as a baseline and define your own init containers. The configuration for these init containers works as follows:
+
+* The init container runs the FoundationDB sidecar image for the desired minor version, with arguments for copying binaries.
+* It takes a `--copy-library` argument providing the version you want to use, which will typically match the minor version of the image in this pattern.
+* It takes a `--copy-binary` argument for each binary that you want the operator to use/
+* It takes an `--output-dir` argument provided a directory with a fully-qualified version.
+* It takes an `--init-mode` argument telling the sidecar to copy these files and exit.
+* The parent directory of the directory used in the `--output-dir` argument is mapped to a volume mount. That volume mount is also mounted in the manager container for the operator, at the path `/usr/bin/fdb`.
+
+At start time, the operator scans this directory for version-specific binaries, and remaps the files to match the locations where the operator needs them.
+
+## Customizing the Primary Client Library
+
+By default, the primary client library used by the operator is the oldest supported version, as discussed above. If you want to use a newer version of the client library as your primary client, you can control that through additonal init containers. 
+
+```yaml
+# This provides partial configuration for the deployment to show what needs to change in order to
+# use a special client library.
+apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: controller-manager
+ spec:
+   template:
+     spec:
+       initContainers:
+         # Install this library in a special location to force the operator to
+         # use it as the primary library.
+         - name: foundationdb-kubernetes-init-7-1-primary
+           image: foundationdb/foundationdb-kubernetes-sidecar:7.1.5
+           args:
+             # Note that we are only copying a library, rather than copying any binaries. 
+             - "--copy-library"
+             - "7.1"
+             - "--output-dir"
+             - "/var/output-files/primary" # Note that we use `primary` as the subdirectory rather than specifying the FoundationDB version like we did in the other examples.
+             - "--init-mode"
+           volumeMounts:
+             - name: fdb-binaries
+               mountPath: /var/output-files
+         # Install binaries alone, to a different directory than the primary client library.
+         - name: foundationdb-kubernetes-init-7-1
+           image: foundationdb/foundationdb-kubernetes-sidecar:7.1.5
+           args:
+             - "--copy-binary"
+             - "fdbcli"
+             - "--copy-binary"
+             - "fdbbackup"
+             - "--copy-binary"
+             - "fdbrestore"
+             - "--output-dir"
+             - "/var/output-files/7.1.5"
+             - "--init-mode"
+           volumeMounts:
+             - name: fdb-binaries
+               mountPath: /var/output-files
+       containers:
+         - name: manager
+           env:
+             # Set the LD_LIBRARY_PATH environment variable to tell FoundationDB to load its primary client library from this directory instead of the directory provided by the image.
+             - name: LD_LIBRARY_PATH
+               value: /usr/bin/fdb/primary/lib
+```
+
+## Next
+
+You can continue on to the [next section](replacements_and_deletions.md) or go back to the [table of contents](index.md).

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/FoundationDB/fdb-kubernetes-operator
 go 1.17
 
 require (
-	github.com/apple/foundationdb/bindings/go v0.0.0-20220513200452-e6fa4d7422d2
+	github.com/apple/foundationdb/bindings/go v0.0.0-20201222225940-f3aef311ccfb
 	github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20220513200452-e6fa4d7422d2
 	github.com/fatih/color v1.10.0
 	github.com/go-logr/logr v0.4.0
@@ -98,7 +98,6 @@ require (
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
-github.com/apple/foundationdb/bindings/go v0.0.0-20220513200452-e6fa4d7422d2 h1:uURaQ56I7ydPCn+epTnZ2b1bGhKpHYYVn/Ybd6ToCH8=
-github.com/apple/foundationdb/bindings/go v0.0.0-20220513200452-e6fa4d7422d2/go.mod h1:w63jdZTFCtvdjsUj5yrdKgjxaAD5uXQX6hJ7EaiLFRs=
+github.com/apple/foundationdb/bindings/go v0.0.0-20201222225940-f3aef311ccfb h1:Hgm6BKE5OE/coggPjBSZNQFk+9ku+J+XV/LQ7Mh2Utw=
+github.com/apple/foundationdb/bindings/go v0.0.0-20201222225940-f3aef311ccfb/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=
 github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20220513200452-e6fa4d7422d2 h1:qQW+EDheBFF09sjMwEJu7cc6LBQKnsbIVTgj9i12lws=
 github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20220513200452-e6fa4d7422d2/go.mod h1:LgBm9afX7nbQnDQa6bOXluKRnXypEDni36EJExtih80=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 func main() {
-	fdb.MustAPIVersion(610)
+	fdb.MustAPIVersion(620)
 	operatorOpts := setup.Options{}
 	operatorOpts.BindFlags(flag.CommandLine)
 


### PR DESCRIPTION
# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

This reverts the builds to use version 6.2 of the FDB binding and client package, and increases the API version selected at runtime to `620`. This aligns all these points of configuration with the oldest supported version of FDB, and avoids issues with using older client libraries with newer versions of the bindings.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

*Are there any design details that you would like to discuss further?*

No.

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I've tested this build manually against 6.3 clusters to ensure things continue working with newer versions.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

## Documentation

*Did you update relevant documentation within this repository?*

Yes, I've added documentation on how we should maintain this configuration in future releases. I've also filled in documentation on supporting newer FDB versions.

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.