### PR TITLE
Add recommended running env for setup_e2e.sh and fix a broken link in getting_started

### DIFF
--- a/docs/manual/getting_started.md
+++ b/docs/manual/getting_started.md
@@ -40,7 +40,7 @@ This will create a cluster with 3 storage processes, 4 log processes, and 7 stat
 
 You can run `kubectl get foundationdbcluster sample-cluster` to check the progress of reconciliation. Once the reconciled generation appears in this output, the cluster should be up and ready. After creating the cluster, you can connect to the cluster by running `kubectl exec -it sample-cluster-log-1 -- fdbcli`.
 
-This example requires non-trivial resources, based on what a process will need in a production environment. This means that is too large to run in a local testing environment. It also requires disk I/O features that are not present in Docker for Mac. If you want to run these tests in that kind of environment, you can try bringing in the resource requirements, knobs, and fault domain information from a [local testing example](../../config/samples/cluster_local.yaml).
+This example requires non-trivial resources, based on what a process will need in a production environment. This means that is too large to run in a local testing environment. It also requires disk I/O features that are not present in Docker for Mac. If you want to run these tests in that kind of environment, you can try bringing in the resource requirements, knobs, and fault domain information from a [local testing example](../../config/samples/cluster.yaml).
 
 In addition to the pods, the operator will create a Persistent Volume Claim for any stateful
 processes in the cluster. In this example, each volume will be 128 GB.

--- a/scripts/setup_e2e.sh
+++ b/scripts/setup_e2e.sh
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script works out of box for Linux env (tested on Ubuntu 16.04.5 LTS), after installing dependent software;
+# It's not recommended to run on Mac without Docker native support because it may involve non-trivial debug effort.
 set -eo errexit
 
 # wait_for_node_setup is used to wait until the kubelet has started and the Pod CIDR is available.

--- a/scripts/setup_e2e.sh
+++ b/scripts/setup_e2e.sh
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script works out of box for Linux env (tested on Ubuntu 16.04.5 LTS), after installing dependent software;
-# It's not recommended to run on Mac without Docker native support because it may involve non-trivial debug effort.
+# This script works out of the box for Linux environments (tested on Ubuntu 16.04.5 LTS), after installing dependent software (kind, Docker, and kustomize);
+# Running in other environments may involve non-trivial debugging effort.
 set -eo errexit
 
 # wait_for_node_setup is used to wait until the kubelet has started and the Pod CIDR is available.


### PR DESCRIPTION
# Description

Add comment on the environment where the setup_e2e.sh can work out of box. 
Fix a broken link in getting_started.md.

## Type of change
- Documentation
