### PR TITLE
Adjust client check for cases where a newer client version is available

### DIFF
--- a/api/v1beta2/foundationdb_status.go
+++ b/api/v1beta2/foundationdb_status.go
@@ -246,6 +246,9 @@ type FoundationDBStatusSupportedVersion struct {
 	// SourceVersion is the version of the source code that the client library
 	// was built from.
 	SourceVersion string `json:"source_version,omitempty"`
+
+	// Count provides the number of clients connected to the database with this specific version.
+	Count int `json:"count,omitempty"`
 }
 
 // FoundationDBStatusConnectedClient provides information about a client that

--- a/api/v1beta2/foundationdb_status_test.go
+++ b/api/v1beta2/foundationdb_status_test.go
@@ -289,6 +289,7 @@ var _ = Describe("FoundationDBStatus", func() {
 						SupportedVersions: []FoundationDBStatusSupportedVersion{
 							{
 								ClientVersion: "Unknown",
+								Count:         10,
 								ConnectedClients: []FoundationDBStatusConnectedClient{
 									{
 										Address:  "10.1.38.92:52762",
@@ -337,6 +338,7 @@ var _ = Describe("FoundationDBStatus", func() {
 							},
 							{
 								ClientVersion: "6.1.8",
+								Count:         8,
 								ConnectedClients: []FoundationDBStatusConnectedClient{
 									{
 										Address:  "10.1.38.106:35640",
@@ -377,6 +379,7 @@ var _ = Describe("FoundationDBStatus", func() {
 							},
 							{
 								ClientVersion: "6.2.15",
+								Count:         8,
 								ConnectedClients: []FoundationDBStatusConnectedClient{
 									{
 										Address:  "10.1.38.106:35640",
@@ -671,6 +674,7 @@ var _ = Describe("FoundationDBStatus", func() {
 				SupportedVersions: []FoundationDBStatusSupportedVersion{
 					{
 						ClientVersion: "6.2.30",
+						Count:         3,
 						ConnectedClients: []FoundationDBStatusConnectedClient{
 							{
 								Address:  "10.1.18.249:34874",
@@ -691,6 +695,7 @@ var _ = Describe("FoundationDBStatus", func() {
 					},
 					{
 						ClientVersion: "6.3.10",
+						Count:         3,
 						ConnectedClients: []FoundationDBStatusConnectedClient{
 							{
 								Address:  "10.1.18.249:34874",
@@ -711,6 +716,7 @@ var _ = Describe("FoundationDBStatus", func() {
 					},
 					{
 						ClientVersion: "7.1.0-rc1",
+						Count:         8,
 						ConnectedClients: []FoundationDBStatusConnectedClient{
 							{
 								Address:  "10.1.18.249:34874",

--- a/controllers/check_client_compatibility_test.go
+++ b/controllers/check_client_compatibility_test.go
@@ -1,0 +1,211 @@
+/*
+ * check_client_compatibility_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import (
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// generateSupportedVersion will generate the slice of fdbv1beta2.FoundationDBStatusSupportedVersion the assumption for this method is that all keys in maxProtocolVersions
+// are also keys in versions.
+func generateSupportedVersion(versions map[string][]string, maxProtocolVersions map[string][]string) []fdbv1beta2.FoundationDBStatusSupportedVersion {
+	supportedVersions := make([]fdbv1beta2.FoundationDBStatusSupportedVersion, 0, len(versions))
+	for version, addresses := range versions {
+		protocolClients := make([]fdbv1beta2.FoundationDBStatusConnectedClient, 0, len(addresses))
+		for _, address := range addresses {
+			protocolClients = append(protocolClients, fdbv1beta2.FoundationDBStatusConnectedClient{
+				Address: address,
+			})
+		}
+
+		parsedVersion, err := fdbv1beta2.ParseFdbVersion(version)
+		Expect(err).NotTo(HaveOccurred())
+
+		maxProtocolClients := make([]fdbv1beta2.FoundationDBStatusConnectedClient, 0, len(addresses))
+		if maxProtocolAddresses, ok := maxProtocolVersions[version]; ok {
+			for _, addr := range maxProtocolAddresses {
+				maxProtocolClients = append(maxProtocolClients, fdbv1beta2.FoundationDBStatusConnectedClient{
+					Address: addr,
+				})
+			}
+		}
+
+		supportedVersions = append(supportedVersions, fdbv1beta2.FoundationDBStatusSupportedVersion{
+			ClientVersion:      version,
+			ProtocolVersion:    parsedVersion.Compact(),
+			ConnectedClients:   protocolClients,
+			MaxProtocolClients: maxProtocolClients,
+			Count:              len(protocolClients),
+		})
+	}
+
+	return supportedVersions
+}
+
+var _ = Describe("checkClientCompatibility", func() {
+	When("getting the list of unsupported clients", func() {
+		var supportedVersions []fdbv1beta2.FoundationDBStatusSupportedVersion
+		var unsupportedClients []string
+		var compatibleClientsCount int
+		var version fdbv1beta2.Version
+		var protocolVersion string
+		var inputSupportedVersions map[string][]string
+
+		JustBeforeEach(func() {
+			var err error
+			unsupportedClients, compatibleClientsCount, err = getUnsupportedClientsAndCheckIfCompatibleClientsAreIncluded(supportedVersions, protocolVersion, version)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		BeforeEach(func() {
+			inputSupportedVersions = map[string][]string{
+				"7.1.27": {
+					"192.168.0.1:4500",
+					"192.168.0.2:4500",
+					"192.168.0.3:4500",
+				},
+				"6.3.25": {
+					"192.168.0.1:4500",
+					"192.168.0.2:4500",
+					"192.168.0.3:4500",
+				},
+				"6.2.23": {
+					"192.168.0.1:4500",
+					"192.168.0.2:4500",
+					"192.168.0.3:4500",
+				},
+				"6.1.23": {
+					"192.168.0.1:4500",
+					"192.168.0.2:4500",
+					"192.168.0.3:4500",
+				},
+			}
+		})
+
+		When("checking for the latest reported version", func() {
+			BeforeEach(func() {
+				version = fdbv1beta2.Version{Major: 7, Minor: 1, Patch: 27}
+				protocolVersion = version.Compact()
+			})
+
+			When("all clients support the latest version", func() {
+				BeforeEach(func() {
+					supportedVersions = generateSupportedVersion(inputSupportedVersions, map[string][]string{
+						version.String(): {
+							"192.168.0.1:4500",
+							"192.168.0.2:4500",
+							"192.168.0.3:4500",
+						},
+					})
+				})
+
+				It("should return an empty list of unsupported clients", func() {
+					Expect(unsupportedClients).To(BeEmpty())
+					Expect(compatibleClientsCount).To(BeNumerically("==", 3))
+				})
+			})
+
+			When("one client doesn't support the latest version", func() {
+				BeforeEach(func() {
+					supportedVersions = generateSupportedVersion(inputSupportedVersions, map[string][]string{
+						version.String(): {
+							"192.168.0.1:4500",
+							"192.168.0.2:4500",
+						},
+						"6.3.25": {
+							"192.168.0.3:4500",
+						},
+					})
+				})
+
+				It("should return an empty list of unsupported clients", func() {
+					Expect(unsupportedClients).To(ContainElements("192.168.0.3:4500"))
+					Expect(unsupportedClients).To(HaveLen(1))
+					Expect(compatibleClientsCount).To(BeNumerically("==", 3))
+				})
+			})
+		})
+
+		When("checking for a version that is not the latest version", func() {
+			BeforeEach(func() {
+				version = fdbv1beta2.Version{Major: 6, Minor: 3, Patch: 25}
+				protocolVersion = version.Compact()
+			})
+
+			When("all clients support an even newer version", func() {
+				BeforeEach(func() {
+					supportedVersions = generateSupportedVersion(inputSupportedVersions, map[string][]string{
+						"7.1.27": {
+							"192.168.0.1:4500",
+							"192.168.0.2:4500",
+							"192.168.0.3:4500",
+						},
+					})
+				})
+
+				It("should return an empty list of unsupported clients", func() {
+					Expect(unsupportedClients).To(BeEmpty())
+					Expect(compatibleClientsCount).To(BeNumerically("==", 3))
+				})
+			})
+
+			When("all clients support an even newer version but not support the requested version", func() {
+				BeforeEach(func() {
+					delete(inputSupportedVersions, version.String())
+					supportedVersions = generateSupportedVersion(inputSupportedVersions, map[string][]string{
+						"7.1.27": {
+							"192.168.0.1:4500",
+							"192.168.0.2:4500",
+							"192.168.0.3:4500",
+						},
+					})
+
+				})
+
+				It("should return an empty list of unsupported clients", func() {
+					Expect(unsupportedClients).To(BeEmpty())
+					Expect(compatibleClientsCount).To(BeNumerically("==", 0))
+				})
+			})
+
+			When("all clients support an even newer version but one client doesn't support the requested version", func() {
+				BeforeEach(func() {
+					inputSupportedVersions[version.String()] = inputSupportedVersions[version.String()][:2]
+					supportedVersions = generateSupportedVersion(inputSupportedVersions, map[string][]string{
+						"7.1.27": {
+							"192.168.0.1:4500",
+							"192.168.0.2:4500",
+							"192.168.0.3:4500",
+						},
+					})
+
+				})
+
+				It("should return an empty list of unsupported clients", func() {
+					Expect(unsupportedClients).To(BeEmpty())
+					Expect(compatibleClientsCount).To(BeNumerically("==", 2))
+				})
+			})
+		})
+	})
+})

--- a/docs/manual/technical_design.md
+++ b/docs/manual/technical_design.md
@@ -136,7 +136,13 @@ The `UpdateConfigMap` subreconciler creates a `ConfigMap` object for the cluster
 
 ### CheckClientCompatibility
 
-The `CheckClientCompatibility` subreconciler is used during upgrades to ensure that every client is compatible with the new version of FoundationDB. When it detects that the `version` in the cluster spec is protocol-compatible with the `runningVersion` in the cluster status, this will do nothing. When these are different, it means there is a pending upgrade. This subreconciler will check the `connected_clients` field in the database status, and if it finds any clients whose max supported protocol version is not the same as the `version` from the cluster spec, it will fail reconciliation. This prevents upgrading a database until all clients have been updated with a compatible client library.
+The `CheckClientCompatibility` subreconciler is used during upgrades to ensure that every client is compatible with the new version of FoundationDB.
+When it detects that the `version` in the cluster spec is protocol-compatible with the `runningVersion` in the cluster status, this will do nothing.
+When these are different, it means there is a pending upgrade.
+This subreconciler will check the `connected_clients` field in the database status, and if it finds any clients whose max supported protocol version is not the same as or newer than the `version` from the cluster spec, it will fail reconciliation.
+In addition it check that all reported clients support a protocol compatible version for the desired upgrade version, if not all reported clients support a compatible version the reconcilation will fail and upgrades will be blocked.
+
+This prevents upgrading a database until all clients have been updated with a compatible client library.
 
 You can skip this check by setting the `ignoreUpgradabilityChecks` flag in the cluster spec.
 


### PR DESCRIPTION
# Description

There could be cases where a client already supports a newer version than the version the cluster will be upgraded to. Before the check was failing, with the new approach we ensure all connected clients support a compatible version.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

Unit tests added.

## Documentation

Updated documentation.

## Follow-up

None.
