### PR TITLE
If the cluster is upgraded wait for all processes to be ready

### DIFF
--- a/internal/restarts/restarts.go
+++ b/internal/restarts/restarts.go
@@ -1,0 +1,44 @@
+/*
+ * restarts.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package restarts
+
+import fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+
+// GetFilterConditions returns the filter conditions to get the processes that should be restarted.
+func GetFilterConditions(cluster *fdbv1beta2.FoundationDBCluster) map[fdbv1beta2.ProcessGroupConditionType]bool {
+	if !cluster.IsBeingUpgraded() {
+		// If we don't upgrade our cluster we can ignore all process groups that are not reachable and therefore will
+		// not get any ConfigMap updates.
+		return map[fdbv1beta2.ProcessGroupConditionType]bool{
+			fdbv1beta2.IncorrectCommandLine: true,
+			fdbv1beta2.IncorrectPodSpec:     false,
+			fdbv1beta2.SidecarUnreachable:   false,
+		}
+	}
+
+	// If we perform an upgrade we have to wait until all processes are
+	// ready to be restarted. Therefore we can't ignore process groups with the SidecarUnreachable condition.
+	// We could be less restrictive here in cases where we perform a version compatible upgrade.m
+	return map[fdbv1beta2.ProcessGroupConditionType]bool{
+		fdbv1beta2.IncorrectCommandLine: true,
+		fdbv1beta2.IncorrectPodSpec:     false,
+	}
+}

--- a/internal/restarts/restarts_test.go
+++ b/internal/restarts/restarts_test.go
@@ -1,0 +1,71 @@
+/*
+ * restarts.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package restarts
+
+import (
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("restarts", func() {
+	DescribeTable("when getting the filter conditions for a cluster", func(cluster *fdbv1beta2.FoundationDBCluster, expected map[fdbv1beta2.ProcessGroupConditionType]bool) {
+		Expect(GetFilterConditions(cluster)).To(Equal(expected))
+	},
+		Entry("when no upgrade is performed",
+			&fdbv1beta2.FoundationDBCluster{
+				Spec: fdbv1beta2.FoundationDBClusterSpec{
+					Version: "7.1.25",
+				},
+				Status: fdbv1beta2.FoundationDBClusterStatus{
+					RunningVersion: "7.1.25",
+				},
+			},
+			map[fdbv1beta2.ProcessGroupConditionType]bool{
+				fdbv1beta2.IncorrectCommandLine: true,
+				fdbv1beta2.IncorrectPodSpec:     false,
+				fdbv1beta2.SidecarUnreachable:   false,
+			}),
+		Entry("when the running version is missing",
+			&fdbv1beta2.FoundationDBCluster{
+				Spec: fdbv1beta2.FoundationDBClusterSpec{
+					Version: "7.1.25",
+				},
+			},
+			map[fdbv1beta2.ProcessGroupConditionType]bool{
+				fdbv1beta2.IncorrectCommandLine: true,
+				fdbv1beta2.IncorrectPodSpec:     false,
+				fdbv1beta2.SidecarUnreachable:   false,
+			}),
+		Entry("when an upgrade is performed",
+			&fdbv1beta2.FoundationDBCluster{
+				Spec: fdbv1beta2.FoundationDBClusterSpec{
+					Version: "7.1.25",
+				},
+				Status: fdbv1beta2.FoundationDBClusterStatus{
+					RunningVersion: "6.3.25",
+				},
+			},
+			map[fdbv1beta2.ProcessGroupConditionType]bool{
+				fdbv1beta2.IncorrectCommandLine: true,
+				fdbv1beta2.IncorrectPodSpec:     false,
+			}))
+})

--- a/internal/restarts/restarts_test.go
+++ b/internal/restarts/restarts_test.go
@@ -67,5 +67,6 @@ var _ = Describe("restarts", func() {
 			map[fdbv1beta2.ProcessGroupConditionType]bool{
 				fdbv1beta2.IncorrectCommandLine: true,
 				fdbv1beta2.IncorrectPodSpec:     false,
-			}))
+			}),
+	)
 })

--- a/internal/restarts/suite_test.go
+++ b/internal/restarts/suite_test.go
@@ -1,0 +1,33 @@
+/*
+ * suite_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package restarts
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Restarts Suite")
+}


### PR DESCRIPTION
# Description

Ensure we wait for all processes before doing the upgrade and don't skip processes in the `SidecarUnreachable` state. I believe in the long term we want to implement some kind of a ratio to ignore some processes before doing the upgrade (instead of blocking until the issue is resolved).

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

See above, we probably want to rethink the upgrade prerequisites to not require all processes being ready to be upgraded but rather a % or fixed number of processes.

## Testing

Unit tests + I tested this with the e2e tests to ensure the upgrade is blocked until all processes are "ready" to be upgraded.

## Documentation

-

## Follow-up

-