### PR TITLE
Make sure we always check the sidecar to get the most recent information about the updated ConfigMap

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -57,7 +57,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		return &requeue{curError: err}
 	}
 
-	minimumUptime, addressMap, err := internal.GetMinimumUptimeAndAddressMap(cluster, status, r.EnableRecoveryState)
+	minimumUptime, addressMap, err := internal.GetMinimumUptimeAndAddressMap(logger, cluster, status, r.EnableRecoveryState)
 	if err != nil {
 		return &requeue{curError: err}
 	}

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -41,8 +41,7 @@ var _ = Describe("choose_removals", func() {
 
 	BeforeEach(func() {
 		cluster = internal.CreateDefaultCluster()
-		err = k8sClient.Create(context.TODO(), cluster)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(context.TODO(), cluster)).NotTo(HaveOccurred())
 
 		result, err := reconcileCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -245,13 +245,14 @@ func (r *FoundationDBClusterReconciler) SetupWithManager(mgr ctrl.Manager, maxCo
 	return builder.Complete(r)
 }
 
-func (r *FoundationDBClusterReconciler) updatePodDynamicConf(cluster *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod) (bool, error) {
+func (r *FoundationDBClusterReconciler) updatePodDynamicConf(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod) (bool, error) {
 	if cluster.ProcessGroupIsBeingRemoved(podmanager.GetProcessGroupID(cluster, pod)) {
 		return true, nil
 	}
+
 	podClient, message := r.getPodClient(cluster, pod)
 	if podClient == nil {
-		log.Info("Unable to generate pod client", "namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", podmanager.GetProcessGroupID(cluster, pod), "message", message)
+		logger.Info("Unable to generate pod client", "message", message)
 		return false, nil
 	}
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2191,7 +2191,7 @@ var _ = Describe("cluster_controller", func() {
 			})
 		})
 
-		Context("with a version incompatible upgrade", func() {
+		When("doing an version incompatible upgrade", func() {
 			var adminClient *mock.AdminClient
 
 			BeforeEach(func() {
@@ -2203,8 +2203,7 @@ var _ = Describe("cluster_controller", func() {
 			Context("with the delete strategy", func() {
 				BeforeEach(func() {
 					cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyDelete
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
 				It("should bounce the processes", func() {
@@ -2217,8 +2216,7 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should set the image on the pods", func() {
 					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
 
 					for _, pod := range pods.Items {
 						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
@@ -2233,8 +2231,7 @@ var _ = Describe("cluster_controller", func() {
 			Context("with the replace transaction strategy", func() {
 				BeforeEach(func() {
 					cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyTransactionReplacement
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
 				It("should bounce the processes", func() {
@@ -2247,8 +2244,7 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should set the image on the pods", func() {
 					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
 
 					for _, pod := range pods.Items {
 						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
@@ -2261,8 +2257,7 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should replace the transaction system Pods", func() {
 					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
 
 					originalNames := make([]string, 0, len(originalPods.Items))
 					for _, pod := range originalPods.Items {
@@ -2289,8 +2284,7 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should not replace the storage Pods", func() {
 					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
 
 					originalNames := make([]string, 0, len(originalPods.Items))
 					for _, pod := range originalPods.Items {
@@ -2319,8 +2313,7 @@ var _ = Describe("cluster_controller", func() {
 			Context("with the replacement strategy", func() {
 				BeforeEach(func() {
 					cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyReplacement
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
 				It("should bounce the processes", func() {
@@ -2333,8 +2326,7 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should set the image on the pods", func() {
 					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
 
 					for _, pod := range pods.Items {
 						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
@@ -2343,8 +2335,7 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should replace the process group", func() {
 					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
 
 					originalNames := make([]string, 0, len(originalPods.Items))
 					for _, pod := range originalPods.Items {
@@ -2363,14 +2354,12 @@ var _ = Describe("cluster_controller", func() {
 			Context("with all upgradable clients", func() {
 				BeforeEach(func() {
 					adminClient.MockClientVersion(fdbv1beta2.Versions.NextMajorVersion.String(), []string{"127.0.0.2:3687"})
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
 				It("should not set a message about the client upgradability", func() {
 					events := &corev1.EventList{}
-					err = k8sClient.List(context.TODO(), events)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.List(context.TODO(), events)).NotTo(HaveOccurred())
 					var matchingEvents []corev1.Event
 					for _, event := range events.Items {
 						if event.InvolvedObject.UID == cluster.ObjectMeta.UID && event.Reason == "UnsupportedClient" {
@@ -2393,17 +2382,14 @@ var _ = Describe("cluster_controller", func() {
 
 				Context("with the check enabled", func() {
 					BeforeEach(func() {
-						err = k8sClient.Update(context.TODO(), cluster)
-						Expect(err).NotTo(HaveOccurred())
+						Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 						shouldCompleteReconciliation = false
 					})
 
 					It("should set a message about the client upgradability", func() {
 						events := &corev1.EventList{}
 						var matchingEvents []corev1.Event
-
-						err = k8sClient.List(context.TODO(), events)
-						Expect(err).NotTo(HaveOccurred())
+						Expect(k8sClient.List(context.TODO(), events)).NotTo(HaveOccurred())
 
 						for _, event := range events.Items {
 							if event.InvolvedObject.UID == cluster.ObjectMeta.UID && event.Reason == "UnsupportedClient" {
@@ -2421,14 +2407,13 @@ var _ = Describe("cluster_controller", func() {
 				Context("with the check disabled", func() {
 					BeforeEach(func() {
 						cluster.Spec.IgnoreUpgradabilityChecks = true
-						err = k8sClient.Update(context.TODO(), cluster)
-						Expect(err).NotTo(HaveOccurred())
+						Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 					})
 
 					It("should not set a message about the client upgradability", func() {
 						events := &corev1.EventList{}
-						err = k8sClient.List(context.TODO(), events)
-						Expect(err).NotTo(HaveOccurred())
+						Expect(k8sClient.List(context.TODO(), events)).NotTo(HaveOccurred())
+
 						var matchingEvents []corev1.Event
 						for _, event := range events.Items {
 							if event.InvolvedObject.UID == cluster.ObjectMeta.UID && event.Reason == "UnsupportedClient" {
@@ -2441,6 +2426,34 @@ var _ = Describe("cluster_controller", func() {
 					It("should update the running version", func() {
 						Expect(cluster.Status.RunningVersion).To(Equal(cluster.Spec.Version))
 					})
+				})
+			})
+
+			When("one processes is missing the localities", func() {
+				BeforeEach(func() {
+					adminClient.MockMissingLocalities(fdbv1beta2.ProcessGroupID(originalPods.Items[0].Labels[cluster.GetProcessClassLabel()]), true)
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+				})
+
+				It("should bounce the processes", func() {
+					addresses := make(map[string]fdbv1beta2.None, len(originalPods.Items))
+					for _, pod := range originalPods.Items {
+						addresses[fmt.Sprintf("%s:4501", pod.Status.PodIP)] = fdbv1beta2.None{}
+					}
+					Expect(adminClient.KilledAddresses).To(Equal(addresses))
+				})
+
+				It("should set the image on the pods", func() {
+					pods := &corev1.PodList{}
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+
+					for _, pod := range pods.Items {
+						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
+					}
+				})
+
+				It("should update the running version", func() {
+					Expect(cluster.Status.RunningVersion).To(Equal(cluster.Spec.Version))
 				})
 			})
 		})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -175,12 +175,7 @@ func setupClusterForTest(cluster *fdbv1beta2.FoundationDBCluster) error {
 		return err
 	}
 
-	err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
 }
 
 func createTestClusterReconciler() *FoundationDBClusterReconciler {

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -95,7 +95,7 @@ var _ = Describe("update_status", func() {
 				processGroupStatus := fdbv1beta2.NewProcessGroupStatus("storage-1337", fdbv1beta2.ProcessClassStorage, []string{"1.1.1.1"})
 				// Reset the status to only tests for the missing Pod
 				processGroupStatus.ProcessGroupConditions = []*fdbv1beta2.ProcessGroupCondition{}
-				Expect(validateProcessGroup(context.TODO(), clusterReconciler, cluster, nil, nil, processGroupStatus)).NotTo(HaveOccurred())
+				Expect(validateProcessGroup(context.TODO(), clusterReconciler, cluster, nil, nil, "", processGroupStatus)).NotTo(HaveOccurred())
 				Expect(len(processGroupStatus.ProcessGroupConditions)).To(Equal(1))
 				Expect(processGroupStatus.ProcessGroupConditions[0].ProcessGroupConditionType).To(Equal(fdbv1beta2.MissingPod))
 			})
@@ -103,7 +103,7 @@ var _ = Describe("update_status", func() {
 
 		When("a process group is fine", func() {
 			It("should not get any condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(processGroupStatus)).To(BeNumerically(">", 4))
 				processGroup := processGroupStatus[len(processGroupStatus)-4]
@@ -118,7 +118,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				missingProcesses := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.MissingPod, false)
@@ -137,7 +137,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				incorrectProcesses := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.IncorrectCommandLine, false)
@@ -156,7 +156,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				missingProcesses := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.MissingProcesses, false)
@@ -177,7 +177,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				incorrectPods := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.IncorrectPodSpec, false)
@@ -203,7 +203,7 @@ var _ = Describe("update_status", func() {
 			It("should get a condition assigned", func() {
 				// Ensure that we have the same number of Pods and processes
 				Expect(allPods).To(HaveLen(len(processMap)))
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				missingProcesses := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.PodFailing, false)
@@ -224,7 +224,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				failingPods := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.PodFailing, false)
@@ -245,7 +245,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				failingPods := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.PodFailing, false)
@@ -270,7 +270,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should mark the process group for removal", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				removalCount := 0
@@ -301,7 +301,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should be mark the process group for removal without exclusion", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				removalCount := 0
@@ -341,7 +341,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should mark the process group as unreachable", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				unreachableCount := 0
@@ -365,7 +365,7 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("should remove the condition", func() {
-					processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+					processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 					Expect(err).NotTo(HaveOccurred())
 
 					unreachableCount := 0
@@ -393,7 +393,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should mark the process group as Pod pending", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				pendingCount := 0

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -53,8 +53,7 @@ var _ = Describe("update_status", func() {
 
 		BeforeEach(func() {
 			cluster = internal.CreateDefaultCluster()
-			err = setupClusterForTest(cluster)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(setupClusterForTest(cluster)).NotTo(HaveOccurred())
 
 			pods, err = clusterReconciler.PodLifecycleManager.GetPods(context.TODO(), clusterReconciler, cluster, internal.GetSinglePodListOptions(cluster, "storage-1")...)
 			Expect(err).NotTo(HaveOccurred())
@@ -67,8 +66,7 @@ var _ = Describe("update_status", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			configMap = &corev1.ConfigMap{}
-			err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name + "-config"}, configMap)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name + "-config"}, configMap)).NotTo(HaveOccurred())
 		})
 
 		JustBeforeEach(func() {
@@ -97,8 +95,7 @@ var _ = Describe("update_status", func() {
 				processGroupStatus := fdbv1beta2.NewProcessGroupStatus("storage-1337", fdbv1beta2.ProcessClassStorage, []string{"1.1.1.1"})
 				// Reset the status to only tests for the missing Pod
 				processGroupStatus.ProcessGroupConditions = []*fdbv1beta2.ProcessGroupCondition{}
-				err := validateProcessGroup(context.TODO(), clusterReconciler, cluster, nil, nil, "", processGroupStatus)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(validateProcessGroup(context.TODO(), clusterReconciler, cluster, nil, nil, processGroupStatus)).NotTo(HaveOccurred())
 				Expect(len(processGroupStatus.ProcessGroupConditions)).To(Equal(1))
 				Expect(processGroupStatus.ProcessGroupConditions[0].ProcessGroupConditionType).To(Equal(fdbv1beta2.MissingPod))
 			})
@@ -106,7 +103,7 @@ var _ = Describe("update_status", func() {
 
 		When("a process group is fine", func() {
 			It("should not get any condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(processGroupStatus)).To(BeNumerically(">", 4))
 				processGroup := processGroupStatus[len(processGroupStatus)-4]
@@ -121,7 +118,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				missingProcesses := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.MissingPod, false)
@@ -140,7 +137,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				incorrectProcesses := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.IncorrectCommandLine, false)
@@ -159,7 +156,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				missingProcesses := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.MissingProcesses, false)
@@ -180,7 +177,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				incorrectPods := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.IncorrectPodSpec, false)
@@ -206,7 +203,7 @@ var _ = Describe("update_status", func() {
 			It("should get a condition assigned", func() {
 				// Ensure that we have the same number of Pods and processes
 				Expect(allPods).To(HaveLen(len(processMap)))
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				missingProcesses := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.PodFailing, false)
@@ -227,7 +224,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				failingPods := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.PodFailing, false)
@@ -248,7 +245,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				failingPods := fdbv1beta2.FilterByCondition(processGroupStatus, fdbv1beta2.PodFailing, false)
@@ -273,7 +270,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should mark the process group for removal", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				removalCount := 0
@@ -304,7 +301,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should be mark the process group for removal without exclusion", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				removalCount := 0
@@ -344,7 +341,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should mark the process group as unreachable", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				unreachableCount := 0
@@ -368,7 +365,7 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("should remove the condition", func() {
-					processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+					processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 					Expect(err).NotTo(HaveOccurred())
 
 					unreachableCount := 0
@@ -396,7 +393,7 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should mark the process group as Pod pending", func() {
-				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs)
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, allPods, allPvcs)
 				Expect(err).NotTo(HaveOccurred())
 
 				pendingCount := 0

--- a/internal/configmap_helper.go
+++ b/internal/configmap_helper.go
@@ -178,6 +178,7 @@ func GetConfigMapMonitorConfEntry(pClass fdbv1beta2.ProcessClass, imageType FDBI
 
 		return fmt.Sprintf("fdbmonitor-conf-%s-json", pClass)
 	}
+
 	if serversPerPod > 1 && pClass == fdbv1beta2.ProcessClassStorage {
 		return fmt.Sprintf("fdbmonitor-conf-%s-density-%d", pClass, serversPerPod)
 	}

--- a/internal/fdb_status_helper_test.go
+++ b/internal/fdb_status_helper_test.go
@@ -22,7 +22,6 @@ package internal
 
 import (
 	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/internal/locality/locality_test.go
+++ b/internal/locality/locality_test.go
@@ -675,8 +675,7 @@ var _ = Describe("Change coordinators", func() {
 					})
 			})
 
-			It("should ignore the process"+
-				"", func() {
+			It("should ignore the process", func() {
 				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
 				Expect(coordinatorsValid).To(BeTrue())
 				Expect(addressesValid).To(BeTrue())
@@ -686,18 +685,35 @@ var _ = Describe("Change coordinators", func() {
 
 		When("a process misses the public-address flag", func() {
 			BeforeEach(func() {
+				process := status.Cluster.Processes["3"]
+				process.CommandLine = ""
+				status.Cluster.Processes["3"] = process
+
+				Expect(status.Cluster.Processes["3"].CommandLine).To(BeEmpty())
+			})
+
+			It("should report that not all addresses and coordinators are valid", func() {
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+				Expect(coordinatorsValid).To(BeFalse())
+				Expect(addressesValid).To(BeFalse())
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("a process is missing localities", func() {
+			BeforeEach(func() {
 				status.Cluster.Processes["4"] = fdbv1beta2.FoundationDBStatusProcessInfo{
 					Address: fdbv1beta2.ProcessAddress{
-						IPAddress: net.ParseIP("1.1.1.4"),
-						Port:      4501,
+						IPAddress: net.ParseIP("127.0.0.1"),
 					},
+					ProcessClass: fdbv1beta2.ProcessClassLog,
 				}
 			})
 
-			It("should report that not all addresses are valid", func() {
+			It("should be ignored", func() {
 				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
 				Expect(coordinatorsValid).To(BeTrue())
-				Expect(addressesValid).To(BeFalse())
+				Expect(addressesValid).To(BeTrue())
 				Expect(err).To(BeNil())
 			})
 		})

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -65,6 +65,20 @@ type AdminClient struct {
 	uptimeSecondsForMaintenanceZone          float64
 }
 
+/*
+   "c8dd8904031dfff5df292c2f328df269": {
+     "address": "100.80.88.131:4500:tls",
+     "class_type": "log",
+     "roles": [
+       {
+         "role": "coordinator"
+       }
+     ]
+   },
+
+TODO: allow to mock such a bad process in the status output.
+*/
+
 // adminClientCache provides a cache of mock admin clients.
 var adminClientCache = make(map[string]*AdminClient)
 var adminClientMutex sync.Mutex


### PR DESCRIPTION
# Description

This change makes sure we are not using the ConfigMap Annotation to check if a Pod has all the recent files. This can be critical during upgrades when the Annotation was already updated to another value.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

This will result in a higher resource consumption on the operator side since the operator has to do those requests in 2 different places.

## Testing

Unit tests and e2e tests will be running.

## Documentation

-

## Follow-up

-