### PR TITLE
Ensure we skip all work in the bounce reconciler if we disable restarts

### DIFF
--- a/api/v1beta2/foundationdb_database_configuration.go
+++ b/api/v1beta2/foundationdb_database_configuration.go
@@ -579,7 +579,6 @@ func (configuration DatabaseConfiguration) AreSeparatedProxiesConfigured() bool 
 // AreSeparatedProxiesConfigured(), then this function will return the
 // string "commit_proxies=%d grv_proxies=%d", otherwise just
 // "proxies=%d" using the correct counts of the configuration object.
-//
 func (configuration DatabaseConfiguration) GetProxiesString(version Version) string {
 	counts := configuration.GetRoleCountsWithDefaults(version, DesiredFaultTolerance(configuration.RedundancyMode))
 	if version.HasSeparatedProxies() && configuration.AreSeparatedProxiesConfigured() {

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1210,7 +1210,6 @@ func (cluster *FoundationDBCluster) CheckReconciliation(log logr.Logger) (bool, 
 				if condition.ProcessGroupConditionType == IncorrectCommandLine && cluster.Status.Generations.NeedsBounce == 0 {
 					logger.Info("Pending restart of fdbserver processes", "state", "NeedsBounce")
 					cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
-					reconciled = false
 				}
 				conditions = append(conditions, condition.ProcessGroupConditionType)
 			}

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -3141,6 +3141,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				Expect(cluster.Status.Generations).To(Equal(ClusterGenerationStatus{
 					Reconciled:          1,
 					HasUnhealthyProcess: 2,
+					NeedsBounce:         2,
 				}))
 
 				cluster = createCluster()
@@ -3392,6 +3393,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				Expect(cluster.Status.Generations).To(Equal(ClusterGenerationStatus{
 					Reconciled:          1,
 					HasUnhealthyProcess: 2,
+					NeedsBounce:         2,
 				}))
 
 				cluster = createCluster()

--- a/api/v1beta2/groupversion_info.go
+++ b/api/v1beta2/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta2 contains API Schema definitions for the apps v1beta2 API group
-//+kubebuilder:object:generate=true
-//+groupName=apps.foundationdb.org
+// +kubebuilder:object:generate=true
+// +groupName=apps.foundationdb.org
 package v1beta2
 
 import (

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -26,15 +26,13 @@ import (
 	"math"
 	"time"
 
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
-
-	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
-
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
-
-	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 )
 
 // bounceProcesses provides a reconciliation step for bouncing fdbserver
@@ -43,6 +41,10 @@ type bounceProcesses struct{}
 
 // reconcile runs the reconciler's work.
 func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+	if !pointer.BoolDeref(cluster.Spec.AutomationOptions.KillProcesses, true) {
+		return nil
+	}
+
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "bounceProcesses")
 	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
 	if err != nil {
@@ -60,10 +62,98 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		return &requeue{curError: err}
 	}
 
+	addresses, req := getProcessesReadyForRestart(ctx, logger, r, cluster, addressMap)
+	if req != nil {
+		return req
+	}
+
+	if len(addresses) == 0 {
+		return nil
+	}
+
+	if minimumUptime < float64(cluster.GetMinimumUptimeSecondsForBounce()) {
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsBounce",
+			fmt.Sprintf("Spec require a bounce of some processes, but the cluster has only been up for %f seconds", minimumUptime))
+		cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
+		err = r.updateOrApply(ctx, cluster)
+		if err != nil {
+			logger.Error(err, "Error updating cluster status")
+		}
+
+		// Retry after we waited the minimum uptime
+		return &requeue{
+			message: "Cluster needs to stabilize before bouncing",
+			delay:   time.Second * time.Duration(cluster.GetMinimumUptimeSecondsForBounce()-int(minimumUptime)),
+		}
+	}
+
+	var lockClient fdbadminclient.LockClient
+	useLocks := cluster.ShouldUseLocks()
+	if useLocks {
+		lockClient, err = r.getLockClient(cluster)
+		if err != nil {
+			return &requeue{curError: err}
+		}
+	}
+	version, err := fdbv1beta2.ParseFdbVersion(cluster.Spec.Version)
+	if err != nil {
+		return &requeue{curError: err}
+	}
+
+	upgrading := cluster.Status.RunningVersion != cluster.Spec.Version
+
+	if useLocks && upgrading {
+		processGroupIDs := make([]string, 0, len(cluster.Status.ProcessGroups))
+		for _, processGroup := range cluster.Status.ProcessGroups {
+			processGroupIDs = append(processGroupIDs, processGroup.ProcessGroupID)
+		}
+		err = lockClient.AddPendingUpgrades(version, processGroupIDs)
+		if err != nil {
+			return &requeue{curError: err}
+		}
+	}
+
+	hasLock, err := r.takeLock(cluster, fmt.Sprintf("bouncing processes: %v", addresses))
+	if !hasLock {
+		return &requeue{curError: err}
+	}
+
+	if useLocks && upgrading {
+		var req *requeue
+		addresses, req = getAddressesForUpgrade(logger, r, status, lockClient, cluster, version)
+		if req != nil {
+			return req
+		}
+		if addresses == nil {
+			return &requeue{curError: fmt.Errorf("unknown error when getting addresses that are ready for upgrade")}
+		}
+	}
+
+	logger.Info("Bouncing processes", "addresses", addresses, "upgrading", upgrading)
+	r.Recorder.Event(cluster, corev1.EventTypeNormal, "BouncingProcesses", fmt.Sprintf("Bouncing processes: %v", addresses))
+	err = adminClient.KillProcesses(addresses)
+	if err != nil {
+		return &requeue{curError: err}
+	}
+
+	// If the cluster was upgraded we will requeue and let the update_status command set the correct version.
+	// Updating the version in this method has the drawback that we upgrade the version independent of the success
+	// of the kill command. The kill command is not reliable, which means that some kill request might not be
+	// delivered and the return value will still not contain any error.
+	if upgrading {
+		return &requeue{message: "fetch latest status after upgrade"}
+	}
+
+	return nil
+}
+
+// getProcessesReadyForRestart returns a slice of process addresses that can be restarted. If addresses are missing or not all processes
+// have the latest configuration this method will return a requeue struct with more details.
+func getProcessesReadyForRestart(ctx context.Context, logger logr.Logger, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, addressMap map[string][]fdbv1beta2.ProcessAddress) ([]fdbv1beta2.ProcessAddress, *requeue) {
 	processesToBounce := fdbv1beta2.FilterByConditions(cluster.Status.ProcessGroups, map[fdbv1beta2.ProcessGroupConditionType]bool{
 		fdbv1beta2.IncorrectCommandLine: true,
 		fdbv1beta2.IncorrectPodSpec:     false,
-		fdbv1beta2.SidecarUnreachable:   false, // ignore all Process groups that are not reachable and therefore will not get any config map updates.
+		fdbv1beta2.SidecarUnreachable:   false, // ignore all Process groups that are not reachable and therefore will not get any ConfigMap updates.
 	}, true)
 
 	addresses := make([]fdbv1beta2.ProcessAddress, 0, len(processesToBounce))
@@ -95,10 +185,10 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		processGroupID := podmanager.GetProcessGroupIDFromProcessID(process)
 		pod, err := r.PodLifecycleManager.GetPods(ctx, r, cluster, internal.GetSinglePodListOptions(cluster, processGroupID)...)
 		if err != nil {
-			return &requeue{curError: err}
+			return nil, &requeue{curError: err}
 		}
 		if len(pod) == 0 {
-			return &requeue{message: fmt.Sprintf("No pod defined for process group ID: \"%s\"", processGroupID), delay: podSchedulingDelayDuration}
+			return nil, &requeue{message: fmt.Sprintf("No pod defined for process group ID: \"%s\"", processGroupID), delay: podSchedulingDelayDuration}
 		}
 
 		synced, err := r.updatePodDynamicConf(cluster, pod[0])
@@ -109,107 +199,19 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 	}
 
 	if len(missingAddress) > 0 {
-		return &requeue{curError: fmt.Errorf("could not find address for processes: %s", missingAddress)}
+		return nil, &requeue{curError: fmt.Errorf("could not find address for processes: %s", missingAddress), delayedRequeue: true}
 	}
 
 	if !allSynced {
-		return &requeue{message: "Waiting for config map to sync to all pods"}
+		return nil, &requeue{message: "Waiting for config map to sync to all pods", delayedRequeue: true}
 	}
 
