### PR TITLE
Make sure to only check exclusions if we have 1 active generation

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -504,16 +504,10 @@ func getRemainingAndExcludedFromStatus(status *fdbv1beta2.FoundationDBStatus, ad
 	// for the active generations we have the risk to remove a log process that still has mutations on it that must be
 	// popped.
 	if status.Cluster.RecoveryState.ActiveGenerations > 1 {
-		notExcluded := make([]fdbv1beta2.ProcessAddress, 0, len(addresses))
-
-		for _, addr := range addresses {
-			notExcluded = append(notExcluded, addr)
-		}
-
 		return exclusionStatus{
 			inProgress:      nil,
 			fullyExcluded:   nil,
-			notExcluded:     notExcluded,
+			notExcluded:     addresses,
 			missingInStatus: nil,
 		}
 	}

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -498,6 +498,26 @@ func getRemainingAndExcludedFromStatus(status *fdbv1beta2.FoundationDBStatus, ad
 	notExcludedAddresses := map[string]fdbv1beta2.None{}
 	fullyExcludedAddresses := map[string]fdbv1beta2.None{}
 	visitedAddresses := map[string]fdbv1beta2.None{}
+
+	// If there are more than 1 active generations we can not handout any information about excluded processes based on
+	// the cluster status information as only the latest log processes will have the log process role. If we don't check
+	// for the active generations we have the risk to remove a log process that still has mutations on it that must be
+	// popped.
+	if status.Cluster.RecoveryState.ActiveGenerations > 1 {
+		notExcluded := make([]fdbv1beta2.ProcessAddress, 0, len(addresses))
+
+		for _, addr := range addresses {
+			notExcluded = append(notExcluded, addr)
+		}
+
+		return exclusionStatus{
+			inProgress:      nil,
+			fullyExcluded:   nil,
+			notExcluded:     notExcluded,
+			missingInStatus: nil,
+		}
+	}
+
 	for _, addr := range addresses {
 		notExcludedAddresses[addr.MachineAddress()] = fdbv1beta2.None{}
 	}

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -118,6 +118,41 @@ var _ = Describe("admin_client_test", func() {
 				nil,
 				[]fdbv1beta2.ProcessAddress{addr5},
 			),
+			Entry("when the process is excluded but the cluster status has multiple generations",
+				&fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						RecoveryState: fdbv1beta2.RecoveryState{
+							ActiveGenerations: 2,
+						},
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"1": {
+								Address:  addr1,
+								Excluded: true,
+							},
+							"2": {
+								Address: addr2,
+							},
+							"3": {
+								Address: addr3,
+							},
+							"4": {
+								Address:  addr4,
+								Excluded: true,
+								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+									{
+										Role: "tester",
+									},
+								},
+							},
+						},
+					},
+				},
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				nil,
+			),
 		)
 	})
 


### PR DESCRIPTION
# Description

Only perform the exclusion check if we have 1 active generation, otherwise assume no process is fully excluded.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Unit tests + e2e tests are running.

## Documentation

-

## Follow-up

Implement: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/990 (will only work for 7+ clusters)
