### PR TITLE
Expose mock admin client and lock client

### DIFF
--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -46,7 +46,7 @@ type FoundationDBBackupReconciler struct {
 	Recorder               record.EventRecorder
 	Log                    logr.Logger
 	InSimulation           bool
-	DatabaseClientProvider DatabaseClientProvider
+	DatabaseClientProvider fdbadminclient.DatabaseClientProvider
 	ServerSideApply        bool
 }
 
@@ -105,7 +105,7 @@ func (r *FoundationDBBackupReconciler) Reconcile(ctx context.Context, request ct
 }
 
 // getDatabaseClientProvider gets the client provider for a reconciler.
-func (r *FoundationDBBackupReconciler) getDatabaseClientProvider() DatabaseClientProvider {
+func (r *FoundationDBBackupReconciler) getDatabaseClientProvider() fdbadminclient.DatabaseClientProvider {
 	if r.DatabaseClientProvider != nil {
 		return r.DatabaseClientProvider
 	}

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -23,6 +23,8 @@ package controllers
 import (
 	"fmt"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -55,13 +57,13 @@ func reloadBackupGenerations(backup *fdbv1beta2.FoundationDBBackup) (fdbv1beta2.
 var _ = Describe("backup_controller", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
 	var backup *fdbv1beta2.FoundationDBBackup
-	var adminClient *mockAdminClient
+	var adminClient *mock.AdminClient
 	var err error
 
 	BeforeEach(func() {
 		cluster = internal.CreateDefaultCluster()
 		backup = internal.CreateDefaultBackup(cluster)
-		adminClient, err = newMockAdminClientUncast(cluster, k8sClient)
+		adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -306,8 +308,8 @@ var _ = Describe("backup_controller", func() {
 			})
 
 			It("should append the custom parameters to the command", func() {
-				Expect(len(adminClient.knobs)).To(BeNumerically("==", 1))
-				Expect(adminClient.knobs).To(ContainElements("--knob_http_verbose_level=3"))
+				Expect(len(adminClient.Knobs)).To(BeNumerically("==", 1))
+				Expect(adminClient.Knobs).To(ContainElements("--knob_http_verbose_level=3"))
 			})
 		})
 	})

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -23,6 +23,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal/locality"
 	"github.com/go-logr/logr"
 

--- a/controllers/change_coordinators_test.go
+++ b/controllers/change_coordinators_test.go
@@ -27,6 +27,8 @@ import (
 	"net"
 	"strings"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal/locality"
 	"github.com/go-logr/logr"
 
@@ -41,7 +43,7 @@ import (
 
 var _ = Describe("Change coordinators", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
-	var adminClient *mockAdminClient
+	var adminClient *mock.AdminClient
 
 	BeforeEach(func() {
 		cluster = internal.CreateDefaultCluster()
@@ -60,7 +62,7 @@ var _ = Describe("Change coordinators", func() {
 		err := setupClusterForTest(cluster)
 		Expect(err).NotTo(HaveOccurred())
 
-		adminClient, err = newMockAdminClientUncast(cluster, k8sClient)
+		adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -23,6 +23,8 @@ package controllers
 import (
 	"context"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
@@ -32,7 +34,7 @@ import (
 
 var _ = Describe("choose_removals", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
-	var adminClient *mockAdminClient
+	var adminClient *mock.AdminClient
 	var err error
 	var requeue *requeue
 	var removals []string
@@ -50,7 +52,7 @@ var _ = Describe("choose_removals", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(generation).To(Equal(int64(1)))
 
-		adminClient, err = newMockAdminClientUncast(cluster, k8sClient)
+		adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -57,7 +57,7 @@ type FoundationDBClusterReconciler struct {
 	EnableRecoveryState                bool
 	PodLifecycleManager                podmanager.PodLifecycleManager
 	PodClientProvider                  func(*fdbv1beta2.FoundationDBCluster, *corev1.Pod) (podclient.FdbPodClient, error)
-	DatabaseClientProvider             DatabaseClientProvider
+	DatabaseClientProvider             fdbadminclient.DatabaseClientProvider
 	DeprecationOptions                 internal.DeprecationOptions
 	GetTimeout                         time.Duration
 	PostTimeout                        time.Duration
@@ -320,7 +320,7 @@ func (r *FoundationDBClusterReconciler) getPodClient(cluster *fdbv1beta2.Foundat
 }
 
 // getDatabaseClientProvider gets the client provider for a reconciler.
-func (r *FoundationDBClusterReconciler) getDatabaseClientProvider() DatabaseClientProvider {
+func (r *FoundationDBClusterReconciler) getDatabaseClientProvider() fdbadminclient.DatabaseClientProvider {
 	if r.DatabaseClientProvider != nil {
 		return r.DatabaseClientProvider
 	}

--- a/controllers/maintenance_mode_checker_test.go
+++ b/controllers/maintenance_mode_checker_test.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
@@ -39,7 +41,7 @@ var _ = Describe("maintenance_mode_checker", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
 	var err error
 	var requeue *requeue
-	var adminClient *mockAdminClient
+	var adminClient *mock.AdminClient
 
 	BeforeEach(func() {
 		cluster = internal.CreateDefaultCluster()
@@ -56,7 +58,7 @@ var _ = Describe("maintenance_mode_checker", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(generation).To(Equal(int64(1)))
 
-		adminClient, err = newMockAdminClientUncast(cluster, k8sClient)
+		adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -148,7 +150,7 @@ var _ = Describe("maintenance_mode_checker", func() {
 	})
 
 	AfterEach(func() {
-		clearMockAdminClients()
+		mock.ClearMockAdminClients()
 		k8sClient.Clear()
 	})
 })

--- a/controllers/remove_incompatible_processes_test.go
+++ b/controllers/remove_incompatible_processes_test.go
@@ -23,6 +23,8 @@ package controllers
 import (
 	"context"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
+
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
@@ -114,9 +116,9 @@ var _ = Describe("restart_incompatible_pods", func() {
 		When("the subreconciler is enabled", func() {
 			BeforeEach(func() {
 				clusterReconciler.EnableRestartIncompatibleProcesses = true
-				adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+				adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 				Expect(err).NotTo(HaveOccurred())
-				adminClient.frozenStatus = &fdbv1beta2.FoundationDBStatus{
+				adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
 					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 						IncompatibleConnections: []string{},
 					},
@@ -125,9 +127,9 @@ var _ = Describe("restart_incompatible_pods", func() {
 
 			When("no incompatible processes are reported", func() {
 				BeforeEach(func() {
-					adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
-					adminClient.frozenStatus = &fdbv1beta2.FoundationDBStatus{
+					adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
 						Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 							IncompatibleConnections: []string{},
 						},
@@ -144,9 +146,9 @@ var _ = Describe("restart_incompatible_pods", func() {
 
 			When("no matching incompatible processes are reported", func() {
 				BeforeEach(func() {
-					adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
-					adminClient.frozenStatus = &fdbv1beta2.FoundationDBStatus{
+					adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
 						Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 							IncompatibleConnections: []string{
 								"192.192.192.192:4500:tls",
@@ -165,9 +167,9 @@ var _ = Describe("restart_incompatible_pods", func() {
 
 			When("matching incompatible processes are reported", func() {
 				BeforeEach(func() {
-					adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
-					adminClient.frozenStatus = &fdbv1beta2.FoundationDBStatus{
+					adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
 						Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
 							DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
 								Available: true,
@@ -194,9 +196,9 @@ var _ = Describe("restart_incompatible_pods", func() {
 
 				When("the database is unavailable", func() {
 					BeforeEach(func() {
-						adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 						Expect(err).NotTo(HaveOccurred())
-						adminClient.frozenStatus.Client.DatabaseStatus.Available = false
+						adminClient.FrozenStatus.Client.DatabaseStatus.Available = false
 					})
 
 					It("should have no deletions", func() {
@@ -209,9 +211,9 @@ var _ = Describe("restart_incompatible_pods", func() {
 
 				When("matching incompatible processes are reported but port is zero", func() {
 					BeforeEach(func() {
-						adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 						Expect(err).NotTo(HaveOccurred())
-						adminClient.frozenStatus.Cluster.IncompatibleConnections[0] = cluster.Status.ProcessGroups[0].Addresses[0] + ":0:tls"
+						adminClient.FrozenStatus.Cluster.IncompatibleConnections[0] = cluster.Status.ProcessGroups[0].Addresses[0] + ":0:tls"
 					})
 
 					It("should have no deletions", func() {
@@ -242,9 +244,9 @@ var _ = Describe("restart_incompatible_pods", func() {
 		When("matching incompatible processes are reported and the subreconciler is disabled", func() {
 			BeforeEach(func() {
 				clusterReconciler.EnableRestartIncompatibleProcesses = false
-				adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+				adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 				Expect(err).NotTo(HaveOccurred())
-				adminClient.frozenStatus = &fdbv1beta2.FoundationDBStatus{
+				adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
 					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
 						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
 							Available: true,

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
+
 	"k8s.io/utils/pointer"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
@@ -94,7 +96,7 @@ var _ = Describe("remove_process_groups", func() {
 				Expect(marked).To(BeTrue())
 				Expect(processGroup).To(BeNil())
 				// Exclude the process group
-				adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+				adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 				Expect(err).NotTo(HaveOccurred())
 				adminClient.ExcludedAddresses = removedProcessGroup.Addresses
 			})
@@ -113,9 +115,9 @@ var _ = Describe("remove_process_groups", func() {
 
 				When("the cluster has degraded availability fault tolerance", func() {
 					BeforeEach(func() {
-						adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 						Expect(err).NotTo(HaveOccurred())
-						adminClient.maxZoneFailuresWithoutLosingAvailability = pointer.Int(0)
+						adminClient.MaxZoneFailuresWithoutLosingAvailability = pointer.Int(0)
 					})
 
 					It("should not remove that process group", func() {
@@ -131,9 +133,9 @@ var _ = Describe("remove_process_groups", func() {
 
 				When("the cluster has degraded data fault tolerance", func() {
 					BeforeEach(func() {
-						adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 						Expect(err).NotTo(HaveOccurred())
-						adminClient.maxZoneFailuresWithoutLosingData = pointer.Int(0)
+						adminClient.MaxZoneFailuresWithoutLosingData = pointer.Int(0)
 					})
 
 					It("should not remove that process group", func() {
@@ -149,9 +151,9 @@ var _ = Describe("remove_process_groups", func() {
 
 				When("the cluster is not available", func() {
 					BeforeEach(func() {
-						adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 						Expect(err).NotTo(HaveOccurred())
-						adminClient.frozenStatus = &fdbv1beta2.FoundationDBStatus{
+						adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
 							Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
 								DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
 									Available: false,
@@ -188,7 +190,7 @@ var _ = Describe("remove_process_groups", func() {
 					Expect(marked).To(BeTrue())
 					Expect(processGroup).To(BeNil())
 					// Exclude the process group
-					adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 					adminClient.ExcludedAddresses = append(adminClient.ExcludedAddresses, secondRemovedProcessGroup.Addresses...)
 				})

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -24,6 +24,8 @@ import (
 	ctx "context"
 	"time"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
+
 	"k8s.io/utils/pointer"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
@@ -53,7 +55,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 	})
 
 	JustBeforeEach(func() {
-		adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+		adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(adminClient).NotTo(BeNil())
 		result = replaceFailedProcessGroups{}.reconcile(ctx.Background(), clusterReconciler, cluster)
@@ -261,9 +263,9 @@ var _ = Describe("replace_failed_process_groups", func() {
 					processGroup := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, "storage-2")
 					processGroup.Addresses = nil
 
-					adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
-					adminClient.frozenStatus = &fdbv1beta2.FoundationDBStatus{
+					adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
 						Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
 							DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
 								Available: false,
@@ -286,9 +288,9 @@ var _ = Describe("replace_failed_process_groups", func() {
 					processGroup := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, "storage-2")
 					processGroup.Addresses = nil
 
-					adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
+					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
-					adminClient.maxZoneFailuresWithoutLosingData = pointer.Int(0)
+					adminClient.MaxZoneFailuresWithoutLosingData = pointer.Int(0)
 				})
 
 				It("should return nil", func() {

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -44,7 +44,7 @@ type FoundationDBRestoreReconciler struct {
 	client.Client
 	Recorder               record.EventRecorder
 	Log                    logr.Logger
-	DatabaseClientProvider DatabaseClientProvider
+	DatabaseClientProvider fdbadminclient.DatabaseClientProvider
 	ServerSideApply        bool
 }
 
@@ -88,7 +88,7 @@ func (r *FoundationDBRestoreReconciler) Reconcile(ctx context.Context, request c
 }
 
 // getDatabaseClientProvider gets the client provider for a reconciler.
-func (r *FoundationDBRestoreReconciler) getDatabaseClientProvider() DatabaseClientProvider {
+func (r *FoundationDBRestoreReconciler) getDatabaseClientProvider() fdbadminclient.DatabaseClientProvider {
 	if r.DatabaseClientProvider != nil {
 		return r.DatabaseClientProvider
 	}

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -22,6 +22,7 @@ package controllers
 
 import (
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -38,13 +39,13 @@ func reloadRestore(restore *fdbv1beta2.FoundationDBRestore) error {
 var _ = Describe("restore_controller", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
 	var restore *fdbv1beta2.FoundationDBRestore
-	var adminClient *mockAdminClient
+	var adminClient *mock.AdminClient
 	var err error
 
 	BeforeEach(func() {
 		cluster = internal.CreateDefaultCluster()
 		restore = createDefaultRestore(cluster)
-		adminClient, err = newMockAdminClientUncast(cluster, k8sClient)
+		adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -107,8 +108,8 @@ var _ = Describe("restore_controller", func() {
 			})
 
 			It("should append the custom parameters to the command", func() {
-				Expect(len(adminClient.knobs)).To(BeNumerically("==", 1))
-				Expect(adminClient.knobs).To(ContainElements("--knob_http_verbose_level=3"))
+				Expect(len(adminClient.Knobs)).To(BeNumerically("==", 1))
+				Expect(adminClient.Knobs).To(ContainElements("--knob_http_verbose_level=3"))
 			})
 		})
 	})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
@@ -80,14 +82,14 @@ var _ = BeforeSuite(func() {
 		Log:                    ctrl.Log.WithName("controllers").WithName("FoundationDBBackup"),
 		Recorder:               k8sClient,
 		InSimulation:           true,
-		DatabaseClientProvider: mockDatabaseClientProvider{},
+		DatabaseClientProvider: mock.DatabaseClientProvider{},
 	}
 
 	restoreReconciler = &FoundationDBRestoreReconciler{
 		Client:                 k8sClient,
 		Log:                    ctrl.Log.WithName("controllers").WithName("FoundationDBRestore"),
 		Recorder:               k8sClient,
-		DatabaseClientProvider: mockDatabaseClientProvider{},
+		DatabaseClientProvider: mock.DatabaseClientProvider{},
 	}
 })
 
@@ -98,8 +100,8 @@ var _ = AfterSuite(func() {
 
 var _ = AfterEach(func() {
 	k8sClient.Clear()
-	clearMockAdminClients()
-	clearMockLockClients()
+	mock.ClearMockAdminClients()
+	mock.ClearMockLockClients()
 })
 
 func createDefaultRestore(cluster *fdbv1beta2.FoundationDBCluster) *fdbv1beta2.FoundationDBRestore {
@@ -185,6 +187,6 @@ func createTestClusterReconciler() *FoundationDBClusterReconciler {
 		InSimulation:           true,
 		PodLifecycleManager:    podmanager.StandardPodLifecycleManager{},
 		PodClientProvider:      internal.NewMockFdbPodClient,
-		DatabaseClientProvider: mockDatabaseClientProvider{},
+		DatabaseClientProvider: mock.DatabaseClientProvider{},
 	}
 }

--- a/controllers/update_lock_configuration_test.go
+++ b/controllers/update_lock_configuration_test.go
@@ -22,6 +22,7 @@ package controllers
 
 import (
 	"context"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 
@@ -32,7 +33,7 @@ import (
 
 var _ = Describe("update_lock_configuration", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
-	var lockClient *mockLockClient
+	var lockClient *mock.LockClient
 	var err error
 	var requeue *requeue
 
@@ -55,7 +56,7 @@ var _ = Describe("update_lock_configuration", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(generation).To(Equal(int64(1)))
 
-		lockClient = newMockLockClientUncast(cluster)
+		lockClient = mock.NewMockLockClientUncast(cluster)
 	})
 
 	JustBeforeEach(func() {

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -23,6 +23,8 @@ package controllers
 import (
 	"context"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
+
 	"k8s.io/utils/pointer"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
@@ -40,7 +42,7 @@ var _ = Describe("update_status", func() {
 	Context("validate process group", func() {
 		var cluster *fdbv1beta2.FoundationDBCluster
 		var configMap *corev1.ConfigMap
-		var adminClient *mockAdminClient
+		var adminClient *mock.AdminClient
 		var pods []*corev1.Pod
 		var processMap map[string][]fdbv1beta2.FoundationDBStatusProcessInfo
 		var err error
@@ -59,7 +61,7 @@ var _ = Describe("update_status", func() {
 				pods[0].Status.ContainerStatuses = append(pods[0].Status.ContainerStatuses, corev1.ContainerStatus{Ready: true, Name: container.Name})
 			}
 
-			adminClient, err = newMockAdminClientUncast(cluster, k8sClient)
+			adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
 			Expect(err).NotTo(HaveOccurred())
 
 			configMap = &corev1.ConfigMap{}

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
-	"github.com/FoundationDB/fdb-kubernetes-operator/controllers"
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/go-logr/logr"
@@ -165,7 +164,7 @@ func (p *realDatabaseClientProvider) GetAdminClient(cluster *fdbv1beta2.Foundati
 
 // NewDatabaseClientProvider generates a client provider for talking to real
 // databases.
-func NewDatabaseClientProvider(log logr.Logger) controllers.DatabaseClientProvider {
+func NewDatabaseClientProvider(log logr.Logger) fdbadminclient.DatabaseClientProvider {
 	return &realDatabaseClientProvider{
 		log: log.WithName("fdbclient"),
 	}

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -100,7 +100,7 @@ type AdminClient interface {
 	// GetCoordinatorSet returns a set of the current coordinators.
 	GetCoordinatorSet() (map[string]struct{}, error)
 
-	// SetKnobs sets the knobs that should be used for the commandline call.
+	// SetKnobs sets the Knobs that should be used for the commandline call.
 	SetKnobs([]string)
 
 	// GetMaintenanceZone gets current maintenance zone, if any

--- a/pkg/fdbadminclient/database_provider.go
+++ b/pkg/fdbadminclient/database_provider.go
@@ -1,9 +1,9 @@
 /*
- * fdb_client.go
+ * database_provider.go
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,10 @@
  * limitations under the License.
  */
 
-package controllers
+package fdbadminclient
 
 import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
-	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,22 +29,9 @@ import (
 // communicate with the database.
 type DatabaseClientProvider interface {
 	// GetLockClient generates a client for working with locks through the database.
-	GetLockClient(cluster *fdbv1beta2.FoundationDBCluster) (fdbadminclient.LockClient, error)
+	GetLockClient(cluster *fdbv1beta2.FoundationDBCluster) (LockClient, error)
 
 	// GetAdminClient generates a client for performing administrative actions
 	// against the database.
-	GetAdminClient(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client) (fdbadminclient.AdminClient, error)
-}
-
-type mockDatabaseClientProvider struct{}
-
-// GetLockClient generates a client for working with locks through the database.
-func (p mockDatabaseClientProvider) GetLockClient(cluster *fdbv1beta2.FoundationDBCluster) (fdbadminclient.LockClient, error) {
-	return newMockLockClient(cluster)
-}
-
-// GetAdminClient generates a client for performing administrative actions
-// against the database.
-func (p mockDatabaseClientProvider) GetAdminClient(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client) (fdbadminclient.AdminClient, error) {
-	return newMockAdminClient(cluster, kubernetesClient)
+	GetAdminClient(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client) (AdminClient, error)
 }

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020-2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2020-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-package controllers
+package mock
 
 import (
 	"context"
@@ -28,23 +28,24 @@ import (
 	"sync"
 	"time"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
-	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// mockAdminClient provides a mock implementation of the cluster admin interface
-type mockAdminClient struct {
+// AdminClient provides a mock implementation of the cluster admin interface
+type AdminClient struct {
 	Cluster                                  *fdbv1beta2.FoundationDBCluster
 	KubeClient                               client.Client
 	DatabaseConfiguration                    *fdbv1beta2.DatabaseConfiguration
 	ExcludedAddresses                        []string
 	ReincludedAddresses                      map[string]bool
 	KilledAddresses                          []string
-	frozenStatus                             *fdbv1beta2.FoundationDBStatus
+	FrozenStatus                             *fdbv1beta2.FoundationDBStatus
 	Backups                                  map[string]fdbv1beta2.FoundationDBBackupStatusBackupDetails
 	restoreURL                               string
 	clientVersions                           map[string][]string
@@ -52,34 +53,34 @@ type mockAdminClient struct {
 	additionalProcesses                      []fdbv1beta2.ProcessGroupStatus
 	localityInfo                             map[string]map[string]string
 	incorrectCommandLines                    map[string]bool
-	maxZoneFailuresWithoutLosingData         *int
-	maxZoneFailuresWithoutLosingAvailability *int
-	knobs                                    []string
-	maintenanceZone                          string
+	MaxZoneFailuresWithoutLosingData         *int
+	MaxZoneFailuresWithoutLosingAvailability *int
+	Knobs                                    []string
+	MaintenanceZone                          string
 	maintenanceZoneStartTimestamp            time.Time
 	uptimeSecondsForMaintenanceZone          float64
 }
 
 // adminClientCache provides a cache of mock admin clients.
-var adminClientCache = make(map[string]*mockAdminClient)
+var adminClientCache = make(map[string]*AdminClient)
 var adminClientMutex sync.Mutex
 
-// newMockAdminClient creates an admin client for a cluster.
-func newMockAdminClient(cluster *fdbv1beta2.FoundationDBCluster, kubeClient client.Client) (fdbadminclient.AdminClient, error) {
-	return newMockAdminClientUncast(cluster, kubeClient)
+// NewMockAdminClient creates an admin client for a cluster.
+func NewMockAdminClient(cluster *fdbv1beta2.FoundationDBCluster, kubeClient client.Client) (fdbadminclient.AdminClient, error) {
+	return NewMockAdminClientUncast(cluster, kubeClient)
 }
 
-// newMockAdminClientUncast creates a mock admin client for a cluster.
+// NewMockAdminClientUncast creates a mock admin client for a cluster.
 // nolint:unparam
 // is required because we always return a nil error
-func newMockAdminClientUncast(cluster *fdbv1beta2.FoundationDBCluster, kubeClient client.Client) (*mockAdminClient, error) {
+func NewMockAdminClientUncast(cluster *fdbv1beta2.FoundationDBCluster, kubeClient client.Client) (*AdminClient, error) {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
 	cachedClient := adminClientCache[cluster.Name]
 
 	if cachedClient == nil {
-		cachedClient = &mockAdminClient{
+		cachedClient = &AdminClient{
 			Cluster:              cluster.DeepCopy(),
 			KubeClient:           kubeClient,
 			ReincludedAddresses:  make(map[string]bool),
@@ -95,18 +96,18 @@ func newMockAdminClientUncast(cluster *fdbv1beta2.FoundationDBCluster, kubeClien
 	return cachedClient, nil
 }
 
-// clearMockAdminClients clears the cache of mock Admin clients
-func clearMockAdminClients() {
-	adminClientCache = map[string]*mockAdminClient{}
+// ClearMockAdminClients clears the cache of mock Admin clients
+func ClearMockAdminClients() {
+	adminClientCache = map[string]*AdminClient{}
 }
 
 // GetStatus gets the database's status
-func (client *mockAdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
+func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
-	if client.frozenStatus != nil {
-		return client.frozenStatus, nil
+	if client.FrozenStatus != nil {
+		return client.FrozenStatus, nil
 	}
 	pods := &corev1.PodList{}
 	err := client.KubeClient.List(context.TODO(), pods)
@@ -210,7 +211,7 @@ func (client *mockAdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, erro
 			}
 
 			var uptimeSeconds float64 = 60000
-			if client.maintenanceZone == pod.Name || client.maintenanceZone == "simulation" {
+			if client.MaintenanceZone == pod.Name || client.MaintenanceZone == "simulation" {
 				if client.uptimeSecondsForMaintenanceZone != 0.0 {
 					uptimeSeconds = client.uptimeSecondsForMaintenanceZone
 				} else {
@@ -241,7 +242,7 @@ func (client *mockAdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, erro
 			}
 
 			var uptimeSeconds float64 = 60000
-			if client.maintenanceZone == processGroup.ProcessGroupID || client.maintenanceZone == "simulation" {
+			if client.MaintenanceZone == processGroup.ProcessGroupID || client.MaintenanceZone == "simulation" {
 				if client.uptimeSecondsForMaintenanceZone != 0.0 {
 					uptimeSeconds = client.uptimeSecondsForMaintenanceZone
 				} else {
@@ -325,22 +326,22 @@ func (client *mockAdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, erro
 		}
 	}
 	faultToleranceSubtractor := 0
-	if client.maintenanceZone != "" {
+	if client.MaintenanceZone != "" {
 		faultToleranceSubtractor = 1
 	}
-	if client.maxZoneFailuresWithoutLosingData == nil {
+	if client.MaxZoneFailuresWithoutLosingData == nil {
 		status.Cluster.FaultTolerance.MaxZoneFailuresWithoutLosingData = client.Cluster.DesiredFaultTolerance() - faultToleranceSubtractor
 	}
 
-	if client.maxZoneFailuresWithoutLosingAvailability == nil {
+	if client.MaxZoneFailuresWithoutLosingAvailability == nil {
 		status.Cluster.FaultTolerance.MaxZoneFailuresWithoutLosingAvailability = client.Cluster.DesiredFaultTolerance() - faultToleranceSubtractor
 	}
-	status.Cluster.MaintenanceZone = client.maintenanceZone
+	status.Cluster.MaintenanceZone = client.MaintenanceZone
 	return status, nil
 }
 
 // ConfigureDatabase changes the database configuration
-func (client *mockAdminClient) ConfigureDatabase(configuration fdbv1beta2.DatabaseConfiguration, _ bool, version string) error {
+func (client *AdminClient) ConfigureDatabase(configuration fdbv1beta2.DatabaseConfiguration, _ bool, version string) error {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -361,7 +362,7 @@ func (client *mockAdminClient) ConfigureDatabase(configuration fdbv1beta2.Databa
 
 // ExcludeProcesses starts evacuating processes so that they can be removed
 // from the database.
-func (client *mockAdminClient) ExcludeProcesses(addresses []fdbv1beta2.ProcessAddress) error {
+func (client *AdminClient) ExcludeProcesses(addresses []fdbv1beta2.ProcessAddress) error {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -394,7 +395,7 @@ func (client *mockAdminClient) ExcludeProcesses(addresses []fdbv1beta2.ProcessAd
 
 // IncludeProcesses removes processes from the exclusion list and allows
 // them to take on roles again.
-func (client *mockAdminClient) IncludeProcesses(addresses []fdbv1beta2.ProcessAddress) error {
+func (client *AdminClient) IncludeProcesses(addresses []fdbv1beta2.ProcessAddress) error {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -424,7 +425,7 @@ func (client *mockAdminClient) IncludeProcesses(addresses []fdbv1beta2.ProcessAd
 //
 // The list returned by this method will be the addresses that are *not*
 // safe to remove.
-func (client *mockAdminClient) CanSafelyRemove(addresses []fdbv1beta2.ProcessAddress) ([]fdbv1beta2.ProcessAddress, error) {
+func (client *AdminClient) CanSafelyRemove(addresses []fdbv1beta2.ProcessAddress) ([]fdbv1beta2.ProcessAddress, error) {
 	skipExclude := map[string]fdbv1beta2.None{}
 
 	// Check which process groups have the skip exclusion flag or are already
@@ -457,14 +458,12 @@ func (client *mockAdminClient) CanSafelyRemove(addresses []fdbv1beta2.ProcessAdd
 		remaining = append(remaining, addr)
 	}
 
-	t := client.ExcludedAddresses
-	log.Info("CanSafelyRemove", "addresses", addresses, "skipExclude", skipExclude, "remaining", remaining, "excluded", t)
 	return remaining, nil
 }
 
 // GetExclusions gets a list of the addresses currently excluded from the
 // database.
-func (client *mockAdminClient) GetExclusions() ([]fdbv1beta2.ProcessAddress, error) {
+func (client *AdminClient) GetExclusions() ([]fdbv1beta2.ProcessAddress, error) {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -481,7 +480,7 @@ func (client *mockAdminClient) GetExclusions() ([]fdbv1beta2.ProcessAddress, err
 }
 
 // KillProcesses restarts processes
-func (client *mockAdminClient) KillProcesses(addresses []fdbv1beta2.ProcessAddress) error {
+func (client *AdminClient) KillProcesses(addresses []fdbv1beta2.ProcessAddress) error {
 	adminClientMutex.Lock()
 	for _, addr := range addresses {
 		client.KilledAddresses = append(client.KilledAddresses, addr.String())
@@ -503,7 +502,7 @@ func (client *mockAdminClient) KillProcesses(addresses []fdbv1beta2.ProcessAddre
 }
 
 // ChangeCoordinators changes the coordinator set
-func (client *mockAdminClient) ChangeCoordinators(addresses []fdbv1beta2.ProcessAddress) (string, error) {
+func (client *AdminClient) ChangeCoordinators(addresses []fdbv1beta2.ProcessAddress) (string, error) {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -525,7 +524,7 @@ func (client *mockAdminClient) ChangeCoordinators(addresses []fdbv1beta2.Process
 }
 
 // GetConnectionString fetches the latest connection string.
-func (client *mockAdminClient) GetConnectionString() (string, error) {
+func (client *AdminClient) GetConnectionString() (string, error) {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -534,7 +533,7 @@ func (client *mockAdminClient) GetConnectionString() (string, error) {
 
 // VersionSupported reports whether we can support a cluster with a given
 // version.
-func (client *mockAdminClient) VersionSupported(versionString string) (bool, error) {
+func (client *AdminClient) VersionSupported(versionString string) (bool, error) {
 	version, err := fdbv1beta2.ParseFdbVersion(versionString)
 	if err != nil {
 		return false, err
@@ -549,12 +548,12 @@ func (client *mockAdminClient) VersionSupported(versionString string) (bool, err
 
 // GetProtocolVersion determines the protocol version that is used by a
 // version of FDB.
-func (client *mockAdminClient) GetProtocolVersion(version string) (string, error) {
+func (client *AdminClient) GetProtocolVersion(version string) (string, error) {
 	return version, nil
 }
 
 // StartBackup starts a new backup.
-func (client *mockAdminClient) StartBackup(url string, snapshotPeriodSeconds int) error {
+func (client *AdminClient) StartBackup(url string, snapshotPeriodSeconds int) error {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -567,7 +566,7 @@ func (client *mockAdminClient) StartBackup(url string, snapshotPeriodSeconds int
 }
 
 // PauseBackups pauses backups.
-func (client *mockAdminClient) PauseBackups() error {
+func (client *AdminClient) PauseBackups() error {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -579,7 +578,7 @@ func (client *mockAdminClient) PauseBackups() error {
 }
 
 // ResumeBackups resumes backups.
-func (client *mockAdminClient) ResumeBackups() error {
+func (client *AdminClient) ResumeBackups() error {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -591,7 +590,7 @@ func (client *mockAdminClient) ResumeBackups() error {
 }
 
 // ModifyBackup reconfigures the backup.
-func (client *mockAdminClient) ModifyBackup(snapshotPeriodSeconds int) error {
+func (client *AdminClient) ModifyBackup(snapshotPeriodSeconds int) error {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -602,7 +601,7 @@ func (client *mockAdminClient) ModifyBackup(snapshotPeriodSeconds int) error {
 }
 
 // StopBackup stops a backup.
-func (client *mockAdminClient) StopBackup(url string) error {
+func (client *AdminClient) StopBackup(url string) error {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -617,7 +616,7 @@ func (client *mockAdminClient) StopBackup(url string) error {
 }
 
 // GetBackupStatus gets the status of the current backup.
-func (client *mockAdminClient) GetBackupStatus() (*fdbv1beta2.FoundationDBLiveBackupStatus, error) {
+func (client *AdminClient) GetBackupStatus() (*fdbv1beta2.FoundationDBLiveBackupStatus, error) {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -636,7 +635,7 @@ func (client *mockAdminClient) GetBackupStatus() (*fdbv1beta2.FoundationDBLiveBa
 }
 
 // StartRestore starts a new restore.
-func (client *mockAdminClient) StartRestore(url string, _ []fdbv1beta2.FoundationDBKeyRange) error {
+func (client *AdminClient) StartRestore(url string, _ []fdbv1beta2.FoundationDBKeyRange) error {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -645,7 +644,7 @@ func (client *mockAdminClient) StartRestore(url string, _ []fdbv1beta2.Foundatio
 }
 
 // GetRestoreStatus gets the status of the current restore.
-func (client *mockAdminClient) GetRestoreStatus() (string, error) {
+func (client *AdminClient) GetRestoreStatus() (string, error) {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -653,7 +652,7 @@ func (client *mockAdminClient) GetRestoreStatus() (string, error) {
 }
 
 // MockClientVersion returns a mocked client version
-func (client *mockAdminClient) MockClientVersion(version string, clients []string) {
+func (client *AdminClient) MockClientVersion(version string, clients []string) {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -664,7 +663,7 @@ func (client *mockAdminClient) MockClientVersion(version string, clients []strin
 }
 
 // MockAdditionalProcesses adds additional processes to the cluster status.
-func (client *mockAdminClient) MockAdditionalProcesses(processes []fdbv1beta2.ProcessGroupStatus) {
+func (client *AdminClient) MockAdditionalProcesses(processes []fdbv1beta2.ProcessGroupStatus) {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
@@ -673,18 +672,18 @@ func (client *mockAdminClient) MockAdditionalProcesses(processes []fdbv1beta2.Pr
 
 // MockMissingProcessGroup updates the mock for whether a process group should
 // be missing from the cluster status.
-func (client *mockAdminClient) MockMissingProcessGroup(processGroupID string, missing bool) {
+func (client *AdminClient) MockMissingProcessGroup(processGroupID string, missing bool) {
 	client.missingProcessGroups[processGroupID] = missing
 }
 
 // MockLocalityInfo sets mock locality information for a process.
-func (client *mockAdminClient) MockLocalityInfo(processGroupID string, locality map[string]string) {
+func (client *AdminClient) MockLocalityInfo(processGroupID string, locality map[string]string) {
 	client.localityInfo[processGroupID] = locality
 }
 
 // MockIncorrectCommandLine updates the mock for whether a process group should
 // be have an incorrect command-line.
-func (client *mockAdminClient) MockIncorrectCommandLine(processGroupID string, incorrect bool) {
+func (client *AdminClient) MockIncorrectCommandLine(processGroupID string, incorrect bool) {
 	if client.incorrectCommandLines == nil {
 		client.incorrectCommandLines = make(map[string]bool)
 	}
@@ -693,14 +692,14 @@ func (client *mockAdminClient) MockIncorrectCommandLine(processGroupID string, i
 
 // Close shuts down any resources for the client once it is no longer
 // needed.
-func (client *mockAdminClient) Close() error {
+func (client *AdminClient) Close() error {
 	return nil
 }
 
 // FreezeStatus causes the GetStatus method to return its current value until
 // UnfreezeStatus is called, or another method is called which would invalidate
 // the status.
-func (client *mockAdminClient) FreezeStatus() error {
+func (client *AdminClient) FreezeStatus() error {
 	status, err := client.GetStatus()
 	if err != nil {
 		return err
@@ -709,21 +708,21 @@ func (client *mockAdminClient) FreezeStatus() error {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
-	client.frozenStatus = status
+	client.FrozenStatus = status
 	return nil
 }
 
 // UnfreezeStatus causes the admin client to start recalculating the status
 // on every call to GetStatus
-func (client *mockAdminClient) UnfreezeStatus() {
+func (client *AdminClient) UnfreezeStatus() {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
-	client.frozenStatus = nil
+	client.FrozenStatus = nil
 }
 
 // GetCoordinatorSet gets the current coordinators from the status
-func (client *mockAdminClient) GetCoordinatorSet() (map[string]struct{}, error) {
+func (client *AdminClient) GetCoordinatorSet() (map[string]struct{}, error) {
 	status, err := client.GetStatus()
 	if err != nil {
 		return nil, err
@@ -732,30 +731,30 @@ func (client *mockAdminClient) GetCoordinatorSet() (map[string]struct{}, error) 
 	return internal.GetCoordinatorsFromStatus(status), nil
 }
 
-// SetKnobs sets the knobs that should be used for the commandline call.
-func (client *mockAdminClient) SetKnobs(knobs []string) {
-	client.knobs = knobs
+// SetKnobs sets the Knobs that should be used for the commandline call.
+func (client *AdminClient) SetKnobs(knobs []string) {
+	client.Knobs = knobs
 }
 
 // GetMaintenanceZone gets current maintenance zone, if any
-func (client *mockAdminClient) GetMaintenanceZone() (string, error) {
-	return client.maintenanceZone, nil
+func (client *AdminClient) GetMaintenanceZone() (string, error) {
+	return client.MaintenanceZone, nil
 }
 
 // SetMaintenanceZone places zone into maintenance mode
-func (client *mockAdminClient) SetMaintenanceZone(zone string, _ int) error {
-	client.maintenanceZone = zone
+func (client *AdminClient) SetMaintenanceZone(zone string, _ int) error {
+	client.MaintenanceZone = zone
 	client.maintenanceZoneStartTimestamp = time.Now()
 	return nil
 }
 
-// Reset maintenance mode
-func (client *mockAdminClient) ResetMaintenanceMode() error {
-	client.maintenanceZone = ""
+// ResetMaintenanceMode resets the maintenance zone
+func (client *AdminClient) ResetMaintenanceMode() error {
+	client.MaintenanceZone = ""
 	return nil
 }
 
-// Reset maintenance mode
-func (client *mockAdminClient) MockUptimeSecondsForMaintenanceZone(seconds float64) {
+// MockUptimeSecondsForMaintenanceZone mocks the uptime for maintenance zone
+func (client *AdminClient) MockUptimeSecondsForMaintenanceZone(seconds float64) {
 	client.uptimeSecondsForMaintenanceZone = seconds
 }

--- a/pkg/fdbadminclient/mock/admin_client_mock_test.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock_test.go
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020-2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2020-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-package controllers
+package mock
 
 import (
 	"net"
@@ -43,7 +43,7 @@ var _ = Describe("mock_client", func() {
 
 		DescribeTable("should return the correct image",
 			func(input testCase) {
-				admin, err := newMockAdminClient(input.cluster, nil)
+				admin, err := NewMockAdminClient(input.cluster, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = admin.ExcludeProcesses(input.exclusions)

--- a/pkg/fdbadminclient/mock/database_provider.go
+++ b/pkg/fdbadminclient/mock/database_provider.go
@@ -1,0 +1,41 @@
+/*
+ * database_provider.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mock
+
+import (
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DatabaseClientProvider is a DatabaseClientProvider thar provides mocked clients for testing.
+type DatabaseClientProvider struct{}
+
+// GetLockClient generates a client for working with locks through the database.
+func (p DatabaseClientProvider) GetLockClient(cluster *fdbv1beta2.FoundationDBCluster) (fdbadminclient.LockClient, error) {
+	return NewMockLockClient(cluster)
+}
+
+// GetAdminClient generates a client for performing administrative actions
+// against the database.
+func (p DatabaseClientProvider) GetAdminClient(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client) (fdbadminclient.AdminClient, error) {
+	return NewMockAdminClient(cluster, kubernetesClient)
+}

--- a/pkg/fdbadminclient/mock/lock_client.go
+++ b/pkg/fdbadminclient/mock/lock_client.go
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-package controllers
+package mock
 
 import (
 	"sort"
@@ -29,8 +29,8 @@ import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 )
 
-// mockLockClient provides a mock client for managing operation locks.
-type mockLockClient struct {
+// LockClient provides a mock client for managing operation locks.
+type LockClient struct {
 	// cluster stores the cluster this client is working with.
 	cluster *fdbv1beta2.FoundationDBCluster
 
@@ -43,18 +43,18 @@ type mockLockClient struct {
 }
 
 // TakeLock attempts to acquire a lock.
-func (client *mockLockClient) TakeLock() (bool, error) {
+func (client *LockClient) TakeLock() (bool, error) {
 	return true, nil
 }
 
 // Disabled determines if the client should automatically grant locks.
-func (client *mockLockClient) Disabled() bool {
+func (client *LockClient) Disabled() bool {
 	return !client.cluster.ShouldUseLocks()
 }
 
 // AddPendingUpgrades registers information about which process groups are
 // pending an upgrade to a new version.
-func (client *mockLockClient) AddPendingUpgrades(version fdbv1beta2.Version, processGroupIDs []string) error {
+func (client *LockClient) AddPendingUpgrades(version fdbv1beta2.Version, processGroupIDs []string) error {
 	if client.pendingUpgrades[version] == nil {
 		client.pendingUpgrades[version] = make(map[string]bool)
 	}
@@ -66,7 +66,7 @@ func (client *mockLockClient) AddPendingUpgrades(version fdbv1beta2.Version, pro
 
 // GetPendingUpgrades returns the stored information about which process
 // groups are pending an upgrade to a new version.
-func (client *mockLockClient) GetPendingUpgrades(version fdbv1beta2.Version) (map[string]bool, error) {
+func (client *LockClient) GetPendingUpgrades(version fdbv1beta2.Version) (map[string]bool, error) {
 	upgrades := client.pendingUpgrades[version]
 	if upgrades == nil {
 		return make(map[string]bool), nil
@@ -75,13 +75,13 @@ func (client *mockLockClient) GetPendingUpgrades(version fdbv1beta2.Version) (ma
 }
 
 // GetDenyList retrieves the current deny list from the database.
-func (client *mockLockClient) GetDenyList() ([]string, error) {
+func (client *LockClient) GetDenyList() ([]string, error) {
 	return client.denyList, nil
 }
 
 // UpdateDenyList updates the deny list to match a list of entries.
 // This will return the complete deny list after these changes are made.
-func (client *mockLockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntry) error {
+func (client *LockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntry) error {
 	newDenyList := make([]string, 0, len(client.denyList)+len(locks))
 	newDenyMap := make(map[string]bool)
 	for _, id := range client.denyList {
@@ -108,22 +108,22 @@ func (client *mockLockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntr
 }
 
 // lockClientCache provides a cache of mock lock clients.
-var lockClientCache = make(map[string]*mockLockClient)
+var lockClientCache = make(map[string]*LockClient)
 var lockClientMutex sync.Mutex
 
-// newMockLockClient creates a mock lock client.
-func newMockLockClient(cluster *fdbv1beta2.FoundationDBCluster) (fdbadminclient.LockClient, error) {
-	return newMockLockClientUncast(cluster), nil
+// NewMockLockClient creates a mock lock client.
+func NewMockLockClient(cluster *fdbv1beta2.FoundationDBCluster) (fdbadminclient.LockClient, error) {
+	return NewMockLockClientUncast(cluster), nil
 }
 
 // NewMockLockClientUncast creates a mock lock client.
-func newMockLockClientUncast(cluster *fdbv1beta2.FoundationDBCluster) *mockLockClient {
+func NewMockLockClientUncast(cluster *fdbv1beta2.FoundationDBCluster) *LockClient {
 	lockClientMutex.Lock()
 	defer lockClientMutex.Unlock()
 
 	client := lockClientCache[cluster.Name]
 	if client == nil {
-		client = &mockLockClient{cluster: cluster, pendingUpgrades: make(map[fdbv1beta2.Version]map[string]bool)}
+		client = &LockClient{cluster: cluster, pendingUpgrades: make(map[fdbv1beta2.Version]map[string]bool)}
 		lockClientCache[cluster.Name] = client
 	}
 	return client
@@ -131,11 +131,11 @@ func newMockLockClientUncast(cluster *fdbv1beta2.FoundationDBCluster) *mockLockC
 
 // ClearPendingUpgrades clears any stored information about pending
 // upgrades.
-func (client *mockLockClient) ClearPendingUpgrades() error {
+func (client *LockClient) ClearPendingUpgrades() error {
 	return nil
 }
 
-// clearMockLockClients clears the cache of mock lock clients
-func clearMockLockClients() {
-	lockClientCache = map[string]*mockLockClient{}
+// ClearMockLockClients clears the cache of mock lock clients
+func ClearMockLockClients() {
+	lockClientCache = map[string]*LockClient{}
 }

--- a/pkg/fdbadminclient/mock/suite_test.go
+++ b/pkg/fdbadminclient/mock/suite_test.go
@@ -1,0 +1,33 @@
+/*
+ * suite_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mock
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mock Admin Client")
+}


### PR DESCRIPTION
# Description

This will expose the mock implementations for the AdminClient and the LockClient. The idea is to make it available for users of the fdbclient package for unit tests.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Discussion

Since we are moving things around this will be a breaking change but my exception is that this allows users to use the mock client without breaking to many things in the future.

## Testing

Local testing with another test repository.

## Documentation

-

## Follow-up

-
