### PR TITLE
Update examples and better document how to run a multi-region FDB cluster

### DIFF
--- a/config/deployment/manager.yaml
+++ b/config/deployment/manager.yaml
@@ -64,7 +64,7 @@ spec:
             - name: fdb-binaries
               mountPath: /var/output-files
         - name: foundationdb-kubernetes-init-7-1
-          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.15-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.27-1
           args:
             - "--copy-library"
             - "7.1"
@@ -75,7 +75,7 @@ spec:
             - "--copy-binary"
             - "fdbrestore"
             - "--output-dir"
-            - "/var/output-files/7.1.15"
+            - "/var/output-files/7.1.27"
             - "--init-mode"
           volumeMounts:
             - name: fdb-binaries

--- a/config/deployment/manager.yaml
+++ b/config/deployment/manager.yaml
@@ -64,7 +64,7 @@ spec:
             - name: fdb-binaries
               mountPath: /var/output-files
         - name: foundationdb-kubernetes-init-7-1
-          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.27-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.26-1
           args:
             - "--copy-library"
             - "7.1"
@@ -75,7 +75,7 @@ spec:
             - "--copy-binary"
             - "fdbrestore"
             - "--output-dir"
-            - "/var/output-files/7.1.27"
+            - "/var/output-files/7.1.26"
             - "--init-mode"
           volumeMounts:
             - name: fdb-binaries

--- a/config/samples/backup.yaml
+++ b/config/samples/backup.yaml
@@ -53,7 +53,7 @@ spec:
         secret:
           secretName: fdb-kubernetes-operator-secrets
   snapshotPeriodSeconds: 3600
-  version: 6.3.22
+  version: 7.1.26
 ---
 apiVersion: apps.foundationdb.org/v1beta2
 kind: FoundationDBCluster
@@ -123,4 +123,4 @@ spec:
     enableLivenessProbe: true
     enableReadinessProbe: false
   useExplicitListenAddress: true
-  version: 6.3.22
+  version: 7.1.26

--- a/config/samples/client.yaml
+++ b/config/samples/client.yaml
@@ -33,7 +33,7 @@ spec:
         - name: FDB_CLUSTER_FILE
           value: /var/dynamic-conf/fdb.cluster
         - name: FDB_API_VERSION
-          value: "610"
+          value: "630"
         - name: FDB_NETWORK_OPTION_TRACE_LOG_GROUP
           value: test-cluster-client
         - name: FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY
@@ -58,13 +58,13 @@ spec:
         - --copy-file
         - fdb.cluster
         - --copy-library
-        - "6.2"
-        - --copy-library
         - "6.3"
+        - --copy-library
+        - "7.1"
         - --init-mode
         - --require-not-empty
         - fdb.cluster
-        image: foundationdb/foundationdb-kubernetes-sidecar:6.3.24-1
+        image: foundationdb/foundationdb-kubernetes-sidecar:7.1.26-1
         name: foundationdb-kubernetes-init
         volumeMounts:
         - mountPath: /var/input-files
@@ -149,4 +149,4 @@ spec:
     enableLivenessProbe: true
     enableReadinessProbe: false
   useExplicitListenAddress: true
-  version: 6.3.22
+  version: 7.1.26

--- a/config/samples/cluster.yaml
+++ b/config/samples/cluster.yaml
@@ -66,4 +66,4 @@ spec:
     enableLivenessProbe: true
     enableReadinessProbe: false
   useExplicitListenAddress: true
-  version: 6.3.22
+  version: 7.1.26

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -218,9 +218,9 @@ spec:
         - --copy-binary
         - fdbrestore
         - --output-dir
-        - /var/output-files/7.1.15
+        - /var/output-files/7.1.27
         - --init-mode
-        image: foundationdb/foundationdb-kubernetes-sidecar:7.1.15-1
+        image: foundationdb/foundationdb-kubernetes-sidecar:7.1.27-1
         name: foundationdb-kubernetes-init-7-1
         volumeMounts:
         - mountPath: /var/output-files

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -218,9 +218,9 @@ spec:
         - --copy-binary
         - fdbrestore
         - --output-dir
-        - /var/output-files/7.1.27
+        - /var/output-files/7.1.26
         - --init-mode
