### PR TITLE
Correct typo for replaceProcessGroup

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -490,7 +490,7 @@ type ProcessGroupStatus struct {
 	// This is only used within the reconciliation process, and should not be considered authoritative.
 	// Deprecated: Use ExclusionTimestamp instead.
 	Excluded bool `json:"excluded,omitempty"`
-	// ExcludedTimestamp defines when the process group has been fully excluded.
+	// ExclusionTimestamp defines when the process group has been fully excluded.
 	// This is only used within the reconciliation process, and should not be considered authoritative.
 	ExclusionTimestamp *metav1.Time `json:"exclusionTimestamp,omitempty"`
 	// ExclusionSkipped determines if exclusion has been skipped for a process, which will allow the process group to be removed without exclusion.

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -319,7 +319,7 @@ type ProcessGroupStatus struct {
 	Addresses []string `json:"addresses,omitempty"`
 	// RemoveTimestamp if not empty defines when the process group was marked for removal.
 	RemovalTimestamp *metav1.Time `json:"removalTimestamp,omitempty"`
-	// ExcludedTimestamp defines when the process group has been fully excluded.
+	// ExclusionTimestamp defines when the process group has been fully excluded.
 	// This is only used within the reconciliation process, and should not be considered authoritative.
 	ExclusionTimestamp *metav1.Time `json:"exclusionTimestamp,omitempty"`
 	// ExclusionSkipped determines if exclusion has been skipped for a process, which will allow the process group to be removed without exclusion.

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -394,7 +394,7 @@ ProcessGroupStatus represents the status of a ProcessGroup.
 | processClass | ProcessClass represents the class the process group has. | [ProcessClass](#processclass) | false |
 | addresses | Addresses represents the list of addresses the process group has been known to have. | []string | false |
 | removalTimestamp | RemoveTimestamp if not empty defines when the process group was marked for removal. | *metav1.Time | false |
-| exclusionTimestamp | ExcludedTimestamp defines when the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | *metav1.Time | false |
+| exclusionTimestamp | ExclusionTimestamp defines when the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | *metav1.Time | false |
 | exclusionSkipped | ExclusionSkipped determines if exclusion has been skipped for a process, which will allow the process group to be removed without exclusion. | bool | false |
 | processGroupConditions | ProcessGroupConditions represents a list of degraded conditions that the process group is in. | []*[ProcessGroupCondition](#processgroupcondition) | false |
 

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -23,11 +23,12 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"github.com/fatih/color"
 	"log"
 	"math/rand"
 	"os"
 	"time"
+
+	"github.com/fatih/color"
 
 	"strings"
 
@@ -94,7 +95,7 @@ func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
 	return cmd
 }
 
-// confirmAction requests a user to confirm it's action
+// confirmAction requests a user to confirm its action
 func confirmAction(action string) bool {
 	reader := bufio.NewReader(os.Stdin)
 


### PR DESCRIPTION
# Description

ReplaceProcessGroup procedure has typo in its help message and comment.
This PR fixex the typos.


## Type of change

- Bug fix (non-breaking change which fixes an issue)
No functional change.


## Testing
No testing since it's not changing functionality. 
