### PR TITLE
Remove staging phase for version compatible upgrades

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1552,6 +1552,18 @@ func (cluster *FoundationDBCluster) IsBeingUpgraded() bool {
 	return cluster.Status.RunningVersion != "" && cluster.Status.RunningVersion != cluster.Spec.Version
 }
 
+// IsBeingUpgradedWithVersionIncompatibleVersion determines whether the cluster has a pending upgrade to a version incompatible version.
+func (cluster *FoundationDBCluster) IsBeingUpgradedWithVersionIncompatibleVersion() bool {
+	if !cluster.IsBeingUpgraded() {
+		return false
+	}
+
+	runningVersion, _ := ParseFdbVersion(cluster.Status.RunningVersion)
+	desiredVersion, _ := ParseFdbVersion(cluster.Spec.Version)
+
+	return !runningVersion.IsProtocolCompatible(desiredVersion)
+}
+
 // VersionCompatibleUpgradeInProgress returns true if the cluster is currently being upgraded and the upgrade is to
 // a version compatible version.
 func (cluster *FoundationDBCluster) VersionCompatibleUpgradeInProgress() bool {

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -4939,4 +4939,51 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			)
 		})
 	})
+
+	DescribeTable("when checking if the cluster is being upgraded", func(cluster *FoundationDBCluster, isUpgraded bool, isCompatibleUpgrade bool) {
+		Expect(cluster.IsBeingUpgraded()).To(Equal(isUpgraded))
+
+		if !isUpgraded {
+			return
+		}
+
+		Expect(cluster.VersionCompatibleUpgradeInProgress()).To(Equal(isCompatibleUpgrade))
+		Expect(cluster.IsBeingUpgradedWithVersionIncompatibleVersion()).To(Equal(!isCompatibleUpgrade))
+	}, Entry("no upgrade in progress",
+		&FoundationDBCluster{
+			Spec: FoundationDBClusterSpec{
+				Version: "7.1.27",
+			},
+			Status: FoundationDBClusterStatus{
+				RunningVersion: "7.1.27",
+			},
+		}, false, false),
+		Entry("patch upgrade",
+			&FoundationDBCluster{
+				Spec: FoundationDBClusterSpec{
+					Version: "7.1.29",
+				},
+				Status: FoundationDBClusterStatus{
+					RunningVersion: "7.1.27",
+				},
+			}, true, true),
+		Entry("minor upgrade",
+			&FoundationDBCluster{
+				Spec: FoundationDBClusterSpec{
+					Version: "7.2.3",
+				},
+				Status: FoundationDBClusterStatus{
+					RunningVersion: "7.1.27",
+				},
+			}, true, false),
+		Entry("major upgrade",
+			&FoundationDBCluster{
+				Spec: FoundationDBClusterSpec{
+					Version: "8.0.0",
+				},
+				Status: FoundationDBClusterStatus{
+					RunningVersion: "7.1.27",
+				},
+			}, true, false),
+	)
 })

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -62,24 +62,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		return &requeue{curError: err}
 	}
 
-	// In the case of version compatible upgrades we have to check if some processes are already running with the new
-	// desired version e.g. because they were restarted by an event outside of the control of the operator.
-	var upgradedProcesses int
-	if cluster.VersionCompatibleUpgradeInProgress() {
-		for _, process := range status.Cluster.Processes {
-			dcID := process.Locality[fdbv1beta2.FDBLocalityDCIDKey]
-			// Ignore processes that are not managed by this operator instance
-			if dcID != cluster.Spec.DataCenter {
-				continue
-			}
-
-			if process.Version == cluster.Spec.Version {
-				upgradedProcesses++
-			}
-		}
-	}
-
-	addresses, req := getProcessesReadyForRestart(logger, cluster, addressMap, upgradedProcesses)
+	addresses, req := getProcessesReadyForRestart(logger, cluster, addressMap)
 	if req != nil {
 		return req
 	}
@@ -117,7 +100,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		return &requeue{curError: err}
 	}
 
