### PR TITLE
extending the cordon command for all clusters

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2275,18 +2275,3 @@ func (cluster *FoundationDBCluster) Validate() error {
 
 	return fmt.Errorf(strings.Join(validations, ", "))
 }
-
-// ContainsPod checks if the given Pod is part of the cluster or not.
-func (cluster *FoundationDBCluster) ContainsPod(pod corev1.Pod) bool {
-	clusterMatchingLabels := cluster.GetMatchLabels()
-	podLabels := pod.GetLabels()
-	if len(clusterMatchingLabels) > len(podLabels) {
-		return false
-	}
-	for clusterLabelKey, clusterLabelValue := range clusterMatchingLabels {
-		if podLabelValue, found := podLabels[clusterLabelKey]; !found || clusterLabelValue != podLabelValue {
-			return false
-		}
-	}
-	return true
-}

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2275,3 +2275,17 @@ func (cluster *FoundationDBCluster) Validate() error {
 
 	return fmt.Errorf(strings.Join(validations, ", "))
 }
+
+func (cluster *FoundationDBCluster) ContainsPod(pod corev1.Pod) bool {
+	clusterMatchingLabels := cluster.GetMatchLabels()
+	podLabels := pod.GetLabels()
+	if len(clusterMatchingLabels) > len(podLabels) {
+		return false
+	}
+	for clusterLabelKey, clusterLabelValue := range clusterMatchingLabels {
+		if podLabelValue, found := podLabels[clusterLabelKey]; !found || clusterLabelValue != podLabelValue {
+			return false
+		}
+	}
+	return true
+}

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2276,6 +2276,7 @@ func (cluster *FoundationDBCluster) Validate() error {
 	return fmt.Errorf(strings.Join(validations, ", "))
 }
 
+// ContainsPod checks if the given Pod is part of the cluster or not.
 func (cluster *FoundationDBCluster) ContainsPod(pod corev1.Pod) bool {
 	clusterMatchingLabels := cluster.GetMatchLabels()
 	podLabels := pod.GetLabels()

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -1039,3 +1039,18 @@ func GetObjectMetadata(cluster *fdbv1beta2.FoundationDBCluster, base *metav1.Obj
 func GetPodDNSName(cluster *fdbv1beta2.FoundationDBCluster, podName string) string {
 	return fmt.Sprintf("%s.%s.%s.svc.%s", podName, cluster.Name, cluster.Namespace, cluster.GetDNSDomain())
 }
+
+// ContainsPod checks if the given Pod is part of the cluster or not.
+func ContainsPod(cluster *fdbv1beta2.FoundationDBCluster, pod corev1.Pod) bool {
+	clusterMatchingLabels := cluster.GetMatchLabels()
+	podLabels := pod.GetLabels()
+	if len(clusterMatchingLabels) > len(podLabels) {
+		return false
+	}
+	for clusterLabelKey, clusterLabelValue := range clusterMatchingLabels {
+		if podLabelValue, found := podLabels[clusterLabelKey]; !found || clusterLabelValue != podLabelValue {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -3307,4 +3307,20 @@ var _ = Describe("pod_models", func() {
 				ProcessGroupIDPrefix: "prefix",
 			},
 		}, "test-storage-1", "prefix-storage-1"))
+
+	Describe("ContainsPod", func() {
+		var pod1, pod2 *corev1.Pod
+		BeforeEach(func() {
+			pod1, err = GetPod(cluster, fdbv1beta2.ProcessClassStorage, 1)
+			Expect(err).NotTo(HaveOccurred())
+			pod2, err = GetPod(cluster, fdbv1beta2.ProcessClassStorage, 2)
+			Expect(err).NotTo(HaveOccurred())
+			pod2.Labels[fdbv1beta2.FDBClusterLabel] = "incorrect-cluster-name"
+		})
+
+		It("should check whether the Pod belongs to the cluster", func() {
+			Expect(ContainsPod(cluster, *pod1)).To(BeTrue())
+			Expect(ContainsPod(cluster, *pod2)).To(BeFalse())
+		})
+	})
 })

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -222,34 +222,6 @@ func allConditionsValid(conditions []string) error {
 	return fmt.Errorf(errString.String())
 }
 
-type messageType int
-
-const (
-	errorMessage messageType = iota
-	warnMessage
-	goodMessage
-)
-
-func printStatement(cmd *cobra.Command, line string, mesType messageType) {
-	if mesType == errorMessage {
-		color.Set(color.FgRed)
-		cmd.PrintErrf("✖ %s\n", line)
-		color.Unset()
-		return
-	}
-
-	if mesType == warnMessage {
-		color.Set(color.FgYellow)
-		cmd.PrintErrf("⚠ %s\n", line)
-		color.Unset()
-		return
-	}
-
-	color.Set(color.FgGreen)
-	cmd.Printf("✔ %s\n", line)
-	color.Unset()
-}
-
 func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluster, autoFix bool, wait bool, ignoreConditions []string, ignoreRemovals bool, sleep uint16) error {
 	var foundIssues bool
 	cmd.Printf("Checking cluster: %s/%s\n", cluster.Namespace, cluster.Name)

--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -146,7 +146,7 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 		}
 
 		clusterNames := getClusterNames(cmd, inputClusterName, pods, clusterLabel)