-        image: foundationdb/foundationdb-kubernetes-sidecar:7.1.27-1
+        image: foundationdb/foundationdb-kubernetes-sidecar:7.1.26-1
         name: foundationdb-kubernetes-init-7-1
         volumeMounts:
         - mountPath: /var/output-files

--- a/config/samples/restore.yaml
+++ b/config/samples/restore.yaml
@@ -54,7 +54,7 @@ spec:
         secret:
           secretName: fdb-kubernetes-operator-secrets
   snapshotPeriodSeconds: 3600
-  version: 6.3.22
+  version: 7.1.26
 ---
 apiVersion: apps.foundationdb.org/v1beta2
 kind: FoundationDBCluster
@@ -124,7 +124,7 @@ spec:
     enableLivenessProbe: true
     enableReadinessProbe: false
   useExplicitListenAddress: true
-  version: 6.3.22
+  version: 7.1.26
 ---
 apiVersion: apps.foundationdb.org/v1beta2
 kind: FoundationDBRestore

--- a/config/tests/backup/base/backup.yaml
+++ b/config/tests/backup/base/backup.yaml
@@ -3,7 +3,7 @@ kind: FoundationDBBackup
 metadata:
   name: test-cluster
 spec:
-  version: 6.3.22
+  version: 7.1.26
   clusterName: test-cluster
   snapshotPeriodSeconds: 3600
   blobStoreConfiguration:

--- a/config/tests/base/cluster.yaml
+++ b/config/tests/base/cluster.yaml
@@ -3,7 +3,7 @@ kind: FoundationDBCluster
 metadata:
   name: test-cluster
 spec:
-  version: 6.3.22
+  version: 7.1.26
   faultDomain:
     # Use fake fault domains to support running in a single-node Kubernetes
     # cluster.

--- a/config/tests/client/client.yaml
+++ b/config/tests/client/client.yaml
@@ -17,14 +17,14 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: foundationdb-kubernetes-init
-          image: foundationdb/foundationdb-kubernetes-sidecar:6.3.24-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.26-1
           args:
             - "--copy-file"
             - "fdb.cluster"
             - "--copy-library"
-            - "6.2"
-            - "--copy-library"
             - "6.3"
+            - "--copy-library"
+            - "7.1"
             - "--init-mode"
             - "--require-not-empty"
             - "fdb.cluster"
@@ -41,7 +41,7 @@ spec:
             - name: FDB_CLUSTER_FILE
               value: /var/dynamic-conf/fdb.cluster
             - name: FDB_API_VERSION
-              value: "610"
+              value: "630"
             - name: FDB_NETWORK_OPTION_TRACE_LOG_GROUP
               value: test-cluster-client
             - name: FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY

--- a/config/tests/dns/client.yaml
+++ b/config/tests/dns/client.yaml
@@ -17,7 +17,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: foundationdb-kubernetes-init-7-1
-          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.25-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.26-1
           imagePullPolicy: IfNotPresent
           args:
             - "--copy-file"
@@ -40,7 +40,7 @@ spec:
             - name: FDB_CLUSTER_FILE
               value: /var/dynamic-conf/fdb.cluster
             - name: FDB_API_VERSION
-              value: "610"
+              value: "710"
             - name: FDB_NETWORK_OPTION_TRACE_LOG_GROUP
               value: test-cluster-client
             - name: FDB_NETWORK_OPTION_TRACE_ENABLE

--- a/config/tests/dns/dns.yaml
+++ b/config/tests/dns/dns.yaml
@@ -1,7 +1,4 @@
 - op: add
-  path: "/spec/version"
-  value: 7.1.25
-- op: add
   path: "/spec/routing/useDNSInClusterFile"
   value: true
 - op: remove

--- a/config/tests/multi_dc/final.yaml
+++ b/config/tests/multi_dc/final.yaml
@@ -10,7 +10,7 @@ metadata:
     cluster-group: test-cluster
   name: test-cluster-$dc
 spec:
-  version: 7.1.25
+  version: 7.1.26
   faultDomain:
     key: foundationdb.org/none
   processGroupIDPrefix: $dc

