### PR TITLE
Add an upgrade test case where one sidecar is not ready for the upgrade

### DIFF
--- a/e2e/fixtures/chaos_common.go
+++ b/e2e/fixtures/chaos_common.go
@@ -295,6 +295,10 @@ func isRunning(obj runtime.Object) (bool, error) {
 	if ok {
 		return conditionsAreTrue(podChaos.GetStatus(), podChaos.GetStatus().Conditions), nil
 	}
+	httpChaos, ok := obj.(*chaosmeshv1alpha1.HTTPChaos)
+	if ok {
+		return conditionsAreTrue(httpChaos.GetStatus(), httpChaos.GetStatus().Conditions), nil
+	}
 
 	_, ok = obj.(*chaosmeshv1alpha1.Schedule)
 	if ok {

--- a/e2e/fixtures/chaos_http.go
+++ b/e2e/fixtures/chaos_http.go
@@ -1,0 +1,62 @@
+/*
+ * chaos_http.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures
+
+import (
+	chaosmeshv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+// InjectHTTPClientChaosWrongResultFdbMonitorConf  this method can be used to simulate a bad response from the operator to the sidecar. Currently this method returns as body the value "wrong"
+// when the operator does a request against the check_hash/fdbmonitor.conf endpoint, e.g. during upgrades.
+func (factory *Factory) InjectHTTPClientChaosWrongResultFdbMonitorConf(selector chaosmeshv1alpha1.PodSelectorSpec, namespace string) *ChaosMeshExperiment {
+	return factory.CreateExperiment(&chaosmeshv1alpha1.HTTPChaos{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RandStringRunes(32),
+			Namespace: factory.GetChaosNamespace(),
+			Labels:    factory.GetDefaultLabels(),
+		},
+		Spec: chaosmeshv1alpha1.HTTPChaosSpec{
+			Target:   chaosmeshv1alpha1.PodHttpResponse,
+			Duration: pointer.String(ChaosDurationForever),
+			PodSelector: chaosmeshv1alpha1.PodSelector{
+				Selector: selector,
+				Mode:     chaosmeshv1alpha1.AllMode,
+			},
+			Port:   8080,
+			Method: pointer.String("GET"),
+			Path:   pointer.String("check_hash/fdbmonitor.conf"),
+			PodHttpChaosActions: chaosmeshv1alpha1.PodHttpChaosActions{
+				Replace: &chaosmeshv1alpha1.PodHttpChaosReplaceActions{
+					Body: []byte("wrong"),
+				},
+			},
+			TLS: &chaosmeshv1alpha1.PodHttpChaosTLS{
+				SecretName:      factory.GetSecretName(),
+				SecretNamespace: namespace,
+				CertName:        "tls.crt",
+				KeyName:         "tls.key",
+				CAName:          pointer.String("ca.pem"),
+			},
+		},
+	})
+}

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -202,6 +202,13 @@ func (factory *Factory) createPodTemplate(
 				{
 					Name:            fdbv1beta2.SidecarContainerName,
 					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						//Privileged:               pointer.Bool(true),
+						//AllowPrivilegeEscalation: pointer.Bool(true), // for performance profiling
+						ReadOnlyRootFilesystem: pointer.Bool(
+							false,
+						), // to allow I/O chaos to succeed
+					},
 					Resources: corev1.ResourceRequirements{
 						Requests: sideResources,
 					},

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -739,7 +739,7 @@ var _ = Describe("Operator Upgrades", Label("e2e"), func() {
 			// Ensure the upgrade proceeds and is able to finish.
 			verifyVersion(fdbCluster, targetVersion)
 		},
-		EntryDescription("Upgrade from %[1]s to %[2]s with one coordinator not being restarted"),
+		EntryDescription("Upgrade from %[1]s to %[2]s and one process has the fdbmonitor.conf file not ready"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
 })

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -655,13 +655,13 @@ var _ = Describe("Operator Upgrades", Label("e2e"), func() {
 
 			Eventually(func() bool {
 				pod := fdbCluster.GetPod(faultyPod.Name)
-				log.Println("status:", pod.Status)
 
 				for _, status := range pod.Status.ContainerStatuses {
 					if status.Name != fdbv1beta2.SidecarContainerName {
 						continue
 					}
 
+					log.Println("expected", sidecarImage, "got", status.Image)
 					return status.Image == sidecarImage
 				}
 
@@ -708,7 +708,8 @@ var _ = Describe("Operator Upgrades", Label("e2e"), func() {
 			}
 			faultyProcessGroupID := fixtures.GetProcessGroupID(faultyPod)
 
-			// The upgrade will be stuck until the coordinators are restarted
+			// The upgrade will be stuck until the I/O chaos is removed and the sidecar is able to provide the latest
+			// fdbmonitor conf file.
 			Eventually(func() bool {
 				cluster := fdbCluster.GetCluster()
 				for _, processGroup := range cluster.Status.ProcessGroups {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/apple/foundationdb/bindings/go v0.0.0-20201222225940-f3aef311ccfb
 	github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20220513200452-e6fa4d7422d2
-	github.com/chaos-mesh/chaos-mesh/api/v1alpha1 v0.0.0-20220226050744-799408773657
+	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20221122113336-10bc9220553c
 	github.com/fatih/color v1.14.1
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chaos-mesh/chaos-mesh/api/v1alpha1 v0.0.0-20220226050744-799408773657 h1:CyuI+igIjadM/GRnE2o0q+WCwipDh0n2cUYFPAvxziM=
-github.com/chaos-mesh/chaos-mesh/api/v1alpha1 v0.0.0-20220226050744-799408773657/go.mod h1:JRiumF+RFsH1mrrP8FUsi9tExPylKkO/oSRWeQEUdLE=
+github.com/chaos-mesh/chaos-mesh/api v0.0.0-20221122113336-10bc9220553c h1:XADyZxDBxMSDFLBFWeoVTEr05UQcQA/U0ZIHNhZCLwA=
+github.com/chaos-mesh/chaos-mesh/api v0.0.0-20221122113336-10bc9220553c/go.mod h1:heHWKECNnFzjjCJOS2sgiT1e8AjstcfVevzXj5HmDvg=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -385,6 +385,7 @@ func (client *realFdbPodAnnotationClient) UpdateFile(name string, contents strin
 		}
 		return match, nil
 	}
+
 	return false, fmt.Errorf("unknown file %s", name)
 }
 


### PR DESCRIPTION
# Description

Adding a new test case to ensure the upgrade is blocked if not all Pods are ready to be restarted.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

I ran a manual test:

```text
------------------------------
[AfterSuite]
/Users/jscheuermann/go/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_upgrades/operator_upgrades_test.go:36
[AfterSuite] PASSED [0.000 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.011 seconds]
------------------------------

Ran 1 of 11 Specs in 269.758 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 10 Skipped
PASS | FOCUSED
FAIL    github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_upgrades      270.177s
FAIL
make: *** [test_operator_upgrades.run] Error 1
```

## Documentation

Added in the test case.

## Follow-up

-