### PR TITLE
Make sure we do a delayed reconcile if the incompatible check has an error

### DIFF
--- a/controllers/remove_incompatible_processes.go
+++ b/controllers/remove_incompatible_processes.go
@@ -42,7 +42,7 @@ func (removeIncompatibleProcesses) reconcile(ctx context.Context, r *FoundationD
 	err := processIncompatibleProcesses(ctx, r, logger, cluster)
 
 	if err != nil {
-		return &requeue{curError: err, delay: 15 * time.Second}
+		return &requeue{curError: err, delay: 15 * time.Second, delayedRequeue: true}
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Ensure we are not blocking the next steps of the reconciliation if the removeIncompatibleProcesses get's an error back, e.g. because the FDB cluster is unavailable.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Local + e2e.

## Documentation

N/A

## Follow-up

-