### PR TITLE
Remove the internal Pod map and use the controller runtime cache

### DIFF
--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -5018,4 +5018,52 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				},
 			}, true, false),
 	)
+
+	DescribeTable("when getting the Pod name for a Process group", func(cluster *FoundationDBCluster, processGroup *ProcessGroupStatus, expected string) {
+		Expect(processGroup.GetPodName(cluster)).To(Equal(expected))
+	}, Entry("when the process group has no prefix",
+		&FoundationDBCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "testing-cluster",
+			},
+		},
+		&ProcessGroupStatus{
+			ProcessGroupID: "storage-1",
+			ProcessClass:   ProcessClassStorage,
+		},
+		"testing-cluster-storage-1"),
+		Entry("when the process group has a prefix",
+			&FoundationDBCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-cluster",
+				},
+			},
+			&ProcessGroupStatus{
+				ProcessGroupID: "this-is-my-fancy-prefix-storage-1",
+				ProcessClass:   ProcessClassStorage,
+			},
+			"testing-cluster-storage-1"),
+		Entry("when the process group has no prefix and the process class has an underscore",
+			&FoundationDBCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-cluster",
+				},
+			},
+			&ProcessGroupStatus{
+				ProcessGroupID: "cluster-controller-1",
+				ProcessClass:   ProcessClassClusterController,
+			},
+			"testing-cluster-cluster-controller-1"),
+		Entry("when the process group has a prefix and the process class has an underscore",
+			&FoundationDBCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-cluster",
+				},
+			},
+			&ProcessGroupStatus{
+				ProcessGroupID: "this-is-my-fancy-prefix-cluster-controller-1",
+				ProcessClass:   ProcessClassClusterController,
+			},
+			"testing-cluster-cluster-controller-1"),
+	)
 })

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -74,7 +74,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 		taintKeyStarDuration := int64(20)
 		taintKeyMaintenance := "foundationdb.org/maintenance"
 		taintKeyMaintenanceDuration := int64(10)
-		var allPods []*corev1.Pod
+
 		var allPvcs *corev1.PersistentVolumeClaimList
 		var podOnTaintedNode *corev1.Pod
 		var targetPodProcessGroupID fdbv1beta2.ProcessGroupID
@@ -117,9 +117,6 @@ var _ = Describe("replace_failed_process_groups", func() {
 				processMap[fdbv1beta2.ProcessGroupID(processID)] = append(processMap[fdbv1beta2.ProcessGroupID(processID)], process)
 			}
 
-			allPods, err = clusterReconciler.PodLifecycleManager.GetPods(ctx.TODO(), clusterReconciler, cluster, internal.GetPodListOptions(cluster, "", "")...)
-			Expect(err).NotTo(HaveOccurred())
-
 			allPvcs = &corev1.PersistentVolumeClaimList{}
 			err = clusterReconciler.List(ctx.TODO(), allPvcs, internal.GetPodListOptions(cluster, "", "")...)
 			Expect(err).NotTo(HaveOccurred())
@@ -139,7 +136,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			targetPodProcessGroupID = internal.GetProcessGroupIDFromMeta(cluster, podOnTaintedNode.ObjectMeta)
 
 			// Call validateProcessGroups to set processGroupStatus to tainted condition
-			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs, logger)
+			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPvcs, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(processGroupsStatus)).To(BeNumerically(">", 4))
 			processGroup := processGroupsStatus[len(processGroupsStatus)-4]
@@ -159,7 +156,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			Expect(k8sClient.Update(ctx.TODO(), node)).NotTo(HaveOccurred())
 			log.Info("Taint node", "Node name", podOnTaintedNode.Name, "Node taints", node.Spec.Taints)
 
-			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs, logger)
+			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPvcs, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(processGroupsStatus)).To(BeNumerically(">", 4))
 			targetProcessGroupStatus := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, targetPodProcessGroupID)
@@ -183,7 +180,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			Expect(k8sClient.Update(ctx.TODO(), node)).NotTo(HaveOccurred())
 			log.Info("Taint node", "Node name", podOnTaintedNode.Name, "Node taints", node.Spec.Taints)
 
-			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs, logger)
+			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPvcs, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(processGroupsStatus)).To(BeNumerically(">", 4))
 			targetProcessGroupStatus := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, targetPodProcessGroupID)
