### PR TITLE
Reduce API call to Kubernetes to fetch process group ID information

### DIFF
--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -37,6 +37,17 @@ import (
 
 var processClassSanitizationPattern = regexp.MustCompile("[^a-z0-9-]")
 
+// GetProcessGroupIDFromPodName returns the process group ID for a given Pod name.
+func GetProcessGroupIDFromPodName(cluster *fdbv1beta2.FoundationDBCluster, podName string) string {
+	tmpName := strings.ReplaceAll(podName, cluster.Name, "")[1:]
+
+	if cluster.Spec.ProcessGroupIDPrefix != "" {
+		return fmt.Sprintf("%s-%s", cluster.Spec.ProcessGroupIDPrefix, tmpName)
+	}
+
+	return tmpName
+}
+
 // GetProcessGroupID generates an ID for a process group.
 //
 // This will return the pod name and the processGroupID ID.

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -3181,4 +3181,21 @@ var _ = Describe("pod_models", func() {
 			Expect(GetPodDNSName(cluster, "operator-test-storage-1")).To(Equal("operator-test-storage-1.operator-test-1.my-ns.svc.cluster.example"))
 		})
 	})
+
+	DescribeTable("getting the process group ID from the Pod name", func(cluster *fdbv1beta2.FoundationDBCluster, podName string, expected string) {
+		Expect(GetProcessGroupIDFromPodName(cluster, podName)).To(Equal(expected))
+	},
+		Entry("cluster without prefix", &fdbv1beta2.FoundationDBCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+		}, "test-storage-1", "storage-1"),
+		Entry("cluster with prefix", &fdbv1beta2.FoundationDBCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: fdbv1beta2.FoundationDBClusterSpec{
+				ProcessGroupIDPrefix: "prefix",
+			},
+		}, "test-storage-1", "prefix-storage-1"))
 })

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -399,7 +399,7 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, clusterName st
 		confirmed := false
 
 		if len(failedProcessGroups) > 0 {
-			err := replaceProcessGroups(kubeClient, cluster.Name, failedProcessGroups, namespace, true, false, wait, false)
+			err := replaceProcessGroups(kubeClient, cluster.Name, failedProcessGroups, namespace, true, wait, false, true)
 			if err != nil {
 				return err
 			}

--- a/kubectl-fdb/cmd/buggify_crash_loop.go
+++ b/kubectl-fdb/cmd/buggify_crash_loop.go
@@ -66,12 +66,7 @@ func newBuggifyCrashLoop(streams genericclioptions.IOStreams) *cobra.Command {
 				return err
 			}
 
-			processGroups, err := getProcessGroupIDsFromPod(kubeClient, cluster, args, namespace)
-			if err != nil {
-				return err
-			}
-
-			return updateCrashLoopList(kubeClient, cluster, processGroups, namespace, wait, clear, clean)
+			return updateCrashLoopList(kubeClient, cluster, args, namespace, wait, clear, clean)
 		},
 		Example: `
 # Add process groups into crash loop state for a cluster in the current namespace
@@ -104,12 +99,17 @@ kubectl fdb -n default buggify crash-loop -c cluster pod-1 pod-2
 }
 
 // updateCrashLoopList updates the crash-loop list of the cluster
-func updateCrashLoopList(kubeClient client.Client, clusterName string, processGroups []string, namespace string, wait bool, clear bool, clean bool) error {
+func updateCrashLoopList(kubeClient client.Client, clusterName string, pods []string, namespace string, wait bool, clear bool, clean bool) error {
 	cluster, err := loadCluster(kubeClient, namespace, clusterName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return fmt.Errorf("could not get cluster: %s/%s", namespace, clusterName)
 		}
+		return err
+	}
+
+	processGroups, err := getProcessGroupIDsFromPodName(cluster, pods)
+	if err != nil {
 		return err
 	}
 

--- a/kubectl-fdb/cmd/buggify_crash_loop_test.go
+++ b/kubectl-fdb/cmd/buggify_crash_loop_test.go
@@ -56,7 +56,6 @@ var _ = Describe("[plugin] buggify crash-loop instances command", func() {
 
 	When("running buggify crash-loop instances command", func() {
 		When("adding instances to crash-loop list from a cluster", func() {
-
 			type testCase struct {
 				Instances                    []string
 				ExpectedInstancesInCrashLoop []string
@@ -83,13 +82,13 @@ var _ = Describe("[plugin] buggify crash-loop instances command", func() {
 				},
 				Entry("Adding single instance.",
 					testCase{
-						Instances:                    []string{"instance-1"},
-						ExpectedInstancesInCrashLoop: []string{"instance-1"},
+						Instances:                    []string{"test-storage-1"},
+						ExpectedInstancesInCrashLoop: []string{"storage-1"},
 					}),
 				Entry("Adding multiple instances.",
 					testCase{
-						Instances:                    []string{"instance-1", "instance-2"},
-						ExpectedInstancesInCrashLoop: []string{"instance-1", "instance-2"},
+						Instances:                    []string{"test-storage-1", "test-storage-2"},
+						ExpectedInstancesInCrashLoop: []string{"storage-1", "storage-2"},
 					}),
 			)
 
@@ -97,7 +96,7 @@ var _ = Describe("[plugin] buggify crash-loop instances command", func() {
 				var kubeClient client.Client
 
 				BeforeEach(func() {
-					cluster.Spec.Buggify.CrashLoop = []string{"instance-1"}
+					cluster.Spec.Buggify.CrashLoop = []string{"storage-1"}
 					scheme := runtime.NewScheme()
 					_ = clientgoscheme.AddToScheme(scheme)
 					_ = fdbv1beta2.AddToScheme(scheme)
@@ -125,18 +124,18 @@ var _ = Describe("[plugin] buggify crash-loop instances command", func() {
 					},
 					Entry("Adding the same instance.",
 						testCase{
-							Instances:                    []string{"instance-1"},
-							ExpectedInstancesInCrashLoop: []string{"instance-1"},
+							Instances:                    []string{"test-storage-1"},
+							ExpectedInstancesInCrashLoop: []string{"storage-1"},
 						}),
 					Entry("Adding different instance.",
 						testCase{
-							Instances:                    []string{"instance-2"},
-							ExpectedInstancesInCrashLoop: []string{"instance-1", "instance-2"},
+							Instances:                    []string{"test-storage-2"},
+							ExpectedInstancesInCrashLoop: []string{"storage-1", "storage-2"},
 						}),
 					Entry("Adding multiple instances.",
 						testCase{
-							Instances:                    []string{"instance-2", "instance-3"},
-							ExpectedInstancesInCrashLoop: []string{"instance-1", "instance-2", "instance-3"},
+							Instances:                    []string{"test-storage-2", "test-storage-3"},
+							ExpectedInstancesInCrashLoop: []string{"storage-1", "storage-2", "storage-3"},
 						}),
 				)
 			})
@@ -146,7 +145,7 @@ var _ = Describe("[plugin] buggify crash-loop instances command", func() {
 			var kubeClient client.Client
 
 			BeforeEach(func() {
-				cluster.Spec.Buggify.CrashLoop = []string{"instance-1", "instance-2", "instance-3"}
+				cluster.Spec.Buggify.CrashLoop = []string{"storage-1", "storage-2", "storage-3"}
 				scheme := runtime.NewScheme()
 				_ = clientgoscheme.AddToScheme(scheme)
 				_ = fdbv1beta2.AddToScheme(scheme)
@@ -174,13 +173,13 @@ var _ = Describe("[plugin] buggify crash-loop instances command", func() {
 				},
 				Entry("Removing single instance.",
 					testCase{
-						Instances:                    []string{"instance-1"},
-						ExpectedInstancesInCrashLoop: []string{"instance-2", "instance-3"},
+						Instances:                    []string{"test-storage-1"},
+						ExpectedInstancesInCrashLoop: []string{"storage-2", "storage-3"},
 					}),
 				Entry("Removing multiple instances.",
 					testCase{
-						Instances:                    []string{"instance-2", "instance-3"},
-						ExpectedInstancesInCrashLoop: []string{"instance-1"},
+						Instances:                    []string{"test-storage-2", "test-storage-3"},
+						ExpectedInstancesInCrashLoop: []string{"storage-1"},
 					}),
 			)
 
@@ -190,7 +189,7 @@ var _ = Describe("[plugin] buggify crash-loop instances command", func() {
 			var kubeClient client.Client
 
 			BeforeEach(func() {
-				cluster.Spec.Buggify.CrashLoop = []string{"instance-1", "instance-2", "instance-3"}
+				cluster.Spec.Buggify.CrashLoop = []string{"storage-1", "storage-2", "storage-3"}
 				scheme := runtime.NewScheme()
 				_ = clientgoscheme.AddToScheme(scheme)
 				_ = fdbv1beta2.AddToScheme(scheme)

--- a/kubectl-fdb/cmd/buggify_no_schedule.go
+++ b/kubectl-fdb/cmd/buggify_no_schedule.go
@@ -66,12 +66,7 @@ func newBuggifyNoSchedule(streams genericclioptions.IOStreams) *cobra.Command {
 				return err
 			}
 
-			processGroups, err := getProcessGroupIDsFromPod(kubeClient, cluster, args, namespace)
-			if err != nil {
-				return err
-			}
-
-			return updateNoScheduleList(kubeClient, cluster, processGroups, namespace, wait, clear, clean)
+			return updateNoScheduleList(kubeClient, cluster, args, namespace, wait, clear, clean)
 		},
 		Example: `
 # Add process groups into no-schedule state for a cluster in the current namespace