-		for _, clusterName := range clusterNames {
+		for clusterName := range clusterNames {
 			cmd.Printf("Starting operation on %s, node: %s\n", clusterName, node)
 			cluster, err := loadCluster(kubeClient, namespace, clusterName)
 			if err != nil {
@@ -214,19 +214,19 @@ func fetchPods(kubeClient client.Client, inputClusterName string, namespace stri
 	return pods, nil
 }
 
-func getClusterNames(cmd *cobra.Command, inputClusterName string, pods corev1.PodList, clusterLabel string) []string {
+func getClusterNames(cmd *cobra.Command, inputClusterName string, pods corev1.PodList, clusterLabel string) map[string]fdbv1beta2.None {
 	if inputClusterName != "" {
-		return []string{inputClusterName}
+		return map[string]fdbv1beta2.None{inputClusterName: {}}
 	}
 
-	clusterNames := make([]string, 0, len(pods.Items))
+	clusterNames := make(map[string]fdbv1beta2.None)
 	for _, pod := range pods.Items {
 		clusterName, ok := pod.Labels[clusterLabel]
 		if !ok {
 			printStatement(cmd, fmt.Sprintf("could not fetch cluster name from Pod: %s\n", pod.Name), errorMessage)
 			continue
 		}
-		clusterNames = append(clusterNames, clusterName)
+		clusterNames[clusterName] = fdbv1beta2.None{}
 	}
 	return clusterNames
 }

--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -197,9 +197,9 @@ func fetchPods(kubeClient client.Client, inputClusterName string, namespace stri
 				Selector: fields.OneTermEqualSelector("spec.nodeName", node),
 			})
 	} else {
-		cluster, err := loadCluster(kubeClient, namespace, inputClusterName)
-		if err != nil {
-			return pods, fmt.Errorf("unable to load cluster: %s, skipping\n", inputClusterName)
+		cluster, error := loadCluster(kubeClient, namespace, inputClusterName)
+		if error != nil {
+			return pods, fmt.Errorf("unable to load cluster: %s, skipping", inputClusterName)
 		}
 		err = kubeClient.List(ctx.Background(), &pods,
 			client.InNamespace(namespace),

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -45,11 +45,11 @@ var _ = FDescribe("[plugin] cordon command", func() {
 
 		BeforeEach(func() {
 			// creating pods for first cluster.
-			createPods(clusterName, namespace, 1)
+			Expect(createPods(clusterName, namespace, 1)).NotTo(HaveOccurred())
 
 			// creating a second cluster
 			cluster2 := createCluster("test2", namespace)
-			createPods(cluster2.Name, namespace, 3)
+			Expect(createPods(cluster2.Name, namespace, 3)).NotTo(HaveOccurred())
 		})
 
 		DescribeTable("should cordon all targeted processes",
@@ -148,7 +148,7 @@ var _ = FDescribe("[plugin] cordon command", func() {
 	})
 })
 
-func createPods(inputClusterName string, inputNamespace string, id int) {
+func createPods(inputClusterName string, inputNamespace string, id int) error {
 	pods := []corev1.Pod{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -181,6 +181,10 @@ func createPods(inputClusterName string, inputNamespace string, id int) {
 	}
 
 	for _, pod := range pods {
-		Expect(k8sClient.Create(context.TODO(), &pod)).NotTo(HaveOccurred())
+		err := k8sClient.Create(context.TODO(), &pod)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -48,9 +48,7 @@ var _ = Describe("[plugin] cordon command", func() {
 			Expect(createPods(clusterName, namespace, 1)).NotTo(HaveOccurred())
 
 			// creating a second cluster
-			cluster2 := createCluster("test2", namespace)
-			Expect(k8sClient.Create(context.TODO(), cluster2)).NotTo(HaveOccurred())
-			Expect(createPods(cluster2.Name, namespace, 3)).NotTo(HaveOccurred())
+			Expect(createPods(secondClusterName, namespace, 3)).NotTo(HaveOccurred())
 		})
 
 		DescribeTable("should cordon all targeted processes",
@@ -60,7 +58,7 @@ var _ = Describe("[plugin] cordon command", func() {
 
 				var clusterNames []string
 				if len(input.clusterName) == 0 {
-					clusterNames = []string{clusterName, "test2"}
+					clusterNames = []string{clusterName, secondClusterName}
 				} else {
 					clusterNames = []string{input.clusterName}
 				}
@@ -142,7 +140,7 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             true,
 					ExpectedInstancesToRemove: []string{"instance-3"},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
-					clusterName:  "test2",
+					clusterName:  secondCluster.Name,
 					customLabels: []string{fdbv1beta2.FDBClusterLabel},
 				}),
 			Entry("Cordon node from all clusters without exclusion",

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -49,6 +49,7 @@ var _ = Describe("[plugin] cordon command", func() {
 
 			// creating a second cluster
 			cluster2 := createCluster("test2", namespace)
+			Expect(k8sClient.Create(context.TODO(), cluster2)).NotTo(HaveOccurred())
 			Expect(createPods(cluster2.Name, namespace, 3)).NotTo(HaveOccurred())
 		})
 

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = FDescribe("[plugin] cordon command", func() {
+var _ = Describe("[plugin] cordon command", func() {
 	When("running cordon command", func() {
 		type testCase struct {
 			nodes                                     []string
@@ -142,6 +142,33 @@ var _ = FDescribe("[plugin] cordon command", func() {
 					ExpectedInstancesToRemove: []string{"instance-3"},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
 					clusterName:  "test2",
+					customLabels: []string{fdbv1beta2.FDBClusterLabel},
+				}),
+			Entry("Cordon node from all clusters without exclusion",
+				testCase{
+					nodes:                     []string{"node-1"},
+					WithExclusion:             true,
+					ExpectedInstancesToRemove: []string{"instance-1", "instance-3"},
+					ExpectedInstancesToRemoveWithoutExclusion: []string{},
+					clusterName:  "",
+					customLabels: []string{fdbv1beta2.FDBClusterLabel},
+				}),
+			Entry("Cordon all node from all clusters with exclusion",
+				testCase{
+					nodes:                     []string{"node-1", "node-2"},
+					WithExclusion:             true,
+					ExpectedInstancesToRemove: []string{},
+					ExpectedInstancesToRemoveWithoutExclusion: []string{"instance-1", "instance-2", "instance-3", "instance-4"},
+					clusterName:  "",
+					customLabels: []string{fdbv1beta2.FDBClusterLabel},
+				}),
+			Entry("Cordon no node nodes without exclusion with custom label",
+				testCase{
+					nodes:                     []string{""},
+					WithExclusion:             false,
+					ExpectedInstancesToRemove: []string{},
+					ExpectedInstancesToRemoveWithoutExclusion: []string{},
+					clusterName:  "",
 					customLabels: []string{fdbv1beta2.FDBClusterLabel},
 				}),
 		)

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -31,14 +31,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("[plugin] cordon command", func() {
+var _ = FDescribe("[plugin] cordon command", func() {
 	When("running cordon command", func() {
 		type testCase struct {
 			nodes                                     []string
 			WithExclusion                             bool
 			ExpectedInstancesToRemove                 []string
 			ExpectedInstancesToRemoveWithoutExclusion []string
-			useCustomLabel                            bool
+			clusterName                               string
 			customLabel                               string
 		}
 
@@ -81,7 +81,7 @@ var _ = Describe("[plugin] cordon command", func() {
 
 		DescribeTable("should cordon all targeted processes",
 			func(input testCase) {
-				err := cordonNode(k8sClient, cluster, input.nodes, namespace, input.WithExclusion, false, 0, input.useCustomLabel, input.customLabel)
+				err := cordonNode(k8sClient, input.clusterName, input.nodes, namespace, input.WithExclusion, false, 0, input.customLabel)
 				Expect(err).NotTo(HaveOccurred())
 
 				var resCluster fdbv1beta2.FoundationDBCluster
@@ -101,8 +101,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             true,
 					ExpectedInstancesToRemove: []string{"instance-1"},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
-					useCustomLabel: false,
-					customLabel:    fdbv1beta2.FDBClusterLabel,
+					clusterName: cluster.Name,
+					customLabel: fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon node without exclusion",
 				testCase{
@@ -110,8 +110,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []string{},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{"instance-1"},
-					useCustomLabel: false,
-					customLabel:    fdbv1beta2.FDBClusterLabel,
+					clusterName: cluster.Name,
+					customLabel: fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon no nodes with exclusion",
 				testCase{
@@ -119,8 +119,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             true,
 					ExpectedInstancesToRemove: []string{},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
-					useCustomLabel: false,
-					customLabel:    fdbv1beta2.FDBClusterLabel,
+					clusterName: cluster.Name,
+					customLabel: fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon no node nodes without exclusion",
 				testCase{
@@ -128,8 +128,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []string{},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
-					useCustomLabel: false,
-					customLabel:    fdbv1beta2.FDBClusterLabel,
+					clusterName: cluster.Name,
+					customLabel: fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon all nodes with exclusion",
 				testCase{
@@ -137,8 +137,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             true,
 					ExpectedInstancesToRemove: []string{"instance-1", "instance-2"},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
-					useCustomLabel: false,
-					customLabel:    fdbv1beta2.FDBClusterLabel,
+					clusterName: cluster.Name,
+					customLabel: fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon all nodes without exclusion",
 				testCase{
@@ -146,8 +146,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []string{},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{"instance-1", "instance-2"},
-					useCustomLabel: false,
-					customLabel:    fdbv1beta2.FDBClusterLabel,
+					clusterName: cluster.Name,
+					customLabel: fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon node with custom label without exclusion",
 				testCase{
@@ -155,8 +155,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             true,
 					ExpectedInstancesToRemove: []string{"instance-1"},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
-					useCustomLabel: true,
-					customLabel:    fdbv1beta2.FDBClusterLabel,
+					clusterName: "",
+					customLabel: fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon nodes with custom label without exclusion",
 				testCase{
@@ -164,8 +164,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []string{},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{"instance-1", "instance-2"},
-					useCustomLabel: true,
-					customLabel:    fdbv1beta2.FDBClusterLabel,
+					clusterName: "",
+					customLabel: fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon no nodes with exclusion with custom label",
 				testCase{
@@ -173,8 +173,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             true,
 					ExpectedInstancesToRemove: []string{},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
-					useCustomLabel: true,
-					customLabel:    fdbv1beta2.FDBClusterLabel,
+					clusterName: "",
+					customLabel: fdbv1beta2.FDBClusterLabel,
 				}),
 		)
 	})

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"context"
-
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,6 +38,8 @@ var _ = Describe("[plugin] cordon command", func() {
 			WithExclusion                             bool
 			ExpectedInstancesToRemove                 []string
 			ExpectedInstancesToRemoveWithoutExclusion []string
+			useCustomLabel                            bool
+			customLabel                               string
 		}
 
 		BeforeEach(func() {
@@ -80,7 +81,7 @@ var _ = Describe("[plugin] cordon command", func() {
 
 		DescribeTable("should cordon all targeted processes",
 			func(input testCase) {
-				err := cordonNode(k8sClient, cluster, input.nodes, namespace, input.WithExclusion, false, 0)
+				err := cordonNode(k8sClient, cluster, input.nodes, namespace, input.WithExclusion, false, 0, input.useCustomLabel, input.customLabel)
 				Expect(err).NotTo(HaveOccurred())
 
 				var resCluster fdbv1beta2.FoundationDBCluster
@@ -100,6 +101,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             true,
 					ExpectedInstancesToRemove: []string{"instance-1"},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
+					useCustomLabel: false,
+					customLabel:    fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon node without exclusion",
 				testCase{
@@ -107,6 +110,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []string{},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{"instance-1"},
+					useCustomLabel: false,
+					customLabel:    fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon no nodes with exclusion",
 				testCase{
@@ -114,6 +119,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             true,
 					ExpectedInstancesToRemove: []string{},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
+					useCustomLabel: false,
+					customLabel:    fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon no node nodes without exclusion",
 				testCase{
@@ -121,6 +128,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []string{},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
+					useCustomLabel: false,
+					customLabel:    fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon all nodes with exclusion",
 				testCase{
@@ -128,6 +137,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             true,
 					ExpectedInstancesToRemove: []string{"instance-1", "instance-2"},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{},
+					useCustomLabel: false,
+					customLabel:    fdbv1beta2.FDBClusterLabel,
 				}),
 			Entry("Cordon all nodes without exclusion",
 				testCase{
@@ -135,6 +146,35 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []string{},
 					ExpectedInstancesToRemoveWithoutExclusion: []string{"instance-1", "instance-2"},
+					useCustomLabel: false,
+					customLabel:    fdbv1beta2.FDBClusterLabel,
+				}),
+			Entry("Cordon node with custom label without exclusion",
+				testCase{
+					nodes:                     []string{"node-1"},
+					WithExclusion:             true,
+					ExpectedInstancesToRemove: []string{"instance-1"},
+					ExpectedInstancesToRemoveWithoutExclusion: []string{},
+					useCustomLabel: true,
+					customLabel:    fdbv1beta2.FDBClusterLabel,
+				}),
+			Entry("Cordon nodes with custom label without exclusion",
+				testCase{
+					nodes:                     []string{"node-1", "node-2"},
+					WithExclusion:             false,
+					ExpectedInstancesToRemove: []string{},
+					ExpectedInstancesToRemoveWithoutExclusion: []string{"instance-1", "instance-2"},
+					useCustomLabel: true,
+					customLabel:    fdbv1beta2.FDBClusterLabel,
+				}),
+			Entry("Cordon no nodes with exclusion with custom label",
+				testCase{
+					nodes:                     []string{""},
+					WithExclusion:             true,
+					ExpectedInstancesToRemove: []string{},
+					ExpectedInstancesToRemoveWithoutExclusion: []string{},
+					useCustomLabel: true,
+					customLabel:    fdbv1beta2.FDBClusterLabel,
 				}),
 		)
 	})

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"github.com/fatih/color"
 	"log"
 	"math/rand"
 	"os"
@@ -115,4 +116,32 @@ func confirmAction(action string) bool {
 			return false
 		}
 	}
+}
+
+type messageType int
+
+const (
+	errorMessage messageType = iota
+	warnMessage
+	goodMessage
+)
+
+func printStatement(cmd *cobra.Command, line string, mesType messageType) {
+	if mesType == errorMessage {
+		color.Set(color.FgRed)
+		cmd.PrintErrf("✖ %s\n", line)
+		color.Unset()
+		return
+	}
+
+	if mesType == warnMessage {
+		color.Set(color.FgYellow)
+		cmd.PrintErrf("⚠ %s\n", line)
+		color.Unset()
+		return
+	}
+
+	color.Set(color.FgGreen)
+	cmd.Printf("✔ %s\n", line)
+	color.Unset()
 }

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -31,17 +31,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	cluster = &fdbv1beta2.FoundationDBCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterName,
-			Namespace: namespace,
-		},
-		Spec: fdbv1beta2.FoundationDBClusterSpec{
-			ProcessCounts: fdbv1beta2.ProcessCounts{
-				Storage: 1,
-			},
-		},
-	}
+	cluster = createCluster(clusterName, namespace)
 })
 
 var _ = JustBeforeEach(func() {
@@ -51,3 +41,17 @@ var _ = JustBeforeEach(func() {
 var _ = AfterEach(func() {
 	k8sClient.Clear()
 })
+
+func createCluster(givenName string, givenNamespace string) *fdbv1beta2.FoundationDBCluster {
+	return &fdbv1beta2.FoundationDBCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      givenName,
+			Namespace: givenNamespace,
+		},
+		Spec: fdbv1beta2.FoundationDBClusterSpec{
+			ProcessCounts: fdbv1beta2.ProcessCounts{
+				Storage: 1,
+			},
+		},
+	}
+}

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -17,8 +17,6 @@ import (
 var k8sClient *mockclient.MockClient
 var cluster *fdbv1beta2.FoundationDBCluster
 var clusterName = "test"
-var secondCluster *fdbv1beta2.FoundationDBCluster
-var secondClusterName = "test2"
 var namespace = "test"
 
 func TestCmd(t *testing.T) {
@@ -34,12 +32,10 @@ var _ = BeforeSuite(func() {
 
 var _ = BeforeEach(func() {
 	cluster = createCluster(clusterName, namespace)
-	secondCluster = createCluster(secondClusterName, namespace)
 })
 
 var _ = JustBeforeEach(func() {
 	Expect(k8sClient.Create(context.TODO(), cluster)).NotTo(HaveOccurred())
-	Expect(k8sClient.Create(context.TODO(), secondCluster)).NotTo(HaveOccurred())
 })
 
 var _ = AfterEach(func() {

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -31,7 +31,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	cluster = createCluster(clusterName, namespace)
+	cluster = generateClusterStruct(clusterName, namespace)
 })
 
 var _ = JustBeforeEach(func() {
@@ -42,11 +42,11 @@ var _ = AfterEach(func() {
 	k8sClient.Clear()
 })
 
-func createCluster(givenName string, givenNamespace string) *fdbv1beta2.FoundationDBCluster {
+func generateClusterStruct(name string, namespace string) *fdbv1beta2.FoundationDBCluster {
 	return &fdbv1beta2.FoundationDBCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      givenName,
-			Namespace: givenNamespace,
+			Name:      name,
+			Namespace: namespace,
 		},
 		Spec: fdbv1beta2.FoundationDBClusterSpec{
 			ProcessCounts: fdbv1beta2.ProcessCounts{

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -17,6 +17,8 @@ import (
 var k8sClient *mockclient.MockClient
 var cluster *fdbv1beta2.FoundationDBCluster
 var clusterName = "test"
+var secondCluster *fdbv1beta2.FoundationDBCluster
+var secondClusterName = "test2"
 var namespace = "test"
 
 func TestCmd(t *testing.T) {
@@ -32,10 +34,12 @@ var _ = BeforeSuite(func() {
 
 var _ = BeforeEach(func() {
 	cluster = createCluster(clusterName, namespace)
+	secondCluster = createCluster(secondClusterName, namespace)
 })
 
 var _ = JustBeforeEach(func() {
 	Expect(k8sClient.Create(context.TODO(), cluster)).NotTo(HaveOccurred())
+	Expect(k8sClient.Create(context.TODO(), secondCluster)).NotTo(HaveOccurred())
 })
 
 var _ = AfterEach(func() {


### PR DESCRIPTION
# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

Currently the `cordon` command in plugin requires a cluster name to remove all the pods that are running of a specific node on a cluster. This PR is to extend that behaviour to remove all the pods that are running on that node irrespective of the cluster name. This requires us to use a new flag `use-custom-label` which enables this new feature and then we also need to provide a `custom-label`. The default value of `custom-label` is `fdb-cluster-name` is nothing was given. 

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)


## Discussion

*Are there any design details that you would like to discuss further?*
No

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

Added unit test

## Documentation

*Did you update relevant documentation within this repository?*
Yes

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
