### PR TITLE
Expose Pod Mock Client for testing

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	mockpodclient "github.com/FoundationDB/fdb-kubernetes-operator/pkg/podclient/mock"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
@@ -186,7 +188,7 @@ func createTestClusterReconciler() *FoundationDBClusterReconciler {
 		Recorder:               k8sClient,
 		InSimulation:           true,
 		PodLifecycleManager:    podmanager.StandardPodLifecycleManager{},
-		PodClientProvider:      internal.NewMockFdbPodClient,
+		PodClientProvider:      mockpodclient.NewMockFdbPodClient,
 		DatabaseClientProvider: mock.DatabaseClientProvider{},
 	}
 }

--- a/controllers/update_lock_configuration_test.go
+++ b/controllers/update_lock_configuration_test.go
@@ -22,6 +22,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -89,9 +89,7 @@ func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReco
 			continue
 		}
 
-		imageType := internal.GetImageType(pod)
-
-		configMapHash, err := internal.GetDynamicConfHash(configMap, processClass, imageType, serverPerPod)
+		configMapHash, err := internal.GetDynamicConfHash(configMap, processClass, internal.GetImageType(pod), serverPerPod)
 		if err != nil {
 			curLogger.Error(err, "Error when receiving dynamic ConfigMap hash")
 			errs = append(errs, err)

--- a/internal/locality/locality_test.go
+++ b/internal/locality/locality_test.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podclient/mock"
+
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -459,7 +461,7 @@ var _ = Describe("Change coordinators", func() {
 	)
 
 	DescribeTable("when getting the locality info from a sidecar", func(cluster *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod, expected Info, expectedError bool) {
-		client, err := internal.NewMockFdbPodClient(cluster, pod)
+		client, err := mock.NewMockFdbPodClient(cluster, pod)
 		Expect(err).NotTo(HaveOccurred())
 
 		info, err := InfoFromSidecar(cluster, client)

--- a/internal/monitor_conf.go
+++ b/internal/monitor_conf.go
@@ -39,6 +39,11 @@ func GetStartCommand(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1
 		return "", err
 	}
 
+	return getStartCommandWithSubstitutions(cluster, processClass, substitutions, processNumber, processCount)
+}
+
+// getStartCommandWithSubstitutions will be used by GetStartCommand and for internal testing.
+func getStartCommandWithSubstitutions(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, substitutions map[string]string, processNumber int, processCount int) (string, error) {
 	if substitutions == nil {
 		return "", nil
 	}

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -23,6 +23,7 @@ package mock
 import (
 	"context"
 	"fmt"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podclient/mock"
 	"net"
 	"strings"
 	"sync"
@@ -139,7 +140,7 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 	}
 
 	for _, pod := range pods.Items {
-		podClient, _ := internal.NewMockFdbPodClient(client.Cluster, &pod)
+		podClient, _ := mock.NewMockFdbPodClient(client.Cluster, &pod)
 
 		processCount, err := internal.GetStorageServersPerPodForPod(&pod)
 		if err != nil {

--- a/pkg/podclient/mock/pod_client.go
+++ b/pkg/podclient/mock/pod_client.go
@@ -1,0 +1,58 @@
+/*
+ * pod_client.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mock
+
+import (
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podclient"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// FdbPodClient provides a mock connection to a pod
+type FdbPodClient struct {
+	Cluster *fdbv1beta2.FoundationDBCluster
+	Pod     *corev1.Pod
+	logger  logr.Logger
+}
+
+// NewMockFdbPodClient builds a mock client for working with an FDB pod
+func NewMockFdbPodClient(cluster *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod) (podclient.FdbPodClient, error) {
+	return &FdbPodClient{Cluster: cluster, Pod: pod, logger: logr.New(log.NewDelegatingLogSink(log.NullLogSink{}))}, nil
+}
+
+// UpdateFile checks if a file is up-to-date and tries to update it.
+func (client *FdbPodClient) UpdateFile(_ string, _ string) (bool, error) {
+	return true, nil
+}
+
+// IsPresent checks whether a file in the sidecar is present.
+func (client *FdbPodClient) IsPresent(_ string) (bool, error) {
+	return true, nil
+}
+
+// GetVariableSubstitutions gets the current keys and values that this
+// process group will substitute into its monitor conf.
+func (client *FdbPodClient) GetVariableSubstitutions() (map[string]string, error) {
+	return internal.GetSubstitutionsFromClusterAndPod(client.logger, client.Cluster, client.Pod)
+}


### PR DESCRIPTION
# Description

This allows to use the mock Pod Client in different repositories and make it easier to consume/test the Pod client interface.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

This is not a breaking change, since all interfaces stay the same.

## Testing

Unit tests + e2e pipeline.

## Documentation

-

## Follow-up

-