### PR TITLE
Fix nil pointer error

### DIFF
--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -194,17 +194,19 @@ func (client *realFdbPodSidecarClient) makeRequest(method, path string) (string,
 	case http.MethodGet:
 		retryClient.HTTPClient.Timeout = client.getTimeout
 		resp, err = retryClient.Get(url)
-		defer resp.Body.Close()
 	case http.MethodPost:
 		retryClient.HTTPClient.Timeout = client.postTimeout
 		resp, err = retryClient.Post(url, "application/json", strings.NewReader(""))
-		defer resp.Body.Close()
 	default:
 		return "", 0, fmt.Errorf("unknown HTTP method %s", method)
 	}
 
 	if err != nil {
 		return "", 0, err
+	}
+
+	if resp != nil {
+		defer resp.Body.Close()
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -31,6 +31,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -171,11 +172,35 @@ func (client *realFdbPodSidecarClient) getListenIP() string {
 	return ""
 }
 
+// generateRequest will generate a retryablehttp.Request for the provided parameters or an error if a request cannot be
+// generated.
+func generateRequest(retryClient *retryablehttp.Client, url string, method string, getTimeout time.Duration, postTimeout time.Duration) (*retryablehttp.Request, error) {
+	switch method {
+	case http.MethodGet:
+		retryClient.HTTPClient.Timeout = getTimeout
+		return retryablehttp.NewRequest(http.MethodGet, url, nil)
+	case http.MethodPost:
+		retryClient.HTTPClient.Timeout = postTimeout
+		req, err := retryablehttp.NewRequest(http.MethodPost, url, strings.NewReader(""))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}
+
+	return nil, fmt.Errorf("unknown HTTP method %s", method)
+}
+
 // makeRequest submits a request to the sidecar.
 func (client *realFdbPodSidecarClient) makeRequest(method, path string) (string, int, error) {
 	var err error
 
-	protocol := "http"
+	target := url.URL{
+		Scheme: "http",
+		Host:   client.getListenIP() + ":8080",
+		Path:   path,
+	}
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 2
 	retryClient.RetryWaitMax = 1 * time.Second
@@ -185,28 +210,21 @@ func (client *realFdbPodSidecarClient) makeRequest(method, path string) (string,
 
 	if client.useTLS {
 		retryClient.HTTPClient.Transport = &http.Transport{TLSClientConfig: client.tlsConfig}
-		protocol = "https"
+		target.Scheme = "https"
 	}
 
-	url := fmt.Sprintf("%s://%s:8080/%s", protocol, client.getListenIP(), path)
-	var resp *http.Response
-	switch method {
-	case http.MethodGet:
-		retryClient.HTTPClient.Timeout = client.getTimeout
-		resp, err = retryClient.Get(url)
-	case http.MethodPost:
-		retryClient.HTTPClient.Timeout = client.postTimeout
-		resp, err = retryClient.Post(url, "application/json", strings.NewReader(""))
-	default:
-		return "", 0, fmt.Errorf("unknown HTTP method %s", method)
-	}
-
+	req, err := generateRequest(retryClient, target.String(), method, client.getTimeout, client.postTimeout)
 	if err != nil {
 		return "", 0, err
 	}
 
+	resp, err := retryClient.Do(req)
 	if resp != nil {
 		defer resp.Body.Close()
+	}
+
+	if err != nil {
+		return "", 0, err
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/internal/pod_client_test.go
+++ b/internal/pod_client_test.go
@@ -22,8 +22,12 @@ package internal
 
 import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/hashicorp/go-retryablehttp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"net/http"
+	"net/url"
+	"time"
 )
 
 var _ = Describe("pod_client", func() {
@@ -56,6 +60,49 @@ var _ = Describe("pod_client", func() {
 			pod, err := GetPod(cluster, fdbv1beta2.ProcessClassStorage, 1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podHasSidecarTLS(pod)).To(BeTrue())
+		})
+	})
+
+	When("generating a request", func() {
+		var retryClient *retryablehttp.Client
+		var target url.URL
+		getTimeout := 1 * time.Second
+		postTimeout := 10 * time.Second
+
+		BeforeEach(func() {
+			retryClient = retryablehttp.NewClient()
+			target = url.URL{
+				Scheme: "http",
+				Host:   "127.0.0.1:8080",
+				Path:   "test",
+			}
+		})
+
+		When("generating a http get request", func() {
+			It("should generate the request", func() {
+				req, err := generateRequest(retryClient, target.String(), http.MethodGet, getTimeout, postTimeout)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(req.Method).To(Equal(http.MethodGet))
+				Expect(retryClient.HTTPClient.Timeout).To(Equal(getTimeout))
+			})
+		})
+
+		When("generating a http post request", func() {
+			It("should generate the request", func() {
+				req, err := generateRequest(retryClient, target.String(), http.MethodPost, getTimeout, postTimeout)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(req.Method).To(Equal(http.MethodPost))
+				Expect(retryClient.HTTPClient.Timeout).To(Equal(postTimeout))
+				Expect(req.Header).To(HaveKeyWithValue("Content-Type", []string{"application/json"}))
+			})
+		})
+
+		When("generating a http delete request", func() {
+			It("should generate the request", func() {
+				req, err := generateRequest(retryClient, target.String(), http.MethodDelete, getTimeout, postTimeout)
+				Expect(err).To(HaveOccurred())
+				Expect(req).To(BeNil())
+			})
 		})
 	})
 })


### PR DESCRIPTION
# Description

If the operator is not able to communicate with the sidecar HTTP server an error will be returned and the response will be nil. In the current implementation this would lead to a nil pointer exception: `panic: runtime error: invalid memory address or nil pointer dereference`

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

Local testing + e2e tests.

## Documentation

-

## Follow-up

-
