### PR TITLE
Update maintenance mode information in the update_status controller

### DIFF
--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -263,6 +263,12 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 		return status.ProcessGroups[i].ProcessGroupID < status.ProcessGroups[j].ProcessGroupID
 	})
 
+	// Update maintenance mode information in "status".
+	err = updateMaintenanceModeInfo(r, cluster, &status)
+	if err != nil {
+		return &requeue{curError: err}
+	}
+
 	cluster.Status = status
 
 	_, err = cluster.CheckReconciliation(log)
@@ -868,4 +874,35 @@ func updateFaultDomains(logger logr.Logger, processes map[fdbv1beta2.ProcessGrou
 
 		status.ProcessGroups[idx].FaultDomain = faultDomain
 	}
+}
+
+func updateMaintenanceModeInfo(r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBClusterStatus) error {
+	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r.Client)
+	if err != nil {
+		return err
+	}
+	defer adminClient.Close()
+
+	maintenanceZone, err := adminClient.GetMaintenanceZone()
+	if err != nil {
+		return err
+	}
+
+	// Cluster is not in maintenance mode.
+	if maintenanceZone == "" {
+		if cluster.Status.MaintenanceModeInfo.ZoneID != "" {
+			status.MaintenanceModeInfo = fdbv1beta2.MaintenanceModeInfo{}
+		}
+		return nil
+	}
+
+	// FDB Cluster is in maintenance mode but not due to this operator actions.
+	if maintenanceZone != cluster.Status.MaintenanceModeInfo.ZoneID {
+		if cluster.Status.MaintenanceModeInfo.ZoneID != "" {
+			status.MaintenanceModeInfo = fdbv1beta2.MaintenanceModeInfo{}
+		}
+		return nil
+	}
+
+	return nil
 }

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -150,6 +150,7 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 		status.Health.Healthy = databaseStatus.Client.DatabaseStatus.Healthy
 		status.Health.FullReplication = databaseStatus.Cluster.FullReplication
 		status.Health.DataMovementPriority = databaseStatus.Cluster.Data.MovingData.HighestPriority
+		status.MaintenanceModeInfo.ZoneID = databaseStatus.Cluster.MaintenanceZone
 	}
 
 	cluster.Status.RequiredAddresses = status.RequiredAddresses

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -22,10 +22,11 @@ package controllers
 
 import (
 	"context"
+	"time"
+
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -671,6 +672,7 @@ var _ = Describe("update_status", func() {
 		var cluster *fdbv1beta2.FoundationDBCluster
 		var err error
 		var requeue *requeue
+		var adminClient *mock.AdminClient
 
 		BeforeEach(func() {
 			cluster = internal.CreateDefaultCluster()
@@ -684,6 +686,9 @@ var _ = Describe("update_status", func() {
 			generation, err := reloadCluster(cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(generation).To(Equal(int64(1)))
+
+			adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		JustBeforeEach(func() {
@@ -725,6 +730,7 @@ var _ = Describe("update_status", func() {
 					Expect(cluster.Status.MaintenanceModeInfo).To(Equal(fdbv1beta2.MaintenanceModeInfo{ZoneID: "operator-test-1-storage-4"}))
 				})
 			})
+		})
 	})
 
 	DescribeTable("when getting the running version from the running processes", func(versionMap map[string]int, fallback string, expected string) {

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -715,6 +715,16 @@ var _ = Describe("update_status", func() {
 				})
 			})
 		})
+
+		Context("testing maintenance mode functionality", func() {
+			When("maintenance mode is on", func() {
+				BeforeEach(func() {
+					Expect(adminClient.SetMaintenanceZone("operator-test-1-storage-4", 0)).NotTo(HaveOccurred())
+				})
+				It("status maintenance zone should match", func() {
+					Expect(cluster.Status.MaintenanceModeInfo).To(Equal(fdbv1beta2.MaintenanceModeInfo{ZoneID: "operator-test-1-storage-4"}))
+				})
+			})
 	})
 
 	DescribeTable("when getting the running version from the running processes", func(versionMap map[string]int, fallback string, expected string) {


### PR DESCRIPTION
# Description

Make "update_status" reconciler to also update maintenance mode information in cluster status.

## Type of change

*Please select one of the options below.*

- Other (re-organizes code; likely we will need to revisit the logic in the maintenance_mode reconciler)

## Discussion

*Are there any design details that you would like to discuss further?*

As mentioned above, it is likely we will need to revisit the logic in the maintenance_mode reconciler.

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

CI will run the operator unit tests.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

Yes, nightly operator regression tests.

## Documentation

*Did you update relevant documentation within this repository?*

No.

*If this change is adding new functionality, do we need to describe it in our user manual?*

Not sure (this PR is providing the functionality that is needed in order to implement the CanI sub-system).

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

No (maybe at a later point).

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

No (maybe at a later point).

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

As mentioned above, we will likely need to revisit the logic in the maintenance_mode reconciler.

*Does this introduce new defaults that we should re-evaluate in the future?*

Not sure.
