### PR TITLE
Update FDB version used for e2e tests

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -9,7 +9,7 @@ TIMEOUT?=168h
 
 NAMESPACE?=
 CONTEXT?=
-FDB_VERSION?=7.1.27
+FDB_VERSION?=7.1.31
 PREVIOUS_FDB_VERSION?=6.3.25
 ## Expectation is that you are running standard build image which generates both regular and debug (Symbols) images.
 FDB_IMAGE?=foundationdb/foundationdb:$(FDB_VERSION)


### PR DESCRIPTION
# Description

Make use of the latest FDB 7.1 release (7.1.31) for our e2e tests.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

This should resolved the last flakiness of our tests where we same the exclude command failing with `10% free space`.

## Testing

e2e pipeline will be running.

## Documentation

-

## Follow-up

-
