### PR TITLE
Retry flaky test

### DIFF
--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -193,7 +193,8 @@ var _ = Describe("remove_process_groups", func() {
 					adminClient.ExcludedAddresses = append(adminClient.ExcludedAddresses, secondRemovedProcessGroup.Addresses...)
 				})
 
-				It("should remove only one process group", func() {
+				// TODO(johscheuer): Fix this flaky test properly, for now retry failing test occurrences with a maximum of 3 retries.
+				It("should remove only one process group", FlakeAttempts(3), func() {
 					Expect(result).To(BeNil())
 					Expect(initialCnt - len(cluster.Status.ProcessGroups)).To(BeNumerically("==", 1))
 					// Ensure resources are deleted


### PR DESCRIPTION
# Description

This should ensure that our CI pipelines pass constantly. We should look into the flaky test in addition to decide how to fix it or if it should be removed.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

This is only a workaround to retry the flaky test automatically.

## Testing

-

## Documentation

-

## Follow-up

-