@@ -194,7 +191,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			node.Spec.Taints = []corev1.Taint{}
 			err = k8sClient.Update(ctx.TODO(), node)
 			Expect(err).NotTo(HaveOccurred())
-			processGroupsStatus, err = validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs, logger)
+			processGroupsStatus, err = validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPvcs, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(processGroupsStatus)).To(BeNumerically(">", 4))
 			targetProcessGroupStatus = fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, targetPodProcessGroupID)
@@ -217,7 +214,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			log.Info("Taint node", "Node name", podOnTaintedNode.Name, "Node taints", node.Spec.Taints, "TaintTime", node.Spec.Taints[0].TimeAdded.Time, "Now", time.Now())
 			Expect(k8sClient.Update(ctx.TODO(), node)).NotTo(HaveOccurred())
 
-			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs, logger)
+			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPvcs, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(processGroupsStatus)).To(BeNumerically(">", 4))
 			targetProcessGroupStatus := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, targetPodProcessGroupID)
@@ -249,7 +246,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			log.Info("Taint node", "Node name", podOnTaintedNode.Name, "Node taints", node.Spec.Taints, "TaintTime", node.Spec.Taints[0].TimeAdded.Time, "Now", time.Now())
 			Expect(k8sClient.Update(ctx.TODO(), node)).NotTo(HaveOccurred())
 
-			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs, logger)
+			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPvcs, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(processGroupsStatus)).To(BeNumerically(">", 4))
 			targetProcessGroupStatus := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, targetPodProcessGroupID)
@@ -287,7 +284,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			}
 			Expect(tainted).To(Equal(int64(0)))
 
-			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPods, allPvcs, logger)
+			processGroupsStatus, err := validateProcessGroups(ctx.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPvcs, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(processGroupsStatus)).To(BeNumerically(">", 4))
 			targetProcessGroupStatus := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, targetPodProcessGroupID)
