### PR TITLE
Fix the internal handling of the lock client for get pending upgrades

### DIFF
--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -187,19 +187,23 @@ func (client *realLockClient) GetPendingUpgrades(version fdbv1beta2.Version) (ma
 			return nil, err
 		}
 		results := tr.GetRange(keyRange, fdb.RangeOptions{}).GetSliceOrPanic()
-		upgrades := make(map[string]bool, len(results))
+		upgrades := make(map[fdbv1beta2.ProcessGroupID]bool, len(results))
 		for _, result := range results {
-			upgrades[string(result.Value)] = true
+			upgrades[fdbv1beta2.ProcessGroupID(result.Value)] = true
 		}
+
 		return upgrades, nil
 	})
+
 	if err != nil {
 		return nil, err
 	}
+
 	upgradeMap, isMap := upgrades.(map[fdbv1beta2.ProcessGroupID]bool)
 	if !isMap {
 		return nil, fmt.Errorf("invalid return value from transaction in GetPendingUpgrades: %v", upgrades)
 	}
+
 	return upgradeMap, nil
 }
 
@@ -221,6 +225,7 @@ func (client *realLockClient) ClearPendingUpgrades() error {
 		tr.ClearRange(keyRange)
 		return nil, nil
 	})
+
 	return err
 }
 


### PR DESCRIPTION
# Description

In https://github.com/FoundationDB/fdb-kubernetes-operator/pull/1498 we added a new typed string but we forgot to adjust the type in some places.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

e2e test. Currently this code path is not unit tested, I'm. going to create a new issue for doing that.

## Documentation

-

## Follow-up

-