### PR TITLE
Use deterministic name for cluster file

### DIFF
--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -23,7 +23,9 @@ package fdbclient
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"path"
 	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
@@ -41,27 +43,40 @@ const (
 // DefaultCLITimeout is the default timeout for CLI commands.
 var DefaultCLITimeout = 10 * time.Second
 
-// getFDBDatabase opens an FDB database. The result will be cached for
-// subsequent calls, based on the cluster namespace and name.
+// createClusterFile will create or update the cluster file for the specified cluster.
+func createClusterFile(cluster *fdbv1beta2.FoundationDBCluster) (string, error) {
+	return ensureClusterFileIsPresent(os.TempDir(), string(cluster.UID), cluster.Status.ConnectionString)
+}
+
+// ensureClusterFileIsPresent will ensure that the cluster file with the specified connection string is present.
+func ensureClusterFileIsPresent(dir string, uid string, connectionString string) (string, error) {
+	clusterFileName := path.Join(dir, uid)
+
+	// Try to read the file to check if the file already exists and if so, if the content matches
+	content, err := os.ReadFile(clusterFileName)
+
+	// If the file doesn't exist we have to create it
+	if errors.Is(err, fs.ErrNotExist) {
+		return clusterFileName, os.WriteFile(clusterFileName, []byte(connectionString), 0777)
+	}
+
+	// The content of the cluster file is already correct.
+	if string(content) == connectionString {
+		return clusterFileName, nil
+	}
+
+	// The content doesn't match, so we have to write the new content to the cluster file.
+	return clusterFileName, os.WriteFile(clusterFileName, []byte(connectionString), 0777)
+}
+
+// getFDBDatabase opens an FDB database.
 func getFDBDatabase(cluster *fdbv1beta2.FoundationDBCluster) (fdb.Database, error) {
-	clusterFile, err := os.CreateTemp("", "")
+	clusterFile, err := createClusterFile(cluster)
 	if err != nil {
 		return fdb.Database{}, err
 	}
 
-	defer clusterFile.Close()
-	clusterFilePath := clusterFile.Name()
-
-	_, err = clusterFile.WriteString(cluster.Status.ConnectionString)
-	if err != nil {
-		return fdb.Database{}, err
-	}
-	err = clusterFile.Close()
-	if err != nil {
-		return fdb.Database{}, err
-	}
-
-	database, err := fdb.OpenDatabase(clusterFilePath)
+	database, err := fdb.OpenDatabase(clusterFile)
 	if err != nil {
 		return fdb.Database{}, err
 	}

--- a/fdbclient/common_test.go
+++ b/fdbclient/common_test.go
@@ -1,0 +1,82 @@
+/*
+ * common_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fdbclient
+
+import (
+	"os"
+	"path"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("common_test", func() {
+	When("creating the cluster file", func() {
+		var clusterFile string
+		var tmpDir string
+		uid := "testuid"
+		connectionString := "test@test:127.0.0.1:4500"
+
+		JustBeforeEach(func() {
+			var err error
+			tmpDir = GinkgoT().TempDir()
+			clusterFile, err = ensureClusterFileIsPresent(tmpDir, uid, connectionString)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		When("the cluster file doesn't exist", func() {
+			It("should create the cluster file with the correct content", func() {
+				Expect(clusterFile).To(Equal(path.Join(tmpDir, uid)))
+				content, err := os.ReadFile(clusterFile)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal(connectionString))
+			})
+		})
+
+		When("the cluster file exist with the wrong content", func() {
+			BeforeEach(func() {
+				err := os.WriteFile(path.Join(os.TempDir(), uid), []byte("wrong"), 0777)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should update the cluster file with the correct content", func() {
+				Expect(clusterFile).To(Equal(path.Join(tmpDir, uid)))
+				content, err := os.ReadFile(clusterFile)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal(connectionString))
+			})
+		})
+
+		When("the cluster file exist with the correct content", func() {
+			BeforeEach(func() {
+				err := os.WriteFile(path.Join(os.TempDir(), uid), []byte(connectionString), 0777)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should keep the cluster file with the correct content", func() {
+				Expect(clusterFile).To(Equal(path.Join(tmpDir, uid)))
+				content, err := os.ReadFile(clusterFile)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal(connectionString))
+			})
+		})
+	})
+})


### PR DESCRIPTION
# Description

This removes a resource leak. Before that we never removed the cluster files when we use lock client or if we used the client libraries.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

This change will add a `Close()` method to the lock client to ensure the files are removed once the lock client is not required anymore.

## Testing

Local testing + unit tests.

## Documentation

-

## Follow-up

-
