### PR TITLE
Add the current running node for a Pod into the Pod annotations

### DIFF
--- a/api/v1beta2/foundationdb_labels.go
+++ b/api/v1beta2/foundationdb_labels.go
@@ -45,6 +45,10 @@ const (
 	// IP for a pod.
 	PublicIPAnnotation = "foundationdb.org/public-ip"
 
+	// NodeAnnotation is an annotation key that specifies where a Pod is currently running on.
+	// The information is fetched from Pod.Spec.NodeName of the Pod resource.
+	NodeAnnotation = "foundationdb.org/current-node"
+
 	// FDBProcessGroupIDLabel represents the label that is used to represent a instance ID
 	FDBProcessGroupIDLabel = "foundationdb.org/fdb-process-group-id"
 

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -141,7 +141,7 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 		removeIncompatibleProcesses{},
 		updateSidecarVersions{},
 		updatePodConfig{},
-		updateLabels{},
+		updateMetadata{},
 		updateDatabaseConfiguration{},
 		chooseRemovals{},
 		excludeProcesses{},

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1302,16 +1302,18 @@ var _ = Describe("cluster_controller", func() {
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
 							fdbv1beta2.LastConfigMapKey:            configMapHash,
 							fdbv1beta2.LastSpecKey:                 hash,
-							"foundationdb.org/public-ip-source":    "pod",
+							fdbv1beta2.PublicIPSourceAnnotation:    "pod",
 							"foundationdb.org/existing-annotation": "test-value",
 							"fdb-annotation":                       "value1",
+							fdbv1beta2.NodeAnnotation:              item.Spec.NodeName,
 						}))
 					} else {
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
 							fdbv1beta2.LastConfigMapKey:         configMapHash,
 							fdbv1beta2.LastSpecKey:              hash,
-							"foundationdb.org/public-ip-source": "pod",
+							fdbv1beta2.PublicIPSourceAnnotation: "pod",
 							"fdb-annotation":                    "value1",
+							fdbv1beta2.NodeAnnotation:           item.Spec.NodeName,
 						}))
 					}
 				}
@@ -1440,7 +1442,8 @@ var _ = Describe("cluster_controller", func() {
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
 							fdbv1beta2.LastConfigMapKey:         configMapHash,
 							fdbv1beta2.LastSpecKey:              hash,
-							"foundationdb.org/public-ip-source": "pod",
+							fdbv1beta2.PublicIPSourceAnnotation: "pod",
+							fdbv1beta2.NodeAnnotation:           item.Spec.NodeName,
 						}))
 					}
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1300,18 +1300,18 @@ var _ = Describe("cluster_controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 					if item.Labels[fdbv1beta2.FDBProcessGroupIDLabel] == "storage-1" {
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-							"foundationdb.org/last-applied-config-map": configMapHash,
-							"foundationdb.org/last-applied-spec":       hash,
-							"foundationdb.org/public-ip-source":        "pod",
-							"foundationdb.org/existing-annotation":     "test-value",
-							"fdb-annotation":                           "value1",
+							fdbv1beta2.LastConfigMapKey:            configMapHash,
+							fdbv1beta2.LastSpecKey:                 hash,
+							"foundationdb.org/public-ip-source":    "pod",
+							"foundationdb.org/existing-annotation": "test-value",
+							"fdb-annotation":                       "value1",
 						}))
 					} else {
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-							"foundationdb.org/last-applied-config-map": configMapHash,
-							"foundationdb.org/last-applied-spec":       hash,
-							"foundationdb.org/public-ip-source":        "pod",
-							"fdb-annotation":                           "value1",
+							fdbv1beta2.LastConfigMapKey:         configMapHash,
+							fdbv1beta2.LastSpecKey:              hash,
+							"foundationdb.org/public-ip-source": "pod",
+							"fdb-annotation":                    "value1",
 						}))
 					}
 				}
@@ -1323,7 +1323,7 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 				for _, item := range pvcs.Items {
 					Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-						"foundationdb.org/last-applied-spec": "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
+						fdbv1beta2.LastSpecKey: "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
 					}))
 				}
 
