### PR TITLE
Initial support for three data hall replication

### DIFF
--- a/api/v1beta2/foundationdb_database_configuration_test.go
+++ b/api/v1beta2/foundationdb_database_configuration_test.go
@@ -158,6 +158,42 @@ var _ = Describe("DatabaseConfiguration", func() {
 		})
 	})
 
+	When("a three_data_hall cluster with the default values is provided", func() {
+		var cluster *FoundationDBCluster
+
+		BeforeEach(func() {
+			cluster = &FoundationDBCluster{
+				Spec: FoundationDBClusterSpec{
+					Version:  "7.1.33",
+					DataHall: "az1",
+					ProcessCounts: ProcessCounts{
+						Stateless: -1,
+					},
+					DatabaseConfiguration: DatabaseConfiguration{
+						StorageEngine:  StorageEngineSSD,
+						RedundancyMode: RedundancyModeThreeDataHall,
+						UsableRegions:  1,
+					},
+				},
+			}
+		})
+
+		When("getting the default process counts", func() {
+			var err error
+			var counts ProcessCounts
+
+			BeforeEach(func() {
+				counts, err = cluster.GetProcessCountsWithDefaults()
+			})
+
+			It("It should calculate the default process counts", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(counts.Log).To(BeNumerically("==", 6)) // 4 required + 2 additional
+				Expect(counts.Storage).To(BeNumerically("==", 5))
+			})
+		})
+	})
+
 	When("using ProcessCounts", func() {
 		When("calculating the total number of processes", func() {
 			var counts ProcessCounts

--- a/api/v1beta2/foundationdb_labels.go
+++ b/api/v1beta2/foundationdb_labels.go
@@ -72,6 +72,10 @@ const (
 	// the zone ID.
 	FDBLocalityZoneIDKey = "zoneid"
 
+	// FDBLocalityMachineIDKey represents the key in the locality map that holds
+	// the machine ID.
+	FDBLocalityMachineIDKey = "machineid"
+
 	// FDBLocalityDCIDKey represents the key in the locality map that holds
 	// the DC ID.
 	FDBLocalityDCIDKey = "dcid"
@@ -86,4 +90,12 @@ const (
 
 	// FDBLocalityExclusionPrefix represents the exclusion prefix for locality based exclusions.
 	FDBLocalityExclusionPrefix = "locality_instance_id"
+
+	// FDBLocalityDataHallKey represents the key in the locality map that holds
+	// the data hall.
+	FDBLocalityDataHallKey = "data_hall"
+
+	// FDBLocalityDCIDlKey represents the key in the locality map that holds
+	// the data center ID.
+	FDBLocalityDCIDlKey = "dcid"
 )

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1268,7 +1268,7 @@ func (cluster *FoundationDBCluster) GetProcessSettings(processClass ProcessClass
 // The default Storage value will be 2F + 1, where F is the cluster's fault
 // tolerance.
 //
-// The default Logs value will be 3.
+// The default Logs value will be 3 or 4 for three_data_hall.
 //
 // The default Proxies value will be 3.
 //
@@ -1430,10 +1430,9 @@ func (cluster *FoundationDBCluster) MinimumFaultDomains() int {
 	return MinimumFaultDomains(cluster.Spec.DatabaseConfiguration.RedundancyMode)
 }
 
-// DesiredCoordinatorCount returns the number of coordinators to recruit for
-// a cluster.
+// DesiredCoordinatorCount returns the number of coordinators to recruit for a cluster.
 func (cluster *FoundationDBCluster) DesiredCoordinatorCount() int {
-	if cluster.Spec.DatabaseConfiguration.UsableRegions > 1 {
+	if cluster.Spec.DatabaseConfiguration.UsableRegions > 1 || cluster.Spec.DatabaseConfiguration.RedundancyMode == RedundancyModeThreeDataHall {
 		return 9
 	}
 

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -10355,6 +10355,7 @@ spec:
                     - single
                     - double
                     - triple
+                    - three_data_hall
                     maxLength: 100
                     type: string
                   regions:
@@ -14090,6 +14091,7 @@ spec:
                     - single
                     - double
                     - triple
+                    - three_data_hall
                     maxLength: 100
                     type: string
                   regions:

--- a/config/tests/three_data_hall/Readme.md
+++ b/config/tests/three_data_hall/Readme.md
@@ -1,0 +1,21 @@
+# Three-Data-hall example
+
+This example requires that your Kubernetes cluster has nodes which are labeled with `topology.kubernetes.io/zone`.
+The example requires at least 3 unique zones, those can be faked for testing, by adding the labels to a node.
+If you want to use cloud provider specific zone label values you can set the `AZ1`, `AZ2` and `AZ3` environment variables.
+
+## Create the Three-Data-Hall cluster
+
+This will bring up a FDB cluster using the three-data-hall redundancy mode.
+
+```bash
+./create.bash
+```
+
+## Delete
+
+This will remove all created resources:
+
+```bash
+./delete.bash
+```

--- a/config/tests/three_data_hall/create.bash
+++ b/config/tests/three_data_hall/create.bash
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# This directory provides an example of creating a cluster using the three_data_hall
+# replication topology.
+#
+# This example is built for local testing, so it will create all of the Pods
+# within a single Kubernetes cluster, but will give false locality information for the zones
+# to make the processes believe they are in different locations.
+#
+# You can use this script to bootstrap the cluster. Once it finishes, you can
+# make changes to the cluster by editing the final.yaml file and running the
+# apply.bash script. You can clean up the clusters by running the delete.bash
+# script.
+DIR="${BASH_SOURCE%/*}"
+
+. $DIR/functions.bash
+
+AZ1=${AZ1:-"az1"}
+AZ2=${AZ2:-"az2"}
+AZ3=${AZ3:-"az3"}
+
+applyFile "${DIR}/stage_1.yaml" "${AZ1}" '""'
+checkReconciliationLoop test-cluster-${AZ1}
+connectionString=$(getConnectionString test-cluster-${AZ1})
+
+applyFile "${DIR}/final.yaml" "${AZ1}" "${connectionString}"
+applyFile "${DIR}/final.yaml" ${AZ2} "${connectionString}"
+applyFile "${DIR}/final.yaml" ${AZ3} "${connectionString}"
+
+checkReconciliationLoop test-cluster-${AZ1}
+checkReconciliationLoop test-cluster-${AZ2}
+checkReconciliationLoop test-cluster-${AZ3}

--- a/config/tests/three_data_hall/delete.bash
+++ b/config/tests/three_data_hall/delete.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eu
+
+kubectl delete fdb -l cluster-group=test-cluster

--- a/config/tests/three_data_hall/final.yaml
+++ b/config/tests/three_data_hall/final.yaml
@@ -1,0 +1,40 @@
+# This file provides an example of a cluster you can run in a local testing
+# environment to create a simulation of a three_data_hall cluster.
+#
+# This requires variables to be interpolated for $az and $connectionString
+apiVersion: apps.foundationdb.org/v1beta2
+kind: FoundationDBCluster
+metadata:
+  labels:
+    cluster-group: test-cluster
+  name: test-cluster-$az
+spec:
+  version: 7.1.26
+  faultDomain:
+    key: foundationdb.org/none
+  processGroupIDPrefix: $az
+  dataHall: $az
+  processCounts:
+    stateless: -1
+  seedConnectionString: $connectionString
+  databaseConfiguration:
+    redundancy_mode: "three_data_hall"
+  processes:
+    general:
+      customParameters:
+      - "knob_disable_posix_kernel_aio=1"
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: "16G"
+      podTemplate:
+        spec:
+          nodeSelector:
+            "topology.kubernetes.io/zone": "$az"
+          containers:
+            - name: foundationdb
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 128Mi

--- a/config/tests/three_data_hall/functions.bash
+++ b/config/tests/three_data_hall/functions.bash
@@ -1,0 +1,29 @@
+function applyFile() {
+	az=${2}
+
+	az="${az}" connectionString="${3}" envsubst < "${1}"| kubectl apply -f -
+}
+
+function checkReconciliation() {
+	clusterName=$1
+
+	generationsOutput=$(kubectl get fdb "${clusterName}" -o jsonpath='{.metadata.generation} {.status.generations.reconciled}')
+	read -ra generations <<< "${generationsOutput}"
+	if [[ ("${#generations[@]}" -ge 2) && ("${generations[0]}" == "${generations[1]}") ]]; then
+		return 1
+	else
+		echo "Latest generations for $clusterName: $generationsOutput"
+		return 0
+	fi
+}
+
+function getConnectionString() {
+	kubectl get fdb "${1}" -o jsonpath='{.status.connectionString}'
+}
+
+function checkReconciliationLoop() {
+	while checkReconciliation "${1}" ; do
+		echo "Waiting for reconciliation"
+		sleep 5
+	done
+}

--- a/config/tests/three_data_hall/stage_1.yaml
+++ b/config/tests/three_data_hall/stage_1.yaml
@@ -1,0 +1,40 @@
+# This file provides an example of a cluster you can run in a local testing
+# environment to create a simulation of a three_data_hall cluster.
+#
+# This requires variables to be interpolated for $az and $connectionString
+apiVersion: apps.foundationdb.org/v1beta2
+kind: FoundationDBCluster
+metadata:
+  labels:
+    cluster-group: test-cluster
+  name: test-cluster-$az
+spec:
+  version: 7.1.26
+  faultDomain:
+    key: foundationdb.org/none
+  processGroupIDPrefix: $az
+  dataHall: $az
+  processCounts:
+    stateless: -1
+  seedConnectionString: $connectionString
+  databaseConfiguration:
+    redundancy_mode: "triple"
+  processes:
+    general:
+      customParameters:
+      - "knob_disable_posix_kernel_aio=1"
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: "16G"
+      podTemplate:
+        spec:
+          nodeSelector:
+            "topology.kubernetes.io/zone": "$az"
+          containers:
+            - name: foundationdb
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 128Mi

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -157,13 +157,11 @@ func selectCoordinators(logger logr.Logger, cluster *fdbv1beta2.FoundationDBClus
 		return []locality.Info{}, err
 	}
 
-	hardLimits := locality.GetHardLimits(cluster)
-
 	coordinators, err := locality.ChooseDistributedProcesses(cluster, candidates, coordinatorCount, locality.ProcessSelectionConstraint{
 		HardLimits: locality.GetHardLimits(cluster),
 	})
 
-	logger.Info("Current coordinators", "coordinators", coordinators, "selectedCoordinatorCount", len(coordinators), "coordinatorCount", coordinatorCount, "error", err, "hardLimits", hardLimits)
+	logger.Info("Current coordinators", "coordinators", coordinators, "error", err)
 	if err != nil {
 		return candidates, err
 	}

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -157,11 +157,13 @@ func selectCoordinators(logger logr.Logger, cluster *fdbv1beta2.FoundationDBClus
 		return []locality.Info{}, err
 	}
 
+	hardLimits := locality.GetHardLimits(cluster)
+
 	coordinators, err := locality.ChooseDistributedProcesses(cluster, candidates, coordinatorCount, locality.ProcessSelectionConstraint{
-		HardLimits: locality.GetHardLimits(cluster),
+		HardLimits: hardLimits,
 	})
 
-	logger.Info("Current coordinators", "coordinators", coordinators, "coordinatorCount", coordinatorCount)
+	logger.Info("Current coordinators", "coordinators", coordinators, "selectedCoordinatorCount", len(coordinators), "coordinatorCount", coordinatorCount, "error", err, "hardLimits", hardLimits)
 	if err != nil {
 		return candidates, err
 	}

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -160,7 +160,7 @@ func selectCoordinators(logger logr.Logger, cluster *fdbv1beta2.FoundationDBClus
 	hardLimits := locality.GetHardLimits(cluster)
 
 	coordinators, err := locality.ChooseDistributedProcesses(cluster, candidates, coordinatorCount, locality.ProcessSelectionConstraint{
-		HardLimits: hardLimits,
+		HardLimits: locality.GetHardLimits(cluster),
 	})
 
 	logger.Info("Current coordinators", "coordinators", coordinators, "selectedCoordinatorCount", len(coordinators), "coordinatorCount", coordinatorCount, "error", err, "hardLimits", hardLimits)

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -161,7 +161,7 @@ func selectCoordinators(logger logr.Logger, cluster *fdbv1beta2.FoundationDBClus
 		HardLimits: locality.GetHardLimits(cluster),
 	})
 
-	logger.Info("Current coordinators", "coordinators", coordinators)
+	logger.Info("Current coordinators", "coordinators", coordinators, "coordinatorCount", coordinatorCount)
 	if err != nil {
 		return candidates, err
 	}

--- a/controllers/change_coordinators_test.go
+++ b/controllers/change_coordinators_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Change coordinators", func() {
 			})
 		})
 
-		When("Using a HA clusters", func() {
+		FWhen("Using a HA clusters", func() {
 			var status *fdbv1beta2.FoundationDBStatus
 			var candidates []locality.Info
 			var excludes []string

--- a/controllers/change_coordinators_test.go
+++ b/controllers/change_coordinators_test.go
@@ -247,11 +247,9 @@ var _ = Describe("Change coordinators", func() {
 				var err error
 				status, err = adminClient.GetStatus()
 				Expect(err).NotTo(HaveOccurred())
-
-				// generate status for 2 dcs and 1 sate
 				status.Cluster.Processes = generateProcessInfoForMultiRegion(dcCnt, satCnt, excludes)
 
-				candidates, err = selectCoordinators(logr.Discard(), cluster, status)
+				candidates, err = selectCoordinators(testLogger, cluster, status)
 				if shouldFail {
 					Expect(err).To(HaveOccurred())
 				} else {
@@ -805,9 +803,7 @@ func generateProcessInfoForMultiRegion(dcCount int, satCount int, excludes []str
 	}
 
 	for i := 0; i < satCount; i++ {
-		dcid := fmt.Sprintf("sat%d", i)
-
-		generateProcessInfoDetails(res, dcid, "", logCnt, excludes, fdbv1beta2.ProcessClassLog)
+		generateProcessInfoDetails(res, fmt.Sprintf("sat%d", i), "", logCnt, excludes, fdbv1beta2.ProcessClassLog)
 	}
 
 	return res

--- a/controllers/change_coordinators_test.go
+++ b/controllers/change_coordinators_test.go
@@ -241,8 +241,9 @@ var _ = Describe("Change coordinators", func() {
 
 			JustBeforeEach(func() {
 				cluster.Spec.DatabaseConfiguration.UsableRegions = 2
-				cluster.Spec.DataCenter = "primary"
+				cluster.Spec.DataCenter = "dc0"
 				cluster.Spec.ProcessGroupsToRemove = removals
+				setDatabaseConfiguration(cluster, satCnt)
 
 				var err error
 				status, err = adminClient.GetStatus()
@@ -868,5 +869,73 @@ func generateProcessInfoDetails(res map[fdbv1beta2.ProcessGroupID]fdbv1beta2.Fou
 		}
 
 		res[fdbv1beta2.ProcessGroupID(zoneID)] = processInfo
+	}
+}
+
+func setDatabaseConfiguration(cluster *fdbv1beta2.FoundationDBCluster, satCnt int) {
+	if satCnt == 1 {
+		cluster.Spec.DatabaseConfiguration.Regions = []fdbv1beta2.Region{
+			{
+				DataCenters: []fdbv1beta2.DataCenter{
+					{
+						ID: "dc0",
+					},
+					{
+						ID:        "sat0",
+						Satellite: 1,
+					},
+					{
+						ID:        "dc1",
+						Satellite: 1,
+						Priority:  1,
+					},
+				},
+			},
+			{
+				DataCenters: []fdbv1beta2.DataCenter{
+					{
+						ID: "dc1",
+					},
+					{
+						ID:        "sat0",
+						Satellite: 1,
+					},
+					{
+						ID:        "dc0",
+						Satellite: 1,
+						Priority:  1,
+					},
+				},
+			},
+		}
+		return
+	}
+
+	if satCnt == 2 {
+		cluster.Spec.DatabaseConfiguration.Regions = []fdbv1beta2.Region{
+			{
+				DataCenters: []fdbv1beta2.DataCenter{
+					{
+						ID: "dc0",
+					},
+					{
+						ID:        "sat0",
+						Satellite: 1,
+					},
+				},
+			},
+			{
+				DataCenters: []fdbv1beta2.DataCenter{
+					{
+						ID:       "dc1",
+						Priority: 1,
+					},
+					{
+						ID:        "sat1",
+						Satellite: 1,
+					},
+				},
+			},
+		}
 	}
 }

--- a/controllers/change_coordinators_test.go
+++ b/controllers/change_coordinators_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Change coordinators", func() {
 			})
 		})
 
-		FWhen("Using a HA clusters", func() {
+		When("Using a HA clusters", func() {
 			var status *fdbv1beta2.FoundationDBStatus
 			var candidates []locality.Info
 			var excludes []string

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -22,6 +22,7 @@ package controllers
 
 import (
 	"context"
+	"github.com/go-logr/logr"
 	"testing"
 	"time"
 
@@ -67,9 +68,11 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "FDB Controllers")
 }
 
+var testLogger logr.Logger
+
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
-
+	testLogger = logf.Log
 	Expect(scheme.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(fdbv1beta2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 

--- a/internal/locality/locality.go
+++ b/internal/locality/locality.go
@@ -148,7 +148,7 @@ type ProcessSelectionConstraint struct {
 
 // ChooseDistributedProcesses recruits a maximally well-distributed set
 // of processes from a set of potential candidates.
-func gChooseDistributedProcesses(cluster *fdbv1beta2.FoundationDBCluster, processes []Info, count int, constraint ProcessSelectionConstraint) ([]Info, error) {
+func ChooseDistributedProcesses(cluster *fdbv1beta2.FoundationDBCluster, processes []Info, count int, constraint ProcessSelectionConstraint) ([]Info, error) {
 	chosen := make([]Info, 0, count)
 	chosenIDs := make(map[string]bool, count)
 

--- a/internal/locality/locality.go
+++ b/internal/locality/locality.go
@@ -148,7 +148,7 @@ type ProcessSelectionConstraint struct {
 
 // ChooseDistributedProcesses recruits a maximally well-distributed set
 // of processes from a set of potential candidates.
-func ChooseDistributedProcesses(cluster *fdbv1beta2.FoundationDBCluster, processes []Info, count int, constraint ProcessSelectionConstraint) ([]Info, error) {
+func gChooseDistributedProcesses(cluster *fdbv1beta2.FoundationDBCluster, processes []Info, count int, constraint ProcessSelectionConstraint) ([]Info, error) {
 	chosen := make([]Info, 0, count)
 	chosenIDs := make(map[string]bool, count)
 
@@ -258,7 +258,6 @@ func GetHardLimits(cluster *fdbv1beta2.FoundationDBCluster) map[string]int {
 	}
 
 	maxCoordinatorsPerDC := int(math.Ceil(float64(cluster.DesiredCoordinatorCount()) / float64(cluster.Spec.DatabaseConfiguration.CountUniqueDataCenters())))
-
 	return map[string]int{
 		fdbv1beta2.FDBLocalityDCIDKey:   maxCoordinatorsPerDC,
 		fdbv1beta2.FDBLocalityZoneIDKey: 1,

--- a/internal/locality/locality.go
+++ b/internal/locality/locality.go
@@ -155,6 +155,9 @@ func ChooseDistributedProcesses(cluster *fdbv1beta2.FoundationDBCluster, process
 	fields := constraint.Fields
 	if len(fields) == 0 {
 		fields = []string{fdbv1beta2.FDBLocalityZoneIDKey, fdbv1beta2.FDBLocalityDCIDKey}
+		if cluster.Spec.DatabaseConfiguration.RedundancyMode == fdbv1beta2.RedundancyModeThreeDataHall {
+			fields = append(fields, fdbv1beta2.FDBLocalityDataHallKey)
+		}
 	}
 
 	chosenCounts := make(map[string]map[string]int, len(fields))
@@ -230,19 +233,34 @@ func ChooseDistributedProcesses(cluster *fdbv1beta2.FoundationDBCluster, process
 		}
 	}
 
+	if len(chosen) != count {
+		return chosen, notEnoughProcessesError{Desired: count, Chosen: len(chosen), Options: processes}
+	}
+
 	return chosen, nil
 }
 
 // GetHardLimits returns the distribution of localities.
 func GetHardLimits(cluster *fdbv1beta2.FoundationDBCluster) map[string]int {
 	if cluster.Spec.DatabaseConfiguration.UsableRegions <= 1 {
+		if cluster.Spec.DatabaseConfiguration.RedundancyMode == fdbv1beta2.RedundancyModeThreeDataHall {
+			return map[string]int{
+				// Assumption here is that we have 3 data halls and we want to spread the coordinators
+				// equally across those 3 data halls.
+				fdbv1beta2.FDBLocalityDataHallKey: 3,
+				fdbv1beta2.FDBLocalityZoneIDKey:   1,
+			}
+		}
+
 		return map[string]int{fdbv1beta2.FDBLocalityZoneIDKey: 1}
 	}
 
-	// TODO (johscheuer): should we calculate that based on the number of DCs?
-	maxCoordinatorsPerDC := int(math.Floor(float64(cluster.DesiredCoordinatorCount()) / 2.0))
+	maxCoordinatorsPerDC := int(math.Ceil(float64(cluster.DesiredCoordinatorCount()) / float64(cluster.Spec.DatabaseConfiguration.CountUniqueDataCenters())))
 
-	return map[string]int{fdbv1beta2.FDBLocalityZoneIDKey: 1, fdbv1beta2.FDBLocalityDCIDKey: maxCoordinatorsPerDC}
+	return map[string]int{
+		fdbv1beta2.FDBLocalityZoneIDKey: 1,
+		fdbv1beta2.FDBLocalityDCIDKey:   maxCoordinatorsPerDC,
+	}
 }
 
 // CheckCoordinatorValidity determines if the cluster's current coordinators

--- a/internal/locality/locality.go
+++ b/internal/locality/locality.go
@@ -243,6 +243,8 @@ func ChooseDistributedProcesses(cluster *fdbv1beta2.FoundationDBCluster, process
 // GetHardLimits returns the distribution of localities.
 func GetHardLimits(cluster *fdbv1beta2.FoundationDBCluster) map[string]int {
 	if cluster.Spec.DatabaseConfiguration.UsableRegions <= 1 {
+		// For the three_data_hall redundancy mode we will recruit 9 coordinators and those hard limits are only used
+		// for selecting coordinators. We want to make sure we select coordinators across as many fault domains as possible.
 		if cluster.Spec.DatabaseConfiguration.RedundancyMode == fdbv1beta2.RedundancyModeThreeDataHall {
 			return map[string]int{
 				// Assumption here is that we have 3 data halls and we want to spread the coordinators
@@ -258,8 +260,8 @@ func GetHardLimits(cluster *fdbv1beta2.FoundationDBCluster) map[string]int {
 	maxCoordinatorsPerDC := int(math.Ceil(float64(cluster.DesiredCoordinatorCount()) / float64(cluster.Spec.DatabaseConfiguration.CountUniqueDataCenters())))
 
 	return map[string]int{
-		fdbv1beta2.FDBLocalityZoneIDKey: 1,
 		fdbv1beta2.FDBLocalityDCIDKey:   maxCoordinatorsPerDC,
+		fdbv1beta2.FDBLocalityZoneIDKey: 1,
 	}
 }
 

--- a/internal/locality/locality_test.go
+++ b/internal/locality/locality_test.go
@@ -813,6 +813,40 @@ var _ = Describe("Localities", func() {
 		Context("with multiple regions", func() {
 			BeforeEach(func() {
 				cluster.Spec.DatabaseConfiguration.UsableRegions = 2
+				cluster.Spec.DatabaseConfiguration.Regions = []fdbv1beta2.Region{
+					{
+						DataCenters: []fdbv1beta2.DataCenter{
+							{
+								ID: "dc1",
+							},
+							{
+								ID:        "dc2",
+								Satellite: 1,
+							},
+							{
+								ID:        "dc3",
+								Satellite: 1,
+								Priority:  1,
+							},
+						},
+					},
+					{
+						DataCenters: []fdbv1beta2.DataCenter{
+							{
+								ID: "dc3",
+							},
+							{
+								ID:        "dc2",
+								Satellite: 1,
+							},
+							{
+								ID:        "dc1",
+								Satellite: 1,
+								Priority:  1,
+							},
+						},
+					},
+				}
 
 				status.Cluster.Processes["4"] = generateDummyProcessInfo("test-4", "dc2", 4501, false)
 				status.Cluster.Processes["5"] = generateDummyProcessInfo("test-5", "dc2", 4501, false)
@@ -884,6 +918,7 @@ var _ = Describe("Localities", func() {
 						}
 					}
 				})
+
 				It("should report the coordinators as not valid", func() {
 					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
 					Expect(coordinatorsValid).To(BeFalse())

--- a/internal/locality/locality_test.go
+++ b/internal/locality/locality_test.go
@@ -913,8 +913,8 @@ var _ = Describe("Localities", func() {
 			Context("with coordinators divided across two DCs", func() {
 				BeforeEach(func() {
 					for _, process := range status.Cluster.Processes {
-						if process.Locality["dcid"] == "dc3" {
-							process.Locality["dcid"] = "dc1"
+						if process.Locality[fdbv1beta2.FDBLocalityDCIDlKey] == "dc3" {
+							process.Locality[fdbv1beta2.FDBLocalityDCIDlKey] = "dc1"
 						}
 					}
 				})

--- a/internal/locality/locality_test.go
+++ b/internal/locality/locality_test.go
@@ -116,7 +116,7 @@ func generateDefaultStatus(tls bool) *fdbv1beta2.FoundationDBStatus {
 	}
 }
 
-var _ = Describe("Change coordinators", func() {
+var _ = Describe("Localities", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
 
 	BeforeEach(func() {
@@ -359,17 +359,87 @@ var _ = Describe("Change coordinators", func() {
 				fdbv1beta2.FDBLocalityZoneIDKey: 1,
 			},
 		),
-		Entry("default cluster with two usable regiosn",
+		Entry("default cluster with two usable regions and 4 DCs",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
 					DatabaseConfiguration: fdbv1beta2.DatabaseConfiguration{
 						UsableRegions: 2,
+						Regions: []fdbv1beta2.Region{
+							{
+								DataCenters: []fdbv1beta2.DataCenter{
+									{
+										ID: "dc1",
+									},
+									{
+										ID: "dc2",
+									},
+								},
+							},
+							{
+								DataCenters: []fdbv1beta2.DataCenter{
+									{
+										ID: "dc3",
+									},
+									{
+										ID: "dc4",
+									},
+								},
+							},
+						},
 					},
 				},
 			},
 			map[string]int{
 				fdbv1beta2.FDBLocalityZoneIDKey: 1,
-				fdbv1beta2.FDBLocalityDCIDKey:   4,
+				fdbv1beta2.FDBLocalityDCIDKey:   3,
+			},
+		),
+		Entry("default cluster with two usable regions and 3 DCs",
+			&fdbv1beta2.FoundationDBCluster{
+				Spec: fdbv1beta2.FoundationDBClusterSpec{
+					DatabaseConfiguration: fdbv1beta2.DatabaseConfiguration{
+						UsableRegions: 2,
+						Regions: []fdbv1beta2.Region{
+							{
+								DataCenters: []fdbv1beta2.DataCenter{
+									{
+										ID: "dc1",
+									},
+									{
+										ID: "dc2",
+									},
+								},
+							},
+							{
+								DataCenters: []fdbv1beta2.DataCenter{
+									{
+										ID: "dc3",
+									},
+									{
+										ID: "dc2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			map[string]int{
+				fdbv1beta2.FDBLocalityZoneIDKey: 1,
+				fdbv1beta2.FDBLocalityDCIDKey:   3,
+			},
+		),
+		Entry("default cluster with one usable region and three data hall",
+			&fdbv1beta2.FoundationDBCluster{
+				Spec: fdbv1beta2.FoundationDBClusterSpec{
+					DatabaseConfiguration: fdbv1beta2.DatabaseConfiguration{
+						RedundancyMode: fdbv1beta2.RedundancyModeThreeDataHall,
+					},
+				},
+			},
+			map[string]int{
+				fdbv1beta2.FDBLocalityDataHallKey: 3,
+				fdbv1beta2.FDBLocalityZoneIDKey:   1,
 			},
 		),
 	)


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/348

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

When running a FoundationDB cluster on public cloud providers it can be useful to use three data hall as redundancy more and spread Pods across multiple availability zones. So far the operator was not supporting this mode. Now the operator supports this mode with minimal code changes, the drawback is, that a user has to create 3 `FoundationDBCluster` resources.

## Testing

I did some manual testing:

```bash
$ kubectl get fdb,po 

NAME                                                                GENERATION   RECONCILED   AVAILABLE   FULLREPLICATION   VERSION   AGE
foundationdbcluster.apps.foundationdb.org/test-cluster-us-west-2a   2            2            true        true              7.1.26    8m49s
foundationdbcluster.apps.foundationdb.org/test-cluster-us-west-2b   1            1             true        true              7.1.26    5m58s
foundationdbcluster.apps.foundationdb.org/test-cluster-us-west-2c   1            1            true        true              7.1.26    5m54s

NAME                                                              READY   STATUS    RESTARTS   AGE
pod/fdb-kubernetes-operator-controller-manager-7c55d7786c-424nj   1/1     Running   0          9m2s
pod/fdb-kubernetes-operator-controller-manager-7c55d7786c-929kw   1/1     Running   0          9m12s
pod/grafana-74f64cbb9f-rpdhs                                      1/1     Running   0          38d
pod/test-cluster-us-west-2a-log-1                                 2/2     Running   0          8m41s
pod/test-cluster-us-west-2a-log-2                                 2/2     Running   0          8m41s
pod/test-cluster-us-west-2a-log-3                                 2/2     Running   0          8m41s
pod/test-cluster-us-west-2a-log-4                                 2/2     Running   0          8m41s
pod/test-cluster-us-west-2a-log-5                                 2/2     Running   0          8m41s
pod/test-cluster-us-west-2a-log-6                                 2/2     Running   0          6m3s
pod/test-cluster-us-west-2a-storage-1                             2/2     Running   0          8m41s
pod/test-cluster-us-west-2a-storage-2                             2/2     Running   0          8m41s
pod/test-cluster-us-west-2a-storage-3                             2/2     Running   0          8m41s
pod/test-cluster-us-west-2a-storage-4                             2/2     Running   0          8m41s
pod/test-cluster-us-west-2a-storage-5                             2/2     Running   0          8m41s
pod/test-cluster-us-west-2b-log-1                                 2/2     Running   0          5m59s
pod/test-cluster-us-west-2b-log-2                                 2/2     Running   0          5m59s
pod/test-cluster-us-west-2b-log-3                                 2/2     Running   0          5m59s
pod/test-cluster-us-west-2b-log-4                                 2/2     Running   0          5m59s
pod/test-cluster-us-west-2b-log-5                                 2/2     Running   0          5m59s
pod/test-cluster-us-west-2b-log-6                                 2/2     Running   0          5m59s
pod/test-cluster-us-west-2b-storage-1                             2/2     Running   0          5m59s
pod/test-cluster-us-west-2b-storage-2                             2/2     Running   0          5m59s
pod/test-cluster-us-west-2b-storage-3                             2/2     Running   0          5m59s
pod/test-cluster-us-west-2b-storage-4                             2/2     Running   0          5m59s
pod/test-cluster-us-west-2b-storage-5                             2/2     Running   0          5m59s
pod/test-cluster-us-west-2c-log-1                                 2/2     Running   0          5m55s
pod/test-cluster-us-west-2c-log-2                                 2/2     Running   0          5m55s
pod/test-cluster-us-west-2c-log-3                                 2/2     Running   0          5m55s
pod/test-cluster-us-west-2c-log-4                                 2/2     Running   0          5m55s
pod/test-cluster-us-west-2c-log-5                                 2/2     Running   0          5m55s
pod/test-cluster-us-west-2c-log-6                                 2/2     Running   0          5m55s
pod/test-cluster-us-west-2c-storage-1                             2/2     Running   0          5m55s
pod/test-cluster-us-west-2c-storage-2                             2/2     Running   0          5m55s
pod/test-cluster-us-west-2c-storage-3                             2/2     Running   0          5m55s
pod/test-cluster-us-west-2c-storage-4                             2/2     Running   0          5m55s
pod/test-cluster-us-west-2c-storage-5                             2/2     Running   0          5m55s
```

and `fdbcli` show the correct config:

```bash
fdb> status

Using cluster file `/var/dynamic-conf/fdb.cluster'.

Configuration:
  Redundancy mode        - three_data_hall
  Storage engine         - ssd-2
  Coordinators           - 9
  Desired Commit Proxies - 2
  Desired GRV Proxies    - 1
  Desired Resolvers      - 1
  Desired Logs           - 4
  Desired Remote Logs    - -1
  Desired Log Routers    - -1
  Usable Regions         - 1

Cluster:
  FoundationDB processes - 33
  Zones                  - 33
  Machines               - 33
  Memory availability    - 8.0 GB per process on machine with least available
  Fault Tolerance        - 2 machines
  Server time            - 05/30/23 11:41:30

Data:
  Replication health     - Healthy
  Moving data            - 0.000 GB
  Sum of key-value sizes - 0 MB
  Disk space used        - 1.993 GB

Operating space:
  Storage server         - 14.9 GB free on most full server
  Log server             - 14.9 GB free on most full server

Workload:
  Read rate              - 16 Hz
  Write rate             - 0 Hz
  Transactions started   - 17 Hz
  Transactions committed - 1 Hz
  Conflict rate          - 0 Hz

Backup and DR:
  Running backups        - 0
  Running DRs            - 0

Client time: 05/30/23 11:41:30
```

## Documentation

Added to this PR.

## Follow-up

We can improve the three data hall setup in the future to only require one single `FoundationDBCluster` resource, but that will require additional changes in the operator.

As a follow up we could think about adding support for three_data_center as well. Based on my current understanding those modes are similar.