### PR TITLE
Update e2e README.md

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -48,7 +48,7 @@ If those tests are running on a cluster that has no chaos-mesh installed, you ca
 ### Running e2e tests in kind
 
 [kind](https://kind.sigs.k8s.io) provides an easy way to run a local Kubernetes cluster.
-The following steps assume that `kind` is already installed.
+The following steps assume that `kind` and `helm` are already installed.
 
 ```bash
 make -C e2e kind-setup


### PR DESCRIPTION
## Description

running the provided commands threw an error:

```
fdb-kubernetes-operator/e2e/scripts/setup_e2e.sh: line 74: helm: command not found
```

Installing helm in the testing machine fixed it. 

In this PR we update the docs to include this dependency.

# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation
- Other

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

## Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
