### PR TITLE
Improve operator restart logic for upgrades

### DIFF
--- a/api/v1beta2/foundationdb_labels.go
+++ b/api/v1beta2/foundationdb_labels.go
@@ -72,4 +72,8 @@ const (
 	// FDBLocalityDNSNameKey represents the key in the locality map that holds
 	// the DNS name for the pod.
 	FDBLocalityDNSNameKey = "dns_name"
+
+	// FDBLocalityProcessIDKey represents the key in the locality map that
+	// holds the process ID.
+	FDBLocalityProcessIDKey = "process_id"
 )

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1548,9 +1548,9 @@ func (cluster *FoundationDBCluster) IsBeingUpgraded() bool {
 	return cluster.Status.RunningVersion != "" && cluster.Status.RunningVersion != cluster.Spec.Version
 }
 
-// VersionCompatibleUpgradeIsProgress returns true if the cluster is currently being upgraded and the upgrade is to
+// VersionCompatibleUpgradeInProgress returns true if the cluster is currently being upgraded and the upgrade is to
 // a version compatible version.
-func (cluster *FoundationDBCluster) VersionCompatibleUpgradeIsProgress() bool {
+func (cluster *FoundationDBCluster) VersionCompatibleUpgradeInProgress() bool {
 	if !cluster.IsBeingUpgraded() {
 		return false
 	}

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -183,7 +183,7 @@ func getProcessesReadyForRestart(logger logr.Logger, cluster *fdbv1beta2.Foundat
 			continue
 		}
 
-		// Ignore processes that are missing for more than 30 seconds e.g. if the process is network partitioned.
+		// Ignore processes that are missing for more than 30 seconds e.mg. if the process is network partitioned.
 		// This is required since the update status will not update the SidecarUnreachable setting if a process is
 		// missing in the status.
 		if missingTime := processGroup.GetConditionTime(fdbv1beta2.MissingProcesses); missingTime != nil {

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -183,7 +183,7 @@ func getProcessesReadyForRestart(logger logr.Logger, cluster *fdbv1beta2.Foundat
 			continue
 		}
 
-		// Ignore processes that are missing for more than 30 seconds e.mg. if the process is network partitioned.
+		// Ignore processes that are missing for more than 30 seconds e.g. if the process is network partitioned.
 		// This is required since the update status will not update the SidecarUnreachable setting if a process is
 		// missing in the status.
 		if missingTime := processGroup.GetConditionTime(fdbv1beta2.MissingProcesses); missingTime != nil {

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -65,7 +65,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 	// In the case of version compatible upgrades we have to check if some processes are already running with the new
 	// desired version e.g. because they were restarted by an event outside of the control of the operator.
 	var upgradedProcesses int
-	if cluster.VersionCompatibleUpgradeIsProgress() {
+	if cluster.VersionCompatibleUpgradeInProgress() {
 		for _, process := range status.Cluster.Processes {
 			dcID := process.Locality[fdbv1beta2.FDBLocalityDCIDKey]
 			// Ignore processes that are not managed by this operator instance

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -62,7 +62,24 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		return &requeue{curError: err}
 	}
 
-	addresses, req := getProcessesReadyForRestart(logger, cluster, addressMap)
+	// In the case of version compatible upgrades we have to check if some processes are already running with the new
+	// desired version e.g. because they were restarted by an event outside of the control of the operator.
+	var upgradedProcesses int
+	if cluster.VersionCompatibleUpgradeIsProgress() {
+		for _, process := range status.Cluster.Processes {
+			dcID := process.Locality[fdbv1beta2.FDBLocalityDCIDKey]
+			// Ignore processes that are not managed by this operator instance
+			if dcID != cluster.Spec.DataCenter {
+				continue
+			}
+
+			if process.Version == cluster.Spec.Version {
+				upgradedProcesses++
+			}
+		}
+	}
+
+	addresses, req := getProcessesReadyForRestart(logger, cluster, addressMap, upgradedProcesses)
 	if req != nil {
 		return req
 	}
@@ -154,34 +171,40 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 
 // getProcessesReadyForRestart returns a slice of process addresses that can be restarted. If addresses are missing or not all processes
 // have the latest configuration this method will return a requeue struct with more details.
-func getProcessesReadyForRestart(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, addressMap map[string][]fdbv1beta2.ProcessAddress) ([]fdbv1beta2.ProcessAddress, *requeue) {
-	processesToBounce := fdbv1beta2.FilterByConditions(cluster.Status.ProcessGroups, restarts.GetFilterConditions(cluster), true)
-	addresses := make([]fdbv1beta2.ProcessAddress, 0, len(processesToBounce))
+func getProcessesReadyForRestart(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, addressMap map[string][]fdbv1beta2.ProcessAddress, upgradedProcesses int) ([]fdbv1beta2.ProcessAddress, *requeue) {
+	addresses := make([]fdbv1beta2.ProcessAddress, 0, len(cluster.Status.ProcessGroups))
 	allSynced := true
 	var missingAddress []string
 
-	for _, process := range processesToBounce {
-		processGroup := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, process)
-		if cluster.SkipProcessGroup(processGroup) {
+	filterConditions := restarts.GetFilterConditions(cluster)
+	var missingProcesses int
+	for _, processGroup := range cluster.Status.ProcessGroups {
+		if cluster.SkipProcessGroup(processGroup) || processGroup.IsMarkedForRemoval() {
 			continue
 		}
 
-		// Ignore processes that are missing for more than 30 seconds e.g. if the process is network partitioned.
+		// Ignore processes that are missing for more than 30 seconds e.mg. if the process is network partitioned.
 		// This is required since the update status will not update the SidecarUnreachable setting if a process is
 		// missing in the status.
 		if missingTime := processGroup.GetConditionTime(fdbv1beta2.MissingProcesses); missingTime != nil {
 			if time.Unix(*missingTime, 0).Add(cluster.GetIgnoreMissingProcessesSeconds()).Before(time.Now()) {
 				logger.Info("ignore process group with missing process", "processGroupID", processGroup.ProcessGroupID)
+				missingProcesses++
 				continue
 			}
 		}
 
-		if addressMap[process] == nil {
-			missingAddress = append(missingAddress, process)
+		if !processGroup.MatchesConditions(filterConditions) {
+			logger.Info("ignore process group with non matching conditions", "processGroupID", processGroup.ProcessGroupID)
 			continue
 		}
 
-		addresses = append(addresses, addressMap[process]...)
+		if addressMap[processGroup.ProcessGroupID] == nil {
+			missingAddress = append(missingAddress, processGroup.ProcessGroupID)
+			continue
+		}
+
+		addresses = append(addresses, addressMap[processGroup.ProcessGroupID]...)
 
 		if processGroup.GetConditionTime(fdbv1beta2.IncorrectConfigMap) != nil {
 			allSynced = false
@@ -190,7 +213,7 @@ func getProcessesReadyForRestart(logger logr.Logger, cluster *fdbv1beta2.Foundat
 	}
 
 	if len(missingAddress) > 0 {
-		return nil, &requeue{curError: fmt.Errorf("could not find address for processes: %s", missingAddress), delayedRequeue: true}
+		return nil, &requeue{message: fmt.Sprintf("could not find address for processes: %s", missingAddress), delayedRequeue: true}
 	}
 
 	if !allSynced {
@@ -200,17 +223,21 @@ func getProcessesReadyForRestart(logger logr.Logger, cluster *fdbv1beta2.Foundat
 	counts, err := cluster.GetProcessCountsWithDefaults()
 	if err != nil {
 		return nil, &requeue{
-			curError: err,
+			curError:       err,
+			delayedRequeue: true,
 		}
 	}
 
-	// If we upgrade the cluster wait until all processes are ready for the restart. In the future we can adjust this
-	// to only be a requirement for version incompatible upgrades. In addition we probably only want to block for a
-	// certain threshold either as a percentage or as a fixed number (which could also be 0).
-	if cluster.IsBeingUpgraded() && counts.Total() != len(addresses) {
+	// If we upgrade the cluster wait until all processes are ready for the restart. We don't want to block the restart
+	// if some processes are already upgraded e.g. in the case of version compatible upgrades and we also don't want to
+	// block the restart command if a process is missing longer than the specified GetIgnoreMissingProcessesSeconds.
+	// Those checks should ensure we only run the restart command if all processes that have to be restarted and are connected
+	// to cluster are ready to be restarted.
+	if cluster.IsBeingUpgraded() && (counts.Total()-missingProcesses-upgradedProcesses) != len(addresses) {
 		return nil, &requeue{
 			message:        fmt.Sprintf("expected %d processes, got %d processes ready to restart", counts.Total(), len(addresses)),
-			delayedRequeue: true}
+			delayedRequeue: true,
+		}
 	}
 
 	return addresses, nil
@@ -224,9 +251,9 @@ func getAddressesForUpgrade(logger logr.Logger, r *FoundationDBClusterReconciler
 		return nil, &requeue{curError: err}
 	}
 
-	if !databaseStatus.Client.DatabaseStatus.Available {
-		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpgradeRequeued", "Database is unavailable")
-		return nil, &requeue{message: "Deferring upgrade until database is available"}
+	if !internal.HasDesiredFaultToleranceFromStatus(logger, databaseStatus, cluster) {
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpgradeRequeued", "Database is unavailable or doesn't have expected fault tolerance")
+		return nil, &requeue{message: "Deferring upgrade until database is available or expected fault tolerance is met"}
 	}
 
 	notReadyProcesses := make([]string, 0)

--- a/controllers/remove_incompatible_processes.go
+++ b/controllers/remove_incompatible_processes.go
@@ -102,7 +102,7 @@ func processIncompatibleProcesses(ctx context.Context, r *FoundationDBClusterRec
 	}
 
 	// Ensure the cluster is running at fault tolerance before recreating Pods.
-	hasDesiredFaultTolerance, err := internal.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
+	hasDesiredFaultTolerance := internal.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
 	if err != nil {
 		logger.V(1).Info("Cluster doesn't have required fault tolerance won't delete Pods")
 		return err

--- a/controllers/remove_incompatible_processes.go
+++ b/controllers/remove_incompatible_processes.go
@@ -103,11 +103,6 @@ func processIncompatibleProcesses(ctx context.Context, r *FoundationDBClusterRec
 
 	// Ensure the cluster is running at fault tolerance before recreating Pods.
 	hasDesiredFaultTolerance := internal.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
-	if err != nil {
-		logger.V(1).Info("Cluster doesn't have required fault tolerance won't delete Pods")
-		return err
-	}
-
 	if !hasDesiredFaultTolerance {
 		logger.V(1).Info("Skipping reconciler and waiting until cluster has desired fault tolerance")
 		return nil

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -82,10 +82,6 @@ func (u removeProcessGroups) reconcile(ctx context.Context, r *FoundationDBClust
 	// We could be smarter here and only block removals that target stateful processes by e.g. filtering those out of the
 	// processGroupsToRemove slice.
 	hasDesiredFaultTolerance := internal.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
-	if err != nil {
-		return &requeue{curError: err}
-	}
-
 	if !hasDesiredFaultTolerance {
 		return &requeue{
 			message: "Removals cannot proceed because cluster has degraded fault tolerance",

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -81,7 +81,7 @@ func (u removeProcessGroups) reconcile(ctx context.Context, r *FoundationDBClust
 	// query the cluster gets into a degraded state.
 	// We could be smarter here and only block removals that target stateful processes by e.g. filtering those out of the
 	// processGroupsToRemove slice.
-	hasDesiredFaultTolerance, err := internal.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
+	hasDesiredFaultTolerance := internal.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
 	if err != nil {
 		return &requeue{curError: err}
 	}

--- a/internal/fault_tolerance.go
+++ b/internal/fault_tolerance.go
@@ -39,17 +39,17 @@ func HasDesiredFaultTolerance(log logr.Logger, adminClient fdbadminclient.AdminC
 		return false, err
 	}
 
-	return HasDesiredFaultToleranceFromStatus(log, status, cluster)
+	return HasDesiredFaultToleranceFromStatus(log, status, cluster), nil
 }
 
 // HasDesiredFaultToleranceFromStatus checks if the cluster has the desired fault tolerance based on the provided status.
-func HasDesiredFaultToleranceFromStatus(log logr.Logger, status *fdbv1beta2.FoundationDBStatus, cluster *fdbv1beta2.FoundationDBCluster) (bool, error) {
+func HasDesiredFaultToleranceFromStatus(log logr.Logger, status *fdbv1beta2.FoundationDBStatus, cluster *fdbv1beta2.FoundationDBCluster) bool {
 	if !status.Client.DatabaseStatus.Available {
 		log.Info("Cluster is not available",
 			"namespace", cluster.Namespace,
 			"cluster", cluster.Name)
 
-		return false, nil
+		return false
 	}
 
 	expectedFaultTolerance := cluster.DesiredFaultTolerance()
@@ -61,5 +61,5 @@ func HasDesiredFaultToleranceFromStatus(log logr.Logger, status *fdbv1beta2.Foun
 	return hasDesiredFaultTolerance(
 		expectedFaultTolerance,
 		status.Cluster.FaultTolerance.MaxZoneFailuresWithoutLosingData,
-		status.Cluster.FaultTolerance.MaxZoneFailuresWithoutLosingAvailability), nil
+		status.Cluster.FaultTolerance.MaxZoneFailuresWithoutLosingAvailability)
 }

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -45,18 +45,18 @@ type AdminClient struct {
 	KubeClient                               client.Client
 	DatabaseConfiguration                    *fdbv1beta2.DatabaseConfiguration
 	ExcludedAddresses                        map[string]fdbv1beta2.None
-	ReincludedAddresses                      map[string]bool
 	KilledAddresses                          map[string]fdbv1beta2.None
 	Knobs                                    map[string]fdbv1beta2.None
 	FrozenStatus                             *fdbv1beta2.FoundationDBStatus
 	Backups                                  map[string]fdbv1beta2.FoundationDBBackupStatusBackupDetails
 	clientVersions                           map[string][]string
-	missingProcessGroups                     map[string]bool
 	currentCommandLines                      map[string]string
 	VersionProcessGroups                     map[string]string
+	missingProcessGroups                     map[string]bool
+	incorrectCommandLines                    map[string]bool
+	ReincludedAddresses                      map[string]bool
 	additionalProcesses                      []fdbv1beta2.ProcessGroupStatus
 	localityInfo                             map[string]map[string]string
-	incorrectCommandLines                    map[string]bool
 	MaxZoneFailuresWithoutLosingData         *int
 	MaxZoneFailuresWithoutLosingAvailability *int
 	MaintenanceZone                          string

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -53,6 +53,7 @@ type AdminClient struct {
 	clientVersions                           map[string][]string
 	missingProcessGroups                     map[string]bool
 	currentCommandLines                      map[string]string
+	VersionProcessGroups                     map[string]string
 	additionalProcesses                      []fdbv1beta2.ProcessGroupStatus
 	localityInfo                             map[string]map[string]string
 	incorrectCommandLines                    map[string]bool
@@ -93,6 +94,7 @@ func NewMockAdminClientUncast(cluster *fdbv1beta2.FoundationDBCluster, kubeClien
 			localityInfo:         make(map[string]map[string]string),
 			currentCommandLines:  make(map[string]string),
 			Knobs:                make(map[string]fdbv1beta2.None),
+			VersionProcessGroups: make(map[string]string),
 		}
 		adminClientCache[cluster.Name] = cachedClient
 		cachedClient.Backups = make(map[string]fdbv1beta2.FoundationDBBackupStatusBackupDetails)
@@ -216,7 +218,7 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 			}
 
 			if processCount > 1 {
-				locality["process_id"] = fmt.Sprintf("%s-%d", processGroupID, processIndex)
+				locality[fdbv1beta2.FDBLocalityProcessIDKey] = fmt.Sprintf("%s-%d", processGroupID, processIndex)
 			}
 
 			var uptimeSeconds float64 = 60000
@@ -228,13 +230,18 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 				}
 			}
 
+			version, ok := client.VersionProcessGroups[locality[fdbv1beta2.FDBLocalityProcessIDKey]]
+			if !ok {
+				version = client.Cluster.Status.RunningVersion
+			}
+
 			status.Cluster.Processes[fmt.Sprintf("%s-%d", pod.Name, processIndex)] = fdbv1beta2.FoundationDBStatusProcessInfo{
 				Address:       fullAddress,
 				ProcessClass:  internal.GetProcessClassFromMeta(client.Cluster, pod.ObjectMeta),
 				CommandLine:   command,
 				Excluded:      excluded,
 				Locality:      locality,
-				Version:       client.Cluster.Status.RunningVersion,
+				Version:       version,
 				UptimeSeconds: uptimeSeconds,
 				Roles:         fdbRoles,
 			}


### PR DESCRIPTION
# Description

This is an attempt to relax the constraint for upgrades to ensure we account for scenarios where some processes are already upgraded (or are missing). Otherwise it could happen that a upgrade is blocked by a single process that was restarted and is already running on the new version.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Unit tests + e2e tests.

## Documentation

I will write down a more in depth document about the upgrade process: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1473

## Follow-up

See above.