@@ -105,12 +100,17 @@ kubectl fdb -n default buggify no-schedule  -c cluster pod-1 pod-2
 }
 
 // updateNoScheduleList updates the removal list of the cluster
-func updateNoScheduleList(kubeClient client.Client, clusterName string, processGroups []string, namespace string, wait bool, clear bool, clean bool) error {
+func updateNoScheduleList(kubeClient client.Client, clusterName string, pods []string, namespace string, wait bool, clear bool, clean bool) error {
 	cluster, err := loadCluster(kubeClient, namespace, clusterName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return fmt.Errorf("could not get cluster: %s/%s", namespace, clusterName)
 		}
+		return err
+	}
+
+	processGroups, err := getProcessGroupIDsFromPodName(cluster, pods)
+	if err != nil {
 		return err
 	}
 

--- a/kubectl-fdb/cmd/buggify_no_schedule_test.go
+++ b/kubectl-fdb/cmd/buggify_no_schedule_test.go
@@ -82,13 +82,13 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 				},
 				Entry("Adding single instance.",
 					testCase{
-						Instances:                     []string{"instance-1"},
-						ExpectedInstancesInNoSchedule: []string{"instance-1"},
+						Instances:                     []string{"test-storage-1"},
+						ExpectedInstancesInNoSchedule: []string{"storage-1"},
 					}),
 				Entry("Adding multiple instances.",
 					testCase{
-						Instances:                     []string{"instance-1", "instance-2"},
-						ExpectedInstancesInNoSchedule: []string{"instance-1", "instance-2"},
+						Instances:                     []string{"test-storage-1", "test-storage-2"},
+						ExpectedInstancesInNoSchedule: []string{"storage-1", "storage-2"},
 					}),
 			)
 
