### PR TITLE
Update go version to 1.17.11 and correct the same FDB library

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  FDB_VER: "7.1.5"
+  FDB_VER: "6.2.29"
 
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17.8
+          go-version: 1.17.11
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.17.8
+        go-version: 1.17.11
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
@@ -100,7 +100,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.17.8
+        go-version: 1.17.11
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17.8
+          go-version: 1.17.11
       - name: Release binaries
         run: make release
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.17.8 as builder
+FROM docker.io/library/golang:1.17.11 as builder
 
 # Install FDB this version is only required to compile the fdb operator
 ARG FDB_VERSION=6.2.29

--- a/distrolesss.dockerfile
+++ b/distrolesss.dockerfile
@@ -1,8 +1,8 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.17.8 as builder
+FROM docker.io/library/golang:1.17.11 as builder
 
 # Install FDB this version is only required to compile the fdb operator
-ARG FDB_VERSION=7.1.5
+ARG FDB_VERSION=6.2.29
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 ARG TAG="latest"
 


### PR DESCRIPTION
# Description

Update the used go version to the latest 1.17 with the latest security fixes.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

Locally.

## Documentation

-

## Follow-up

-
