### PR TITLE
Add ignore log group in e2e tests

### DIFF
--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -67,6 +67,9 @@ func (factory *Factory) createFDBClusterSpec(
 				},
 				// Allow the operator to remove all Pods that are excluded and marked for deletion to remove at once.
 				RemovalMode: fdbv1beta2.PodUpdateModeAll,
+				IgnoreLogGroupsForUpgrade: []string{
+					"fdb-kubernetes-operator",
+				},
 			},
 			Routing: fdbv1beta2.RoutingConfig{
 				UseDNSInClusterFile: pointer.Bool(false),


### PR DESCRIPTION
# Description

This change should allow the 7.1 -> 7.2 upgrades to succeed.

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1566

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

I will run a test upgrade from 7.1 -> 7.2

## Documentation

I add the documentation for the upgrades from 7.1 -> 7.2 in another doc.

## Follow-up

Add documentation for the upgrade setup.