--- a/config/tests/multi_dc/stage_1.yaml
+++ b/config/tests/multi_dc/stage_1.yaml
@@ -10,7 +10,7 @@ metadata:
     cluster-group: test-cluster
   name: test-cluster-$dc
 spec:
-  version: 7.1.25
+  version: 7.1.26
   faultDomain:
     key: foundationdb.org/none
   processGroupIDPrefix: $dc

--- a/config/tests/multi_kc/final.yaml
+++ b/config/tests/multi_kc/final.yaml
@@ -10,7 +10,7 @@ metadata:
     cluster-group: test-cluster
   name: test-cluster-$zone
 spec:
-  version: 7.1.25
+  version: 7.1.26
   faultDomain:
     key: foundationdb.org/kubernetes-cluster
     value: $zone

--- a/config/tests/multi_kc/stage_1.yaml
+++ b/config/tests/multi_kc/stage_1.yaml
@@ -10,7 +10,7 @@ metadata:
     cluster-group: test-cluster
   name: test-cluster-$zone
 spec:
-  version: 7.1.25
+  version: 7.1.26
   faultDomain:
     key: foundationdb.org/kubernetes-cluster
     value: $zone

--- a/docs/manual/backup.md
+++ b/docs/manual/backup.md
@@ -18,7 +18,7 @@ kind: FoundationDBBackup
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   clusterName: sample-cluster
   blobStoreConfiguration:
     accountName: account@object-store.example:443
@@ -105,7 +105,7 @@ kind: FoundationDBBackup
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   clusterName: sample-cluster
   blobStoreConfiguration:
     accountName: account@object-store.example:443

--- a/docs/manual/customization.md
+++ b/docs/manual/customization.md
@@ -14,7 +14,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   spec:
     storageServersPerPod: 2
 ```
@@ -31,7 +31,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   processes:
     general:
       volumeClaimTemplate:
@@ -47,7 +47,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   processes:
     general:
       volumeClaimTemplate:
@@ -65,7 +65,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   processes:
     log:
       volumeClaimTemplate:
@@ -87,7 +87,7 @@ kind: FoundationDBCluster
 metadata:
     name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   processes:
     general:
       podTemplate:
@@ -124,7 +124,7 @@ kind: FoundationDBCluster
 metadata:
     name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   mainContainer:
     imageConfigs:
       - baseImage: docker.example/foundationdb
@@ -143,7 +143,7 @@ kind: FoundationDBCluster
 metadata:
     name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   mainContainer:
     imageConfigs:
       - baseImage: docker.example/foundationdb
@@ -160,11 +160,11 @@ kind: FoundationDBCluster
 metadata:
     name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   mainContainer:
     imageConfigs:
       - baseImage: docker.example/foundationdb
-      - version: 6.2.30
+      - version: 7.1.26
         tag: "build-20210711161700"
       - version: 6.3.0
         tag: "build-20210712161700"
@@ -180,7 +180,7 @@ kind: FoundationDBCluster
 metadata:
     name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   mainContainer:
     imageConfigs:
       - baseImage: docker.example/foundationdb
@@ -369,7 +369,7 @@ kind: FoundationDBCluster
 metadata:
     name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   labels:
     # The default match labels are {"fdb-cluster-name": "sample-cluster"}
     matchLabels:
@@ -390,7 +390,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   labels:
     matchLabels:
       my-cluster: sample-cluster
@@ -411,7 +411,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   labels:
     matchLabels:
       this-cluster: sample-cluster
@@ -428,7 +428,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   labels:
     matchLabels:
       this-cluster: sample-cluster
@@ -450,7 +450,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   labels:
     processClassLabels:
       # Default: ["fdb-process-class", "foundationdb.org/fdb-process-class"]
@@ -470,7 +470,7 @@ kind: FoundationDBCluster
 metadata:
     name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   labels:
     processClassLabels:
       - my-class
@@ -485,7 +485,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   labels:
     processClassLabels:
       - this-class
@@ -511,7 +511,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   useUnifiedImage: true
 ```
 

--- a/docs/manual/fault_domains.md
+++ b/docs/manual/fault_domains.md
@@ -14,7 +14,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   faultDomain:
     key: kubernetes.io/hostname
     valueFrom: spec.nodeName
