### PR TITLE
Add new method to get all process group IDs for removal

### DIFF
--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -4602,10 +4602,6 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				})
 			})
 		})
-
-		// GetProcessGroupsToRemove
-
-		// GetProcessGroupsToRemoveWithoutExclusion
 	})
 
 	When("adding a process to the removal list", func() {

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -53,10 +53,6 @@ func newAnalyzeCmd(streams genericclioptions.IOStreams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sleep, err := cmd.Root().Flags().GetUint16("sleep")
-			if err != nil {
-				return err
-			}
 			autoFix, err := cmd.Flags().GetBool("auto-fix")
 			if err != nil {
 				return err
@@ -141,7 +137,7 @@ func newAnalyzeCmd(streams genericclioptions.IOStreams) *cobra.Command {
 					errs = append(errs, err)
 				}
 
-				err = analyzeCluster(cmd, kubeClient, cluster, autoFix, wait, ignoreConditions, ignoreRemovals, sleep)
+				err = analyzeCluster(cmd, kubeClient, cluster, autoFix, wait, ignoreConditions, ignoreRemovals)
 				if err != nil {
 					errs = append(errs, err)
 				}
@@ -223,7 +219,7 @@ func allConditionsValid(conditions []string) error {
 	return fmt.Errorf(errString.String())
 }
 
-func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluster, autoFix bool, wait bool, ignoreConditions []string, ignoreRemovals bool, sleep uint16) error {
+func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluster, autoFix bool, wait bool, ignoreConditions []string, ignoreRemovals bool) error {
 	var foundIssues bool
 	cmd.Printf("Checking cluster: %s/%s\n", cluster.Namespace, cluster.Name)
 
@@ -394,7 +390,7 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1
 		confirmed := false
 
 		if len(failedProcessGroups) > 0 {
-			err := replaceProcessGroups(kubeClient, cluster.Name, failedProcessGroups, cluster.Namespace, true, wait, false, true, sleep)
+			err := replaceProcessGroups(kubeClient, cluster.Name, failedProcessGroups, cluster.Namespace, true, wait, false, true)
 			if err != nil {
 				return err
 			}

--- a/kubectl-fdb/cmd/analyze_test.go
+++ b/kubectl-fdb/cmd/analyze_test.go
@@ -107,7 +107,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 				inBuffer := bytes.Buffer{}
 
 				cmd := newAnalyzeCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer})
-				err := analyzeCluster(cmd, k8sClient, tc.cluster, tc.AutoFix, tc.NoWait, tc.IgnoredConditions, tc.IgnoreRemovals, 0)
+				err := analyzeCluster(cmd, k8sClient, tc.cluster, tc.AutoFix, tc.NoWait, tc.IgnoredConditions, tc.IgnoreRemovals)
 
 				if err != nil && !tc.HasErrors {
 					Expect(err).To(HaveOccurred())

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -65,8 +65,8 @@ var _ = Describe("[plugin] cordon command", func() {
 				errBuffer := bytes.Buffer{}
 				inBuffer := bytes.Buffer{}
 
-				cmd := newAnalyzeCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer})
-				err := cordonNode(cmd, k8sClient, input.clusterName, input.nodes, namespace, input.WithExclusion, false, 0, input.clusterLabel)
+				cmd := newCordonCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer})
+				err := cordonNode(cmd, k8sClient, input.clusterName, input.nodes, namespace, input.WithExclusion, false, input.clusterLabel)
 				Expect(err).NotTo(HaveOccurred())
 
 				clusterNames := []string{clusterName, secondClusterName}

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -60,7 +60,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 
 			DescribeTable("should cordon all targeted processes",
 				func(tc testCase) {
-					err := replaceProcessGroups(k8sClient, clusterName, tc.Instances, namespace, tc.WithExclusion, false, tc.RemoveAllFailed, false, 0)
+					err := replaceProcessGroups(k8sClient, clusterName, tc.Instances, namespace, tc.WithExclusion, false, tc.RemoveAllFailed, false)
 					Expect(err).NotTo(HaveOccurred())
 
 					var resCluster fdbv1beta2.FoundationDBCluster
@@ -117,7 +117,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				When("adding the same process group to the removal list without exclusion", func() {
 					It("should add the process group to the removal without exclusion list", func() {
 						removals := []string{"test-storage-1"}
-						err := replaceProcessGroups(k8sClient, clusterName, removals, namespace, false, false, false, false, 0)
+						err := replaceProcessGroups(k8sClient, clusterName, removals, namespace, false, false, false, false)
 						Expect(err).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster
@@ -137,7 +137,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				When("adding the same process group to the removal list", func() {
 					It("should add the process group to the removal without exclusion list", func() {
 						removals := []string{"test-storage-1"}
-						err := replaceProcessGroups(k8sClient, clusterName, removals, namespace, true, false, false, false, 0)
+						err := replaceProcessGroups(k8sClient, clusterName, removals, namespace, true, false, false, false)
 						Expect(err).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -53,5 +53,15 @@ func generateClusterStruct(name string, namespace string) *fdbv1beta2.Foundation
 				Storage: 1,
 			},
 		},
+		Status: fdbv1beta2.FoundationDBClusterStatus{
+			ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
+				{
+					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-instance-1"),
+				},
+				{
+					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-instance-2"),
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
# Description

This PR adds two new methods that will return the process group IDs for removal operations. The new methods will be used by the kubectl plugin but could also be used by other clients to set the `cluster.Spec.ProcessGroupsToRemove` setting (or the same for `WithoutExclusion`). The methods will return all process group IDs that are not marked for removal and will filter out process groups that are not part of the `FoundationDBCluster` status process groups or are already marked for removal. This will make sure in the long term, that the list of process groups are eventually cleaned up.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Unit tests.

## Documentation

Added documentation for the methods.

## Follow-up

-
