### PR TITLE
Ensure we only mark the database as unavailable if we can talk to the majority of coordinators

### DIFF
--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -203,7 +203,7 @@ func (factory *Factory) getContainerOverrides(
 	debugSymbols bool,
 ) (fdbv1beta2.ContainerOverrides, fdbv1beta2.ContainerOverrides) {
 	mainImage, mainTag := GetBaseImageAndTag(
-		GetDebugImage(debugSymbols, factory.GetSidecarImage()),
+		GetDebugImage(debugSymbols, factory.GetFoundationDBImage()),
 	)
 
 	mainOverrides := fdbv1beta2.ContainerOverrides{

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -290,7 +290,9 @@ func (fdbCluster FdbCluster) InvariantClusterStatusAvailableWithThreshold(
 func (fdbCluster FdbCluster) InvariantClusterStatusAvailable() error {
 	return fdbCluster.StatusInvariantChecker(
 		"InvariantClusterStatusAvailable",
-		0,
+		// Per default we allow 5 seconds unavailability. Otherwise we could get a few test failures when we do operations
+		// like a replacement on a transaction system Pod and the recovery takes longer.
+		5*time.Second,
 		checkAvailability,
 	)
 }

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -52,7 +52,6 @@ func (fdbCluster *FdbCluster) getStatusFromOperatorPod() *fdbv1beta2.FoundationD
 		return err
 	}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).ShouldNot(gomega.HaveOccurred())
 
-	// TODO remove the gabs dependency in this part and make use of the struct
 	return status
 }
 

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -260,14 +260,8 @@ func (fdbCluster FdbCluster) StatusInvariantChecker(
 	)
 }
 
-// checkAvailability returns nil if the cluster is reachable or if not a quorum of the coordinators are reachable. If
-// the cluster is unreachable an error will be returned.
+// checkAvailability returns nil if the cluster is reachable. If the cluster is unreachable an error will be returned.
 func checkAvailability(status *fdbv1beta2.FoundationDBStatus) error {
-	// If we are not able to reach the quorum of coordinators, we cannot make any assumption about the status of the Cluster.
-	if !status.Client.Coordinators.QuorumReachable {
-		return nil
-	}
-
 	if !status.Client.DatabaseStatus.Available {
 		return fmt.Errorf("cluster is not available")
 	}

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -66,7 +66,7 @@ func clusterSetup(beforeVersion string, availabilityCheck bool) {
 	)
 
 	// We have some tests where we expect some down time e.g. when no coordinator is restarted during an upgrade.
-	// In order to make sure the test is not failing based on the availability check we can disable this test if required.
+	// In order to make sure the test is not failing based on the availability check we can disable the availability check if required.
 	if !availabilityCheck {
 		return
 	}

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -776,7 +776,7 @@ var _ = Describe("Operator Upgrades", Label("e2e"), func() {
 				Skip("this test only affects version incompatible upgrades")
 			}
 
-			clusterSetup(beforeVersion)
+			clusterSetup(beforeVersion, true)
 
 			// Update the cluster version.
 			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -342,8 +342,7 @@ var _ = Describe("Operator Upgrades", Label("e2e"), func() {
 				Skip("this test case only affects version incompatible upgrades")
 			}
 
-			// We ignore the availability check here since this check is sometimes flaky if not all coordinators are running.
-			clusterSetup(beforeVersion, false)
+			clusterSetup(beforeVersion, true)
 
 			// Select one coordinator that will be restarted during the staging phase.
 			coordinators := fdbCluster.GetCoordinators()
@@ -462,8 +461,7 @@ var _ = Describe("Operator Upgrades", Label("e2e"), func() {
 				Skip("operator doesn't support feature for test case")
 			}
 
-			// We ignore the availability check here since this check is sometimes flaky if not all coordinators are running.
-			clusterSetup(beforeVersion, false)
+			clusterSetup(beforeVersion, true)
 
 			// 1. Select one coordinator and use the buggify option to skip it during the restart command.
 			coordinators := fdbCluster.GetCoordinators()

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -545,7 +545,7 @@ var _ = Describe("Operator Upgrades", Label("e2e"), func() {
 			// The cluster should still be able to upgrade.
 			Expect(fdbCluster.UpgradeCluster(targetVersion, true)).NotTo(HaveOccurred())
 		},
-		EntryDescription("Upgrade from %[1]s to %[2]s with one coordinator not being restarted"),
+		EntryDescription("Upgrade from %[1]s to %[2]s and multiple processes are not restarted"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
 
@@ -651,7 +651,7 @@ var _ = Describe("Operator Upgrades", Label("e2e"), func() {
 
 			fdbCluster.SetIgnoreDuringRestart(nil)
 		},
-		EntryDescription("Upgrade from %[1]s to %[2]s with one coordinator not being restarted"),
+		EntryDescription("Upgrade from %[1]s to %[2]s and no coordinator is restarted"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
 

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -342,7 +342,7 @@ var _ = Describe("Operator Upgrades", Label("e2e"), func() {
 				Skip("this test case only affects version incompatible upgrades")
 			}
 
-			clusterSetup(beforeVersion, true)
+			clusterSetup(beforeVersion, false)
 
 			// Select one coordinator that will be restarted during the staging phase.
 			coordinators := fdbCluster.GetCoordinators()


### PR DESCRIPTION
# Description

This change makes the status invariant checker more robust during upgrades. If the operator is not able to communicate to the quorum of the coordinator we cannot make any assumption about the cluster state.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Running e2e tests locally (will report once they finished).

## Documentation

Added in code.

## Follow-up

-
