### PR TITLE
Test upgrade when no remote processes are restarted

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -23,8 +23,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"github.com/FoundationDB/fdb-kubernetes-operator/internal/buggify"
 	"time"
+
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal/buggify"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal/restarts"
 
@@ -134,7 +135,7 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		}
 	}
 
-	filteredAddresses, removedAddresses := buggify.FilterIgnoredProcessGroups(cluster, addresses)
+	filteredAddresses, removedAddresses := buggify.FilterIgnoredProcessGroups(cluster, addresses, status)
 	if removedAddresses {
 		addresses = filteredAddresses
 	}

--- a/controllers/bounce_processes_test.go
+++ b/controllers/bounce_processes_test.go
@@ -23,8 +23,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"github.com/FoundationDB/fdb-kubernetes-operator/internal/buggify"
 	"time"
+
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal/buggify"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
 	"k8s.io/utils/pointer"
@@ -516,7 +517,7 @@ var _ = Describe("bounceProcesses", func() {
 					processAddresses = append(processAddresses, process.Address)
 				}
 
-				filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(cluster, processAddresses)
+				filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(cluster, processAddresses, status)
 			})
 
 			It("should filter the ignored address", func() {
@@ -545,7 +546,7 @@ var _ = Describe("bounceProcesses", func() {
 					processAddresses = append(processAddresses, process.Address)
 				}
 
-				filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(cluster, processAddresses)
+				filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(cluster, processAddresses, status)
 			})
 
 			It("should filter the ignored address", func() {

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -434,4 +434,49 @@ var _ = Describe("Operator HA Upgrades", Label("e2e"), func() {
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
 
+	DescribeTable(
+		"upgrading a cluster when no remote processes are restarted",
+		func(beforeVersion string, targetVersion string) {
+			isAtLeast := factory.OperatorIsAtLeast(
+				"v1.14.0",
+			)
+
+			if !isAtLeast {
+				Skip("operator doesn't support feature for test case")
+			}
+
+			clusterSetup(beforeVersion, false)
+
+			// Select remote processes and use the buggify option to skip those
+			// processes during the restart command.
+			pods := fdbCluster.GetRemote().GetPods()
+			Expect(pods.Items).NotTo(BeEmpty())
+
+			ignoreDuringRestart := make(
+				[]fdbv1beta2.ProcessGroupID,
+				0,
+				len(pods.Items),
+			)
+
+			for _, pod := range pods.Items {
+				ignoreDuringRestart = append(
+					ignoreDuringRestart,
+					fdbv1beta2.ProcessGroupID(pod.Labels[fdbCluster.GetRemote().GetCachedCluster().GetProcessGroupIDLabel()]),
+				)
+			}
+
+			log.Println(
+				"Selected Pods:",
+				ignoreDuringRestart,
+				"to be skipped during the restart",
+			)
+			fdbCluster.GetRemote().SetIgnoreDuringRestart(ignoreDuringRestart)
+
+			// The cluster should still be able to upgrade.
+			Expect(fdbCluster.UpgradeCluster(targetVersion, true)).NotTo(HaveOccurred())
+		},
+		EntryDescription("Upgrade from %[1]s to %[2]s when no remote processes are restarted"),
+		fixtures.GenerateUpgradeTableEntries(testOptions),
+	)
+
 })

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -470,7 +470,9 @@ var _ = Describe("Operator HA Upgrades", Label("e2e"), func() {
 				ignoreDuringRestart,
 				"to be skipped during the restart",
 			)
-			fdbCluster.GetRemote().SetIgnoreDuringRestart(ignoreDuringRestart)
+			for _, cluster := range fdbCluster.GetAllClusters() {
+				cluster.SetIgnoreDuringRestart(ignoreDuringRestart)
+			}
 
 			// The cluster should still be able to upgrade.
 			Expect(fdbCluster.UpgradeCluster(targetVersion, true)).NotTo(HaveOccurred())

--- a/internal/buggify/buggify.go
+++ b/internal/buggify/buggify.go
@@ -62,12 +62,12 @@ func FilterIgnoredProcessGroups(cluster *fdbv1beta2.FoundationDBCluster, address
 	}
 
 	for _, process := range status.Cluster.Processes {
-		processGroupId, ok := process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]
+		processGroupID, ok := process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]
 		if !ok {
 			continue
 		}
 
-		if _, ok := ignoredIDs[fdbv1beta2.ProcessGroupID(processGroupId)]; !ok {
+		if _, ok := ignoredIDs[fdbv1beta2.ProcessGroupID(processGroupID)]; !ok {
 			continue
 		}
 


### PR DESCRIPTION
# Description

Test upgrading an HA cluster when no remote processes are restarted.

Co-authored by: Johannes Scheuermann

## Type of change

*Please select one of the options below.*

- Other (testing related)

## Discussion

*Are there any design details that you would like to discuss further?*

No.

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

Ran the test locally. (Did four runs today, one of those runs didn't complete after about half-an-hour, I think (at which point I stopped the test), the other runs completed successfully.)

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

Yes (we will need to run this test as part of regression testing).

## Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

N/A

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

We will need to investigate any failures of this test (in regression test runs).

*Does this introduce new defaults that we should re-evaluate in the future?*

No.
