### PR TITLE
Disable local FDB client per default

### DIFF
--- a/setup/setup.go
+++ b/setup/setup.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apple/foundationdb/bindings/go/src/fdb"
+
 	"github.com/go-logr/logr"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
@@ -119,6 +121,12 @@ func StartManager(
 	if operatorOpts.PrintVersion {
 		fmt.Printf("version: %s\n", operatorVersion)
 		os.Exit(0)
+	}
+
+	err := fdb.Options().SetDisableLocalClient()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error setting DisableLocalClient: %s\n", err.Error())
+		os.Exit(1)
 	}
 
 	if operatorOpts.LogFile != "" {


### PR DESCRIPTION
# Description

Disable the local FDB client which should not be used, since we make use of the multi version client.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

We can put that setting behind a flag to let people enable/disable it.

## Testing

Unit tests + e2e tests will be run.

## Documentation

We can add a section about that in the manual.

## Follow-up

-
