### PR TITLE
update status cleanup

### DIFF
--- a/controllers/admin_client_mock.go
+++ b/controllers/admin_client_mock.go
@@ -532,6 +532,10 @@ func (client *mockAdminClient) GetConnectionString() (string, error) {
 	return client.Cluster.Status.ConnectionString, nil
 }
 
+func (client *mockAdminClient) GetConnectionStringFromCLI() (string, error) {
+	return client.GetConnectionString()
+}
+
 // VersionSupported reports whether we can support a cluster with a given
 // version.
 func (client *mockAdminClient) VersionSupported(versionString string) (bool, error) {

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -42,6 +42,17 @@ const (
 	podSchedulingDelayDuration = 15 * time.Second
 )
 
+// containsAll determines if one map contains all the keys and matching values
+// from another map.
+func containsAll(current map[string]string, desired map[string]string) bool {
+	for key, value := range desired {
+		if current[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
 // metadataMatches determines if the current metadata on an object matches the
 // metadata specified by the cluster spec.
 func metadataMatches(currentMetadata metav1.ObjectMeta, desiredMetadata metav1.ObjectMeta) bool {

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -102,8 +102,9 @@ var _ = Describe("update_status", func() {
 
 		When("a process group is fine", func() {
 			It("should not get any condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				err = validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
+				processGroupStatus := cluster.Status.ProcessGroups
 				Expect(len(processGroupStatus)).To(BeNumerically(">", 4))
 				processGroup := processGroupStatus[len(processGroupStatus)-4]
 				Expect(processGroup.ProcessGroupID).To(Equal("storage-1"))
@@ -117,8 +118,9 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				err = validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
+				processGroupStatus := cluster.Status.ProcessGroups
 
 				missingProcesses := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.MissingPod, false)
 				Expect(missingProcesses).To(Equal([]string{"storage-1"}))
@@ -136,8 +138,9 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
+				processGroupStatus := cluster.Status.ProcessGroups
 
 				incorrectProcesses := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.IncorrectCommandLine, false)
 				Expect(incorrectProcesses).To(Equal([]string{"storage-1"}))
@@ -155,8 +158,9 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
+				processGroupStatus := cluster.Status.ProcessGroups
 
 				missingProcesses := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.MissingProcesses, false)
 				Expect(missingProcesses).To(Equal([]string{"storage-1"}))
@@ -176,8 +180,9 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
+				processGroupStatus := cluster.Status.ProcessGroups
 
 				incorrectPods := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.IncorrectPodSpec, false)
 				Expect(incorrectPods).To(Equal([]string{"storage-1"}))
@@ -197,8 +202,9 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
+				processGroupStatus := cluster.Status.ProcessGroups
 
 				failingPods := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.PodFailing, false)
 				Expect(failingPods).To(Equal([]string{"storage-1"}))
@@ -218,8 +224,9 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
+				processGroupStatus := cluster.Status.ProcessGroups
 
 				failingPods := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.PodFailing, false)
 				Expect(failingPods).To(Equal([]string{"storage-1"}))
@@ -243,8 +250,9 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should mark the process group for removal", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
+				processGroupStatus := cluster.Status.ProcessGroups
 
 				removalCount := 0
 				for _, processGroup := range processGroupStatus {
@@ -274,8 +282,9 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should be mark the process group for removal without exclusion", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
+				processGroupStatus := cluster.Status.ProcessGroups
 
 				removalCount := 0
 				for _, processGroup := range processGroupStatus {
@@ -314,8 +323,9 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should mark the process group as unreachable", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
+				processGroupStatus := cluster.Status.ProcessGroups
 
 				unreachableCount := 0
 				for _, processGroup := range processGroupStatus {
@@ -338,8 +348,9 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("should remove the condition", func() {
-					processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+					err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 					Expect(err).NotTo(HaveOccurred())
+					processGroupStatus := cluster.Status.ProcessGroups
 
 					unreachableCount := 0
 					for _, processGroup := range processGroupStatus {
@@ -366,8 +377,9 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should mark the process group as Pod pending", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
+				processGroupStatus := cluster.Status.ProcessGroups
 
 				pendingCount := 0
 				for _, processGroup := range processGroupStatus {
@@ -412,7 +424,7 @@ var _ = Describe("update_status", func() {
 
 		When("running the remove duplicate method", func() {
 			BeforeEach(func() {
-				removeDuplicateConditions(status)
+				removeRedundantConditions(status)
 			})
 
 			It("should remove duplicated entries", func() {

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -153,10 +153,6 @@ func getBinaryPath(binaryName string, version string) string {
 	return fmt.Sprintf("%s/%s/%s", os.Getenv("FDB_BINARY_DIR"), parsed.GetBinaryVersion(), binaryName)
 }
 
-func (client *cliAdminClient) runFdbCLICommand(command: string) (string, error) {
-	return client.runCommand(cliCommand { command });
-}
-
 // runCommand executes a command in the CLI.
 func (client *cliAdminClient) runCommand(command cliCommand) (string, error) {
 	version := command.version
@@ -638,10 +634,17 @@ func cleanConnectionStringOutput(input string) string {
 
 // GetConnectionString fetches the latest connection string.
 func (client *cliAdminClient) GetConnectionString() (string, error) {
+	return client.getConnectionString(client.Cluster.UseManagementAPI())
+}
+func (client *cliAdminClient) GetConnectionStringFromCLI() (string, error) {
+	return client.getConnectionString(false)
+}
+
+func (client *cliAdminClient) getConnectionString(useManagementAPI bool) (string, error) {
 	var output string
 	var err error
 
-	if client.Cluster.UseManagementAPI() {
+	if useManagementAPI {
 		// This will call directly the database and fetch the connection string
 		// from the system key space.
 		var outputBytes []byte

--- a/internal/process_class.go
+++ b/internal/process_class.go
@@ -22,6 +22,7 @@ package internal
 
 import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -33,4 +34,14 @@ func ProcessClassFromLabels(cluster *fdbv1beta2.FoundationDBCluster, labels map[
 // GetProcessClassFromMeta fetches the process class from an object's metadata.
 func GetProcessClassFromMeta(cluster *fdbv1beta2.FoundationDBCluster, metadata v1.ObjectMeta) fdbv1beta2.ProcessClass {
 	return ProcessClassFromLabels(cluster, metadata.Labels)
+}
+
+// TryAppendProcessGroupID extracts a process group from a labels map, and appends it to processGroups if it is not already present.
+func TryAppendProcessGroupID(processGroups []*fdbv1beta2.ProcessGroupStatus, cluster *fdbv1beta2.FoundationDBCluster, labels map[string]string) []*fdbv1beta2.ProcessGroupStatus {
+	processGroupID := labels[cluster.GetProcessGroupIDLabel()]
+	if processGroupID == "" || fdbv1beta2.ContainsProcessGroupID(processGroups, processGroupID) {
+		return processGroups
+	} else {
+		return append(processGroups, fdbv1beta2.NewProcessGroupStatus(processGroupID, ProcessClassFromLabels(cluster, labels), nil))
+	}
 }

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -61,6 +61,11 @@ type AdminClient interface {
 	// GetConnectionString fetches the latest connection string.
 	GetConnectionString() (string, error)
 
+	// GetConnectionStringFromCLI uses fdbcli to fetch the latest connection string.
+	// Use GetConnectionString (which supports the multi-version client) unless you
+	// are using this call to infer the currently-running version of FDB.
+	GetConnectionStringFromCLI() (string, error)
+
 	// VersionSupported reports whether we can support a cluster with a given
 	// version.
 	VersionSupported(version string) (bool, error)


### PR DESCRIPTION
# Description

This PR helps reduce improve code complexity in the update status path.  It includes two functional changes:
 - Bypass the multi-version client when checking to see if the operator's FDB server version is correct, and getting an updated connection string.  Without this change, the operator would incorrectly infer the version the FDB cluster was running at.
 - Always use the client library when invoking `status json`.  I added a simple 1-second retry loop, under the assumption that the FDB multi-version client will eventually get lucky and connect to the version of the cluster that is currently available.  (If not, this is a serious FDB bug, and should be addressed there.)

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)
- Documentation
- Other

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

`make test` passes.  We should improve upgrade testing, in general.

## Documentation

*Did you update relevant documentation within this repository?*
Added inline comments

*If this change is adding new functionality, do we need to describe it in our user manual?*
No

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*
N/A

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*
N/A

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

The mock admin client does not inject errors, so we're not getting meaningful test coverage by invoking it.

*Does this introduce new defaults that we should re-evaluate in the future?*

This switches the default value of useClientLibrary from false to true, and removes support for false.  I added a deprecation warning to the docs.