### PR TITLE
Add better logging for fdb client calls

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -97,7 +97,6 @@ func NewCliAdminClient(cluster *fdbv1beta2.FoundationDBCluster, _ client.Client,
 	if err != nil {
 		return nil, err
 	}
-	clusterFilePath := clusterFile.Name()
 
 	defer clusterFile.Close()
 	_, err = clusterFile.WriteString(cluster.Status.ConnectionString)
@@ -109,7 +108,7 @@ func NewCliAdminClient(cluster *fdbv1beta2.FoundationDBCluster, _ client.Client,
 		return nil, err
 	}
 
-	return &cliAdminClient{Cluster: cluster, clusterFilePath: clusterFilePath, useClientLibrary: true, log: log}, nil
+	return &cliAdminClient{Cluster: cluster, clusterFilePath: clusterFile.Name(), useClientLibrary: true, log: log}, nil
 }
 
 // cliCommand describes a command that we are running against FDB.
@@ -620,7 +619,7 @@ func (client *cliAdminClient) GetConnectionString() (string, error) {
 	if client.Cluster.UseManagementAPI() {
 		// This will call directly the database and fetch the connection string
 		// from the system key space.
-		connectionStringBytes, err = getConnectionStringFromDB(client.Cluster)
+		connectionStringBytes, err = getConnectionStringFromDB(client.Cluster, client.log)
 	} else {
 		var output string
 		output, err = client.runCommandWithBackoff("status minimal")

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -72,7 +72,11 @@ func getFDBDatabase(cluster *fdbv1beta2.FoundationDBCluster) (fdb.Database, erro
 	return database, nil
 }
 
-func getValueFromDBUsingKey(cluster *fdbv1beta2.FoundationDBCluster, fdbKey string, extraTimeout int64) ([]byte, error) {
+func getValueFromDBUsingKey(cluster *fdbv1beta2.FoundationDBCluster, log logr.Logger, fdbKey string, extraTimeout int64) ([]byte, error) {
+	log.Info("Fetch values from FDB", "namespace", cluster.Namespace, "cluster", cluster.Name, "key", fdbKey)
+	defer func() {
+		log.Info("Done fetching values from FDB", "namespace", cluster.Namespace, "cluster", cluster.Name, "key", fdbKey)
+	}()
 	database, err := getFDBDatabase(cluster)
 	if err != nil {
 		return nil, err
@@ -108,14 +112,13 @@ func getValueFromDBUsingKey(cluster *fdbv1beta2.FoundationDBCluster, fdbKey stri
 }
 
 // getConnectionStringFromDB gets the database's connection string directly from the system key
-func getConnectionStringFromDB(cluster *fdbv1beta2.FoundationDBCluster) ([]byte, error) {
-	return getValueFromDBUsingKey(cluster, "\xff\xff/connection_string", 1)
+func getConnectionStringFromDB(cluster *fdbv1beta2.FoundationDBCluster, log logr.Logger) ([]byte, error) {
+	return getValueFromDBUsingKey(cluster, log, "\xff\xff/connection_string", 1)
 }
 
 // getStatusFromDB gets the database's status directly from the system key
 func getStatusFromDB(cluster *fdbv1beta2.FoundationDBCluster, log logr.Logger) ([]byte, error) {
-	log.Info("Fetch status from FDB", "namespace", cluster.Namespace, "cluster", cluster.Name)
-	return getValueFromDBUsingKey(cluster, "\xff\xff/status/json", 1000)
+	return getValueFromDBUsingKey(cluster, log, "\xff\xff/status/json", 1000)
 }
 
 type realDatabaseClientProvider struct {


### PR DESCRIPTION
# Description

Adds a logging call when we read a value from FDB with the fdb client and add an additional log when the call ended to see how long the call took.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Locally.

## Documentation

-

## Follow-up

-