@@ -96,7 +96,7 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 				var kubeClient client.Client
 
 				BeforeEach(func() {
-					cluster.Spec.Buggify.NoSchedule = []string{"instance-1"}
+					cluster.Spec.Buggify.NoSchedule = []string{"storage-1"}
 					scheme := runtime.NewScheme()
 					_ = clientgoscheme.AddToScheme(scheme)
 					_ = fdbv1beta2.AddToScheme(scheme)
@@ -124,18 +124,18 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 					},
 					Entry("Adding the same instance.",
 						testCase{
-							Instances:                     []string{"instance-1"},
-							ExpectedInstancesInNoSchedule: []string{"instance-1"},
+							Instances:                     []string{"test-storage-1"},
+							ExpectedInstancesInNoSchedule: []string{"storage-1"},
 						}),
 					Entry("Adding different instance.",
 						testCase{
-							Instances:                     []string{"instance-2"},
-							ExpectedInstancesInNoSchedule: []string{"instance-1", "instance-2"},
+							Instances:                     []string{"test-storage-2"},
+							ExpectedInstancesInNoSchedule: []string{"storage-1", "storage-2"},
 						}),
 					Entry("Adding multiple instances.",
 						testCase{
-							Instances:                     []string{"instance-2", "instance-3"},
-							ExpectedInstancesInNoSchedule: []string{"instance-1", "instance-2", "instance-3"},
+							Instances:                     []string{"test-storage-2", "test-storage-3"},
+							ExpectedInstancesInNoSchedule: []string{"storage-1", "storage-2", "storage-3"},
 						}),
 				)
 			})
