### PR TITLE
Make sure we use the force reconcile method if needed and we dump the state if an upgrade is stuck

### DIFF
--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -124,8 +124,8 @@ type ReconciliationOptions struct {
 	allowSoftReconciliation bool
 	creationTrackerLogger   CreationTrackerLogger
 	minimumGeneration       int64
-	timeOutInSeconds        int64
-	pollTimeInSeconds       int64
+	timeOutInSeconds        int
+	pollTimeInSeconds       int
 }
 
 // ReconciliationOption defines the reconciliation option.
@@ -155,14 +155,14 @@ func MinimumGenerationOption(minimumGeneration int64) ReconciliationOption {
 }
 
 // TimeOutInSecondsOption defines the timeout for the reconciliation. If not set the default is 4800 seconds
-func TimeOutInSecondsOption(timeOutInSeconds int64) ReconciliationOption {
+func TimeOutInSecondsOption(timeOutInSeconds int) ReconciliationOption {
 	return func(options *ReconciliationOptions) {
 		options.timeOutInSeconds = timeOutInSeconds
 	}
 }
 
 // PollTimeInSecondsOption defines the polling time for the reconciliation. If not set the default is 10 seconds
-func PollTimeInSecondsOption(pollTimeInSeconds int64) ReconciliationOption {
+func PollTimeInSecondsOption(pollTimeInSeconds int) ReconciliationOption {
 	return func(options *ReconciliationOptions) {
 		options.pollTimeInSeconds = pollTimeInSeconds
 	}
@@ -207,8 +207,8 @@ func (fdbCluster *FdbCluster) waitForReconciliationToGeneration(
 	minimumGeneration int64,
 	softReconciliationAllowed bool,
 	creationTrackerLogger CreationTrackerLogger,
-	timeOutInSeconds int64, // 4800
-	pollTimeInSeconds int64, // 4
+	timeOutInSeconds int, // 4800
+	pollTimeInSeconds int, // 4
 ) error {
 	if timeOutInSeconds < pollTimeInSeconds {
 		return fmt.Errorf(
@@ -223,14 +223,6 @@ func (fdbCluster *FdbCluster) waitForReconciliationToGeneration(
 		fdbCluster.cluster.Namespace,
 		fdbCluster.cluster.Name,
 	)
-	counter := 0
-	// We want to force reconcile every 5 minutes, otherwise we update the cluster spec to often and we
-	// introduce to many conflicts. This will be resolved once we move to server side apply see:
-	// https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1278
-	forceReconcile := int(300 / pollTimeInSeconds)
-
-	// Printout the initial state of the cluster before we moving forward waiting for the reconciliation.
-	fdbCluster.factory.DumpState(fdbCluster)
 
 	var creationTracker *fdbClusterCreationTracker
 	if creationTrackerLogger != nil {
@@ -240,76 +232,108 @@ func (fdbCluster *FdbCluster) waitForReconciliationToGeneration(
 		)
 	}
 
-	err := wait.PollImmediate(
-		time.Duration(pollTimeInSeconds)*time.Second,
-		time.Duration(timeOutInSeconds)*time.Second,
-		func() (bool, error) {
-			resCluster := fdbCluster.GetCluster()
-			if creationTracker != nil {
-				creationTracker.trackProgress(resCluster)
-			}
+	checkIfReconciliationIsDone := func(cluster *fdbv1beta2.FoundationDBCluster) bool {
+		if creationTracker != nil {
+			creationTracker.trackProgress(cluster)
+		}
 
-			var reconciled bool
-			if softReconciliationAllowed {
-				reconciled = resCluster.Status.Generations.Reconciled == resCluster.ObjectMeta.Generation
-			} else {
-				reconciled = resCluster.Status.Generations == fdbv1beta2.ClusterGenerationStatus{Reconciled: resCluster.ObjectMeta.Generation}
-			}
-			if minimumGeneration > 0 {
-				reconciled = reconciled &&
-					resCluster.Status.Generations.Reconciled >= minimumGeneration
-			}
-			// Healthy is a bad indicator, since the tester pods will leave old processes behind and the cluster thinks it's not healthy...
-			if reconciled && resCluster.Status.Health.Available {
-				log.Printf(
-					"reconciled name=%s, namespace=%s",
-					fdbCluster.cluster.Name,
-					fdbCluster.cluster.Namespace,
-				)
-				return true, nil
-			}
-			// force a reconcile
-			if counter >= forceReconcile {
-				log.Printf("Status Generations=%s",
-					ToJSON(resCluster.Status.Generations))
-				log.Printf(
-					"MedataData Generations=%s",
-					ToJSON(
-						fdbv1beta2.ClusterGenerationStatus{
-							Reconciled: resCluster.ObjectMeta.Generation,
-						},
-					),
-				)
-				fdbCluster.factory.DumpState(fdbCluster)
-				patch := client.MergeFrom(resCluster.DeepCopy())
-				if resCluster.Annotations == nil {
-					resCluster.Annotations = make(map[string]string)
-				}
-				resCluster.Annotations["foundationdb.org/reconcile"] = strconv.FormatInt(
-					time.Now().UnixNano(),
-					10,
-				)
-				// This will apply an Annotation to the object which will trigger the reconcile loop.
-				// This should speed up the reconcile phase.
-				err := fdbCluster.getClient().Patch(
-					ctx.Background(),
-					resCluster,
-					patch)
-				if err != nil {
-					log.Println("error patching annotation to force reconcile, error:", err.Error())
-				}
-				counter = -1
-			}
-			counter++
-			return false, nil
-		},
-	)
+		var reconciled bool
+		if softReconciliationAllowed {
+			reconciled = cluster.Status.Generations.Reconciled == cluster.ObjectMeta.Generation
+		} else {
+			reconciled = cluster.Status.Generations == fdbv1beta2.ClusterGenerationStatus{Reconciled: cluster.ObjectMeta.Generation}
+		}
+
+		if minimumGeneration > 0 {
+			reconciled = reconciled &&
+				cluster.Status.Generations.Reconciled >= minimumGeneration
+		}
+
+		if reconciled {
+			log.Printf(
+				"reconciled name=%s, namespace=%s",
+				fdbCluster.cluster.Name,
+				fdbCluster.cluster.Namespace,
+			)
+			return true
+		}
+
+		return false
+	}
+
+	err := fdbCluster.WaitUntilWithForceReconcile(pollTimeInSeconds, timeOutInSeconds, checkIfReconciliationIsDone)
 
 	if creationTracker != nil {
 		creationTracker.report()
 	}
 
 	return err
+}
+
+// WaitUntilWithForceReconcile will wait either until the checkMethod returns true or until the timeout is hit.
+func (fdbCluster *FdbCluster) WaitUntilWithForceReconcile(pollTimeInSeconds int, timeOutInSeconds int, checkMethod func(cluster *fdbv1beta2.FoundationDBCluster) bool) error {
+	// Printout the initial state of the cluster before we moving forward waiting for the checkMethod to return true.
+	fdbCluster.factory.DumpState(fdbCluster)
+
+	counter := 0
+	// We want to force reconcile every 5 minutes, otherwise we update the cluster spec to often and we
+	// introduce to many conflicts. This will be resolved once we move to server side apply see:
+	// https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1278
+	forceReconcile := 300 / pollTimeInSeconds
+
+	return wait.PollImmediate(
+		time.Duration(pollTimeInSeconds)*time.Second,
+		time.Duration(timeOutInSeconds)*time.Second,
+		func() (bool, error) {
+			resCluster := fdbCluster.GetCluster()
+
+			if checkMethod(resCluster) {
+				return true, nil
+			}
+
+			// Force a reconcile if needed.
+			if counter >= forceReconcile {
+				fdbCluster.ForceReconcile()
+				counter = -1
+			}
+			counter++
+			return false, nil
+		},
+	)
+}
+
+// ForceReconcile will add an annotation with the current timestamp on the FoundationDBCluster resource to make sure
+// the operator reconciliation loop is triggered. This is used to speed up some test cases.
+func (fdbCluster *FdbCluster) ForceReconcile() {
+	log.Printf("Status Generations=%s",
+		ToJSON(fdbCluster.cluster.Status.Generations))
+	log.Printf(
+		"MedataData Generations=%s",
+		ToJSON(
+			fdbv1beta2.ClusterGenerationStatus{
+				Reconciled: fdbCluster.cluster.ObjectMeta.Generation,
+			},
+		),
+	)
+	fdbCluster.factory.DumpState(fdbCluster)
+	patch := client.MergeFrom(fdbCluster.cluster.DeepCopy())
+	if fdbCluster.cluster.Annotations == nil {
+		fdbCluster.cluster.Annotations = make(map[string]string)
+	}
+	fdbCluster.cluster.Annotations["foundationdb.org/reconcile"] = strconv.FormatInt(
+		time.Now().UnixNano(),
+		10,
+	)
+
+	// This will apply an Annotation to the object which will trigger the reconcile loop.
+	// This should speed up the reconcile phase.
+	err := fdbCluster.getClient().Patch(
+		ctx.Background(),
+		fdbCluster.cluster,
+		patch)
+	if err != nil {
+		log.Println("error patching annotation to force reconcile, error:", err.Error())
+	}
 }
 
 // GetCluster returns the FoundationDBCluster of the cluster. This will fetch the latest value from  the Kubernetes API.

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -418,8 +418,6 @@ func (fdbCluster *FdbCluster) UpdateClusterSpecWithSpec(desiredSpec *fdbv1beta2.
 
 		specUpdated := equality.Semantic.DeepEqual(fetchedCluster.Spec, *desiredSpec)
 		log.Println("UpdateClusterSpec: specUpdated:", specUpdated)
-		log.Printf("FetchedSpec %+v\n", fetchedCluster.Spec)
-		log.Printf("DesiredSpec %+v\n", desiredSpec)
 		if specUpdated {
 			return true
 		}

--- a/e2e/fixtures/ha_fdb_cluster.go
+++ b/e2e/fixtures/ha_fdb_cluster.go
@@ -247,7 +247,7 @@ func (haFDBCluster *HaFdbCluster) UpgradeCluster(version string, waitForReconcil
 func (haFDBCluster *HaFdbCluster) UpgradeClusterWithTimeout(
 	version string,
 	waitForReconciliation bool,
-	timeout int64,
+	timeout int,
 ) error {
 	expectedGenerations := map[string]int64{}
 	for _, cluster := range haFDBCluster.GetAllClusters() {

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -171,10 +171,11 @@ var _ = Describe("Operator HA Upgrades", Label("e2e"), func() {
 			initialGeneration := fdbCluster.GetPrimary().GetStatus().Cluster.Generation
 			upgradeAndVerify(fdbCluster, targetVersion)
 			// Verify that the cluster generation number didn't increase by more
-			// than 40 (in an ideal case the number of recoveries that should happen
+			// than 80 (in an ideal case the number of recoveries that should happen
 			// during an upgrade is 9, but in reality that number could be higher
 			// because different server processes may get bounced at different times).
-			Expect(fdbCluster.GetPrimary().GetStatus().Cluster.Generation).To(BeNumerically("<=", initialGeneration+40))
+			// See: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1607
+			Expect(fdbCluster.GetPrimary().GetStatus().Cluster.Generation).To(BeNumerically("<=", initialGeneration+80))
 
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -83,9 +83,9 @@ func clusterSetup(beforeVersion string, availabilityCheck bool) {
 // version compatible upgrades, since incompatible processes won't be part of the cluster anyway. To simplify the check
 // we verify the reported running version from the operator.
 func verifyVersion(cluster *fixtures.FdbCluster, expectedVersion string) {
-	Eventually(func() string {
-		return cluster.GetCluster().Status.RunningVersion
-	}).WithTimeout(10 * time.Minute).WithPolling(2 * time.Second).Should(Equal(expectedVersion))
+	Expect(cluster.WaitUntilWithForceReconcile(2, 600, func(cluster *fdbv1beta2.FoundationDBCluster) bool {
+		return cluster.Status.RunningVersion == expectedVersion
+	})).NotTo(HaveOccurred())
 }
 
 func upgradeAndVerify(cluster *fixtures.FdbCluster, expectedVersion string) {
@@ -441,25 +441,25 @@ var _ = Describe("Operator Upgrades", Label("e2e"), func() {
 			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
 
 			if !fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
-				// 3. Until we remove the partition, cluster should not have
-				//   upgraded. Keep checking for 4m. The desired behavior is that binaries
-				//   are staged but cluster is not bounced to new version.
+				// 3. Until we remove the crash loop setup, cluster should not be upgraded.
+				//    Keep checking for 4m. The desired behavior is that binaries are staged
+				//    but cluster is not restarted to new version.
 				log.Println("upgrade should not finish while sidecar process is unavailable")
 				Consistently(func() bool {
 					return fdbCluster.GetCluster().Status.RunningVersion == beforeVersion
 				}).WithTimeout(4 * time.Minute).WithPolling(2 * time.Second).Should(BeTrue())
 			} else {
-				// It should upgrade the cluster if the version is protocol compatible
+				// It should upgrade the cluster if the version is protocol compatible.
 				Eventually(func() bool {
 					return fdbCluster.GetCluster().Status.RunningVersion == targetVersion
 				}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(BeTrue())
 			}
 
 			// 4. Remove the crash-loop.
-			log.Println("Removing crash-loop from ", pickedPod.Name)
+			log.Println("Removing crash-loop from", pickedPod.Name)
 			fdbCluster.SetCrashLoopContainers(nil, false)
 
-			// 5. upgrade should proceed after we stop killing sidecar.
+			// 5. Upgrade should proceed after we stop killing the sidecar.
 			verifyVersion(fdbCluster, targetVersion)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s with crash-looping sidecar"),


### PR DESCRIPTION
# Description

Make sure we force a reconciliation after some time for the upgrade `verifyVersion` method and make sure we dump the state to make debugging easier.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran tests manually.

## Documentation

-

## Follow-up

-
