### PR TITLE
Remove the keyword "cluster" from the examples for the analyze command.

### DIFF
--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -143,11 +143,11 @@ kubectl fdb -n test-namespace analyze sample-cluster-1
 kubectl fdb analyze --auto-fix sample-cluster-1
 
 # Analyze the cluster "sample-cluster-1" in the current namespace and ignore the IncorrectCommandLine and IncorrectPodSpec condition
-kubectl fdb analyze cluster --ignore-condition=IncorrectCommandLine --ignore-condition=IncorrectPodSpec sample-cluster-1
+kubectl fdb analyze --ignore-condition=IncorrectCommandLine --ignore-condition=IncorrectPodSpec sample-cluster-1
 
 # Per default the plugin will print out how many process groups are marked for removal instead of printing out each process group.
 # This can be disabled by using the ignore-removals flag to print out the details about process groups that are marked for removal.
-kubectl fdb analyze cluster --ignore-removals=false sample-cluster-1
+kubectl fdb analyze --ignore-removals=false sample-cluster-1
 `,
 	}
 	cmd.SetOut(o.Out)


### PR DESCRIPTION
# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

This changes the help text for the analyze command to remove the word "cluster" in some examples where it doesn't seem correct.

## Type of change

*Please select one of the options below.*

- Documentation

## Discussion

*Are there any design details that you would like to discuss further?*

No.

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I ran the unit tests locally.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

## Documentation

*Did you update relevant documentation within this repository?*

Yes.

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.