-	upgrading := cluster.Status.RunningVersion != cluster.Spec.Version
+	upgrading := cluster.IsBeingUpgradedWithVersionIncompatibleVersion()
 
 	if useLocks && upgrading {
 		processGroupIDs := make([]fdbv1beta2.ProcessGroupID, 0, len(cluster.Status.ProcessGroups))
@@ -175,7 +158,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 
 // getProcessesReadyForRestart returns a slice of process addresses that can be restarted. If addresses are missing or not all processes
 // have the latest configuration this method will return a requeue struct with more details.
-func getProcessesReadyForRestart(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, addressMap map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.ProcessAddress, upgradedProcesses int) ([]fdbv1beta2.ProcessAddress, *requeue) {
+func getProcessesReadyForRestart(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, addressMap map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.ProcessAddress) ([]fdbv1beta2.ProcessAddress, *requeue) {
 	addresses := make([]fdbv1beta2.ProcessAddress, 0, len(cluster.Status.ProcessGroups))
 	allSynced := true
 	var missingAddress []fdbv1beta2.ProcessGroupID
@@ -237,7 +220,7 @@ func getProcessesReadyForRestart(logger logr.Logger, cluster *fdbv1beta2.Foundat
 	// block the restart command if a process is missing longer than the specified GetIgnoreMissingProcessesSeconds.
 	// Those checks should ensure we only run the restart command if all processes that have to be restarted and are connected
 	// to cluster are ready to be restarted.
-	if cluster.IsBeingUpgraded() && (counts.Total()-missingProcesses-upgradedProcesses) != len(addresses) {
+	if cluster.IsBeingUpgradedWithVersionIncompatibleVersion() && (counts.Total()-missingProcesses) != len(addresses) {
 		return nil, &requeue{
 			message:        fmt.Sprintf("expected %d processes, got %d processes ready to restart", counts.Total(), len(addresses)),
 			delayedRequeue: true,

--- a/controllers/bounce_processes_test.go
+++ b/controllers/bounce_processes_test.go
@@ -434,34 +434,6 @@ var _ = Describe("bounceProcesses", func() {
 				Expect(pendingUpgrades).NotTo(BeEmpty())
 			})
 		})
-
-		When("one process is already upgraded for a version compatible upgrade", func() {
-			var upgradedProcessGroup *fdbv1beta2.ProcessGroupStatus
-			var targetVersion fdbv1beta2.Version
-
-			BeforeEach(func() {
-				targetVersion = fdbv1beta2.Versions.Default.NextPatchVersion()
-				cluster.Spec.Version = targetVersion.String()
-				upgradedProcessGroup = cluster.Status.ProcessGroups[0]
-				adminClient.VersionProcessGroups[upgradedProcessGroup.ProcessGroupID] = targetVersion.String()
-			})
-
-			It("should requeue", func() {
-				Expect(requeue).NotTo(BeNil())
-				Expect(requeue.message).To(Equal("fetch latest status after upgrade"))
-			})
-
-			It("should kill all processes except the upgraded process", func() {
-				Expect(adminClient.KilledAddresses).NotTo(BeEmpty())
-				Expect(adminClient.KilledAddresses).NotTo(ContainElement(upgradedProcessGroup.Addresses))
-			})
-
-			It("should submit pending upgrade information", func() {
-				pendingUpgrades, err := lockClient.GetPendingUpgrades(targetVersion)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pendingUpgrades).NotTo(BeEmpty())
-			})
-		})
 	})
 
 	When("the buggify option ignoreDuringRestart is set", func() {

--- a/controllers/check_client_compatibility.go
+++ b/controllers/check_client_compatibility.go
@@ -38,7 +38,7 @@ type checkClientCompatibility struct{}
 // reconcile runs the reconciler's work.
 func (c checkClientCompatibility) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "checkClientCompatibility")
-	if !cluster.Status.Configured {
+	if !cluster.Status.Configured && !cluster.IsBeingUpgraded() {
 		return nil
 	}
 

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -299,7 +299,7 @@ func (r *FoundationDBClusterReconciler) updatePodDynamicConf(cluster *fdbv1beta2
 		return false, err
 	}
 
-	if cluster.IsBeingUpgraded() {
+	if cluster.IsBeingUpgradedWithVersionIncompatibleVersion() {
 		return podClient.IsPresent(fmt.Sprintf("bin/%s/fdbserver", cluster.Spec.Version))
 	}
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2012,8 +2012,8 @@ var _ = Describe("cluster_controller", func() {
 			When("downgrading a cluster to another patch version", func() {
 				BeforeEach(func() {
 					cluster.Spec.Version = fdbv1beta2.Versions.PreviousPatchVersion.String()
-					err := k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+					requeueLimit = 50
 				})
 
 				It("should downgrade the cluster", func() {
@@ -2026,8 +2026,7 @@ var _ = Describe("cluster_controller", func() {
 				BeforeEach(func() {
 					shouldCompleteReconciliation = false
 					cluster.Spec.Version = fdbv1beta2.Versions.IncompatibleVersion.String()
-					err := k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
 				It("should not downgrade the cluster", func() {
@@ -2037,7 +2036,161 @@ var _ = Describe("cluster_controller", func() {
 			})
 		})
 
-		Context("with an upgrade", func() {
+		Context("with a patch upgrade", func() {
+			var adminClient *mock.AdminClient
+
+			BeforeEach(func() {
+				cluster.Spec.Version = fdbv1beta2.Versions.NextPatchVersion.String()
+				adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
+				Expect(err).NotTo(HaveOccurred())
+				// Increase the requeue limit here since the operator has do multiple things before being reconciled
+				requeueLimit = 50
+			})
+
+			Context("with the delete strategy", func() {
+				BeforeEach(func() {
+					cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyDelete
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+				})
+
+				It("should upgrade the cluster", func() {
+					Expect(adminClient.KilledAddresses).To(BeEmpty())
+				})
+
+				It("should set the image on the pods", func() {
+					pods := &corev1.PodList{}
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+
+					for _, pod := range pods.Items {
+						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextPatchVersion.String())))
+					}
+				})
+
+				It("should update the running version", func() {
+					Expect(cluster.Status.RunningVersion).To(Equal(cluster.Spec.Version))
+				})
+			})
+
+			Context("with the replace transaction strategy", func() {
+				BeforeEach(func() {
+					cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyTransactionReplacement
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+				})
+
+				It("should not bounce the processes", func() {
+					Expect(adminClient.KilledAddresses).To(BeEmpty())
+				})
+
+				It("should set the image on the pods", func() {
+					pods := &corev1.PodList{}
+					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
+					Expect(err).NotTo(HaveOccurred())
+
+					for _, pod := range pods.Items {
+						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextPatchVersion.String())))
+					}
+				})
+
+				It("should update the running version", func() {
+					Expect(cluster.Status.RunningVersion).To(Equal(cluster.Spec.Version))
+				})
+
+				It("should replace the transaction system Pods", func() {
+					pods := &corev1.PodList{}
+					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
+					Expect(err).NotTo(HaveOccurred())
+
+					originalNames := make([]string, 0, len(originalPods.Items))
+					for _, pod := range originalPods.Items {
+						class := pod.Labels[fdbv1beta2.FDBProcessClassLabel]
+						if !fdbv1beta2.ProcessClass(class).IsTransaction() {
+							continue
+						}
+
+						originalNames = append(originalNames, pod.Name)
+					}
+
+					currentNames := make([]string, 0, len(originalPods.Items))
+					for _, pod := range pods.Items {
+						class := pod.Labels[fdbv1beta2.FDBProcessClassLabel]
+						if !fdbv1beta2.ProcessClass(class).IsTransaction() {
+							continue
+						}
+
+						currentNames = append(currentNames, pod.Name)
+					}
+
+					Expect(currentNames).NotTo(ContainElements(originalNames))
+				})
+
+				It("should not replace the storage Pods", func() {
+					pods := &corev1.PodList{}
+					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
+					Expect(err).NotTo(HaveOccurred())
+
+					originalNames := make([]string, 0, len(originalPods.Items))
+					for _, pod := range originalPods.Items {
+						class := pod.Labels[fdbv1beta2.FDBProcessClassLabel]
+						if fdbv1beta2.ProcessClass(class).IsTransaction() {
+							continue
+						}
+
+						originalNames = append(originalNames, pod.Name)
+					}
+
+					currentNames := make([]string, 0, len(originalPods.Items))
+					for _, pod := range pods.Items {
+						class := pod.Labels[fdbv1beta2.FDBProcessClassLabel]
+						if fdbv1beta2.ProcessClass(class).IsTransaction() {
+							continue
+						}
+
+						currentNames = append(currentNames, pod.Name)
+					}
+
+					Expect(currentNames).To(ContainElements(originalNames))
+				})
+			})
+
+			Context("with the replacement strategy", func() {
+				BeforeEach(func() {
+					cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyReplacement
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+				})
+
+				It("should not bounce the processes", func() {
+					Expect(adminClient.KilledAddresses).To(BeEmpty())
+				})
+
+				It("should set the image on the pods", func() {
+					pods := &corev1.PodList{}
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+
+					for _, pod := range pods.Items {
+						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextPatchVersion.String())))
+					}
+				})
+
+				It("should replace the process group", func() {
+					pods := &corev1.PodList{}
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+
+					originalNames := make([]string, 0, len(originalPods.Items))
+					for _, pod := range originalPods.Items {
+						originalNames = append(originalNames, pod.Name)
+					}
+
+					currentNames := make([]string, 0, len(originalPods.Items))
+					for _, pod := range pods.Items {
+						currentNames = append(currentNames, pod.Name)
+					}
+
+					Expect(currentNames).NotTo(ContainElements(originalNames))
+				})
+			})
+		})
+
+		Context("with a version incompatible upgrade", func() {
 			var adminClient *mock.AdminClient
 
 			BeforeEach(func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -59,6 +59,7 @@ var k8sClient *mockclient.MockClient
 var clusterReconciler *FoundationDBClusterReconciler
 var backupReconciler *FoundationDBBackupReconciler
 var restoreReconciler *FoundationDBRestoreReconciler
+var requeueLimit = 20
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -125,15 +126,15 @@ func createDefaultRestore(cluster *fdbv1beta2.FoundationDBCluster) *fdbv1beta2.F
 }
 
 func reconcileCluster(cluster *fdbv1beta2.FoundationDBCluster) (reconcile.Result, error) {
-	return reconcileObject(clusterReconciler, cluster.ObjectMeta, 20)
+	return reconcileObject(clusterReconciler, cluster.ObjectMeta, requeueLimit)
 }
 
 func reconcileBackup(backup *fdbv1beta2.FoundationDBBackup) (reconcile.Result, error) {
-	return reconcileObject(backupReconciler, backup.ObjectMeta, 20)
+	return reconcileObject(backupReconciler, backup.ObjectMeta, requeueLimit)
 }
 
 func reconcileRestore(restore *fdbv1beta2.FoundationDBRestore) (reconcile.Result, error) {
-	return reconcileObject(restoreReconciler, restore.ObjectMeta, 20)
+	return reconcileObject(restoreReconciler, restore.ObjectMeta, requeueLimit)
 }
 
 func reconcileObject(reconciler reconcile.Reconciler, metadata metav1.ObjectMeta, requeueLimit int) (reconcile.Result, error) {

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -41,7 +41,7 @@ type updateSidecarVersions struct{}
 func (updateSidecarVersions) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updateSidecarVersions")
 	// We don't need to upgrade the sidecar if no upgrade is in progress, we can skip any further work here.
-	if !cluster.IsBeingUpgraded() {
+	if !cluster.IsBeingUpgradedWithVersionIncompatibleVersion() {
 		return nil
 	}
 

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -322,7 +322,7 @@ func (client *cliAdminClient) getStatus() (*fdbv1beta2.FoundationDBStatus, error
 
 	// If the status doesn't contain any processes and we are doing an upgrade, we probably use the wrong fdbcli version
 	// and we have to fallback to the on specified in out spec.version.
-	if (status == nil || len(status.Cluster.Processes) == 0) && client.Cluster.IsBeingUpgraded() {
+	if (status == nil || len(status.Cluster.Processes) == 0) && client.Cluster.IsBeingUpgradedWithVersionIncompatibleVersion() {
 		// Create a copy of the cluster and make use of the desired version instead of the last observed running version.
 		clusterCopy := client.Cluster.DeepCopy()
 		clusterCopy.Status.RunningVersion = clusterCopy.Spec.Version

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -484,7 +484,7 @@ func GetSubstitutionsFromClusterAndPod(logger logr.Logger, cluster *fdbv1beta2.F
 
 	substitutions["FDB_INSTANCE_ID"] = string(GetProcessGroupIDFromMeta(cluster, pod.ObjectMeta))
 
-	if cluster.IsBeingUpgraded() {
+	if cluster.IsBeingUpgradedWithVersionIncompatibleVersion() {
 		substitutions["BINARY_DIR"] = fmt.Sprintf("/var/dynamic-conf/bin/%s", cluster.Spec.Version)
 	} else {
 		substitutions["BINARY_DIR"] = "/usr/bin"

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -415,7 +415,12 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2
 	}
 
 	podName, processGroupID := GetProcessGroupID(cluster, processClass, idNum)
-	image, err := GetImage(mainContainer.Image, cluster.Spec.MainContainer.ImageConfigs, cluster.GetRunningVersion(), false)
+	mainVersion := cluster.GetRunningVersion()
+	if cluster.VersionCompatibleUpgradeInProgress() {
+		mainVersion = cluster.Spec.Version
+	}
+
+	image, err := GetImage(mainContainer.Image, cluster.Spec.MainContainer.ImageConfigs, mainVersion, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -40,12 +40,12 @@ var _ = Describe("pod_models", func() {
 
 	BeforeEach(func() {
 		cluster = CreateDefaultCluster()
-		err := NormalizeClusterSpec(cluster, DeprecationOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(NormalizeClusterSpec(cluster, DeprecationOptions{})).NotTo(HaveOccurred())
 	})
 
 	Describe("GetPod", func() {
 		var pod *corev1.Pod
+
 		Context("with a basic storage process group", func() {
 			BeforeEach(func() {
 				pod, err = GetPod(cluster, fdbv1beta2.ProcessClassStorage, 1)
@@ -175,6 +175,42 @@ var _ = Describe("pod_models", func() {
 
 	Describe("GetPodSpec", func() {
 		var spec *corev1.PodSpec
+
+		Context("with a version compatible upgrade in progress", func() {
+			BeforeEach(func() {
+				cluster.Spec.Version = fdbv1beta2.Versions.NextPatchVersion.String()
+				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should use the image tag defined in the desired version", func() {
+				for _, container := range spec.Containers {
+					if container.Name != fdbv1beta2.MainContainerName {
+						continue
+					}
+
+					Expect(container.Image).To(HaveSuffix(fdbv1beta2.Versions.NextPatchVersion.String()))
+				}
+			})
+		})
+
+		Context("with a version incompatible upgrade in progress", func() {
+			BeforeEach(func() {
+				cluster.Spec.Version = fdbv1beta2.Versions.NextMajorVersion.String()
+				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should use the image tag defined in the running version", func() {
+				for _, container := range spec.Containers {
+					if container.Name != fdbv1beta2.MainContainerName {
+						continue
+					}
+
+					Expect(container.Image).To(HaveSuffix(cluster.Status.RunningVersion))
+				}
+			})
+		})
 
 		Context("with a basic storage process group", func() {
 			BeforeEach(func() {

--- a/internal/restarts/restarts.go
+++ b/internal/restarts/restarts.go
@@ -24,7 +24,7 @@ import fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 
 // GetFilterConditions returns the filter conditions to get the processes that should be restarted.
 func GetFilterConditions(cluster *fdbv1beta2.FoundationDBCluster) map[fdbv1beta2.ProcessGroupConditionType]bool {
-	if !cluster.IsBeingUpgraded() {
+	if !cluster.IsBeingUpgradedWithVersionIncompatibleVersion() {
 		// If we don't upgrade our cluster we can ignore all process groups that are not reachable and therefore will
 		// not get any ConfigMap updates.
 		return map[fdbv1beta2.ProcessGroupConditionType]bool{

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -56,7 +56,8 @@ func CreateDefaultCluster() *fdbv1beta2.FoundationDBCluster {
 			RequiredAddresses: fdbv1beta2.RequiredAddressSet{
 				NonTLS: true,
 			},
-			ProcessGroups: make([]*fdbv1beta2.ProcessGroupStatus, 0),
+			ProcessGroups:  make([]*fdbv1beta2.ProcessGroupStatus, 0),
+			RunningVersion: fdbv1beta2.Versions.Default.String(),
 		},
 	}
 }


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1497

Before this change we used the same mechanism for all kinds of upgrades. With this change we only use the staging approach (copying the new binary inside a running container and then run the kill command) for version incompatible upgrades.

The basic idea of this PR is to skip the staging phase for version compatible upgrades and directly recreate Pods with the new desired image (based on the deployment strategy). This reduces the work we have to do for version compatible upgrades.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

Unit tests and running e2e tests (I'm going to paste the results here once they completed).

## Documentation

This will be done as a follow up in https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1473

## Follow-up

https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1473