### PR TITLE
Add test process count

### DIFF
--- a/api/v1beta1/foundationdb_database_configuration.go
+++ b/api/v1beta1/foundationdb_database_configuration.go
@@ -681,11 +681,14 @@ func fieldIndices(value interface{}, result interface{}, keyType reflect.Type) {
 // GetProcessCountsWithDefaults for more information on the rules for inferring
 // process counts.
 type ProcessCounts struct {
-	Unset             int `json:"unset,omitempty"`
-	Storage           int `json:"storage,omitempty"`
-	Transaction       int `json:"transaction,omitempty"`
-	Resolution        int `json:"resolution,omitempty"`
+	Unset       int `json:"unset,omitempty"`
+	Storage     int `json:"storage,omitempty"`
+	Transaction int `json:"transaction,omitempty"`
+	Resolution  int `json:"resolution,omitempty"`
+	// Deprecated: This setting will be removed in the next major release.
+	// use Test
 	Tester            int `json:"tester,omitempty"`
+	Test              int `json:"test,omitempty"`
 	Proxy             int `json:"proxy,omitempty"`
 	Master            int `json:"master,omitempty"`
 	Stateless         int `json:"stateless,omitempty"`

--- a/api/v1beta2/foundationdb_database_configuration.go
+++ b/api/v1beta2/foundationdb_database_configuration.go
@@ -838,11 +838,14 @@ func fieldIndices(value interface{}, result interface{}, keyType reflect.Type) {
 // GetProcessCountsWithDefaults for more information on the rules for inferring
 // process counts.
 type ProcessCounts struct {
-	Unset             int `json:"unset,omitempty"`
-	Storage           int `json:"storage,omitempty"`
-	Transaction       int `json:"transaction,omitempty"`
-	Resolution        int `json:"resolution,omitempty"`
+	Unset       int `json:"unset,omitempty"`
+	Storage     int `json:"storage,omitempty"`
+	Transaction int `json:"transaction,omitempty"`
+	Resolution  int `json:"resolution,omitempty"`
+	// Deprecated: This setting will be removed in the next major release.
+	// use Test
 	Tester            int `json:"tester,omitempty"`
+	Test              int `json:"test,omitempty"`
 	Proxy             int `json:"proxy,omitempty"`
 	CommitProxy       int `json:"commit_proxy,omitempty"`
 	GrvProxy          int `json:"grv_proxy,omitempty"`

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -4925,6 +4925,8 @@ spec:
                     type: integer
                   storage_cache:
                     type: integer
+                  test:
+                    type: integer
                   tester:
                     type: integer
                   transaction:
@@ -9750,6 +9752,8 @@ spec:
                     type: integer
                   storage_cache:
                     type: integer
+                  test:
+                    type: integer
                   tester:
                     type: integer
                   transaction:
@@ -10189,6 +10193,8 @@ spec:
                   storage:
                     type: integer
                   storage_cache:
+                    type: integer
+                  test:
                     type: integer
                   tester:
                     type: integer

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -621,7 +621,7 @@ func checkCoordinatorValidity(cluster *fdbv1beta2.FoundationDBCluster, status *f
 		}
 
 		if process.ProcessClass == fdbv1beta2.ProcessClassTest {
-			pLogger.Info("Ignoring tester process")
+			pLogger.Info("Ignoring test process")
 			continue
 		}
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2752,6 +2752,33 @@ var _ = Describe("cluster_controller", func() {
 			cluster.Status.ConnectionString = fakeConnectionString
 		})
 
+		Context("with a test process group", func() {
+			BeforeEach(func() {
+				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassTest, nil, cluster.GetStorageServersPerPod())
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should generate the test conf", func() {
+				Expect(conf).To(Equal(strings.Join([]string{
+					"[general]",
+					"kill_on_configuration_change = false",
+					"restart_delay = 60",
+					"[fdbserver.1]",
+					"command = $BINARY_DIR/fdbserver",
+					"cluster_file = /var/fdb/data/fdb.cluster",
+					"seed_cluster_file = /var/dynamic-conf/fdb.cluster",
+					"public_address = $FDB_PUBLIC_IP:4501",
+					"class = test",
+					"logdir = /var/log/fdb-trace-logs",
+					"loggroup = " + cluster.Name,
+					"datadir = /var/fdb/data",
+					"locality_instance_id = $FDB_INSTANCE_ID",
+					"locality_machineid = $FDB_MACHINE_ID",
+					"locality_zoneid = $FDB_ZONE_ID",
+				}, "\n")))
+			})
+		})
+
 		Context("with a basic storage process group", func() {
 			BeforeEach(func() {
 				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -454,7 +454,8 @@ ProcessCounts represents the number of processes we have for each valid process 
 | storage |  | int | false |
 | transaction |  | int | false |
 | resolution |  | int | false |
-| tester |  | int | false |
+| tester | **Deprecated: This setting will be removed in the next major release. use Test** | int | false |
+| test |  | int | false |
 | proxy |  | int | false |
 | commit_proxy |  | int | false |
 | grv_proxy |  | int | false |

--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -730,6 +730,33 @@ var _ = Describe("monitor_conf", func() {
 			})
 		})
 
+		Context("with a test instance", func() {
+			BeforeEach(func() {
+				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassTest, nil, cluster.GetStorageServersPerPod())
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should generate the test conf", func() {
+				Expect(conf).To(Equal(strings.Join([]string{
+					"[general]",
+					"kill_on_configuration_change = false",
+					"restart_delay = 60",
+					"[fdbserver.1]",
+					"command = $BINARY_DIR/fdbserver",
+					"cluster_file = /var/fdb/data/fdb.cluster",
+					"seed_cluster_file = /var/dynamic-conf/fdb.cluster",
+					"public_address = $FDB_PUBLIC_IP:4501",
+					"class = test",
+					"logdir = /var/log/fdb-trace-logs",
+					"loggroup = " + cluster.Name,
+					"datadir = /var/fdb/data",
+					"locality_instance_id = $FDB_INSTANCE_ID",
+					"locality_machineid = $FDB_MACHINE_ID",
+					"locality_zoneid = $FDB_ZONE_ID",
+				}, "\n")))
+			})
+		})
+
 		Context("with DNS names enabled", func() {
 			BeforeEach(func() {
 				cluster.Spec.Routing.UseDNSInClusterFile = pointer.Bool(true)


### PR DESCRIPTION
# Description

This PR adds "test" processCount.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

This changes are based on discussion under 
https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1346

## Testing

Unit test

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

## Documentation

Yes, added description in fdb cluster page.

## Follow-up

Add deprecation for tester
Does not have anything