### PR TITLE
Add Docker login back for pushing from main

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -166,6 +166,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Get the sha
         id: get_sha
         run: echo ::set-output name=TAG::${GITHUB_SHA}


### PR DESCRIPTION
# Description

In https://github.com/FoundationDB/fdb-kubernetes-operator/pull/1355 we did some refactoring and missed to add the login step if we operator on the main branch.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

-

## Documentation

-

## Follow-up

-