@@ -1408,12 +1408,12 @@ var _ = Describe("cluster_controller", func() {
 							Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
 								"fdb-annotation":                       "value1",
 								"foundationdb.org/existing-annotation": "test-value",
-								"foundationdb.org/last-applied-spec":   "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
+								fdbv1beta2.LastSpecKey:                 "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
 							}))
 						} else {
 							Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-								"fdb-annotation":                     "value1",
-								"foundationdb.org/last-applied-spec": "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
+								"fdb-annotation":       "value1",
+								fdbv1beta2.LastSpecKey: "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
 							}))
 
 						}
@@ -1438,9 +1438,9 @@ var _ = Describe("cluster_controller", func() {
 						configMapHash, err := getConfigMapHash(cluster, internal.GetProcessClassFromMeta(cluster, item.ObjectMeta), &item)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-							"foundationdb.org/last-applied-config-map": configMapHash,
-							"foundationdb.org/last-applied-spec":       hash,
-							"foundationdb.org/public-ip-source":        "pod",
+							fdbv1beta2.LastConfigMapKey:         configMapHash,
+							fdbv1beta2.LastSpecKey:              hash,
+							"foundationdb.org/public-ip-source": "pod",
 						}))
 					}
 
@@ -1546,9 +1546,10 @@ var _ = Describe("cluster_controller", func() {
 					configMapHash, err := getConfigMapHash(cluster, internal.GetProcessClassFromMeta(cluster, item.ObjectMeta), &item)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-						"foundationdb.org/last-applied-config-map": configMapHash,
-						"foundationdb.org/last-applied-spec":       hash,
-						"foundationdb.org/public-ip-source":        "pod",
+						fdbv1beta2.LastConfigMapKey:         configMapHash,
+						fdbv1beta2.LastSpecKey:              hash,
+						fdbv1beta2.PublicIPSourceAnnotation: "pod",
+						fdbv1beta2.NodeAnnotation:           item.Spec.NodeName,
 					}))
 				}
 
@@ -1557,7 +1558,7 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 				for _, item := range pvcs.Items {
 					Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-						"foundationdb.org/last-applied-spec": "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
+						fdbv1beta2.LastSpecKey: "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
 					}))
 				}
 			})

--- a/controllers/update_metadata_test.go
+++ b/controllers/update_metadata_test.go
@@ -21,15 +21,14 @@
 package controllers
 
 import (
-	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("Update labels", func() {
+var _ = FDescribe("Update metadata", func() {
 	type testCase struct {
 		pod          *corev1.Pod
 		metadata     metav1.ObjectMeta
@@ -41,27 +40,27 @@ var _ = Describe("Update labels", func() {
 		func(tc testCase) {
 			result := metadataCorrect(tc.metadata, &tc.pod.ObjectMeta)
 			Expect(result).To(Equal(tc.expected))
-			Expect(equality.Semantic.DeepEqual(tc.pod.ObjectMeta.Labels, tc.expectedMeta.Labels)).To(BeTrue())
-			Expect(equality.Semantic.DeepEqual(tc.pod.ObjectMeta.Annotations, tc.expectedMeta.Annotations)).To(BeTrue())
+			Expect(tc.pod.ObjectMeta.Labels).To(Equal(tc.expectedMeta.Labels))
+			Expect(tc.pod.ObjectMeta.Annotations).To(Equal(tc.expectedMeta.Annotations))
 		},
 		Entry("Metadata matches with Pod metadata",
 			testCase{
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbtypes.LastSpecKey: "1",
+							fdbv1beta2.LastSpecKey: "1",
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey: "1",
 					},
 				},
 				expected: true,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey: "1",
 					},
 				},
 			},
@@ -71,19 +70,19 @@ var _ = Describe("Update labels", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbtypes.LastSpecKey: "1",
+							fdbv1beta2.LastSpecKey: "1",
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "2",
+						fdbv1beta2.LastSpecKey: "2",
 					},
 				},
 				expected: true,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey: "1",
 					},
 				},
 			},
@@ -93,22 +92,22 @@ var _ = Describe("Update labels", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbtypes.LastSpecKey: "1",
-							"special":            "43",
+							fdbv1beta2.LastSpecKey: "1",
+							"special":              "43",
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
-						"special":            "42",
+						fdbv1beta2.LastSpecKey: "1",
+						"special":              "42",
 					},
 				},
 				expected: false,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
