### PR TITLE
Generate initial cluster file based on "CoordinatorSelection"

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1840,6 +1840,19 @@ func (cluster *FoundationDBCluster) IsEligibleAsCandidate(pClass ProcessClass) b
 	return false
 }
 
+// GetEligibleCandidateClasses returns process classes that are eligible to become coordinators.
+func (cluster *FoundationDBCluster) GetEligibleCandidateClasses() []ProcessClass {
+	candidateClasses := []ProcessClass{}
+
+	for _, processGroup := range cluster.Status.ProcessGroups {
+		if cluster.IsEligibleAsCandidate(processGroup.ProcessClass) {
+			candidateClasses = append(candidateClasses, processGroup.ProcessClass)
+		}
+	}
+
+	return candidateClasses
+}
+
 // GetClassCandidatePriority returns the priority for a class. This will be used to sort the processes for coordinator selection
 func (cluster *FoundationDBCluster) GetClassCandidatePriority(pClass ProcessClass) int {
 	for _, setting := range cluster.Spec.CoordinatorSelection {

--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -164,11 +164,7 @@ var _ = Describe("admin_client_test", func() {
 						},
 						Version:       cluster.Spec.Version,
 						UptimeSeconds: 60000,
-						Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
-							{
-								Role: string(fdbv1beta2.ProcessRoleCoordinator),
-							},
-						},
+						Roles:         nil,
 					}))
 				})
 			})

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -54,6 +54,7 @@ import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 )
 
+var firstLogIndex = 1
 var firstStorageIndex = 13
 
 func reloadCluster(cluster *fdbv1beta2.FoundationDBCluster) (int64, error) {
@@ -606,8 +607,8 @@ var _ = Describe("cluster_controller", func() {
 					}))
 				})
 
-				It("should change the connection string", func() {
-					Expect(cluster.Status.ConnectionString).NotTo(Equal(originalConnectionString))
+				It("should not change the connection string", func() {
+					Expect(cluster.Status.ConnectionString).To(Equal(originalConnectionString))
 				})
 
 				It("should clear the removal list", func() {
@@ -1946,9 +1947,9 @@ var _ = Describe("cluster_controller", func() {
 			})
 
 			It("should make the processes listen on an IPV6 address", func() {
-				address1 := cluster.Status.ProcessGroups[firstStorageIndex].Addresses[0]
-				address2 := cluster.Status.ProcessGroups[firstStorageIndex+1].Addresses[0]
-				address3 := cluster.Status.ProcessGroups[firstStorageIndex+2].Addresses[0]
+				address1 := cluster.Status.ProcessGroups[firstLogIndex].Addresses[0]
+				address2 := cluster.Status.ProcessGroups[firstLogIndex+1].Addresses[0]
+				address3 := cluster.Status.ProcessGroups[firstLogIndex+2].Addresses[0]
 				Expect(cluster.Status.ConnectionString).To(HaveSuffix(fmt.Sprintf("@[%s]:4501,[%s]:4501,[%s]:4501", address1, address2, address3)))
 			})
 		})


### PR DESCRIPTION
# Description

Modify the initial cluster file sub reconciler to make use of the coordinator selection mechanism. And, update the affected tests.

Addresses issue: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1089

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

- Does the current operator logic always select storage processes as coordinators? If so, this PR may cause log processes to also be selected as coordinators? And, if so, what is the impact of that during recovery? So, overall, is this a good change?

## Testing

Ran the operator unit tests successfully (by doing "make fmt lint test").

## Documentation

TBD: Do we need to update any documentation?

## Follow-up

