### PR TITLE
Revert fault tolerance check to only check availability

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -255,6 +255,10 @@ func getAddressesForUpgrade(logger logr.Logger, r *FoundationDBClusterReconciler
 		return nil, &requeue{curError: err}
 	}
 
+	// We don't want to check for fault tolerance here to make sure the operator is able to restart processes if some
+	// processes where restarted before the operator issued the cluster wide restart. For version incompatible upgrades
+	// that would mean that the processes restarted earlier are not part of the cluster anymore leading to a fault tolerance
+	// drop.
 	if !databaseStatus.Client.DatabaseStatus.Available {
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpgradeRequeued", "Database is unavailable")
 		return nil, &requeue{message: "Deferring upgrade until database is available"}

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -255,9 +255,9 @@ func getAddressesForUpgrade(logger logr.Logger, r *FoundationDBClusterReconciler
 		return nil, &requeue{curError: err}
 	}
 
-	if !internal.HasDesiredFaultToleranceFromStatus(logger, databaseStatus, cluster) {
-		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpgradeRequeued", "Database is unavailable or doesn't have expected fault tolerance")
-		return nil, &requeue{message: "Deferring upgrade until database is available or expected fault tolerance is met"}
+	if !databaseStatus.Client.DatabaseStatus.Available {
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpgradeRequeued", "Database is unavailable")
+		return nil, &requeue{message: "Deferring upgrade until database is available"}
 	}
 
 	notReadyProcesses := make([]string, 0)


### PR DESCRIPTION
# Description

In https://github.com/FoundationDB/fdb-kubernetes-operator/pull/1474/files#diff-d0bee063a26a37c83244adbffd63b8a0daaf66032647b5e17bd78e0ca4cf4310R254 we made a change to check for fault tolerance and not only for availability. In theory this sounds like a good idea but we discovered in our e2e testings that this can block the operator from moving forward with the upgrade e.g. in the case where some processes are restarted before the operator dis the `kill` command.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

e2e tests.

## Documentation

Will be updated in https://github.com/FoundationDB/fdb-kubernetes-operator/pull/1511

## Follow-up

-
