### PR TITLE
Fix bug where config update is triggered to often

### DIFF
--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -73,6 +73,7 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 			logger.V(1).Info("Could not find Pod for process group ID",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue
+			// TODO should not be continue but rather be a requeue?
 		}
 
 		if shouldRequeueDueToTerminatingPod(pod, cluster, processGroup.ProcessGroupID) {

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -23,7 +23,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sort"
 	"time"
 
@@ -192,7 +191,7 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 		status.ConnectionString = cluster.Spec.SeedConnectionString
 	}
 
-	status.HasIncorrectConfigMap = status.HasIncorrectConfigMap || !reflect.DeepEqual(existingConfigMap.Data, configMap.Data) || !metadataMatches(existingConfigMap.ObjectMeta, configMap.ObjectMeta)
+	status.HasIncorrectConfigMap = status.HasIncorrectConfigMap || !equality.Semantic.DeepEqual(existingConfigMap.Data, configMap.Data) || !metadataMatches(existingConfigMap.ObjectMeta, configMap.ObjectMeta)
 
 	service := internal.GetHeadlessService(cluster)
 	existingService := &corev1.Service{}


### PR DESCRIPTION
# Description

Found this bug during some HA upgrade tests. This bug was introduced in https://github.com/FoundationDB/fdb-kubernetes-operator/pull/1187. Running multiple reconfigure commands should be relatively harmless but they trigger probably a new recruitment of the transaction system which means we see more recoveries. 

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Unit testing + e2e tests.

## Documentation

-

## Follow-up

-
