### PR TITLE
Correct the way how the provided images and registry are used

### DIFF
--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -203,7 +203,7 @@ func (factory *Factory) getContainerOverrides(
 	debugSymbols bool,
 ) (fdbv1beta2.ContainerOverrides, fdbv1beta2.ContainerOverrides) {
 	mainImage, mainTag := GetBaseImageAndTag(
-		GetDebugImage(debugSymbols, factory.singleton.fdbImage),
+		GetDebugImage(debugSymbols, factory.GetSidecarImage()),
 	)
 
 	mainOverrides := fdbv1beta2.ContainerOverrides{
@@ -223,7 +223,7 @@ func (factory *Factory) getContainerOverrides(
 	}
 
 	sidecarImage, sidecarTag := GetBaseImageAndTag(
-		GetDebugImage(debugSymbols, factory.singleton.sidecarImage),
+		GetDebugImage(debugSymbols, factory.GetSidecarImage()),
 	)
 	sidecarOverrides := fdbv1beta2.ContainerOverrides{
 		EnableTLS: false,
@@ -689,7 +689,7 @@ func (factory *Factory) DumpStateHaCluster(fdbCluster *HaFdbCluster) {
 
 // OperatorIsAtLeast is a helper method to check is the running operator is at least in the specified version.
 func (factory *Factory) OperatorIsAtLeast(version string) bool {
-	operatorVersion := strings.Split(factory.singleton.operatorImage, ":")[1]
+	operatorVersion := strings.Split(factory.GetOperatorImage(), ":")[1]
 	parsedOperatorVersion, err := fdbv1beta2.ParseFdbVersion(operatorVersion)
 	if err != nil {
 		// If the version can not be parsed be can assume it's either a self build or the latest version.
@@ -757,4 +757,22 @@ func (factory *Factory) CreateIfAbsent(object client.Object) error {
 	}
 
 	return nil
+}
+
+// GetOperatorImage returns the operator image provided via command line. If a registry was definem the registry will be
+// prepended.
+func (factory *Factory) GetOperatorImage() string {
+	return prependRegistry(factory.options.registry, factory.options.operatorImage)
+}
+
+// GetSidecarImage returns the sidecar image provided via command line. If a registry was definem the registry will be
+// prepended.
+func (factory *Factory) GetSidecarImage() string {
+	return prependRegistry(factory.options.registry, factory.options.sidecarImage)
+}
+
+// GetFoundationDBImage returns the FoundationDB image provided via command line. If a registry was definem the registry will be
+// prepended.
+func (factory *Factory) GetFoundationDBImage() string {
+	return prependRegistry(factory.options.registry, factory.options.fdbImage)
 }

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -352,7 +352,7 @@ func getOperatorSidecarConfig(baseImage string, tag string, version string) oper
 //nolint:revive
 func (factory *Factory) getOperatorConfig(namespace string) *operatorConfig {
 	config := &operatorConfig{
-		OperatorImage:    factory.singleton.operatorImage,
+		OperatorImage:    factory.GetOperatorImage(),
 		SecretName:       factory.GetSecretName(),
 		BackupSecretName: factory.GetBackupSecretName(),
 		Namespace:        namespace,
@@ -361,7 +361,7 @@ func (factory *Factory) getOperatorConfig(namespace string) *operatorConfig {
 	config.SidecarVersions = append(
 		config.SidecarVersions,
 		getDefaultOperatorSidecarConfig(
-			factory.options.sidecarImage,
+			factory.GetSidecarImage(),
 			factory.GetFDBVersionAsString(),
 		),
 	)

--- a/e2e/fixtures/singleton.go
+++ b/e2e/fixtures/singleton.go
@@ -45,9 +45,6 @@ type singleton struct {
 	client                  *kubernetes.Clientset
 	controllerRuntimeClient controllerRuntimeClient.Client
 	fdbVersion              fdbv1beta2.Version
-	fdbImage                string
-	operatorImage           string
-	sidecarImage            string
 	namespaces              []string
 }
 
@@ -87,9 +84,6 @@ func getSingleton(options *FactoryOptions) (*singleton, error) {
 	if err != nil {
 		return nil, err
 	}
-	operatorImage := prependRegistry(options.registry, options.operatorImage)
-	fdbImage := prependRegistry(options.registry, options.fdbImage)
-	sidecarImage := prependRegistry(options.registry, options.sidecarImage)
 
 	// Also add Apps v1 and Core v1 to allow to use the controller runtime client
 	// to modify Pods, Deployments etc.
@@ -128,9 +122,6 @@ func getSingleton(options *FactoryOptions) (*singleton, error) {
 		config:                  kubeConfig,
 		client:                  client,
 		fdbVersion:              fdbVersion,
-		operatorImage:           operatorImage,
-		sidecarImage:            sidecarImage,
-		fdbImage:                fdbImage,
 		certificate:             certificate,
 		controllerRuntimeClient: controllerClient,
 	}, nil


### PR DESCRIPTION
# Description

Fix the way how the sidecar is used in the operator setup. I removed the singleton setup and created a method in the factory struct. This should simplify the usage of the images.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

I did a local run with a different registry.

## Documentation

-

## Follow-up

-
