### PR TITLE
Remove lock for exclusions

### DIFF
--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -80,11 +80,6 @@ func (e excludeProcesses) reconcile(_ context.Context, r *FoundationDBClusterRec
 			}
 		}
 
-		hasLock, err := r.takeLock(cluster, fmt.Sprintf("excluding processes: %v", fdbProcessesToExclude))
-		if !hasLock {
-			return &requeue{curError: err}
-		}
-
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "ExcludingProcesses", fmt.Sprintf("Excluding %v", fdbProcessesToExclude))
 
 		err = adminClient.ExcludeProcesses(fdbProcessesToExclude)


### PR DESCRIPTION
# Description

Remove the lock mechanism from the exclude reconciler.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

The initial idea of the lock was to reduce the risk of successive recoveries. This is only true if the exclude is happening in a different Kubernetes cluster/namespace not managed by this operator instance. Exclusions in the same namespace can still trigger successive recoveries. A drawback of this approach is that an exclusion in another Kubernetes cluster/namespace might be delay until this operator instance can get a lock.

If we want to use some safeguards around the exclusion we could think of using the minimum uptime, similar to the bounce reconciler.

## Testing

unit tests.

## Documentation

-

## Follow-up

-
