### PR TITLE
Ensure that the configmap is synced before restarting processes

### DIFF
--- a/internal/restarts/restarts.go
+++ b/internal/restarts/restarts.go
@@ -31,6 +31,7 @@ func GetFilterConditions(cluster *fdbv1beta2.FoundationDBCluster) map[fdbv1beta2
 			fdbv1beta2.IncorrectCommandLine: true,
 			fdbv1beta2.IncorrectPodSpec:     false,
 			fdbv1beta2.SidecarUnreachable:   false,
+			fdbv1beta2.IncorrectConfigMap:   false,
 		}
 	}
 
@@ -40,5 +41,6 @@ func GetFilterConditions(cluster *fdbv1beta2.FoundationDBCluster) map[fdbv1beta2
 	return map[fdbv1beta2.ProcessGroupConditionType]bool{
 		fdbv1beta2.IncorrectCommandLine: true,
 		fdbv1beta2.IncorrectPodSpec:     false,
+		fdbv1beta2.IncorrectConfigMap:   false,
 	}
 }

--- a/internal/restarts/restarts_test.go
+++ b/internal/restarts/restarts_test.go
@@ -43,6 +43,7 @@ var _ = Describe("restarts", func() {
 				fdbv1beta2.IncorrectCommandLine: true,
 				fdbv1beta2.IncorrectPodSpec:     false,
 				fdbv1beta2.SidecarUnreachable:   false,
+				fdbv1beta2.IncorrectConfigMap:   false,
 			}),
 		Entry("when the running version is missing",
 			&fdbv1beta2.FoundationDBCluster{
@@ -54,6 +55,7 @@ var _ = Describe("restarts", func() {
 				fdbv1beta2.IncorrectCommandLine: true,
 				fdbv1beta2.IncorrectPodSpec:     false,
 				fdbv1beta2.SidecarUnreachable:   false,
+				fdbv1beta2.IncorrectConfigMap:   false,
 			}),
 		Entry("when an upgrade is performed",
 			&fdbv1beta2.FoundationDBCluster{
@@ -67,6 +69,7 @@ var _ = Describe("restarts", func() {
 			map[fdbv1beta2.ProcessGroupConditionType]bool{
 				fdbv1beta2.IncorrectCommandLine: true,
 				fdbv1beta2.IncorrectPodSpec:     false,
+				fdbv1beta2.IncorrectConfigMap:   false,
 			}),
 	)
 })


### PR DESCRIPTION
# Description

This ensures that the ConfigMap is synced before restarting processes (this includes the generated fdbmonitor file). The current behaviour only works because of this bug: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/611

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Unit tests and e2e tests.

## Documentation

-

## Follow-up

-
