### PR TITLE
Ensure we call exclude only on missing processes

### DIFF
--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -817,15 +817,6 @@ protocol fdb00b071010000`,
 			}
 		})
 
-		/*
-			test the following cases:
-
-			1.) All processes are fully excluded
-			2.) 1 process is not marked as excluded
-			3.) 1 process is marked as excluded but still has roles
-			4.) 1 process is missing from result
-
-		*/
 		When("all provided processes are fully excluded", func() {
 			BeforeEach(func() {
 				addressesToCheck = []fdbv1beta2.ProcessAddress{
@@ -935,10 +926,11 @@ protocol fdb00b071010000`,
 			})
 
 			It("should return the one process that is still serving a role and the one that is not excluded", func() {
-				Expect(result).To(ConsistOf(fdbv1beta2.ProcessAddress{
-					IPAddress: net.ParseIP("192.168.0.3"),
-					Port:      4500,
-				},
+				Expect(result).To(ConsistOf(
+					fdbv1beta2.ProcessAddress{
+						IPAddress: net.ParseIP("192.168.0.3"),
+						Port:      4500,
+					},
 					fdbv1beta2.ProcessAddress{
 						IPAddress: net.ParseIP("192.168.0.4"),
 						Port:      4500,
@@ -990,6 +982,17 @@ protocol fdb00b071010000`,
 				It("should return an error", func() {
 					Expect(result).To(HaveLen(0))
 					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			When("the missing process is fully excluded or doesn't have any data", func() {
+				BeforeEach(func() {
+					mockRunner.mockedError = nil
+				})
+
+				It("should return an empty result", func() {
+					Expect(result).To(HaveLen(0))
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 		})

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -1,0 +1,107 @@
+/*
+ * fdb_client.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fdbclient
+
+import (
+	"errors"
+	"fmt"
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/apple/foundationdb/bindings/go/src/fdb"
+	"github.com/go-logr/logr"
+	"time"
+)
+
+// fdbLibClient is an interface to interact with FDB over the client libraries
+type fdbLibClient interface {
+	// getValueFromDBUsingKey returns the value of the provided key.
+	getValueFromDBUsingKey(fdbKey string, timeout time.Duration) ([]byte, error)
+}
+
+// realFdbLibClient represents the actual FDB client that will interact with FDB.
+type realFdbLibClient struct {
+	cluster *fdbv1beta2.FoundationDBCluster
+	logger  logr.Logger
+}
+
+func (fdbClient *realFdbLibClient) getValueFromDBUsingKey(fdbKey string, timeout time.Duration) ([]byte, error) {
+	fdbClient.logger.Info("Fetch values from FDB", "key", fdbKey)
+	defer func() {
+		fdbClient.logger.Info("Done fetching values from FDB", "key", fdbKey)
+	}()
+	database, err := getFDBDatabase(fdbClient.cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := database.Transact(func(transaction fdb.Transaction) (interface{}, error) {
+		err := transaction.Options().SetAccessSystemKeys()
+		if err != nil {
+			return nil, err
+		}
+		err = transaction.Options().SetTimeout(timeout.Milliseconds())
+		if err != nil {
+			return nil, err
+		}
+
+		rawResult := transaction.Get(fdb.Key(fdbKey)).MustGet()
+		if len(rawResult) == 0 {
+			return nil, err
+		}
+
+		return rawResult, err
+	})
+
+	if err != nil {
+		var fdbError *fdb.Error
+		if errors.As(err, &fdbError) {
+			// See: https://apple.github.io/foundationdb/api-error-codes.html
+			// 1031: Operation aborted because the transaction timed out
+			if fdbError.Code == 1031 {
+				return nil, fdbv1beta2.TimeoutError{Err: err}
+			}
+		}
+
+		return nil, err
+	}
+
+	byteResult, ok := result.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("could not cast result into byte slice")
+	}
+
+	return byteResult, nil
+}
+
+// mockFdbLibClient is a mock for unit testing.
+type mockFdbLibClient struct {
+	// mockedOutput is the output returned by getValueFromDBUsingKey.
+	mockedOutput []byte
+	// mockedError is the error returned by getValueFromDBUsingKey.
+	mockedError error
+	// requestedKey will be the key that was used to call getValueFromDBUsingKey.
+	requestedKey string
+}
+
+func (fdbClient *mockFdbLibClient) getValueFromDBUsingKey(fdbKey string, _ time.Duration) ([]byte, error) {
+	fdbClient.requestedKey = fdbKey
+
+	return fdbClient.mockedOutput, fdbClient.mockedError
+}


### PR DESCRIPTION
# Description

We've seen some issues with the frequent calling of the `fdbcli exclude` command to check if a process is excluded from the operator side. We already have logic in the operator code to check if a process is safe to delete (serves no roles) based on the cluster status. The only case where we want to call the exclude command is when the operator has an address that is missing in the cluster status json.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

Most of the code changes are unit tests to ensure we cover all important cases.

## Testing

Unit tests and the CI pipeline will run the e2e tests.

## Documentation

We don't have a dedicated doc for how the operator handles exclusions, I think it would be a good idea to start a doc in a different PR: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1549.

## Follow-up

-
