### PR TITLE
Ignore process groups if they have the sidecar unreachable condition in the bounce sub reconciler

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1159,7 +1159,12 @@ func (cluster *FoundationDBCluster) CheckReconciliation(log logr.Logger) (bool, 
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if len(processGroup.ProcessGroupConditions) > 0 && !processGroup.IsMarkedForRemoval() {
-			logger.Info("Has unhealthy process group", "processGroupID", processGroup.ProcessGroupID, "state", "HasUnhealthyProcess")
+			conditions := make([]ProcessGroupConditionType, 0, len(processGroup.ProcessGroupConditions))
+			for _, condition := range processGroup.ProcessGroupConditions {
+				conditions = append(conditions, condition.ProcessGroupConditionType)
+			}
+
+			logger.Info("Has unhealthy process group", "processGroupID", processGroup.ProcessGroupID, "state", "HasUnhealthyProcess", "conditions", conditions)
 			cluster.Status.Generations.HasUnhealthyProcess = cluster.ObjectMeta.Generation
 			reconciled = false
 		}

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -58,7 +58,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 	minimumUptime := math.Inf(1)
 	addressMap := make(map[string][]fdbv1beta2.ProcessAddress, len(status.Cluster.Processes))
 	for _, process := range status.Cluster.Processes {
-		addressMap[process.Locality["instance_id"]] = append(addressMap[process.Locality["instance_id"]], process.Address)
+		addressMap[process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]] = append(addressMap[process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]], process.Address)
 
 		if process.UptimeSeconds < minimumUptime {
 			minimumUptime = process.UptimeSeconds
@@ -68,6 +68,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 	processesToBounce := fdbv1beta2.FilterByConditions(cluster.Status.ProcessGroups, map[fdbv1beta2.ProcessGroupConditionType]bool{
 		fdbv1beta2.IncorrectCommandLine: true,
 		fdbv1beta2.IncorrectPodSpec:     false,
+		fdbv1beta2.SidecarUnreachable:   false, // ignore all Process groups that are not reachable and therefor not get any config map updates.
 	}, true)
 
 	addresses := make([]fdbv1beta2.ProcessAddress, 0, len(processesToBounce))

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -68,7 +68,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 	processesToBounce := fdbv1beta2.FilterByConditions(cluster.Status.ProcessGroups, map[fdbv1beta2.ProcessGroupConditionType]bool{
 		fdbv1beta2.IncorrectCommandLine: true,
 		fdbv1beta2.IncorrectPodSpec:     false,
-		fdbv1beta2.SidecarUnreachable:   false, // ignore all Process groups that are not reachable and therefor not get any config map updates.
+		fdbv1beta2.SidecarUnreachable:   false, // ignore all Process groups that are not reachable and therefore will not get any config map updates.
 	}, true)
 
 	addresses := make([]fdbv1beta2.ProcessAddress, 0, len(processesToBounce))

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -42,6 +42,7 @@ type excludeProcesses struct{}
 
 // reconcile runs the reconciler's work.
 func (e excludeProcesses) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "excludeProcesses")
 	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
 	if err != nil {
 		return &requeue{curError: err}
@@ -62,7 +63,7 @@ func (e excludeProcesses) reconcile(_ context.Context, r *FoundationDBClusterRec
 		if err != nil {
 			return &requeue{curError: err}
 		}
-		log.Info("current exclusions", "ex", exclusions)
+		logger.Info("current exclusions", "ex", exclusions)
 		fdbProcessesToExclude, processClassesToExclude = getProcessesToExclude(exclusions, cluster, removalCount)
 	}
 


### PR DESCRIPTION
# Description

Make the rollout process for config changes more reliable to process groups that are in an unreachable status.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

I think it's safe to ignore process groups if their sidecar is unreachable otherwise one single process group might block the whole reconciliation.

## Testing

Locally. Will add an additional e2e test before merging.

## Documentation

-

## Follow-up

-
