### PR TITLE
Add longer delay after kill command

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -628,7 +628,7 @@ func (client *cliAdminClient) KillProcesses(addresses []fdbv1beta2.ProcessAddres
 	}
 
 	killCommand := fmt.Sprintf(
-		"kill; kill %[1]s; sleep 1; kill %[1]s; sleep 1; kill %[1]s",
+		"kill; kill %[1]s; sleep 1; kill %[1]s; sleep 5; status",
 		fdbv1beta2.ProcessAddressesStringWithoutFlags(addresses, " "),
 	)
 	_, err := client.runCommandWithBackoff(killCommand)

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -628,7 +628,7 @@ func (client *cliAdminClient) KillProcesses(addresses []fdbv1beta2.ProcessAddres
 	}
 
 	killCommand := fmt.Sprintf(
-		"kill; kill %[1]s; sleep 1; kill %[1]s; sleep 5; status",
+		"kill; kill %[1]s; sleep 1; kill %[1]s; sleep 5",
 		fdbv1beta2.ProcessAddressesStringWithoutFlags(addresses, " "),
 	)
 	_, err := client.runCommandWithBackoff(killCommand)


### PR DESCRIPTION
# Description

Adding back the `status` request when killing fdbserver processes to ensure the reboot request was sent to all processes.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

We had this check in an earlier version of the fdbclient but then removed it. This change adds it back again to ensure the reboot command is sent to all processes.

## Testing

e2e test.

## Documentation

-

## Follow-up

-
