### PR TITLE
Fix how goreleaser fetches the current tag

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,6 @@ on:
 env:
   FDB_VER: "6.2.29"
 
-
 jobs:
   lint-go:
     name: Lint go code
@@ -73,10 +72,15 @@ jobs:
         chmod +x kind
         sudo mv kind /usr/local/bin/kind
         ./scripts/setup_kind_local_registry.sh ${{ matrix.kubever }}
+    #  https://github.com/goreleaser/goreleaser/issues/1311
+    - name: Get current semver tag
+      run: echo "::set-output name=CURRENT_TAG::$(git describe --tags --match "v*" --abbrev=0)"
+      id: current-tag
     - name: Check for uncommitted changes
       env:
         # Don't run any tests we run them in the next step
         SKIP_TEST: "1"
+        GORELEASER_CURRENT_TAG: ${{ steps.current-tag.outputs.CURRENT_TAG }}
       run: |
         make clean all
         git diff --exit-code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,10 +44,15 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.17.11
+      #  https://github.com/goreleaser/goreleaser/issues/1311
+      - name: Get current semver tag
+        run: echo "::set-output name=CURRENT_TAG::$(git describe --tags --match "v*" --abbrev=0)"
+        id: current-tag
       - name: Release binaries
         run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ steps.current-tag.outputs.CURRENT_TAG }}
   push_images:
     name: Push Docker images
     needs: create-release


### PR DESCRIPTION
# Description

Part of https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1271

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

The new helm chart release will create tags like `fdb-operator-0.2`, those are not server compatible with goreleaser, so we have to pull the latest server compatible tag ourself (goreleaser doesn't support this).

## Testing

I tested this in my fork: e.g. https://github.com/johscheuer/fdb-kubernetes-operator/runs/7146785492?check_suite_focus=true

## Documentation

-

## Follow-up

-
