### PR TITLE
Take maintenance mode into account while choosing coordinators and read maintenance mode information from special key space

### DIFF
--- a/api/v1beta2/foundationdb_status.go
+++ b/api/v1beta2/foundationdb_status.go
@@ -134,6 +134,8 @@ type FoundationDBStatusProcessInfo struct {
 	// Excluded indicates whether the process has been excluded.
 	Excluded bool `json:"excluded,omitempty"`
 
+	UnderMaintenance bool `json:"under_maintenance,omitempty"`
+
 	// The locality information for the process.
 	Locality map[string]string `json:"locality,omitempty"`
 

--- a/api/v1beta2/foundationdb_status.go
+++ b/api/v1beta2/foundationdb_status.go
@@ -134,6 +134,7 @@ type FoundationDBStatusProcessInfo struct {
 	// Excluded indicates whether the process has been excluded.
 	Excluded bool `json:"excluded,omitempty"`
 
+	// Indicates that the process is in maintenance zone.
 	UnderMaintenance bool `json:"under_maintenance,omitempty"`
 
 	// The locality information for the process.

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -123,7 +123,7 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 func selectCandidates(cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus) ([]locality.Info, error) {
 	candidates := make([]locality.Info, 0, len(status.Cluster.Processes))
 	for _, process := range status.Cluster.Processes {
-		if process.Excluded {
+		if process.Excluded || process.UnderMaintenance {
 			continue
 		}
 

--- a/controllers/change_coordinators_test.go
+++ b/controllers/change_coordinators_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Change coordinators", func() {
 				})
 			})
 
-			FWhen("maintenance mode is on", func() {
+			When("maintenance mode is on", func() {
 				BeforeEach(func() {
 					Expect(adminClient.SetMaintenanceZone("operator-test-1-storage-1", 0)).NotTo(HaveOccurred())
 				})

--- a/controllers/change_coordinators_test.go
+++ b/controllers/change_coordinators_test.go
@@ -203,6 +203,23 @@ var _ = Describe("Change coordinators", func() {
 					}
 				})
 			})
+
+			FWhen("maintenance mode is on", func() {
+				BeforeEach(func() {
+					Expect(adminClient.SetMaintenanceZone("operator-test-1-storage-1", 0)).NotTo(HaveOccurred())
+				})
+
+				It("should not select processes from the maintenance zone", func() {
+					Expect(cluster.DesiredCoordinatorCount()).To(BeNumerically("==", 3))
+					Expect(len(candidates)).To(BeNumerically("==", cluster.DesiredCoordinatorCount()))
+
+					// Should select storage processes only.
+					for _, candidate := range candidates {
+						Expect(candidate.ID).NotTo(Equal("storage-1"))
+						Expect(strings.HasPrefix(candidate.ID, "storage")).To(BeTrue())
+					}
+				})
+			})
 		})
 
 		When("Using a HA clusters", func() {

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1108,7 +1108,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	})
 
 	Context("testing maintenance mode functionality", func() {
-		When("maintenance mode is on", func() {
+		PWhen("maintenance mode is on", func() {
 			BeforeEach(func() {
 				command := fmt.Sprintf("maintenance on %s %s", "operator-test-1-storage-4", "0")
 				_, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(command, false, 40)

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -392,12 +392,11 @@ func (client *cliAdminClient) ConfigureDatabase(configuration fdbv1beta2.Databas
 
 // GetMaintenanceZone gets current maintenance zone, if any. Returns empty string if maintenance mode is off
 func (client *cliAdminClient) GetMaintenanceZone() (string, error) {
-	// TODO: Use special keyspace to just read the maintenance zone info instead of reading the whole status
-	status, err := client.GetStatus()
+	maint, err := client.fdbLibClient.getValueFromDBUsingKey("\xff/maintenance", DefaultCLITimeout)
 	if err != nil {
 		return "", err
 	}
-	return status.Cluster.MaintenanceZone, nil
+	return string(maint), nil
 }
 
 // SetMaintenanceZone places zone into maintenance mode

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -397,7 +397,6 @@ func (client *cliAdminClient) GetMaintenanceZone() (string, error) {
 		return "", err
 	}
 	return string(mode), nil
-	//return string(status.Cluster.MaintenanceZone), nil
 }
 
 // SetMaintenanceZone places zone into maintenance mode

--- a/internal/locality/locality.go
+++ b/internal/locality/locality.go
@@ -341,7 +341,7 @@ func CheckCoordinatorValidity(logger logr.Logger, cluster *fdbv1beta2.Foundation
 			coordinatorAddress = dnsAddress.String()
 		}
 
-		if coordinatorAddress != "" && !process.Excluded && !pendingRemoval {
+		if coordinatorAddress != "" && !process.Excluded && !pendingRemoval && !process.UnderMaintenance {
 			coordinatorStatus[coordinatorAddress] = true
 		}
 

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -226,8 +226,7 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 
 			var uptimeSeconds float64 = 60000
 			underMaintenance := false
-      if string(client.MaintenanceZone) == locality[fdbv1beta2.FDBLocalityZoneIDKey] || client.MaintenanceZone == "simulation" {
-			//if string(client.MaintenanceZone) == locality[fdbv1beta2.FDBLocalityZoneIDKey] || client.MaintenanceZone == "simulation" {
+			if string(client.MaintenanceZone) == locality[fdbv1beta2.FDBLocalityZoneIDKey] || client.MaintenanceZone == "simulation" {
 				if client.uptimeSecondsForMaintenanceZone != 0.0 {
 					uptimeSeconds = client.uptimeSecondsForMaintenanceZone
 				} else {
@@ -293,8 +292,7 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 
 		var uptimeSeconds float64 = 60000
 		underMaintenance := false
-    if string(client.MaintenanceZone) == locality[fdbv1beta2.FDBLocalityZoneIDKey] || client.MaintenanceZone == "simulation" {
-		//if string(client.MaintenanceZone) == locality[fdbv1beta2.FDBLocalityZoneIDKey] || client.MaintenanceZone == "simulation" {
+		if string(client.MaintenanceZone) == locality[fdbv1beta2.FDBLocalityZoneIDKey] || client.MaintenanceZone == "simulation" {
 			if client.uptimeSecondsForMaintenanceZone != 0.0 {
 				uptimeSeconds = client.uptimeSecondsForMaintenanceZone
 			} else {


### PR DESCRIPTION
# Description

Extend the logic that selects/verifies the validity of current coordinators to take maintenance mode information into account.

Read maintenance mode information from special keyspace.

## Type of change

- Other (extends the existing functionality)

## Discussion

*Are there any design details that you would like to discuss further?*

No.

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

Ran the test, locally, that has been added in this PR.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

Yes (nightly regression tests will need to be run).

## Documentation

*Did you update relevant documentation within this repository?*

No.

*If this change is adding new functionality, do we need to describe it in our user manual?*

Maybe (at a later point).

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

No (maybe at a later point).

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

N/A (I think).

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.
