### PR TITLE
Make use of time.duration instead of int for timeout

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -148,7 +148,7 @@ func (command cliCommand) getTimeout() int {
 		return int(command.timeout.Seconds())
 	}
 
-	return DefaultCLITimeout
+	return int(DefaultCLITimeout.Seconds())
 }
 
 // getBinaryPath generates the path to an FDB binary.
@@ -248,13 +248,13 @@ func (client *cliAdminClient) runCommand(command cliCommand) (string, error) {
 // runCommandWithBackoff is a wrapper around runCommand which allows retrying commands if they hit a timeout.
 func (client *cliAdminClient) runCommandWithBackoff(command string) (string, error) {
 	maxTimeoutInSeconds := 40
-	currentTimeoutInSeconds := DefaultCLITimeout
+	currentTimeoutInSeconds := int(DefaultCLITimeout.Seconds())
 
 	var rawResult string
 	var err error
 
 	// This method will be retrying to get the status if a timeout is seen. The timeout will be doubled everytime we try
-	// it with the default timeout of 10 we will try it 3 times with the following timeouts: 10s - 20s - 40s. We have
+	// it with the default timeout of 10s we will try it 3 times with the following timeouts: 10s - 20s - 40s. We have
 	// seen that during upgrades of version incompatible version, when not all coordinators are properly restarted that
 	// the response time will be increased.
 	for currentTimeoutInSeconds <= maxTimeoutInSeconds {

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -247,7 +247,7 @@ func (client *cliAdminClient) runCommand(command cliCommand) (string, error) {
 
 // runCommandWithBackoff is a wrapper around runCommand which allows retrying commands if they hit a timeout.
 func (client *cliAdminClient) runCommandWithBackoff(command string) (string, error) {
-	maxTimeout := time.Second * 40
+	maxTimeout := 40 * time.Second
 	currentTimeout := DefaultCLITimeout
 
 	var rawResult string

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -83,7 +83,7 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 		"Apply defaults from the next major version of the operator. This is only intended for use in development.",
 	)
 	fs.StringVar(&o.LogFile, "log-file", "", "The path to a file to write logs to.")
-	fs.IntVar(&o.CliTimeout, "cli-timeout", 10, "The timeout to use for CLI commands.")
+	fs.IntVar(&o.CliTimeout, "cli-timeout", 10, "The timeout to use for CLI commands in seconds.")
 	fs.IntVar(&o.MaxConcurrentReconciles, "max-concurrent-reconciles", 1, "Defines the maximum number of concurrent reconciles for all controllers.")
 	fs.BoolVar(&o.CleanUpOldLogFile, "cleanup-old-cli-logs", true, "Defines if the operator should delete old fdbcli log files.")
 	fs.DurationVar(&o.LogFileMinAge, "log-file-min-age", 5*time.Minute, "Defines the minimum age of fdbcli log files before removing when \"--cleanup-old-cli-logs\" is set.")
@@ -143,7 +143,7 @@ func StartManager(
 	klog.SetLogger(logger)
 
 	setupLog := logger.WithName("setup")
-	fdbclient.DefaultCLITimeout = operatorOpts.CliTimeout
+	fdbclient.DefaultCLITimeout = time.Duration(operatorOpts.CliTimeout) * time.Second
 
 	options := ctrl.Options{
 		Scheme:             scheme,


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1302

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Unit test + local testing.

## Documentation

-

## Follow-up

-