@@ -30,7 +30,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   faultDomain:
     key: topology.kubernetes.io/zone
     valueFrom: spec.zoneName
@@ -46,7 +46,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   faultDomain:
     key: topology.kubernetes.io/zone
     valueFrom: $RACK
@@ -64,7 +64,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   processGroupIDPrefix: zone2
   faultDomain:
     key: foundationdb.org/kubernetes-cluster
@@ -91,7 +91,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   faultDomain:
     key: foundationdb.org/none
 ```
@@ -100,7 +100,11 @@ This strategy uses the pod name as the fault domain, which allows each process t
 
 ## Multi-Region Replication
 
-The replication strategies above all describe how data is replicated within a data center. They control the `zoneid` field in the cluster's locality. If you want to run a cluster across multiple data centers, you can use FoundationDB's multi-region replication. This can work with any of the replication stragies above. The data center will be a separate fault domain from whatever you provide for the zone.
+The replication strategies above all describe how data is replicated within a data center.
+They control the `zoneid` field in the cluster's locality.
+If you want to run a cluster across multiple data centers, you can use FoundationDB's multi-region replication.
+This can work with any of the replication strategies above.
+The data center will be a separate fault domain from whatever you provide for the zone.
 
 ```yaml
 apiVersion: apps.foundationdb.org/v1beta2
@@ -108,7 +112,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   dataCenter: dc1
   databaseConfiguration:
     regions:
