### PR TITLE
updating the default time for failure detection

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1107,7 +1107,7 @@ type AutomaticReplacementOptions struct {
 
 	// FailureDetectionTimeSeconds controls how long a process must be
 	// failed or missing before it is automatically replaced.
-	// The default is 1800 seconds, or 30 minutes.
+	// The default is 7200 seconds, or 2 hours.
 	FailureDetectionTimeSeconds *int `json:"failureDetectionTimeSeconds,omitempty"`
 
 	// MaxConcurrentReplacements controls how many automatic replacements are allowed to take part.

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -881,7 +881,7 @@ type AutomaticReplacementOptions struct {
 
 	// FailureDetectionTimeSeconds controls how long a process must be
 	// failed or missing before it is automatically replaced.
-	// The default is 1800 seconds, or 30 minutes.
+	// The default is 7200 seconds, or 2 hours.
 	FailureDetectionTimeSeconds *int `json:"failureDetectionTimeSeconds,omitempty"`
 
 	// MaxConcurrentReplacements controls how many automatic replacements are allowed to take part.
@@ -1946,9 +1946,9 @@ func (cluster *FoundationDBCluster) GetEnableAutomaticReplacements() bool {
 	return pointer.BoolDeref(cluster.Spec.AutomationOptions.Replacements.Enabled, true)
 }
 
-// GetFailureDetectionTimeSeconds returns cluster.Spec.AutomationOptions.Replacements.FailureDetectionTimeSeconds or if unset the default 1800
+// GetFailureDetectionTimeSeconds returns cluster.Spec.AutomationOptions.Replacements.FailureDetectionTimeSeconds or if unset the default 7200
 func (cluster *FoundationDBCluster) GetFailureDetectionTimeSeconds() int {
-	return pointer.IntDeref(cluster.Spec.AutomationOptions.Replacements.FailureDetectionTimeSeconds, 1800)
+	return pointer.IntDeref(cluster.Spec.AutomationOptions.Replacements.FailureDetectionTimeSeconds, 7200)
 }
 
 // GetSidecarContainerEnableLivenessProbe returns cluster.Spec.SidecarContainer.EnableLivenessProbe or if unset the default true

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -43,7 +43,7 @@ AutomaticReplacementOptions controls options for automatically replacing failed 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | enabled | Enabled controls whether automatic replacements are enabled. The default is false. | *bool | false |
-| failureDetectionTimeSeconds | FailureDetectionTimeSeconds controls how long a process must be failed or missing before it is automatically replaced. The default is 1800 seconds, or 30 minutes. | *int | false |
+| failureDetectionTimeSeconds | FailureDetectionTimeSeconds controls how long a process must be failed or missing before it is automatically replaced. The default is 7200 seconds, or 2 hours. | *int | false |
 | maxConcurrentReplacements | MaxConcurrentReplacements controls how many automatic replacements are allowed to take part. This will take the list of current replacements and then calculate the difference between maxConcurrentReplacements and the size of the list. e.g. if currently 3 replacements are queued (e.g. in the processGroupsToRemove list) and maxConcurrentReplacements is 5 the operator is allowed to replace at most 2 process groups. Setting this to 0 will basically disable the automatic replacements. | *int | false |
 
 [Back to TOC](#table-of-contents)

--- a/docs/manual/replacements_and_deletions.md
+++ b/docs/manual/replacements_and_deletions.md
@@ -32,7 +32,7 @@ Depending on the cluster size this can require a quota that is has double the ca
 The operator has an option to automatically replace pods that are in a bad state. This behavior is disabled by default, but you can enable it by setting the field `automationOptions.replacements.enabled` in the cluster spec.
 This will replace any pods that meet the following criteria:
 
-* The process group has a condition that is eligible for replacement, and has been in that condition for 1800 seconds. This time window is configurable through `automationOptions.replacements.failureDetectionTimeSeconds`.
+* The process group has a condition that is eligible for replacement, and has been in that condition for 7200 seconds. This time window is configurable through `automationOptions.replacements.failureDetectionTimeSeconds`.
 * The number of process groups that are marked for removal and not fully excluded, counting the process group that is being evaluated for replacement, is less than or equal to 1. This limit is configurable through `automationOptions.replacements.maxConcurrentReplacements`.
 
 The following conditions are currently eligible for replacement:

--- a/internal/deprecations_test.go
+++ b/internal/deprecations_test.go
@@ -216,7 +216,7 @@ var _ = Describe("[internal] deprecations", func() {
 
 				It("should have automatic replacements enabled", func() {
 					Expect(cluster.GetEnableAutomaticReplacements()).To(BeTrue())
-					Expect(cluster.GetFailureDetectionTimeSeconds()).To(Equal(1800))
+					Expect(cluster.GetFailureDetectionTimeSeconds()).To(Equal(7200))
 				})
 
 				It("should have the probe settings for the sidecar", func() {


### PR DESCRIPTION
# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*
Updated the default value for failure detection time to 2 hours from 30 mins.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

*Are there any design details that you would like to discuss further?*
No

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*
Updated the existing test case with correct value. 

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

## Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
