### PR TITLE
Add support for desired and reconciled process groups in status

### DIFF
--- a/api/v1beta2/foundationdb_database_configuration.go
+++ b/api/v1beta2/foundationdb_database_configuration.go
@@ -911,5 +911,20 @@ func (counts ProcessCounts) Diff(currentCounts ProcessCounts) map[ProcessClass]i
 			diff[label] = desired - current
 		}
 	}
+
 	return diff
+}
+
+// Total gets the total number of processes for the cluster configuration.
+func (counts ProcessCounts) Total() int {
+	var total int64
+	desiredValue := reflect.ValueOf(counts)
+	for _, index := range processClassIndices {
+		desired := desiredValue.Field(index).Int()
+		if desired > 0 {
+			total += desired
+		}
+	}
+
+	return int(total)
 }

--- a/api/v1beta2/foundationdb_database_configuration_test.go
+++ b/api/v1beta2/foundationdb_database_configuration_test.go
@@ -157,4 +157,37 @@ var _ = Describe("DatabaseConfiguration", func() {
 			})
 		})
 	})
+
+	When("using ProcessCounts", func() {
+		When("calculating the total number of processes", func() {
+			var counts ProcessCounts
+
+			When("no negative process counts are specified", func() {
+				BeforeEach(func() {
+					counts = ProcessCounts{
+						Storage: 5,
+						Log:     5,
+					}
+				})
+
+				It("should print the correct number of total processes", func() {
+					Expect(counts.Total()).To(BeNumerically("==", 10))
+				})
+			})
+
+			When("negative process counts are specified", func() {
+				BeforeEach(func() {
+					counts = ProcessCounts{
+						Storage:   5,
+						Log:       5,
+						Stateless: -1,
+					}
+				})
+
+				It("should print the correct number of total processes", func() {
+					Expect(counts.Total()).To(BeNumerically("==", 10))
+				})
+			})
+		})
+	})
 })

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -9828,6 +9828,16 @@ spec:
       jsonPath: .status.health.fullReplication
       name: FullReplication
       type: boolean
+    - description: Number of reconciled process groups
+      jsonPath: .status.reconciledProcessGroups
+      name: ReconciledProcessGroups
+      priority: 1
+      type: integer
+    - description: Desired number of process groups
+      jsonPath: .status.desiredProcessGroups
+      name: DesiredProcessGroups
+      priority: 1
+      type: integer
     - description: Running version
       jsonPath: .status.runningVersion
       name: Version
@@ -13678,6 +13688,8 @@ spec:
                   usable_regions:
                     type: integer
                 type: object
+              desiredProcessGroups:
+                type: integer
               generations:
                 properties:
                   hasExtraListeners:
@@ -13798,6 +13810,8 @@ spec:
                       type: string
                   type: object
                 type: array
+              reconciledProcessGroups:
+                type: integer
               requiredAddresses:
                 properties:
                   nonTLS:

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -258,6 +258,8 @@ FoundationDBClusterStatus defines the observed state of FoundationDBCluster
 | processGroups | ProcessGroups contain information about a process group. This information is used in multiple places to trigger the according action. | []*[ProcessGroupStatus](#processgroupstatus) | false |
 | locks | Locks contains information about the locking system. | [LockSystemStatus](#locksystemstatus) | false |
 | maintenanceModeInfo | MaintenenanceModeInfo contains information regarding process groups in maintenance mode | [MaintenanceModeInfo](#maintenancemodeinfo) | false |
+| desiredProcessGroups | DesiredProcessGroups reflects the number of expected running process groups. | int | false |
+| reconciledProcessGroups | ReconciledProcessGroups reflects the number of process groups that have no condition and are not marked for removal. | int | false |
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1298

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

Sadly the current CRD setup (not the setup in our repository) doesn't allow "complex" jsonpath queries, so we have to add two different fields in the kubectl output. The `priority: 1` means that those fields are only be present in the output if someone runs `kubectl get fdb ... -o wide`

## Testing

Local testing and unit tests.

## Documentation

-

## Follow-up

-
