### PR TITLE
Update CronJob and PodDisruptionBudget apiVersion for K8s 1.25 

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         # With a new supported Kubernetes version we should adjust the version
         # See https://kubernetes.io/releases for the current releases
-        kubever: [ "v1.20.0", "v1.21.1", "v1.22.0", "v1.23.0" ]
+        kubever: [ "v1.21.1", "v1.22.0", "v1.23.0" ]
     steps:
     - name: Set up Go
       uses: actions/setup-go@v1

--- a/config/samples/pod_disruption_budget.yaml
+++ b/config/samples/pod_disruption_budget.yaml
@@ -1,6 +1,6 @@
 # Kubernetes won't deliberately cause an interruption to a ready storage pod if
 # that would drop the ready count below 5.
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: sample-cluster-storage
@@ -12,7 +12,7 @@ spec:
       fdb-cluster-name: sample-cluster
       fdb-process-class: storage
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: sample-cluster-log
@@ -24,7 +24,7 @@ spec:
       fdb-cluster-name: sample-cluster
       fdb-process-class: log
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: sample-cluster-transaction

--- a/docs/manual/getting_started.md
+++ b/docs/manual/getting_started.md
@@ -52,7 +52,7 @@ By default each pod will have two containers and one init container. The `founda
 Now that your cluster is deployed, you can easily access the cluster. As an example, we are going to deploy a [Kubernetes Job](https://kubernetes.io/docs/tasks/job/) that will check the status of the cluster every minute. The `cluster file` is available through the exposed `config map` that can be mounted as follows:
 
 ```yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: fdbcli-status-cronjob


### PR DESCRIPTION
# Description

Because `batch/v1beta1` and `policy/v1beta1` will be deprecated in K8s 1.25.

- Update PodDisruptionBudget apiVersion to policy/v1
- Update CronJob apiVersion to batch/v1

## Type of change

*Please select one of the options below.*

- Documentation
- Other

## Discussion

*Are there any design details that you would like to discuss further?* No

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?* 

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

## Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