@@ -565,7 +562,11 @@ var _ = Describe("replace_failed_process_groups", func() {
 		When("multiple nodes are tainted", func() {
 			var taintedNodes []*corev1.Node
 			var setValidTaint bool
+
 			BeforeEach(func() {
+				allPods, err := clusterReconciler.PodLifecycleManager.GetPods(ctx.TODO(), clusterReconciler, cluster, internal.GetPodListOptions(cluster, "", "")...)
+				Expect(err).NotTo(HaveOccurred())
+
 				concurrentTaints := 2
 				Expect(len(allPods)).To(BeNumerically(">", concurrentTaints))
 				taintedNodesIndex := map[int]struct{}{}
@@ -628,7 +629,6 @@ var _ = Describe("replace_failed_process_groups", func() {
 				Expect(getRemovedProcessGroupIDs(cluster)).To(Equal([]fdbv1beta2.ProcessGroupID{}))
 			})
 		})
-
 	})
 
 	Context("with no missing processes", func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -70,10 +70,8 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
 
-	err := scheme.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = fdbv1beta2.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(scheme.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(fdbv1beta2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 	k8sClient = mockclient.NewMockClient(scheme.Scheme)

--- a/controllers/update_pods_test.go
+++ b/controllers/update_pods_test.go
@@ -215,10 +215,8 @@ var _ = Describe("update_pods", func() {
 		})
 
 		JustBeforeEach(func() {
-			pods, err := clusterReconciler.PodLifecycleManager.GetPods(context.TODO(), k8sClient, cluster, internal.GetPodListOptions(cluster, "", "")...)
-			Expect(err).NotTo(HaveOccurred())
-
-			updates, err = getPodsToUpdate(log, clusterReconciler, cluster, internal.CreatePodMap(cluster, pods))
+			var err error
+			updates, err = getPodsToUpdate(context.Background(), log, clusterReconciler, cluster)
 			if !expectedError {
 				Expect(err).NotTo(HaveOccurred())
 			} else {

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -226,20 +226,6 @@ func GetSidecarImage(cluster *fdbv1beta2.FoundationDBCluster, pClass fdbv1beta2.
 	return GetImage(image, imageConfigs, cluster.Spec.Version, false)
 }
 
-// CreatePodMap creates a map with the process group ID as a key and the according Pod as a value
-func CreatePodMap(cluster *fdbv1beta2.FoundationDBCluster, pods []*corev1.Pod) map[fdbv1beta2.ProcessGroupID]*corev1.Pod {
-	podProcessGroupMap := make(map[fdbv1beta2.ProcessGroupID]*corev1.Pod, len(pods))
-	for _, pod := range pods {
-		processGroupID := GetProcessGroupIDFromMeta(cluster, pod.ObjectMeta)
-		if processGroupID == "" {
-			continue
-		}
-		podProcessGroupMap[processGroupID] = pod
-	}
-
-	return podProcessGroupMap
-}
-
 // ParseProcessGroupID extracts the components of an process group ID.
 func ParseProcessGroupID(id fdbv1beta2.ProcessGroupID) (fdbv1beta2.ProcessClass, int, error) {
 	result := processGroupIDRegex.FindStringSubmatch(string(id))

--- a/internal/replacements/suite_test.go
+++ b/internal/replacements/suite_test.go
@@ -1,6 +1,11 @@
 package replacements
 
 import (
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	mockclient "github.com/FoundationDB/fdb-kubernetes-operator/mock-kubernetes-client/client"
+	"k8s.io/client-go/kubernetes/scheme"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -11,3 +16,17 @@ func TestCmd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Replacements Suite")
 }
+
+var k8sClient *mockclient.MockClient
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
+
+	Expect(scheme.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(fdbv1beta2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	k8sClient = mockclient.NewMockClient(scheme.Scheme)
+})
+
+var _ = AfterEach(func() {
+	k8sClient.Clear()
+})

--- a/pkg/podmanager/pod_lifecycle_manager.go
+++ b/pkg/podmanager/pod_lifecycle_manager.go
@@ -34,13 +34,16 @@ import (
 // PodLifecycleManager provides an abstraction around Pod management to allow
 // using intermediary controllers that will manage the Pod lifecycle.
 type PodLifecycleManager interface {
-	// GetPods lists the Pods in the cluster
+	// GetPods lists the Pods in the cluster.
 	GetPods(context.Context, client.Client, *fdbv1beta2.FoundationDBCluster, ...client.ListOption) ([]*corev1.Pod, error)
 
-	// CreatePod creates a new Pod based on a pod definition
+	// GetPod returns the Pod for this cluster with the specified name.
+	GetPod(context.Context, client.Client, *fdbv1beta2.FoundationDBCluster, string) (*corev1.Pod, error)
+
+	// CreatePod creates a new Pod based on a pod definition.
 	CreatePod(context.Context, client.Client, *corev1.Pod) error
 
-	// DeletePod deletes a Pod
+	// DeletePod deletes a Pod.
 	DeletePod(context.Context, client.Client, *corev1.Pod) error
 
 	// CanDeletePods checks whether it is safe to delete pods.
@@ -70,8 +73,7 @@ type PodLifecycleManager interface {
 // that directly creates pods.
 type StandardPodLifecycleManager struct{}
 
-// GetPods returns a list of Pods for FDB pods that have been
-// created.
+// GetPods returns a list of Pods for FDB Pods that have been created.
 func (manager StandardPodLifecycleManager) GetPods(ctx context.Context, r client.Client, cluster *fdbv1beta2.FoundationDBCluster, options ...client.ListOption) ([]*corev1.Pod, error) {
 	pods := &corev1.PodList{}
 	err := r.List(ctx, pods, options...)
@@ -97,6 +99,14 @@ func (manager StandardPodLifecycleManager) GetPods(ctx context.Context, r client
 	}
 
 	return resPods, nil
+}
+
+// GetPod returns the Pod for this cluster with the specified name.
+func (manager StandardPodLifecycleManager) GetPod(ctx context.Context, r client.Client, cluster *fdbv1beta2.FoundationDBCluster, name string) (*corev1.Pod, error) {
+	pod := &corev1.Pod{}
+	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: cluster.Namespace}, pod)
+
+	return pod, err
 }
 
 // CreatePod creates a new Pod based on a Pod definition


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1612

For large clusters it will be more efficient to use the controller-runtime cache directly instead of doing a list and then building our own cache on top of the controller-runtime cache.

## Type of change

*Please select one of the options below.*

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Discussion

This is a breaking change as we extend the `PodLifecycleManager` interface.

## Testing

Adjusted unit tests and e2e tests will be running.

## Documentation

-

## Follow-up

Could be: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1619 to make sure we reduce the number of conversions and parsing in our operator.