### PR TITLE
update sed command to run on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ ${MANIFESTS}: ${CONTROLLER_GEN} ${GO_SRC}
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	# Per default controller-gen will generate a ClusterRole for our example we want to use a Role and the namespace marker doesn't
 	# work since it requires a namespace and kustomize doesn't support to change the Kind.
-	@sed -i 's/kind: ClusterRole/kind: Role/g' ./config/rbac/role.yaml
+	@sed -i -e 's/kind: ClusterRole/kind: Role/g' ./config/rbac/role.yaml
 
 # Run go fmt against code
 fmt: bin/fmt_check


### PR DESCRIPTION
# Description

The command `sed` is failing on Mac as it explicitly requires the `-e` option for `sed` to work.  This command is used in the Makefile to replace `Role` with `ClusterRole` in the role.yaml file 

Before this PR error:
```# Per default controller-gen will generate a ClusterRole for our example we want to use a Role and the namespace marker doesn't
# work since it requires a namespace and kustomize doesn't support to change the Kind.
sed: 1: "./config/rbac/role.yaml": invalid command code .
```

## Type of change

*Please select one of the options below.*

√ Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation
- Other

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

## Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
