### PR TITLE
Correct the way how the connection string is read

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -622,7 +622,7 @@ func (client *cliAdminClient) GetConnectionString() (string, error) {
 		connectionStringBytes, err = getConnectionStringFromDB(client.Cluster, client.log)
 	} else {
 		var output string
-		output, err = client.runCommandWithBackoff("status minimal")
+		output, err = client.runCommandWithBackoff("option on ACCESS_SYSTEM_KEYS; get \xff/coordinators")
 		if err != nil {
 			return "", err
 		}

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -611,33 +611,37 @@ func (client *cliAdminClient) ChangeCoordinators(addresses []fdbv1beta2.ProcessA
 	return connectionString.String(), nil
 }
 
+// cleanConnectionStringOutput is a helper method to remove unrelated output from the get command in the connection string
+// output.
+func cleanConnectionStringOutput(input string) string {
+	startIdx := strings.LastIndex(input, "`")
+	endIdx := strings.LastIndex(input, "'")
+	if startIdx == -1 && endIdx == -1 {
+		return input
+	}
+
+	return input[startIdx+1 : endIdx]
+}
+
 // GetConnectionString fetches the latest connection string.
 func (client *cliAdminClient) GetConnectionString() (string, error) {
-	var connectionStringBytes []byte
+	var output string
 	var err error
 
 	if client.Cluster.UseManagementAPI() {
 		// This will call directly the database and fetch the connection string
 		// from the system key space.
-		connectionStringBytes, err = getConnectionStringFromDB(client.Cluster, client.log)
+		var outputBytes []byte
+		outputBytes, err = getConnectionStringFromDB(client.Cluster, client.log)
+		output = string(outputBytes)
 	} else {
-		var output string
 		output, err = client.runCommandWithBackoff("option on ACCESS_SYSTEM_KEYS; get \xff/coordinators")
-		if err != nil {
-			return "", err
-		}
-
-		if !strings.Contains(output, "The database is available") {
-			return "", fmt.Errorf("unable to fetch connection string: %s", output)
-		}
-
-		connectionStringBytes, err = os.ReadFile(client.clusterFilePath)
 	}
 	if err != nil {
 		return "", err
 	}
 	var connectionString fdbv1beta2.ConnectionString
-	connectionString, err = fdbv1beta2.ParseConnectionString(string(connectionStringBytes))
+	connectionString, err = fdbv1beta2.ParseConnectionString(cleanConnectionStringOutput(output))
 	if err != nil {
 		return "", err
 	}

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -178,4 +178,23 @@ var _ = Describe("admin_client_test", func() {
 			),
 		)
 	})
+
+	When("parsing the connection string", func() {
+		DescribeTable("it should return the correct connection string",
+			func(input string, expected string) {
+				connectingString, err := fdbv1beta2.ParseConnectionString(cleanConnectionStringOutput(input))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(connectingString.String()).To(Equal(expected))
+			},
+			Entry("with a correct response from FDB",
+				">>> option on ACCESS_SYSTEM_KEYS\\nOption enabled for all transactions\\n>>> get \\\\xff/coordinators\\n`\\\\xff/coordinators' is `fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@100.82.81.253:4500:tls,100.82.71.5:4500:tls,100.82.119.151:4500:tls,100.82.122.125:4500:tls,100.82.76.240:4500:tls'\\n",
+				"fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@100.82.81.253:4500:tls,100.82.71.5:4500:tls,100.82.119.151:4500:tls,100.82.122.125:4500:tls,100.82.76.240:4500:tls",
+			),
+
+			Entry("without the byte string response",
+				"fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@100.82.81.253:4500:tls,100.82.71.5:4500:tls,100.82.119.151:4500:tls,100.82.122.125:4500:tls,100.82.76.240:4500:tls",
+				"fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@100.82.81.253:4500:tls,100.82.71.5:4500:tls,100.82.119.151:4500:tls,100.82.122.125:4500:tls,100.82.76.240:4500:tls",
+			),
+		)
+	})
 })

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -113,7 +113,7 @@ func getValueFromDBUsingKey(cluster *fdbv1beta2.FoundationDBCluster, log logr.Lo
 
 // getConnectionStringFromDB gets the database's connection string directly from the system key
 func getConnectionStringFromDB(cluster *fdbv1beta2.FoundationDBCluster, log logr.Logger) ([]byte, error) {
-	return getValueFromDBUsingKey(cluster, log, "\xff\xff/connection_string", 1)
+	return getValueFromDBUsingKey(cluster, log, "\xff/coordinators", 1)
 }
 
 // getStatusFromDB gets the database's status directly from the system key


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1308

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

This ensures that the command returns the current connection string.

## Testing

e2e.

## Documentation

-

## Follow-up

-
