### PR TITLE
Allow to ignore processes that have an unreachable sidecar during upgrades

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -106,7 +106,10 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 	if useLocks && upgrading {
 		// Ignore all Process groups that are not reachable and therefore will not get any ConfigMap updates. Otherwise
 		// a single Pod might block the whole upgrade. The assumption here is that the Pod will be recreated with the
-		// new version in the removeIncompatibleProcesses reconciler.
+		// new version in the removeIncompatibleProcesses reconciler. This can still be an issue in the current
+		// implementation since the AddPendingUpgrades call will only add new pending process groups but never remove
+		// "old" ones (if the process is missing/not part of the FoundationDB status the process will be ignored). Once
+		// we move to a more centralized upgrade process this problem will be solved.
 		processGroupIDs := fdbv1beta2.FilterByConditions(cluster.Status.ProcessGroups, map[fdbv1beta2.ProcessGroupConditionType]bool{
 			fdbv1beta2.SidecarUnreachable: false,
 		}, false)

--- a/controllers/exclude_processes_test.go
+++ b/controllers/exclude_processes_test.go
@@ -23,6 +23,8 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal/safeguards"
+	"github.com/go-logr/logr"
 	"net"
 
 	"k8s.io/utils/pointer"
@@ -38,6 +40,7 @@ var _ = Describe("exclude_processes", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
 	var err error
 
+	// TODO(johschuer): Move those tests into safeguards package.
 	Describe("canExcludeNewProcesses", func() {
 		BeforeEach(func() {
 			cluster = internal.CreateDefaultCluster()
@@ -56,7 +59,7 @@ var _ = Describe("exclude_processes", func() {
 		Context("with a small cluster", func() {
 			When("all processes are healthy", func() {
 				It("should allow the exclusion", func() {
-					canExclude, missing := canExcludeNewProcesses(cluster, fdbv1beta2.ProcessClassStorage)
+					canExclude, missing := safeguards.CanExcludeNewProcesses(logr.Discard(), cluster, fdbv1beta2.ProcessClassStorage)
 					Expect(canExclude).To(BeTrue())
 					Expect(missing).To(BeNil())
 				})
@@ -68,7 +71,7 @@ var _ = Describe("exclude_processes", func() {
 				})
 
 				It("should allow the exclusion", func() {
-					canExclude, missing := canExcludeNewProcesses(cluster, fdbv1beta2.ProcessClassStorage)
+					canExclude, missing := safeguards.CanExcludeNewProcesses(logr.Discard(), cluster, fdbv1beta2.ProcessClassStorage)
 					Expect(canExclude).To(BeTrue())
 					Expect(missing).To(BeNil())
 				})
@@ -80,7 +83,7 @@ var _ = Describe("exclude_processes", func() {
 				})
 
 				It("should not allow the exclusion", func() {
-					canExclude, missing := canExcludeNewProcesses(cluster, fdbv1beta2.ProcessClassStorage)
+					canExclude, missing := safeguards.CanExcludeNewProcesses(logr.Discard(), cluster, fdbv1beta2.ProcessClassStorage)
 					Expect(canExclude).To(BeFalse())
 					Expect(missing).To(Equal([]string{"storage-1", "storage-2"}))
 				})
@@ -92,7 +95,7 @@ var _ = Describe("exclude_processes", func() {
 				})
 
 				It("should allow the exclusion", func() {
-					canExclude, missing := canExcludeNewProcesses(cluster, fdbv1beta2.ProcessClassStorage)
+					canExclude, missing := safeguards.CanExcludeNewProcesses(logr.Discard(), cluster, fdbv1beta2.ProcessClassStorage)
 					Expect(canExclude).To(BeTrue())
 					Expect(missing).To(BeNil())
 				})
@@ -119,7 +122,7 @@ var _ = Describe("exclude_processes", func() {
 				})
 
 				It("should allow the exclusion", func() {
-					canExclude, missing := canExcludeNewProcesses(cluster, fdbv1beta2.ProcessClassStorage)
+					canExclude, missing := safeguards.CanExcludeNewProcesses(logr.Discard(), cluster, fdbv1beta2.ProcessClassStorage)
 					Expect(canExclude).To(BeTrue())
 					Expect(missing).To(BeNil())
 				})
@@ -131,7 +134,7 @@ var _ = Describe("exclude_processes", func() {
 				})
 
 				It("should not allow the exclusion", func() {
-					canExclude, missing := canExcludeNewProcesses(cluster, fdbv1beta2.ProcessClassStorage)
+					canExclude, missing := safeguards.CanExcludeNewProcesses(logr.Discard(), cluster, fdbv1beta2.ProcessClassStorage)
 					Expect(canExclude).To(BeFalse())
 					Expect(missing).To(Equal([]string{"storage-1", "storage-10", "storage-11", "storage-12", "storage-13"}))
 				})

--- a/internal/safeguards/safeguards.go
+++ b/internal/safeguards/safeguards.go
@@ -70,6 +70,7 @@ func CanExcludeNewProcesses(logger logr.Logger, cluster *fdbv1beta2.FoundationDB
 // which checks if at least 90% of the desired processes are pending the upgrade. Processes that are stuck in a terminating
 // state will be ignore for the calculation.
 func HasEnoughProcessesToUpgrade(processGroupIDs []string, processGroups []*fdbv1beta2.ProcessGroupStatus, desiredProcesses fdbv1beta2.ProcessCounts) error {
+	// TODO (johscheuer): Expose this fraction and make it configurable.
 	desiredProcessCounts := int(math.Ceil(float64(desiredProcesses.Total()) * 0.9))
 
 	var terminatingProcesses int
@@ -83,7 +84,7 @@ func HasEnoughProcessesToUpgrade(processGroupIDs []string, processGroups []*fdbv
 
 	processesForUpgrade := len(processGroupIDs) - terminatingProcesses
 	if processesForUpgrade < desiredProcessCounts {
-		return fmt.Errorf("expected to have %d process groups for performing the upgrade, currently only %d process groups are available", desiredProcessCounts, len(processGroupIDs))
+		return fmt.Errorf("expected to have %d process groups for performing the upgrade, currently only %d process groups are available", desiredProcessCounts, processesForUpgrade)
 	}
 
 	return nil

--- a/internal/safeguards/safeguards.go
+++ b/internal/safeguards/safeguards.go
@@ -1,0 +1,90 @@
+/*
+ * safeguards.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package safeguards
+
+import (
+	"fmt"
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/go-logr/logr"
+	"math"
+)
+
+// The fraction of processes that must be present in order to start a new
+// exclusion.
+var missingProcessThreshold = 0.8
+
+// CanExcludeNewProcesses validates if new processes can be excluded.
+func CanExcludeNewProcesses(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass) (bool, []string) {
+	// Block excludes on missing processes not marked for removal
+	missingProcesses := make([]string, 0)
+	validProcesses := make([]string, 0)
+
+	for _, processGroupStatus := range cluster.Status.ProcessGroups {
+		if processGroupStatus.IsMarkedForRemoval() || processGroupStatus.ProcessClass != processClass {
+			continue
+		}
+
+		if processGroupStatus.GetConditionTime(fdbv1beta2.MissingProcesses) != nil ||
+			processGroupStatus.GetConditionTime(fdbv1beta2.MissingPod) != nil {
+			missingProcesses = append(missingProcesses, processGroupStatus.ProcessGroupID)
+			logger.Info("Missing processes", "processGroupID", processGroupStatus.ProcessGroupID)
+			continue
+		}
+
+		validProcesses = append(validProcesses, processGroupStatus.ProcessGroupID)
+	}
+
+	desiredProcesses, err := cluster.GetProcessCountsWithDefaults()
+	if err != nil {
+		logger.Error(err, "Error calculating process counts")
+		return false, missingProcesses
+	}
+	desiredCount := desiredProcesses.Map()[processClass]
+
+	if len(validProcesses) < desiredCount-1 && len(validProcesses) < int(math.Ceil(float64(desiredCount)*missingProcessThreshold)) {
+		return false, missingProcesses
+	}
+
+	return true, nil
+}
+
+// HasEnoughProcessesToUpgrade checks if enough processes are ready to be upgraded. The logic is currently a simple heuristic
+// which checks if at least 90% of the desired processes are pending the upgrade. Processes that are stuck in a terminating
+// state will be ignore for the calculation.
+func HasEnoughProcessesToUpgrade(processGroupIDs []string, processGroups []*fdbv1beta2.ProcessGroupStatus, desiredProcesses fdbv1beta2.ProcessCounts) error {
+	desiredProcessCounts := int(math.Ceil(float64(desiredProcesses.Total()) * 0.9))
+
+	var terminatingProcesses int
+	for _, processGroup := range processGroups {
+		if processGroup.GetConditionTime(fdbv1beta2.ResourcesTerminating) == nil {
+			continue
+		}
+
+		terminatingProcesses++
+	}
+
+	processesForUpgrade := len(processGroupIDs) - terminatingProcesses
+	if processesForUpgrade < desiredProcessCounts {
+		return fmt.Errorf("expected to have %d process groups for performing the upgrade, currently only %d process groups are available", desiredProcessCounts, len(processGroupIDs))
+	}
+
+	return nil
+}

--- a/internal/safeguards/safeguards_test.go
+++ b/internal/safeguards/safeguards_test.go
@@ -1,0 +1,158 @@
+/*
+ * safeguards_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package safeguards
+
+import (
+	"errors"
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+/*
+
+// HasEnoughProcessesToUpgrade checks if enough processes are ready to be upgraded. The logic is currently a simple heuristic
+// which checks if at least 90% of the desired processes are pending the upgrade. Processes that are stuck in a terminating
+// state will be ignore for the calculation.
+func HasEnoughProcessesToUpgrade(processGroupIDs []string, processGroups []*fdbv1beta2.ProcessGroupStatus, desiredProcesses fdbv1beta2.ProcessCounts) error {
+	// TODO(johscheuer): Expose this fraction and make it configurable.
+	desiredProcessCounts := int(math.Ceil(float64(desiredProcesses.Total()) * 0.9))
+
+	var terminatingProcesses int
+	for _, processGroup := range processGroups {
+		if processGroup.GetConditionTime(fdbv1beta2.ResourcesTerminating) == nil {
+			continue
+		}
+
+		terminatingProcesses++
+	}
+
+	processesForUpgrade := len(processGroupIDs) - terminatingProcesses
+	if processesForUpgrade < desiredProcessCounts {
+		return fmt.Errorf("expected to have %d process groups for performing the upgrade, currently only %d process groups are available", desiredProcessCounts, len(processGroupIDs))
+	}
+
+	return nil
+}
+
+*/
+
+var _ = Describe("safeguards", func() {
+	DescribeTable("when testing if enough processes are ready for upgrades", func(processGroupIDs []string, processGroups []*fdbv1beta2.ProcessGroupStatus, desiredProcesses fdbv1beta2.ProcessCounts, expected error) {
+		err := HasEnoughProcessesToUpgrade(processGroupIDs, processGroups, desiredProcesses)
+		if expected == nil {
+			Expect(err).NotTo(HaveOccurred())
+			return
+		}
+
+		Expect(err).To(Equal(expected))
+	},
+		Entry("All process groups are fine",
+			[]string{
+				"storage-1",
+				"storage-2",
+				"storage-3",
+				"storage-4",
+				"storage-5",
+				"storage-6",
+				"storage-7",
+				"storage-8",
+				"storage-9",
+				"storage-10",
+			},
+			[]*fdbv1beta2.ProcessGroupStatus{},
+			fdbv1beta2.ProcessCounts{
+				Storage: 10,
+			},
+			nil,
+		),
+		Entry("To many processes are missing",
+			[]string{
+				"storage-1",
+				"storage-2",
+				"storage-3",
+				"storage-4",
+				"storage-5",
+				"storage-6",
+				"storage-7",
+				"storage-8",
+				"storage-9",
+				"storage-10",
+			},
+			[]*fdbv1beta2.ProcessGroupStatus{},
+			fdbv1beta2.ProcessCounts{
+				Storage: 15,
+			},
+			errors.New("expected to have 14 process groups for performing the upgrade, currently only 10 process groups are available"),
+		),
+		Entry("when processes with terminating state exist",
+			[]string{
+				"storage-1",
+				"storage-2",
+				"storage-3",
+				"storage-4",
+				"storage-5",
+				"storage-6",
+				"storage-7",
+				"storage-8",
+				"storage-9",
+				"storage-10",
+				"storage-11",
+				"storage-12",
+				"storage-13",
+			},
+			[]*fdbv1beta2.ProcessGroupStatus{
+				{
+					ProcessGroupID: "storage-11",
+					ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
+						{
+							ProcessGroupConditionType: fdbv1beta2.ResourcesTerminating,
+							Timestamp:                 time.Now().Unix(),
+						},
+					},
+				},
+				{
+					ProcessGroupID: "storage-12",
+					ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
+						{
+							ProcessGroupConditionType: fdbv1beta2.ResourcesTerminating,
+							Timestamp:                 time.Now().Unix(),
+						},
+					},
+				},
+				{
+					ProcessGroupID: "storage-13",
+					ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
+						{
+							ProcessGroupConditionType: fdbv1beta2.ResourcesTerminating,
+							Timestamp:                 time.Now().Unix(),
+						},
+					},
+				},
+			},
+			fdbv1beta2.ProcessCounts{
+				Storage: 10,
+			},
+			nil,
+		),
+	)
+})

--- a/internal/safeguards/suite_test.go
+++ b/internal/safeguards/suite_test.go
@@ -1,0 +1,13 @@
+package safeguards
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Safeguards Suite")
+}


### PR DESCRIPTION
# Description

The idea here is to tolerate some processes being not able to get the latest fdbserver binary. I currently hardcoded this value to 10% but we can change this if needed.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

Without this change a single Pod that has a unreachable sidecar for different reasons can block the upgrade of a whole cluster.

## Testing

unit tests + e2e tests.

## Documentation

-

## Follow-up

Make those thresholds configurable.