@@ -145,7 +145,7 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 			var kubeClient client.Client
 
 			BeforeEach(func() {
-				cluster.Spec.Buggify.NoSchedule = []string{"instance-1", "instance-2", "instance-3"}
+				cluster.Spec.Buggify.NoSchedule = []string{"storage-1", "storage-2", "storage-3"}
 				scheme := runtime.NewScheme()
 				_ = clientgoscheme.AddToScheme(scheme)
 				_ = fdbv1beta2.AddToScheme(scheme)
@@ -173,13 +173,13 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 				},
 				Entry("Removing single instance.",
 					testCase{
-						Instances:                     []string{"instance-1"},
-						ExpectedInstancesInNoSchedule: []string{"instance-2", "instance-3"},
+						Instances:                     []string{"test-storage-1"},
+						ExpectedInstancesInNoSchedule: []string{"storage-2", "storage-3"},
 					}),
 				Entry("Removing multiple instances.",
 					testCase{
-						Instances:                     []string{"instance-2", "instance-3"},
-						ExpectedInstancesInNoSchedule: []string{"instance-1"},
+						Instances:                     []string{"test-storage-2", "test-storage-3"},
+						ExpectedInstancesInNoSchedule: []string{"storage-1"},
 					}),
 			)
 
@@ -189,7 +189,7 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 			var kubeClient client.Client
 
 			BeforeEach(func() {
-				cluster.Spec.Buggify.NoSchedule = []string{"instance-1", "instance-2", "instance-3"}
+				cluster.Spec.Buggify.NoSchedule = []string{"storage-1", "storage-2", "storage-3"}
 				scheme := runtime.NewScheme()
 				_ = clientgoscheme.AddToScheme(scheme)
 				_ = fdbv1beta2.AddToScheme(scheme)

--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -145,7 +145,7 @@ func cordonNode(kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluste
 		}
 
 		for _, pod := range pods.Items {
-			// With the field selector above this shouldn't be required but it's good to
+			// With the field selector above this shouldn't be required, but it's good to
 			// have a second check.
 			if pod.Spec.NodeName != node {
 				fmt.Printf("Pod: %s is not running on node %s will be ignored\n", pod.Name, node)
@@ -161,5 +161,5 @@ func cordonNode(kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluste
 		}
 	}
 
-	return replaceProcessGroups(kubeClient, cluster.Name, processGroups, namespace, withExclusion, false, wait, false)
+	return replaceProcessGroups(kubeClient, cluster.Name, processGroups, namespace, withExclusion, wait, false, true)
 }

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -26,9 +26,7 @@ import (
 	"log"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
-	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,10 +52,6 @@ func newRemoveProcessGroupCmd(streams genericclioptions.IOStreams) *cobra.Comman
 			if err != nil {
 				return err
 			}
-			withShrink, err := cmd.Flags().GetBool("shrink")
-			if err != nil {
-				return err
-			}
 			useProcessGroupID, err := cmd.Flags().GetBool("use-process-group-id")
 			if err != nil {
 				return err
@@ -77,15 +71,7 @@ func newRemoveProcessGroupCmd(streams genericclioptions.IOStreams) *cobra.Comman
 				return err
 			}
 
-			processGroups := args
-			if !useProcessGroupID {
-				processGroups, err = getProcessGroupIDsFromPod(kubeClient, cluster, processGroups, namespace)
-				if err != nil {
-					return err
-				}
-			}
-
-			return replaceProcessGroups(kubeClient, cluster, processGroups, namespace, withExclusion, withShrink, wait, removeAllFailed)
+			return replaceProcessGroups(kubeClient, cluster, args, namespace, withExclusion, wait, removeAllFailed, useProcessGroupID)
 		},
 		Example: `
 # Remove process groups for a cluster in the current namespace
@@ -105,7 +91,6 @@ kubectl fdb -n default remove process-group -c cluster --remove-all-failed
 
 	cmd.Flags().StringP("fdb-cluster", "c", "", "remove process groupss from the provided cluster.")
 	cmd.Flags().BoolP("exclusion", "e", true, "define if the process groups should be removed with exclusion.")
-	cmd.Flags().Bool("shrink", false, "define if the removed process groups should not be replaced.")
 	cmd.Flags().Bool("remove-all-failed", false, "define if all failed processes should be replaced.")
 	cmd.Flags().Bool("use-process-group-id", false, "define if the process-group should be used instead of the Pod name.")
 	err := cmd.MarkFlagRequired("fdb-cluster")
@@ -122,7 +107,11 @@ kubectl fdb -n default remove process-group -c cluster --remove-all-failed
 }
 
 // replaceProcessGroups adds process groups to the removal list of the cluster
-func replaceProcessGroups(kubeClient client.Client, clusterName string, processGroups []string, namespace string, withExclusion bool, withShrink bool, wait bool, removeAllFailed bool) error {
+func replaceProcessGroups(kubeClient client.Client, clusterName string, processGroups []string, namespace string, withExclusion bool, wait bool, removeAllFailed bool, useProcessGroupID bool) error {
+	if len(processGroups) == 0 && !removeAllFailed {
+		return nil
+	}
+
 	cluster, err := loadCluster(kubeClient, namespace, clusterName)
 
 	if err != nil {
@@ -132,25 +121,11 @@ func replaceProcessGroups(kubeClient client.Client, clusterName string, processG
 		return err
 	}
 
-	if len(processGroups) == 0 && !removeAllFailed {
-		return nil
-	}
-
-	shrinkMap := make(map[fdbv1beta2.ProcessClass]int)
-
-	if withShrink {
-		var pods corev1.PodList
-		err := kubeClient.List(ctx.Background(), &pods,
-			client.InNamespace(namespace),
-			client.MatchingLabels(cluster.GetMatchLabels()),
-		)
+	// In this case the user has Pod name specified
+	if !useProcessGroupID {
+		processGroups, err = getProcessGroupIDsFromPodName(cluster, processGroups)
 		if err != nil {
 			return err
-		}
-
-		for _, pod := range pods.Items {
-			class := internal.GetProcessClassFromMeta(cluster, pod.ObjectMeta)
-			shrinkMap[class]++
 		}
 	}
 
@@ -175,12 +150,8 @@ func replaceProcessGroups(kubeClient client.Client, clusterName string, processG
 		}
 	}
 
-	for class, amount := range shrinkMap {
-		cluster.Spec.ProcessCounts.DecreaseCount(class, amount)
-	}
-
 	if wait {
-		confirmed := confirmAction(fmt.Sprintf("Remove %v from cluster %s/%s with exclude: %t and shrink: %t", processGroups, namespace, clusterName, withExclusion, withShrink))
+		confirmed := confirmAction(fmt.Sprintf("Remove %v from cluster %s/%s with exclude: %t", processGroups, namespace, clusterName, withExclusion))
 		if !confirmed {
 			return fmt.Errorf("user aborted the removal")
 		}


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/761 (by removing this feature)
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1291

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

This change reduces the required API calls to Kubernetes to fetch the process group information, this has a benefit in larger Kubernetes clusters. I decided to remove the shrink logic in the remove process groups subcommand, I'm not aware of a use case where we used this and I don't think the additional complexity is worth it for an unused feature.

The new approach has one minor drawback, which I think is okay: Since the process group ID is now calculated based on the cluster spec we could run in a race condition where a user changes the prefix and the cluster is not yet fully reconciled and the user would use the plugin to remove a process group (which still has the old ID). In this case the workaround would be to not use the Pod and rather specify the process group ID directly.

## Testing

Unit tests + locally.

## Documentation

-

## Follow-up

-