-						"special":            "42",
+						fdbv1beta2.LastSpecKey: "1",
+						"special":              "42",
 					},
 				},
 			},
@@ -118,21 +117,21 @@ var _ = Describe("Update labels", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbtypes.LastSpecKey: "1",
+							fdbv1beta2.LastSpecKey: "1",
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
-						"controller/X":       "wrong",
+						fdbv1beta2.LastSpecKey: "1",
+						"controller/X":         "wrong",
 					},
 				},
 				expected: false,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
-						"controller/X":       "wrong",
+						fdbv1beta2.LastSpecKey: "1",
+						"controller/X":         "wrong",
 					},
 				},
 			},
@@ -142,21 +141,21 @@ var _ = Describe("Update labels", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbtypes.LastSpecKey: "1",
-							"controller/X":       "wrong",
+							fdbv1beta2.LastSpecKey: "1",
+							"controller/X":         "wrong",
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey: "1",
 					},
 				},
 				expected: true,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
-						"controller/X":       "wrong",
+						fdbv1beta2.LastSpecKey: "1",
+						"controller/X":         "wrong",
 					},
 				},
 			},
@@ -166,22 +165,22 @@ var _ = Describe("Update labels", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbtypes.LastSpecKey: "1",
-							"controller/X":       "true",
+							fdbv1beta2.LastSpecKey: "1",
+							"controller/X":         "true",
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
-						"controller/X":       "wrong",
+						fdbv1beta2.LastSpecKey: "1",
+						"controller/X":         "wrong",
 					},
 				},
 				expected: false,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
-						"controller/X":       "wrong",
+						fdbv1beta2.LastSpecKey: "1",
+						"controller/X":         "wrong",
 					},
 				},
 			},
@@ -191,7 +190,7 @@ var _ = Describe("Update labels", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbtypes.LastSpecKey: "1",
+							fdbv1beta2.LastSpecKey: "1",
 						},
 						Labels: map[string]string{
 							"test": "test",
@@ -200,13 +199,13 @@ var _ = Describe("Update labels", func() {
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey: "1",
 					},
 				},
 				expected: true,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey: "1",
 					},
 					Labels: map[string]string{
 						"test": "test",
@@ -219,29 +218,56 @@ var _ = Describe("Update labels", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbtypes.LastSpecKey: "1",
+							fdbv1beta2.LastSpecKey: "1",
 						},
 						Labels: map[string]string{
-							fdbtypes.FDBProcessClassLabel: "storage",
+							fdbv1beta2.FDBProcessClassLabel: "storage",
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey: "1",
 					},
 					Labels: map[string]string{
-						fdbtypes.FDBProcessClassLabel: "log",
+						fdbv1beta2.FDBProcessClassLabel: "log",
 					},
 				},
 				expected: false,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbtypes.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey: "1",
 					},
 
 					Labels: map[string]string{
-						fdbtypes.FDBProcessClassLabel: "log",
+						fdbv1beta2.FDBProcessClassLabel: "log",
+					},
+				},
+			},
+		),
+		Entry("Metadata for a Pod running on a node",
+			testCase{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							fdbv1beta2.LastSpecKey: "1",
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "testing-node",
+					},
+				},
+				metadata: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.LastSpecKey:    "1",
+						fdbv1beta2.NodeAnnotation: "testing-node",
+					},
+				},
+				expected: false,
+				expectedMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.LastSpecKey:    "1",
+						fdbv1beta2.NodeAnnotation: "testing-node",
 					},
 				},
 			},


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1653

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

This additional information in the annotation can be used by other systems that only fetches the metadata of the Pod resources.

## Testing

Unit tests.

## Documentation

-

## Follow-up

-
