### PR TITLE
Initial support for fault domains in CRD

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -330,6 +330,9 @@ type ProcessGroupStatus struct {
 	ExclusionSkipped bool `json:"exclusionSkipped,omitempty"`
 	// ProcessGroupConditions represents a list of degraded conditions that the process group is in.
 	ProcessGroupConditions []*ProcessGroupCondition `json:"processGroupConditions,omitempty"`
+	// FaultDomain represents either the logical grouping that is used to bin pack processes together or the last seen
+	// fault domain from the cluster status.
+	FaultDomain string `json:"faultDomain,omitempty"`
 }
 
 // ProcessGroupID represents the ID of the process group

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -330,8 +330,8 @@ type ProcessGroupStatus struct {
 	ExclusionSkipped bool `json:"exclusionSkipped,omitempty"`
 	// ProcessGroupConditions represents a list of degraded conditions that the process group is in.
 	ProcessGroupConditions []*ProcessGroupCondition `json:"processGroupConditions,omitempty"`
-	// FaultDomain represents either the logical grouping that is used to bin pack processes together or the last seen
-	// fault domain from the cluster status.
+	// FaultDomain represents the last seen fault domain from the cluster status. This can be used if a Pod or process
+	// is not running and would be missing in the cluster status.
 	FaultDomain string `json:"faultDomain,omitempty"`
 }
 

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -13860,6 +13860,8 @@ spec:
                     exclusionTimestamp:
                       format: date-time
                       type: string
+                    faultDomain:
+                      type: string
                     processClass:
                       type: string
                     processGroupConditions:

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -22,15 +22,11 @@ package controllers
 
 import (
 	"context"
-<<<<<<< HEAD
-	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
-=======
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
->>>>>>> e1bcbc65 (Initial support for fault domains in CRD)
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -414,6 +414,7 @@ ProcessGroupStatus represents the status of a ProcessGroup.
 | exclusionTimestamp | ExclusionTimestamp defines when the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | *metav1.Time | false |
 | exclusionSkipped | ExclusionSkipped determines if exclusion has been skipped for a process, which will allow the process group to be removed without exclusion. | bool | false |
 | processGroupConditions | ProcessGroupConditions represents a list of degraded conditions that the process group is in. | []*[ProcessGroupCondition](#processgroupcondition) | false |
+| faultDomain | FaultDomain represents either the logical grouping that is used to bin pack processes together or the last seen fault domain from the cluster status. | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -414,7 +414,7 @@ ProcessGroupStatus represents the status of a ProcessGroup.
 | exclusionTimestamp | ExclusionTimestamp defines when the process group has been fully excluded. This is only used within the reconciliation process, and should not be considered authoritative. | *metav1.Time | false |
 | exclusionSkipped | ExclusionSkipped determines if exclusion has been skipped for a process, which will allow the process group to be removed without exclusion. | bool | false |
 | processGroupConditions | ProcessGroupConditions represents a list of degraded conditions that the process group is in. | []*[ProcessGroupCondition](#processgroupcondition) | false |
-| faultDomain | FaultDomain represents either the logical grouping that is used to bin pack processes together or the last seen fault domain from the cluster status. | string | false |
+| faultDomain | FaultDomain represents the last seen fault domain from the cluster status. This can be used if a Pod or process is not running and would be missing in the cluster status. | string | false |
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1564

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

This is currently only used as an additional information source that can be used in addition to the information from the cluster status.

## Testing

Unit tests.

## Documentation

Will be added before merging.

## Follow-up

We could add the fault domain as a label to make the selection of Pods easier.