### PR TITLE
Add Version Check to Redwood Experimental Storage Engine Type

### DIFF
--- a/api/v1beta2/foundationdb_database_configuration.go
+++ b/api/v1beta2/foundationdb_database_configuration.go
@@ -737,6 +737,8 @@ const (
 	StorageEngineRocksDbV1 StorageEngine = "ssd-rocksdb-v1"
 	// StorageEngineShardedRocksDB defines the storage engine ssd-sharded-rocksdb.
 	StorageEngineShardedRocksDB StorageEngine = "ssd-sharded-rocksdb"
+	// StorageEngineRedwood1Experimental defines the storage engine ssd-redwood-1-experimental.
+	StorageEngineRedwood1Experimental StorageEngine = "ssd-redwood-1-experimental"
 )
 
 // RoleCounts represents the roles whose counts can be customized.

--- a/api/v1beta2/foundationdb_version.go
+++ b/api/v1beta2/foundationdb_version.go
@@ -188,6 +188,8 @@ func (version Version) IsStorageEngineSupported(storageEngine StorageEngine) boo
 		return !version.IsAtLeast(Versions.SupportsRocksDBV1)
 	} else if storageEngine == StorageEngineShardedRocksDB {
 		return version.IsAtLeast(Versions.SupportsShardedRocksDB)
+	} else if storageEngine == StorageEngineRedwood1Experimental {
+		return version.IsAtLeast(Versions.SupportsRedwood1Experimental)
 	}
 	return true
 }
@@ -216,19 +218,21 @@ var Versions = struct {
 	SupportsRocksDBV1,
 	SupportsIsPresent,
 	SupportsShardedRocksDB,
+	SupportsRedwood1Experimental,
 	IncompatibleVersion,
 	PreviousPatchVersion,
 	SupportsRecoveryState,
 	Default Version
 }{
-	Default:                Version{Major: 6, Minor: 2, Patch: 21},
-	IncompatibleVersion:    Version{Major: 6, Minor: 1, Patch: 0},
-	PreviousPatchVersion:   Version{Major: 6, Minor: 2, Patch: 20},
-	NextPatchVersion:       Version{Major: 6, Minor: 2, Patch: 22},
-	NextMajorVersion:       Version{Major: 7, Minor: 0, Patch: 0},
-	MinimumVersion:         Version{Major: 6, Minor: 2, Patch: 20},
-	SupportsRocksDBV1:      Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 4},
-	SupportsIsPresent:      Version{Major: 7, Minor: 1, Patch: 4},
-	SupportsShardedRocksDB: Version{Major: 7, Minor: 2, Patch: 0},
-	SupportsRecoveryState:  Version{Major: 7, Minor: 1, Patch: 22},
+	Default:                      Version{Major: 6, Minor: 2, Patch: 21},
+	IncompatibleVersion:          Version{Major: 6, Minor: 1, Patch: 0},
+	PreviousPatchVersion:         Version{Major: 6, Minor: 2, Patch: 20},
+	NextPatchVersion:             Version{Major: 6, Minor: 2, Patch: 22},
+	NextMajorVersion:             Version{Major: 7, Minor: 0, Patch: 0},
+	MinimumVersion:               Version{Major: 6, Minor: 2, Patch: 20},
+	SupportsRocksDBV1:            Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 4},
+	SupportsIsPresent:            Version{Major: 7, Minor: 1, Patch: 4},
+	SupportsShardedRocksDB:       Version{Major: 7, Minor: 2, Patch: 0},
+	SupportsRedwood1Experimental: Version{Major: 7, Minor: 0, Patch: 0},
+	SupportsRecoveryState:        Version{Major: 7, Minor: 1, Patch: 22},
 }

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -4548,6 +4548,17 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				},
 				fmt.Errorf("storage engine ssd-rocksdb-v1 is not supported on version 6.3.2"),
 			),
+			Entry("using invalid storage engine",
+				&FoundationDBCluster{
+					Spec: FoundationDBClusterSpec{
+						Version: "6.3.24",
+						DatabaseConfiguration: DatabaseConfiguration{
+							StorageEngine: StorageEngineRedwood1Experimental,
+						},
+					},
+				},
+				fmt.Errorf("storage engine ssd-redwood-1-experimental is not supported on version 6.3.24"),
+			),
 			Entry("using valid storage engine",
 				&FoundationDBCluster{
 					Spec: FoundationDBClusterSpec{

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2668,6 +2668,10 @@ var _ = Describe("cluster_controller", func() {
 					})
 				})
 			})
+
+		})
+
+		When("creating a cluster with Redwood as storage engine", func() {
 			When("using ssd-redwood-1-experimental", func() {
 				When("using 7.2.0", func() {
 					BeforeEach(func() {

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2668,6 +2668,61 @@ var _ = Describe("cluster_controller", func() {
 					})
 				})
 			})
+			When("using ssd-redwood-1-experimental", func() {
+				When("using 7.2.0", func() {
+					BeforeEach(func() {
+						cluster.Spec.DatabaseConfiguration.StorageEngine = fdbv1beta2.StorageEngineRedwood1Experimental
+						cluster.Spec.Version = "7.2.0"
+						err := k8sClient.Update(context.TODO(), cluster)
+						Expect(err).NotTo(HaveOccurred())
+					})
+					It("generations are matching", func() {
+						generations, err := reloadClusterGenerations(cluster)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(generations.Reconciled).To(Equal(cluster.ObjectMeta.Generation))
+					})
+				})
+				When("using 7.1.0", func() {
+					BeforeEach(func() {
+						cluster.Spec.DatabaseConfiguration.StorageEngine = fdbv1beta2.StorageEngineRedwood1Experimental
+						cluster.Spec.Version = "7.1.0"
+						err := k8sClient.Update(context.TODO(), cluster)
+						Expect(err).NotTo(HaveOccurred())
+					})
+					It("generations are matching", func() {
+						generations, err := reloadClusterGenerations(cluster)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(generations.Reconciled).To(Equal(cluster.ObjectMeta.Generation))
+					})
+				})
+				When("using 7.0.0", func() {
+					BeforeEach(func() {
+						cluster.Spec.DatabaseConfiguration.StorageEngine = fdbv1beta2.StorageEngineRedwood1Experimental
+						cluster.Spec.Version = "7.0.0"
+						err := k8sClient.Update(context.TODO(), cluster)
+						Expect(err).NotTo(HaveOccurred())
+					})
+					It("generations are matching", func() {
+						generations, err := reloadClusterGenerations(cluster)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(generations.Reconciled).To(Equal(cluster.ObjectMeta.Generation))
+					})
+				})
+				When("using 6.3.24", func() {
+					BeforeEach(func() {
+						cluster.Spec.DatabaseConfiguration.StorageEngine = fdbv1beta2.StorageEngineRedwood1Experimental
+						cluster.Spec.Version = "6.3.24"
+						err := k8sClient.Update(context.TODO(), cluster)
+						Expect(err).NotTo(HaveOccurred())
+						shouldCompleteReconciliation = false
+					})
+					It("generations are not matching", func() {
+						generations, err := reloadClusterGenerations(cluster)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(generations.Reconciled).ToNot(Equal(cluster.ObjectMeta.Generation))
+					})
+				})
+			})
 
 		})
 


### PR DESCRIPTION
# Description

FDB 7.0.0 is the first release of the Redwood Storage Engine. This PR complements version supporting check for Redwood Experimental storage engine type. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

No.

## Testing

Manual testing.
I think no additional testing needed once this is merge.

## Documentation

Didn't update any documentation. I just complemented the operator part, didn't summary any new doc.

## Follow-up

No.
