### PR TITLE
Add validation pattern to ProcessGroupIDPrefix

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -157,6 +157,7 @@ type FoundationDBClusterSpec struct {
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 	// for more details on that.
 	// +kubebuilder:validation:MaxLength=43
+	// +kubebuilder:validation:Pattern:=^[a-z0-9A-Z]([\-._a-z0-9A-Z])*[a-z0-9A-Z]$
 	ProcessGroupIDPrefix string `json:"processGroupIDPrefix,omitempty"`
 
 	// LockOptions allows customizing how we manage locks for global operations.

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -10250,6 +10250,7 @@ spec:
                 type: object
               processGroupIDPrefix:
                 maxLength: 43
+                pattern: ^[a-z0-9A-Z]([\-._a-z0-9A-Z])*[a-z0-9A-Z]$
                 type: string
               processGroupsToRemove:
                 items:


### PR DESCRIPTION
# Description

Add validation pattern to ProcessGroupIDPrefix.

Addresses issue: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1096

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

## Testing

- Ran operator unit tests (by running "make fmt lint test")

## Documentation

## Follow-up

