### PR TITLE
Add an additional wait after installing CRDs in pull request tests.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -94,6 +94,7 @@ jobs:
         kubectl wait --for condition="established" crd --all
         # Ensure we can upgrade the CRD with the current changes
         make install
+        kubectl wait --for condition="established" crd --all
     - name: Ensure samples are in a valid format
       run: |
         kubectl apply -f ./config/samples --dry-run=server


### PR DESCRIPTION
# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

I hit an issue in #1301 where the PRB checks were failing because the PR added new fields in both the CRD and the samples, and the fields weren't available when the samples were validated. This adds an additional check that the CRD updates are complete between the steps where the CRDs are installed and when the samples are validated.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

*Are there any design details that you would like to discuss further?*

No.

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

I've run the steps in the PRB locally.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

We should re-run PR #1301 and confirm that this fix allows the PRBs to pass.

## Documentation

*Did you update relevant documentation within this repository?*

No.

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.