### PR TITLE
remove duplicate updateStatus reconciler

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -130,7 +130,6 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 	}
 
 	subReconcilers := []clusterSubReconciler{
-		updateStatus{},
 		updateLockConfiguration{},
 		updateConfigMap{},
 		checkClientCompatibility{},


### PR DESCRIPTION
remove duplicate updateStatus reconciler 

Signed-off-by: bzd111 <zxc@bzd111.me>

# Description
why clusterSubReconciler slice have duplicate updateStatus struct? I remove the first updateStatus{}.

https://github.com/FoundationDB/fdb-kubernetes-operator/blob/84406f793cf5fb85f14ed2756f33110204b1c42f/controllers/cluster_controller.go#L133

https://github.com/FoundationDB/fdb-kubernetes-operator/blob/84406f793cf5fb85f14ed2756f33110204b1c42f/controllers/cluster_controller.go#L156

