### PR TITLE
Improve the way how the operator handles partitial upgrades

### DIFF
--- a/controllers/remove_incompatible_processes_test.go
+++ b/controllers/remove_incompatible_processes_test.go
@@ -69,7 +69,6 @@ var _ = Describe("restart_incompatible_pods", func() {
 			true),
 	)
 
-	// TODO adjust tests! --> ensure we onlt select processes that are not part of the cluster
 	DescribeTable("when parsing incompatible connections", func(status *fdbv1beta2.FoundationDBStatus, expected map[string]fdbv1beta2.None) {
 		Expect(parseIncompatibleConnections(logr.Discard(), status)).To(Equal(expected))
 	},

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -238,7 +238,6 @@ func (client *cliAdminClient) runCommand(command cliCommand) (string, error) {
 
 		// If we hit a timeout report it as a timeout error
 		if strings.Contains(string(output), "Specified timeout reached") {
-			client.log.Info("runner has timeout issue")
 			// See: https://apple.github.io/foundationdb/api-error-codes.html
 			// 1031: Operation aborted because the transaction timed out
 			return "", &fdbv1beta2.TimeoutError{Err: err}
@@ -310,8 +309,6 @@ func (client *cliAdminClient) getStatusFromCli() (*fdbv1beta2.FoundationDBStatus
 		return nil, err
 	}
 
-	client.log.V(1).Info("Fetched status JSON with fdbcli", "version", client.Cluster.GetRunningVersion(), "status", status)
-
 	return status, nil
 }
 
@@ -325,7 +322,7 @@ func (client *cliAdminClient) getStatus() (*fdbv1beta2.FoundationDBStatus, error
 
 	// If the status doesn't contain any processes and we are doing an upgrade, we probably use the wrong fdbcli version
 	// and we have to fallback to the on specified in out spec.version.
-	if len(status.Cluster.Processes) == 0 && client.Cluster.IsBeingUpgraded() {
+	if (status == nil || len(status.Cluster.Processes) == 0) && client.Cluster.IsBeingUpgraded() {
 		// Create a copy of the cluster and make use of the desired version instead of the last observed running version.
 		clusterCopy := client.Cluster.DeepCopy()
 		clusterCopy.Status.RunningVersion = clusterCopy.Spec.Version

--- a/fdbclient/command_runner.go
+++ b/fdbclient/command_runner.go
@@ -40,11 +40,11 @@ type realCommandRunner struct {
 	log logr.Logger
 }
 
-// getEnvironmentVariablesWithoutBlacklisted returns the current environment variables for the new process with some
+// getEnvironmentVariablesWithoutExcludedFdbEnv returns the current environment variables for the new process with some
 // FDB specific variables filtered out to ensure we don't set any variables that could change the behaviour of fdbcli or
 // the other fdb tools.
 func getEnvironmentVariablesWithoutExcludedFdbEnv() []string {
-	blackListedEnvironmentVariables := map[string]fdbv1beta2.None{
+	excludedEnvironmentVariables := map[string]fdbv1beta2.None{
 		"FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY":       {},
 		"FDB_NETWORK_OPTION_IGNORE_EXTERNAL_CLIENT_FAILURES": {},
 	}
@@ -53,7 +53,7 @@ func getEnvironmentVariablesWithoutExcludedFdbEnv() []string {
 	cmdEnvironmentVariables := make([]string, 0, len(osVariables))
 	for _, env := range osVariables {
 		envKey := strings.Split(env, "=")[0]
-		if _, ok := blackListedEnvironmentVariables[envKey]; ok {
+		if _, ok := excludedEnvironmentVariables[envKey]; ok {
 			continue
 		}
 

--- a/fdbclient/command_runner.go
+++ b/fdbclient/command_runner.go
@@ -72,19 +72,29 @@ func (runner *realCommandRunner) runCommand(ctx context.Context, name string, ar
 
 // mockCommandRunner is a mock implementation of commandRunner and can be used for unit testing.
 type mockCommandRunner struct {
-	// mockedOutput is the output returned by runCommand
+	// mockedOutput is the output returned by runCommand.
 	mockedOutput string
-	// mockedError is the error returned by runCommand
+	// mockedError is the error returned by runCommand.
 	mockedError error
-	// receivedBinary will be the binary that was used to call runCommand
+	// receivedBinary will be the binary that was used to call runCommand.
 	receivedBinary string
-	// receivedArgs will be the args that were used to call runCommand
+	// receivedArgs will be the args that were used to call runCommand.
 	receivedArgs []string
+	// mockedOutputPerBinary is the output returned if the binary is matching. This can be helpful to test the behaviour for
+	// different versions.
+	mockedOutputPerBinary map[string]string
 }
 
 func (runner *mockCommandRunner) runCommand(_ context.Context, name string, arg ...string) ([]byte, error) {
 	runner.receivedBinary = name
 	runner.receivedArgs = arg
 
-	return []byte(runner.mockedOutput), runner.mockedError
+	var mockedOutput string
+	if output, ok := runner.mockedOutputPerBinary[name]; ok {
+		mockedOutput = output
+	} else {
+		mockedOutput = runner.mockedOutput
+	}
+
+	return []byte(mockedOutput), runner.mockedError
 }

--- a/fdbclient/command_runner_test.go
+++ b/fdbclient/command_runner_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"strings"
 )
 
 var _ = Describe("command_runner", func() {
@@ -43,6 +44,26 @@ var _ = Describe("command_runner", func() {
 		It("should execute the command successfully", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(output)).To(Equal("hello\n"))
+		})
+	})
+
+	When("filtering out the excluded FDB environment variables", func() {
+		var envVariablesKeys []string
+
+		BeforeEach(func() {
+			GinkgoT().Setenv("FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY", "")
+			GinkgoT().Setenv("FDB_NETWORK_OPTION_IGNORE_EXTERNAL_CLIENT_FAILURES", "")
+			GinkgoT().Setenv("FDB_TLS_CERTIFICATE_FILE", "")
+
+			for _, env := range getEnvironmentVariablesWithoutExcludedFdbEnv() {
+				envVariablesKeys = append(envVariablesKeys, strings.Split(env, "=")[0])
+			}
+		})
+
+		It("should exclude the listed FDB variables but include all others", func() {
+			Expect(envVariablesKeys).NotTo(ContainElement("FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY"))
+			Expect(envVariablesKeys).NotTo(ContainElement("FDB_NETWORK_OPTION_IGNORE_EXTERNAL_CLIENT_FAILURES"))
+			Expect(envVariablesKeys).To(ContainElement("FDB_TLS_CERTIFICATE_FILE"))
 		})
 	})
 })

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -21,6 +21,7 @@
 package fdbclient
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -142,8 +143,19 @@ func getConnectionStringFromDB(cluster *fdbv1beta2.FoundationDBCluster, log logr
 }
 
 // getStatusFromDB gets the database's status directly from the system key
-func getStatusFromDB(cluster *fdbv1beta2.FoundationDBCluster, log logr.Logger) ([]byte, error) {
-	return getValueFromDBUsingKey(cluster, log, "\xff\xff/status/json", DefaultCLITimeout)
+func getStatusFromDB(cluster *fdbv1beta2.FoundationDBCluster, log logr.Logger) (*fdbv1beta2.FoundationDBStatus, error) {
+	contents, err := getValueFromDBUsingKey(cluster, log, "\xff\xff/status/json", DefaultCLITimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	status := &fdbv1beta2.FoundationDBStatus{}
+	err = json.Unmarshal(contents, status)
+	if err != nil {
+		return nil, err
+	}
+
+	return status, err
 }
 
 type realDatabaseClientProvider struct {

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -155,7 +155,7 @@ func getStatusFromDB(cluster *fdbv1beta2.FoundationDBCluster, log logr.Logger) (
 		return nil, err
 	}
 
-	return status, err
+	return status, nil
 }
 
 type realDatabaseClientProvider struct {


### PR DESCRIPTION
# Description

This change makes sure we are not setting any FDB environment variables for the `fdbcli` command to prevent the use of the multi version client for 7.1+ fdbclis. In addition we added more fallback logic to the `GetStatus` method to transparently try the new (desired) version if the runningVersion is not working.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

This adds some more complexity around the upgrade handling but the multi version client is not reliable in cases where not all coordinators are upgraded.

## Testing

I will see if I can add some additional unit tests and I will do a test with out new upgrade test.

## Documentation

Will be covered in the other upgrade doc issue.

## Follow-up

-
