### PR TITLE
Ignore excluded processes from minimum uptime calculation when doing a rolling bounce

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -57,10 +57,14 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 
 	minimumUptime := math.Inf(1)
 	addressMap := make(map[string][]fdbv1beta2.ProcessAddress, len(status.Cluster.Processes))
+
 	for _, process := range status.Cluster.Processes {
+		if process.Excluded {
+			continue
+		}
 		addressMap[process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]] = append(addressMap[process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]], process.Address)
 
-		if process.UptimeSeconds < minimumUptime {
+		if process.UptimeSeconds < minimumUptime && !process.Excluded {
 			minimumUptime = process.UptimeSeconds
 		}
 	}

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -61,7 +61,6 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 	for _, process := range status.Cluster.Processes {
 		addressMap[process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]] = append(addressMap[process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]], process.Address)
 
-		// comment to trigger PR builder
 		if process.UptimeSeconds < minimumUptime && !process.Excluded {
 			minimumUptime = process.UptimeSeconds
 		}

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -59,9 +59,6 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 	addressMap := make(map[string][]fdbv1beta2.ProcessAddress, len(status.Cluster.Processes))
 
 	for _, process := range status.Cluster.Processes {
-		if process.Excluded {
-			continue
-		}
 		addressMap[process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]] = append(addressMap[process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]], process.Address)
 
 		// comment to trigger PR builder

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -64,6 +64,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		}
 		addressMap[process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]] = append(addressMap[process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]], process.Address)
 
+		// comment to trigger PR builder
 		if process.UptimeSeconds < minimumUptime && !process.Excluded {
 			minimumUptime = process.UptimeSeconds
 		}

--- a/controllers/bounce_processes_test.go
+++ b/controllers/bounce_processes_test.go
@@ -134,7 +134,8 @@ var _ = Describe("bounceProcesses", func() {
 			Expect(processGroup.ProcessGroupID).To(Equal("storage-1"))
 			processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true, nil, "")
 			for _, address := range processGroup.Addresses {
-				adminClient.ExcludeProcesses([]fdbv1beta2.ProcessAddress{{StringAddress: address, Port: 4501}})
+				err := adminClient.ExcludeProcesses([]fdbv1beta2.ProcessAddress{{StringAddress: address, Port: 4501}})
+				Expect(err).To(BeNil())
 			}
 
 		})


### PR DESCRIPTION
# Description

Ignore processes that are excluded when calculating the minimum uptime.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

## Testing
Unit tests

## Documentation

## Follow-up