@@ -131,7 +135,59 @@ This will be used to set the `dcid` locality field.
 The `regions` section of the database describes all of the available regions.
 See the [FoundationDB documentation](https://apple.github.io/foundationdb/configuration.html#configuring-regions) for more information on how to configure regions.
 
-Replicating across data centers will likely mean running your cluster across multiple Kubernetes clusters, even if you are using a single-Kubernetes replication strategy within each DC. This will mean taking on the operational challenges described in the "Multi-Kubernetes Replication" section above.
+Replicating across data centers will likely mean running your cluster across multiple Kubernetes clusters, even if you are using a single-Kubernetes replication strategy within each DC.
+This will mean taking on the operational challenges described in the "Multi-Kubernetes Replication" section above.
+
+An example on how to setup a multi-region FDB cluster with the operator can be found in [multi-dc](../../config/tests/multi_dc).
+If you want to do an experiment locally with Kind you can use the [setup_e2e.sh](../../scripts/setup_e2e.sh) script.
+Basically the example is performing the following steps:
+
+Create a single DC FDB cluster:
+
+```yaml
+apiVersion: apps.foundationdb.org/v1beta2
+kind: FoundationDBCluster
+metadata:
+  name: sample-cluster
+spec:
+  version: 7.1.26
+  dataCenter: dc1
+  # Using the processGroupIDPrefix will prevent name conflicts.
+  processGroupIDPrefix: dc1
+  databaseConfiguration:
+    regions:
+      - datacenters:
+          - id: dc1
+            priority: 1
+```
+
+Once the cluster is fully reconciled you can create the FDB clusters in the other DCs, now with the full configuration and a `seedConnectionString`:
+
+```yaml
+apiVersion: apps.foundationdb.org/v1beta2
+kind: FoundationDBCluster
+metadata:
+  name: sample-cluster
+spec:
+  version: 7.1.26
+  dataCenter: dc1
+  processGroupIDPrefix: dc1
+  seedConnectionString: # Replace with the value from the initial single DC cluster
+  databaseConfiguration:
+    regions:
+      - datacenters:
+          - id: dc1
+            priority: 1
+          - id: dc2
+            priority: 1
+            satellite: 1
+      - datacenters:
+          - id: dc3
+            priority: 0
+          - id: dc4
+            priority: 1
+            satellite: 1
+```
 
 ## Coordinating Global Operations
 

--- a/docs/manual/getting_started.md
+++ b/docs/manual/getting_started.md
@@ -65,7 +65,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: fdbcli-status-cronjob
-            image: foundationdb/foundationdb:7.1.27
+            image: foundationdb/foundationdb:7.1.26
             args:
             - /usr/bin/fdbcli
             - --exec

--- a/docs/manual/getting_started.md
+++ b/docs/manual/getting_started.md
@@ -33,7 +33,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
 ```
 
 This will create a cluster with 3 storage processes, 4 log processes, and 7 stateless processes. Each fdbserver process will be in a separate pod, and the pods will have names of the form `sample-cluster-$role-$n`, where `$n` is the process group ID and `$role` is the role for the process.
@@ -65,7 +65,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: fdbcli-status-cronjob
-            image: foundationdb/foundationdb:6.2.30
+            image: foundationdb/foundationdb:7.1.27
             args:
             - /usr/bin/fdbcli
             - --exec

--- a/docs/manual/operations.md
+++ b/docs/manual/operations.md
@@ -12,12 +12,16 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   processGroupsToRemove:
     - storage-1
 ```
 
-When comparing the desired process count with the current pod count, any pods that are in the pending removal list are not counted. This means that the operator will only consider there to be 2 running storage pods, rather than 3, and will create a new one to fill the gap. Once this is done, it will go through the same removal process described under [Shrinking a Cluster](scaling.md#shrinking-a-cluster). The cluster will remain at full fault tolerance throughout the reconciliation. This allows you to replace an arbitrarily large number of processes in a cluster without any risk of availability loss.
+When comparing the desired process count with the current pod count, any pods that are in the pending removal list are not counted.
+This means that the operator will only consider there to be 2 running storage pods, rather than 3, and will create a new one to fill the gap.
+Once this is done, it will go through the same removal process described under [Shrinking a Cluster](scaling.md#shrinking-a-cluster).
+The cluster will remain at full fault tolerance throughout the reconciliation.
+This allows you to replace an arbitrarily large number of processes in a cluster without any risk of availability loss.
 
 ## Adding a Knob
 
@@ -29,14 +33,16 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   processes:
     general:
       customParameters:
       - "knob_always_causal_read_risky=1"
 ```
 
-The operator will update the monitor conf to contain the new knob, and will then bounce all of the fdbserver processes. As soon as fdbmonitor detects that the fdbserver process has died, it will create a new fdbserver process with the latest config. The cluster should be fully available within 10 seconds of executing the bounce, though this can vary based on cluster size.
+The operator will update the monitor conf to contain the new knob, and will then bounce all of the fdbserver processes.
+As soon as fdbmonitor detects that the fdbserver process has died, it will create a new fdbserver process with the latest config.
+The cluster should be fully available within 10 seconds of executing the bounce, though this can vary based on cluster size and the resources provided to the fdbserver processes.
 
 The process for updating the monitor conf can take several minutes, based on the time it takes Kubernetes to update the config map in the pods.
 
@@ -50,12 +56,10 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.3.12
+  version: 7.2.4
 ```
 
-This will first update the sidecar image in the pod to match the new version, which will restart that container. On restart, it will copy the new FDB binaries into the config volume for the foundationdb container, which will make it available to run. We will then update the fdbmonitor conf to point to the new binaries and bounce all of the fdbserver processes.
-
-Once all of the processes are running at the new version, we will recreate all of the pods so that the `foundationdb` container uses the new version for its own image. This will use the strategies described in [Pod Update Strategy](customization.md#pod-update-strategy).
+The upgrade process is described in more detail in [upgrades](./upgrades.md).
 
 ## Renaming a Cluster
 

--- a/docs/manual/scaling.md
+++ b/docs/manual/scaling.md
@@ -12,7 +12,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   processCounts:
     storage: 6
     log: 5
@@ -39,7 +39,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   databaseConfiguration:
     storage: 6
     logs: 4 # default is 3
@@ -59,7 +59,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   databaseConfiguration:
     storage: 4
 ```
@@ -82,7 +82,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   databaseConfiguration:
     redundancy_mode: triple
     storage: 5

--- a/docs/manual/tls.md
+++ b/docs/manual/tls.md
@@ -22,7 +22,7 @@ kind: FoundationDBCluster
 metadata:
   name: sample-cluster
 spec:
-  version: 6.2.30
+  version: 7.1.26
   trustedCAs:
     - |
       # Put the root CAs you trust here.


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/560 and updates the example version for FDB clusters.

## Type of change

*Please select one of the options below.*

- Documentation

## Discussion

-

## Testing

-

## Documentation

Updated

## Follow-up

-