-	if len(addresses) > 0 {
-		if !pointer.BoolDeref(cluster.Spec.AutomationOptions.KillProcesses, true) {
-			r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsBounce",
-				"Spec require a bounce of some processes, but killing processes is disabled")
-			cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
-			err = r.updateOrApply(ctx, cluster)
-			if err != nil {
-				logger.Error(err, "Error updating cluster status")
-			}
-
-			return &requeue{message: "Kills are disabled"}
-		}
-
-		if minimumUptime < float64(cluster.GetMinimumUptimeSecondsForBounce()) {
-			r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsBounce",
-				fmt.Sprintf("Spec require a bounce of some processes, but the cluster has only been up for %f seconds", minimumUptime))
-			cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
-			err = r.updateOrApply(ctx, cluster)
-			if err != nil {
-				logger.Error(err, "Error updating cluster status")
-			}
-
-			// Retry after we waited the minimum uptime
-			return &requeue{
-				message: "Cluster needs to stabilize before bouncing",
-				delay:   time.Second * time.Duration(cluster.GetMinimumUptimeSecondsForBounce()-int(minimumUptime)),
-			}
-		}
-
-		var lockClient fdbadminclient.LockClient
-		useLocks := cluster.ShouldUseLocks()
-		if useLocks {
-			lockClient, err = r.getLockClient(cluster)
-			if err != nil {
-				return &requeue{curError: err}
-			}
-		}
-		version, err := fdbv1beta2.ParseFdbVersion(cluster.Spec.Version)
-		if err != nil {
-			return &requeue{curError: err}
-		}
-
-		upgrading := cluster.Status.RunningVersion != cluster.Spec.Version
-
-		if useLocks && upgrading {
-			processGroupIDs := make([]string, 0, len(cluster.Status.ProcessGroups))
-			for _, processGroup := range cluster.Status.ProcessGroups {
-				processGroupIDs = append(processGroupIDs, processGroup.ProcessGroupID)
-			}
-			err = lockClient.AddPendingUpgrades(version, processGroupIDs)
-			if err != nil {
-				return &requeue{curError: err}
-			}
-		}
-
-		hasLock, err := r.takeLock(cluster, fmt.Sprintf("bouncing processes: %v", addresses))
-		if !hasLock {
-			return &requeue{curError: err}
-		}
-
-		if useLocks && upgrading {
-			var req *requeue
-			addresses, req = getAddressesForUpgrade(r, status, lockClient, cluster, version)
-			if req != nil {
-				return req
-			}
-			if addresses == nil {
-				return &requeue{curError: fmt.Errorf("unknown error when getting addresses that are ready for upgrade")}
-			}
-		}
-
-		logger.Info("Bouncing processes", "addresses", addresses, "upgrading", upgrading)
-		r.Recorder.Event(cluster, corev1.EventTypeNormal, "BouncingProcesses", fmt.Sprintf("Bouncing processes: %v", addresses))
-		err = adminClient.KillProcesses(addresses)
-		if err != nil {
-			return &requeue{curError: err}
-		}
-
-		// If the cluster was upgraded we will requeue and let the update_status command set the correct version.
-		// Updating the version in this method has the drawback that we upgrade the version independent of the success
-		// of the kill command. The kill command is not reliable, which means that some kill request might not be
-		// delivered and the return value will still not contain any error.
-		if upgrading {
-			return &requeue{message: "fetch latest status after upgrade"}
-		}
-	}
-
-	return nil
+	return addresses, nil
 }
 
 // getAddressesForUpgrade checks that all processes in a cluster are ready to be
 // upgraded and returns the full list of addresses.
-func getAddressesForUpgrade(r *FoundationDBClusterReconciler, databaseStatus *fdbv1beta2.FoundationDBStatus, lockClient fdbadminclient.LockClient, cluster *fdbv1beta2.FoundationDBCluster, version fdbv1beta2.Version) ([]fdbv1beta2.ProcessAddress, *requeue) {
-	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "bounceProcesses")
+func getAddressesForUpgrade(logger logr.Logger, r *FoundationDBClusterReconciler, databaseStatus *fdbv1beta2.FoundationDBStatus, lockClient fdbadminclient.LockClient, cluster *fdbv1beta2.FoundationDBCluster, version fdbv1beta2.Version) ([]fdbv1beta2.ProcessAddress, *requeue) {
 	pendingUpgrades, err := lockClient.GetPendingUpgrades(version)
 	if err != nil {
 		return nil, &requeue{curError: err}


### PR DESCRIPTION
# Description

If we disable to restart FDB processes we want to skip any further work and just skip the whole reconciler.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Local testing + unit tests.

## Documentation

-

## Follow-up

-