### PR TITLE
Make use of retry method to prevent conflicts

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -104,7 +104,7 @@ func processRequeue(requeue *requeue, subReconciler interface{}, object runtime.
 	if err != nil && k8serrors.IsConflict(err) {
 		err = nil
 		if requeue.delay == time.Duration(0) {
-			requeue.delay = time.Minute
+			requeue.delay = 2 * time.Second
 		}
 	}
 


### PR DESCRIPTION
# Description

Fixes https://github.com/FoundationDB/fdb-kubernetes-operator/issues/814 and reduce the number of conflicts the operator sees.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

There might be some other places for the backup and restore controller where we want to add this in the future. From my testing this improves the reconciliation speed and I didn't find any issues running the e2e test suite.

## Testing

Local testing.

## Documentation

-

## Follow-up

-
