### PR TITLE
WIP: Inject timeout + command errors into admin client requests.  Thi…

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1733,6 +1733,18 @@ type BuggifyConfig struct {
 	// that should be put into a crash looping state.
 	CrashLoopContainers []CrashLoopContainerObject `json:"crashLoopContainers,omitempty"`
 
+	// CliTimeoutFraction specifies the fraction (from 0 to 100) of fdbcli requests
+	// that should return spurious timeout errors
+	CliTimeoutPercent int `json:"cliTimeoutFraction,omitempty"`
+
+	// CliErrorFraction specifies the fraction (of non-timed-out requests) that should
+	// return spurious errors instead of running.
+	CliErrorPercent int `json:"cliErrorFraction,omitempty"`
+
+	// CliErrorSucceedAnyway specifies the fraction of spuriously-failed CLI commands
+	// that should run despite returning a timeout or explicit error code.
+	CliErrorSucceedAnywayPercent int `json:"cliErrorSucceedAnywayFraction,omitempty"`
+
 	// EmptyMonitorConf instructs the operator to update all of the fdbmonitor.conf
 	// files to have zero fdbserver processes configured.
 	EmptyMonitorConf bool `json:"emptyMonitorConf,omitempty"`

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -9931,6 +9931,12 @@ spec:
                 type: object
               buggify:
                 properties:
+                  cliErrorFraction:
+                    type: integer
+                  cliErrorSucceedAnywayFraction:
+                    type: integer
+                  cliTimeoutFraction:
+                    type: integer
                   crashLoop:
                     items:
                       type: string

--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -231,8 +231,10 @@ var _ = Describe("admin_client_test", func() {
 
 		Context("with a backup running", func() {
 			BeforeEach(func() {
-				err = mockAdminClient.StartBackup("blobstore://test@test-service/test-backup", 10)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					err = mockAdminClient.StartBackup("blobstore://test@test-service/test-backup", 10)
+					return err
+				}).ShouldNot(HaveOccurred())
 			})
 
 			It("should put the backup in the layer status", func() {
@@ -259,10 +261,14 @@ var _ = Describe("admin_client_test", func() {
 
 			Context("with an resume backup", func() {
 				BeforeEach(func() {
-					err = mockAdminClient.PauseBackups()
-					Expect(err).NotTo(HaveOccurred())
-					err = mockAdminClient.ResumeBackups()
-					Expect(err).NotTo(HaveOccurred())
+					Eventually(func() error {
+						err = mockAdminClient.PauseBackups()
+						return err
+					}).ShouldNot(HaveOccurred())
+					Eventually(func() error {
+						err = mockAdminClient.ResumeBackups()
+						return err
+					}).ShouldNot(HaveOccurred())
 				})
 
 				It("should mark the backup as not paused", func() {
@@ -272,8 +278,10 @@ var _ = Describe("admin_client_test", func() {
 
 			Context("with a stopped backup", func() {
 				BeforeEach(func() {
-					err = mockAdminClient.StopBackup("blobstore://test@test-service/test-backup")
-					Expect(err).NotTo(HaveOccurred())
+					Eventually(func() error {
+						err = mockAdminClient.StopBackup("blobstore://test@test-service/test-backup")
+						return err
+					}).ShouldNot(HaveOccurred())
 				})
 
 				It("should mark the backup as stopped", func() {
@@ -292,8 +300,10 @@ var _ = Describe("admin_client_test", func() {
 	Describe("backup status", func() {
 		var status *fdbv1beta2.FoundationDBLiveBackupStatus
 		JustBeforeEach(func() {
-			status, err = mockAdminClient.GetBackupStatus()
-			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() error {
+				status, err = mockAdminClient.GetBackupStatus()
+				return err
+			}).ShouldNot(HaveOccurred())
 		})
 
 		Context("with a basic cluster", func() {
@@ -381,11 +391,15 @@ var _ = Describe("admin_client_test", func() {
 
 		Context("with a restore running", func() {
 			BeforeEach(func() {
-				err = mockAdminClient.StartRestore("blobstore://test@test-service/test-backup", nil)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					err = mockAdminClient.StartRestore("blobstore://test@test-service/test-backup", nil)
+					return err
+				}).ShouldNot(HaveOccurred())
 
-				status, err = mockAdminClient.GetRestoreStatus()
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					status, err = mockAdminClient.GetRestoreStatus()
+					return err
+				}).ShouldNot(HaveOccurred())
 			})
 
 			It("should contain the backup URL", func() {

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -146,7 +146,12 @@ var _ = Describe("backup_controller", func() {
 			})
 
 			It("should start a backup", func() {
-				status, err := adminClient.GetBackupStatus()
+				var status *fdbv1beta2.FoundationDBLiveBackupStatus
+				Eventually(func() error {
+					status, err = adminClient.GetBackupStatus()
+					return err
+				}).ShouldNot(HaveOccurred())
+
 				Expect(err).NotTo(HaveOccurred())
 				Expect(status.DestinationURL).To(Equal("blobstore://test@test-service/test-backup?bucket=fdb-backups"))
 				Expect(status.Status.Running).To(BeTrue())
@@ -194,8 +199,11 @@ var _ = Describe("backup_controller", func() {
 			})
 
 			It("should stop the backup", func() {
-				status, err := adminClient.GetBackupStatus()
-				Expect(err).NotTo(HaveOccurred())
+				var status *fdbv1beta2.FoundationDBLiveBackupStatus
+				Eventually(func() error {
+					status, err = adminClient.GetBackupStatus()
+					return err
+				}).ShouldNot(HaveOccurred())
 				Expect(status.Status.Running).To(BeFalse())
 			})
 		})
@@ -208,16 +216,21 @@ var _ = Describe("backup_controller", func() {
 			})
 
 			It("should pause the backup", func() {
-				status, err := adminClient.GetBackupStatus()
-				Expect(err).NotTo(HaveOccurred())
+				var status *fdbv1beta2.FoundationDBLiveBackupStatus
+				Eventually(func() error {
+					status, err = adminClient.GetBackupStatus()
+					return err
+				}).ShouldNot(HaveOccurred())
 				Expect(status.BackupAgentsPaused).To(BeTrue())
 			})
 		})
 
 		Context("when resuming a backup", func() {
 			BeforeEach(func() {
-				err = adminClient.PauseBackups()
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					err = adminClient.PauseBackups()
+					return err
+				}).ShouldNot(HaveOccurred())
 
 				backup.Spec.BackupState = ""
 				err = k8sClient.Update(context.TODO(), backup)
@@ -225,8 +238,11 @@ var _ = Describe("backup_controller", func() {
 			})
 
 			It("should resume the backup", func() {
-				status, err := adminClient.GetBackupStatus()
-				Expect(err).NotTo(HaveOccurred())
+				var status *fdbv1beta2.FoundationDBLiveBackupStatus
+				Eventually(func() error {
+					status, err = adminClient.GetBackupStatus()
+					return err
+				}).ShouldNot(HaveOccurred())
 				Expect(status.BackupAgentsPaused).To(BeFalse())
 			})
 		})
@@ -240,8 +256,11 @@ var _ = Describe("backup_controller", func() {
 			})
 
 			It("should modify the backup", func() {
-				status, err := adminClient.GetBackupStatus()
-				Expect(err).NotTo(HaveOccurred())
+				var status *fdbv1beta2.FoundationDBLiveBackupStatus
+				Eventually(func() error {
+					status, err = adminClient.GetBackupStatus()
+					return err
+				}).ShouldNot(HaveOccurred())
 				Expect(status.SnapshotIntervalSeconds).To(Equal(100000))
 			})
 		})

--- a/controllers/change_coordinators_test.go
+++ b/controllers/change_coordinators_test.go
@@ -73,8 +73,10 @@ var _ = Describe("Change coordinators", func() {
 
 			JustBeforeEach(func() {
 				var err error
-				status, err = adminClient.GetStatus()
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					status, err = adminClient.GetStatus()
+					return err
+				}).ShouldNot(HaveOccurred())
 
 				candidates, err = selectCoordinators(logr.Discard(), cluster, status)
 				Expect(err).NotTo(HaveOccurred())
@@ -228,8 +230,10 @@ var _ = Describe("Change coordinators", func() {
 				cluster.Spec.ProcessGroupsToRemove = removals
 
 				var err error
-				status, err = adminClient.GetStatus()
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					status, err = adminClient.GetStatus()
+					return err
+				}).ShouldNot(HaveOccurred())
 
 				// generate status for 2 dcs and 1 sate
 				status.Cluster.Processes = generateProcessInfo(dcCnt, satCnt, excludes)

--- a/controllers/maintenance_mode_checker_test.go
+++ b/controllers/maintenance_mode_checker_test.go
@@ -63,10 +63,15 @@ var _ = Describe("maintenance_mode_checker", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = maintenanceModeChecker{}.reconcile(context.TODO(), clusterReconciler, cluster)
-		Expect(err).NotTo(HaveOccurred())
-		_, err = reloadCluster(cluster)
-		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() error {
+			requeue = maintenanceModeChecker{}.reconcile(context.TODO(), clusterReconciler, cluster)
+			return err
+		}).ShouldNot(HaveOccurred())
+
+		Eventually(func() error {
+			_, err = reloadCluster(cluster)
+			return err
+		}).ShouldNot(HaveOccurred())
 	})
 
 	Context("maintenance mode is off", func() {

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -72,8 +72,12 @@ var _ = Describe("update_status", func() {
 		})
 
 		JustBeforeEach(func() {
-			databaseStatus, err := adminClient.GetStatus()
-			Expect(err).NotTo(HaveOccurred())
+			var databaseStatus *fdbv1beta2.FoundationDBStatus
+			var err error
+			Eventually(func() error {
+				databaseStatus, err = adminClient.GetStatus()
+				return err
+			}).ShouldNot(HaveOccurred())
 			processMap = make(map[string][]fdbv1beta2.FoundationDBStatusProcessInfo)
 			for _, process := range databaseStatus.Cluster.Processes {
 				processID, ok := process.Locality["process_id"]

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -60,6 +60,9 @@ BuggifyConfig provides options for injecting faults into a cluster for testing.
 | noSchedule | NoSchedule defines a list of process group IDs that should fail to schedule. | []string | false |
 | crashLoop | CrashLoops defines a list of process group IDs that should be put into a crash looping state. **Deprecated: use CrashLoopContainers instead.** | []string | false |
 | crashLoopContainers | CrashLoopContainers defines a list of process group IDs and containers that should be put into a crash looping state. | [][CrashLoopContainerObject](#crashloopcontainerobject) | false |
+| cliTimeoutFraction | CliTimeoutFraction specifies the fraction (from 0 to 100) of fdbcli requests that should return spurious timeout errors | int | false |
+| cliErrorFraction | CliErrorFraction specifies the fraction (of non-timed-out requests) that should return spurious errors instead of running. | int | false |
+| cliErrorSucceedAnywayFraction | CliErrorSucceedAnyway specifies the fraction of spuriously-failed CLI commands that should run despite returning a timeout or explicit error code. | int | false |
 | emptyMonitorConf | EmptyMonitorConf instructs the operator to update all of the fdbmonitor.conf files to have zero fdbserver processes configured. | bool | false |
 | ignoreDuringRestart | IgnoreDuringRestart instructs the operator to ignore the provided process groups IDs during the restart command. This can be useful to simulate cases where the kill command is not restarting all processes. IgnoreDuringRestart does not support the wildcard option to ignore all of this specific cluster processes. | []string | false |
 

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path"
@@ -86,21 +85,6 @@ type cliAdminClient struct {
 	// cmdRunner is an interface to run commands. In the real runner we use the exec package to execute binaries. In
 	// the mock runner we can define mocked output for better integration tests,.
 	cmdRunner commandRunner
-}
-
-func shouldInjectTimeout(cluster *fdbv1beta2.FoundationDBCluster) bool {
-	// Intn returns a number in the range [0, n).  We don't want it to return 100, since
-	// that would allow this function to return false when CliTimeoutPercent is 100.
-
-	return cluster != nil && (true || cluster.Spec.Buggify.CliTimeoutPercent > rand.Intn(100))
-}
-
-func shouldInjectCliError(cluster *fdbv1beta2.FoundationDBCluster) bool {
-	return cluster != nil && cluster.Spec.Buggify.CliErrorPercent > rand.Intn(100)
-}
-
-func shouldSucceedAnyway(cluster *fdbv1beta2.FoundationDBCluster) bool {
-	return cluster != nil && cluster.Spec.Buggify.CliErrorSucceedAnywayPercent > rand.Intn(100)
 }
 
 // NewCliAdminClient generates an Admin client for a cluster
@@ -241,16 +225,9 @@ func (client *cliAdminClient) getArgsAndTimeout(command cliCommand) ([]string, t
 
 // runCommand executes a command in the CLI.
 func (client *cliAdminClient) runCommand(command cliCommand) (string, error) {
-	shouldTimeout := shouldInjectTimeout(client.Cluster)
-	shouldError := shouldInjectCliError(client.Cluster)
-	shouldSucceedAnyway := shouldSucceedAnyway(client.Cluster)
-	if !shouldSucceedAnyway {
-		if shouldTimeout {
-			return "", fdbv1beta2.TimeoutError{Err: fmt.Errorf("buggify injected a timeout for command %v", command)}
-		}
-		if shouldError {
-			return "", fmt.Errorf("buggify injected a generic error for command %v", command)
-		}
+	preError, postError := client.Cluster.GetCliBuggifyErrors(fmt.Sprintf("%v", command))
+	if preError != nil {
+		return "", preError
 	}
 	args, hardTimeout := client.getArgsAndTimeout(command)
 	timeoutContext, cancelFunction := context.WithTimeout(context.Background(), hardTimeout)
@@ -281,12 +258,8 @@ func (client *cliAdminClient) runCommand(command cliCommand) (string, error) {
 	} else {
 		debugOutput = outputString
 	}
-	if shouldTimeout || shouldError {
-		client.log.Info("Command completed, but buggify injected an error", "output", outputString, "debugOutput", debugOutput)
-		if shouldTimeout {
-			return "", fdbv1beta2.TimeoutError{Err: fmt.Errorf("buggify injected a timeout after this command succeeded: %v", command)}
-		}
-		return "", fmt.Errorf("buggify injected a generic error after this command succeeded %v", command)
+	if postError != nil {
+		return "", postError
 	}
 	client.log.Info("Command completed", "output", debugOutput)
 

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -37,8 +37,8 @@ func CreateDefaultCluster() *fdbv1beta2.FoundationDBCluster {
 		Spec: fdbv1beta2.FoundationDBClusterSpec{
 			Version: fdbv1beta2.Versions.Default.String(),
 			Buggify: fdbv1beta2.BuggifyConfig{
-				CliTimeoutPercent:            50,
-				CliErrorPercent:              50,
+				CliTimeoutPercent:            1,
+				CliErrorPercent:              1,
 				CliErrorSucceedAnywayPercent: 50,
 			},
 			ProcessCounts: fdbv1beta2.ProcessCounts{

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -36,6 +36,11 @@ func CreateDefaultCluster() *fdbv1beta2.FoundationDBCluster {
 		},
 		Spec: fdbv1beta2.FoundationDBClusterSpec{
 			Version: fdbv1beta2.Versions.Default.String(),
+			Buggify: fdbv1beta2.BuggifyConfig{
+				CliTimeoutPercent:            50,
+				CliErrorPercent:              50,
+				CliErrorSucceedAnywayPercent: 50,
+			},
 			ProcessCounts: fdbv1beta2.ProcessCounts{
 				Storage:           4,
 				ClusterController: 1,

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -115,11 +115,14 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 	adminClientMutex.Lock()
 	defer adminClientMutex.Unlock()
 
-	preError, postError := client.Cluster.GetCliBuggifyErrors("GetStatus")
+	// Disable fault injection for GetStatus.  We should make the "real" version transparently retry, since it is
+	// side effect free.
 
-	if preError != nil {
-		return nil, preError
-	}
+	// preError, postError := client.Cluster.GetCliBuggifyErrors("GetStatus")
+
+	// if preError != nil {
+	// 	return nil, preError
+	// }
 
 	if client.FrozenStatus != nil {
 		return client.FrozenStatus, nil
@@ -360,10 +363,10 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 	}
 	status.Cluster.MaintenanceZone = client.MaintenanceZone
 
-	if postError != nil {
-		// Any side effects the above has will be applied, but the caller will think the call failed.
-		return nil, postError
-	}
+	// if postError != nil {
+	// 	// Any side effects the above has will be applied, but the caller will think the call failed.
+	// 	return nil, postError
+	// }
 	return status, nil
 }
 
@@ -535,6 +538,7 @@ func (client *AdminClient) KillProcesses(addresses []fdbv1beta2.ProcessAddress) 
 	preError, postError := client.Cluster.GetCliBuggifyErrors("KillProcesses")
 
 	if preError != nil {
+		adminClientMutex.Unlock()
 		return preError
 	}
 


### PR DESCRIPTION
…s SHA should fail in FDB kubernetes tests, since it is hard coded to timeout 100% of such requests

# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation
- Other

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

## Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
