### PR TITLE
Initial support for cache status per reconciliation loop

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -924,6 +924,11 @@ type FoundationDBClusterAutomationOptions struct {
 	// processes.
 	KillProcesses *bool `json:"killProcesses,omitempty"`
 
+	// CacheDatabaseStatusForReconciliation defines whether the operator is using the same FoundationDB machine-readable
+	// status for all sub-reconcilers or if the machine-readable status should be fetched by ever sub-reconciler if
+	// required. Enabling this setting might improve the operator reconciliation speed for large clusters.
+	CacheDatabaseStatusForReconciliation *bool `json:"cacheDatabaseStatusForReconciliation,omitempty"`
+
 	// Replacements contains options for automatically replacing failed
 	// processes.
 	Replacements AutomaticReplacementOptions `json:"replacements,omitempty"`
@@ -2527,4 +2532,11 @@ func (cluster *FoundationDBCluster) Validate() error {
 // if operator's TaintReplacementOptions is not set.
 func (cluster *FoundationDBCluster) IsTaintFeatureDisabled() bool {
 	return len(cluster.Spec.AutomationOptions.Replacements.TaintReplacementOptions) == 0
+}
+
+// CacheDatabaseStatusForReconciliation returns if the sub-reconcilers should use a cached machine-readable status. If
+// enabled the machine-readable status will be fetched only once per reconciliation loop and not multiple times. If the
+// value is unset the provided default value will be returned.
+func (cluster *FoundationDBCluster) CacheDatabaseStatusForReconciliation(defaultValue bool) bool {
+	return pointer.BoolDeref(cluster.Spec.AutomationOptions.CacheDatabaseStatusForReconciliation, defaultValue)
 }

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -523,6 +523,11 @@ func (in *FoundationDBClusterAutomationOptions) DeepCopyInto(out *FoundationDBCl
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CacheDatabaseStatusForReconciliation != nil {
+		in, out := &in.CacheDatabaseStatusForReconciliation, &out.CacheDatabaseStatusForReconciliation
+		*out = new(bool)
+		**out = **in
+	}
 	in.Replacements.DeepCopyInto(&out.Replacements)
 	if in.UseNonBlockingExcludes != nil {
 		in, out := &in.UseNonBlockingExcludes, &out.UseNonBlockingExcludes

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -9863,6 +9863,8 @@ spec:
             properties:
               automationOptions:
                 properties:
+                  cacheDatabaseStatusForReconciliation:
+                    type: boolean
                   configureDatabase:
                     type: boolean
                   deletionMode:

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -38,7 +38,7 @@ import (
 type addPods struct{}
 
 // reconcile runs the reconciler's work.
-func (a addPods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (a addPods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	configMap, err := internal.GetConfigMap(cluster)
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "addPods")
 	if err != nil {

--- a/controllers/add_pods_test.go
+++ b/controllers/add_pods_test.go
@@ -62,7 +62,7 @@ var _ = Describe("add_pods", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = addPods{}.reconcile(context.TODO(), clusterReconciler, cluster)
+		requeue = addPods{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -37,7 +37,7 @@ import (
 type addProcessGroups struct{}
 
 // reconcile runs the reconciler's work.
-func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	desiredCountStruct, err := cluster.GetProcessCountsWithDefaults()
 	if err != nil {
 		return &requeue{curError: err}

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -54,7 +54,7 @@ var _ = Describe("add_process_groups", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = addProcessGroups{}.reconcile(context.TODO(), clusterReconciler, cluster)
+		requeue = addProcessGroups{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 		if requeue != nil {
 			Expect(requeue.curError).NotTo(HaveOccurred())
 		}

--- a/controllers/add_pvcs.go
+++ b/controllers/add_pvcs.go
@@ -37,7 +37,7 @@ import (
 type addPVCs struct{}
 
 // reconcile runs the reconciler's work.
-func (a addPVCs) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (a addPVCs) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "addPVCs")
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.IsMarkedForRemoval() {

--- a/controllers/add_pvcs_test.go
+++ b/controllers/add_pvcs_test.go
@@ -61,7 +61,7 @@ var _ = Describe("add_pvcs", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = addPVCs{}.reconcile(context.TODO(), clusterReconciler, cluster)
+		requeue = addPVCs{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -39,7 +39,7 @@ import (
 type addServices struct{}
 
 // reconcile runs the reconciler's work.
-func (a addServices) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (a addServices) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "addServices")
 	service := internal.GetHeadlessService(cluster)
 	if service != nil {

--- a/controllers/add_services_test.go
+++ b/controllers/add_services_test.go
@@ -63,7 +63,7 @@ var _ = Describe("add_services", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = addServices{}.reconcile(context.TODO(), clusterReconciler, cluster)
+		requeue = addServices{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/add_services_test.go
+++ b/controllers/add_services_test.go
@@ -22,8 +22,9 @@ package controllers
 
 import (
 	"context"
-	"k8s.io/utils/pointer"
 	"sort"
+
+	"k8s.io/utils/pointer"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 

--- a/controllers/bounce_processes_test.go
+++ b/controllers/bounce_processes_test.go
@@ -56,7 +56,7 @@ var _ = Describe("bounceProcesses", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = bounceProcesses{}.reconcile(context.TODO(), clusterReconciler, cluster)
+		requeue = bounceProcesses{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 	})
 
 	Context("with a reconciled cluster", func() {

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -37,7 +37,7 @@ import (
 type changeCoordinators struct{}
 
 // reconcile runs the reconciler's work.
-func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "changeCoordinators")
 
 	if !cluster.Status.Configured {
@@ -50,9 +50,12 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 	}
 	defer adminClient.Close()
 
-	status, err := adminClient.GetStatus()
-	if err != nil {
-		return &requeue{curError: err, delayedRequeue: true}
+	// If the status is not cached, we have to fetch it.
+	if status == nil {
+		status, err = adminClient.GetStatus()
+		if err != nil {
+			return &requeue{curError: err}
+		}
 	}
 
 	if status.Cluster.ConnectionString != cluster.Status.ConnectionString {

--- a/controllers/change_coordinators_test.go
+++ b/controllers/change_coordinators_test.go
@@ -623,7 +623,7 @@ var _ = Describe("Change coordinators", func() {
 		})
 
 		JustBeforeEach(func() {
-			requeue = changeCoordinators{}.reconcile(context.TODO(), clusterReconciler, cluster)
+			requeue = changeCoordinators{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 		})
 
 		When("the cluster is healthy", func() {

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -56,7 +56,7 @@ var _ = Describe("choose_removals", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = chooseRemovals{}.reconcile(context.TODO(), clusterReconciler, cluster)
+		requeue = chooseRemovals{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -94,6 +94,11 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 	}
 
 	clusterLog := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name)
+	// Printout the duration of the reconciliation, independent if the reconciliation was successful or had an error.
+	startTime := time.Now()
+	defer func() {
+		clusterLog.Info("Reconciliation run finished", "duration", time.Since(startTime).String())
+	}()
 
 	if cluster.Spec.Skip {
 		clusterLog.Info("Skipping cluster with skip value true", "skip", cluster.Spec.Skip)
@@ -168,12 +173,6 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 	originalGeneration := cluster.ObjectMeta.Generation
 	normalizedSpec := cluster.Spec.DeepCopy()
 	delayedRequeue := false
-
-	// Printout the duration of the reconciliation, independent if the reconciliation was successful or had an error.
-	startTime := time.Now()
-	defer func() {
-		clusterLog.Info("Reconciliation run finished", "duration", time.Since(startTime).String())
-	}()
 
 	for _, subReconciler := range subReconcilers {
 		// We have to set the normalized spec here again otherwise any call to Update() for the status of the cluster

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -49,18 +49,19 @@ import (
 // FoundationDBClusterReconciler reconciles a FoundationDBCluster object
 type FoundationDBClusterReconciler struct {
 	client.Client
-	Recorder                           record.EventRecorder
-	Log                                logr.Logger
-	InSimulation                       bool
-	EnableRestartIncompatibleProcesses bool
-	ServerSideApply                    bool
-	EnableRecoveryState                bool
-	PodLifecycleManager                podmanager.PodLifecycleManager
-	PodClientProvider                  func(*fdbv1beta2.FoundationDBCluster, *corev1.Pod) (podclient.FdbPodClient, error)
-	DatabaseClientProvider             fdbadminclient.DatabaseClientProvider
-	DeprecationOptions                 internal.DeprecationOptions
-	GetTimeout                         time.Duration
-	PostTimeout                        time.Duration
+	Recorder                                    record.EventRecorder
+	Log                                         logr.Logger
+	InSimulation                                bool
+	EnableRestartIncompatibleProcesses          bool
+	ServerSideApply                             bool
+	EnableRecoveryState                         bool
+	CacheDatabaseStatusForReconciliationDefault bool
+	PodLifecycleManager                         podmanager.PodLifecycleManager
+	PodClientProvider                           func(*fdbv1beta2.FoundationDBCluster, *corev1.Pod) (podclient.FdbPodClient, error)
+	DatabaseClientProvider                      fdbadminclient.DatabaseClientProvider
+	DeprecationOptions                          internal.DeprecationOptions
+	GetTimeout                                  time.Duration
+	PostTimeout                                 time.Duration
 }
 
 // NewFoundationDBClusterReconciler creates a new FoundationDBClusterReconciler with defaults.
@@ -125,6 +126,16 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 		return ctrl.Result{}, fmt.Errorf("ClusterSpec is not valid: %w", err)
 	}
 
+	var status *fdbv1beta2.FoundationDBStatus
+	cacheStatus := cluster.CacheDatabaseStatusForReconciliation(r.CacheDatabaseStatusForReconciliationDefault)
+	if cacheStatus {
+		clusterLog.Info("Fetch machine-readable status for reconcilitation loop", "cacheStatus", cacheStatus)
+		status, err = r.getStatusFromClusterOrDummyStatus(clusterLog, cluster)
+		if err != nil {
+			return ctrl.Result{Requeue: true}, err
+		}
+	}
+
 	subReconcilers := []clusterSubReconciler{
 		updateStatus{},
 		updateLockConfiguration{},
@@ -158,13 +169,19 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 	normalizedSpec := cluster.Spec.DeepCopy()
 	delayedRequeue := false
 
+	// Printout the duration of the reconciliation, independent if the reconciliation was successful or had an error.
+	startTime := time.Now()
+	defer func() {
+		clusterLog.Info("Reconciliation run finished", "duration", time.Since(startTime).String())
+	}()
+
 	for _, subReconciler := range subReconcilers {
 		// We have to set the normalized spec here again otherwise any call to Update() for the status of the cluster
 		// will reset all normalized fields...
 		cluster.Spec = *(normalizedSpec.DeepCopy())
 		clusterLog.Info("Attempting to run sub-reconciler", "subReconciler", fmt.Sprintf("%T", subReconciler))
 
-		requeue := subReconciler.reconcile(ctx, r, cluster)
+		requeue := subReconciler.reconcile(ctx, r, cluster, status)
 		if requeue == nil {
 			continue
 		}
@@ -371,7 +388,7 @@ type clusterSubReconciler interface {
 	If reconciliation cannot proceed, this should return a requeue object with
 	a `Message` field.
 	*/
-	reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue
+	reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus) *requeue
 }
 
 // newFdbPodClient builds a client for working with an FDB Pod
@@ -411,4 +428,48 @@ func (r *FoundationDBClusterReconciler) updateOrApply(ctx context.Context, clust
 	}
 
 	return r.Status().Update(ctx, cluster)
+}
+
+// getStatusFromClusterOrDummyStatus will fetch the machine-readable status from the FoundationDBCluster if the cluster is configured. If not a default status is returned indicating, that
+// some configuration is missing.
+func (r *FoundationDBClusterReconciler) getStatusFromClusterOrDummyStatus(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster) (*fdbv1beta2.FoundationDBStatus, error) {
+	if cluster.Status.ConnectionString == "" {
+		return &fdbv1beta2.FoundationDBStatus{
+			Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+				Layers: fdbv1beta2.FoundationDBStatusLayerInfo{
+					Error: "configurationMissing",
+				},
+			},
+		}, nil
+	}
+
+	connectionString, err := tryConnectionOptions(logger, cluster, r)
+	if err != nil {
+		return nil, err
+	}
+	cluster.Status.ConnectionString = connectionString
+
+	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
+	if err != nil {
+		return nil, err
+	}
+
+	defer adminClient.Close()
+
+	status, err := adminClient.GetStatus()
+	if err == nil {
+		return status, nil
+	}
+
+	if cluster.Status.Configured {
+		return nil, err
+	}
+
+	return &fdbv1beta2.FoundationDBStatus{
+		Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+			Layers: fdbv1beta2.FoundationDBStatusLayerInfo{
+				Error: "configurationMissing",
+			},
+		},
+	}, nil
 }

--- a/controllers/delete_pods_for_buggification.go
+++ b/controllers/delete_pods_for_buggification.go
@@ -35,7 +35,7 @@ import (
 type deletePodsForBuggification struct{}
 
 // reconcile runs the reconciler's work.
-func (d deletePodsForBuggification) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (d deletePodsForBuggification) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "deletePodsForBuggification")
 	crashLoopContainerProcessGroups := cluster.GetCrashLoopContainerProcessGroups()
 

--- a/controllers/delete_pods_for_buggification_test.go
+++ b/controllers/delete_pods_for_buggification_test.go
@@ -64,7 +64,7 @@ var _ = Describe("delete_pods_for_buggification", func() {
 		err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		requeue = deletePodsForBuggification{}.reconcile(context.TODO(), clusterReconciler, cluster)
+		requeue = deletePodsForBuggification{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 		if requeue != nil {
 			Expect(requeue.curError).NotTo(HaveOccurred())
 		}

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -26,6 +26,8 @@ import (
 	"math"
 	"net"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal/statuschecks"
+
 	corev1 "k8s.io/api/core/v1"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
@@ -66,7 +68,7 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 	var fdbProcessesToExclude []fdbv1beta2.ProcessAddress
 	var processClassesToExclude map[fdbv1beta2.ProcessClass]fdbv1beta2.None
 	if removalCount > 0 {
-		exclusions, err := adminClient.GetExclusionsFromStatus(status)
+		exclusions, err := statuschecks.GetExclusions(status)
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -38,7 +38,7 @@ import (
 type generateInitialClusterFile struct{}
 
 // reconcile runs the reconciler's work.
-func (g generateInitialClusterFile) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (g generateInitialClusterFile) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "generateInitialClusterFile")
 	if cluster.Status.ConnectionString != "" {
 		return nil

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -23,6 +23,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 )
 

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -30,7 +30,7 @@ import (
 type maintenanceModeChecker struct{}
 
 // reconcile runs the reconciler's work.
-func (maintenanceModeChecker) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (maintenanceModeChecker) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "maintenanceModeChecker")
 
 	if !cluster.UseMaintenaceMode() {

--- a/controllers/maintenance_mode_checker_test.go
+++ b/controllers/maintenance_mode_checker_test.go
@@ -22,8 +22,9 @@ package controllers
 
 import (
 	"context"
-	"k8s.io/utils/pointer"
 	"strings"
+
+	"k8s.io/utils/pointer"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 

--- a/controllers/maintenance_mode_checker_test.go
+++ b/controllers/maintenance_mode_checker_test.go
@@ -55,7 +55,7 @@ var _ = Describe("maintenance_mode_checker", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = maintenanceModeChecker{}.reconcile(context.TODO(), clusterReconciler, cluster)
+		requeue = maintenanceModeChecker{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/controllers/remove_incompatible_processes_test.go
+++ b/controllers/remove_incompatible_processes_test.go
@@ -146,7 +146,7 @@ var _ = Describe("restart_incompatible_pods", func() {
 		})
 
 		JustBeforeEach(func() {
-			err := processIncompatibleProcesses(context.TODO(), clusterReconciler, logr.Discard(), cluster)
+			err := processIncompatibleProcesses(context.TODO(), clusterReconciler, logr.Discard(), cluster, nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -23,9 +23,10 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"github.com/FoundationDB/fdb-kubernetes-operator/internal/buggify"
 	"net"
 	"time"
+
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal/buggify"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal/removals"
 	"github.com/go-logr/logr"

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -23,6 +23,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
 
 	"k8s.io/utils/pointer"

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -55,7 +55,7 @@ var _ = Describe("remove_process_groups", func() {
 		})
 
 		JustBeforeEach(func() {
-			result = removeProcessGroups{}.reconcile(context.TODO(), clusterReconciler, cluster)
+			result = removeProcessGroups{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 		})
 
 		When("trying to remove a coordinator", func() {

--- a/controllers/remove_services.go
+++ b/controllers/remove_services.go
@@ -34,7 +34,7 @@ import (
 type removeServices struct{}
 
 // reconcile runs the reconciler's work.
-func (u removeServices) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (u removeServices) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "removeServices")
 	if cluster.NeedsHeadlessService() {
 		return nil

--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -22,6 +22,7 @@ package controllers
 
 import (
 	"context"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal/replacements"

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -66,7 +66,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 		Expect(adminClient).NotTo(BeNil())
 		err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		result = replaceFailedProcessGroups{}.reconcile(ctx.Background(), clusterReconciler, cluster)
+		result = replaceFailedProcessGroups{}.reconcile(ctx.Background(), clusterReconciler, cluster, nil)
 	})
 
 	Context("replace pod on tainted node", func() {
@@ -163,7 +163,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			Expect(len(targetProcessGroupStatus.ProcessGroupConditions)).To(Equal(1))
 			Expect(targetProcessGroupStatus.ProcessGroupConditions[0].ProcessGroupConditionType).To(Equal(fdbv1beta2.NodeTaintDetected))
 
-			Expect(replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster)).To(BeNil())
+			Expect(replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster, nil)).To(BeNil())
 			Expect(getRemovedProcessGroupIDs(cluster)).To(Equal([]fdbv1beta2.ProcessGroupID{}))
 		})
 
@@ -198,7 +198,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			Expect(len(targetProcessGroupStatus.ProcessGroupConditions)).To(Equal(1))
 			Expect(targetProcessGroupStatus.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(BeNil())
 
-			Expect(replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster)).To(BeNil())
+			Expect(replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster, nil)).To(BeNil())
 			Expect(getRemovedProcessGroupIDs(cluster)).To(Equal([]fdbv1beta2.ProcessGroupID{}))
 		})
 
@@ -223,11 +223,11 @@ var _ = Describe("replace_failed_process_groups", func() {
 			Expect(targetProcessGroupStatus.GetCondition(fdbv1beta2.NodeTaintReplacing).ProcessGroupConditionType).To(Equal(fdbv1beta2.NodeTaintReplacing))
 
 			// cluster won't replace a failed process until GetTaintReplacementTimeSeconds() later
-			Expect(replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster)).To(BeNil())
+			Expect(replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster, nil)).To(BeNil())
 			Expect(getRemovedProcessGroupIDs(cluster)).To(Equal([]fdbv1beta2.ProcessGroupID{}))
 
 			Eventually(func() *requeue {
-				result = replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster)
+				result = replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster, nil)
 				return result
 			}).WithTimeout(time.Duration(cluster.GetTaintReplacementTimeSeconds()*3) * time.Second).WithPolling(1 * time.Second).ShouldNot(BeNil())
 
@@ -255,7 +255,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			Expect(targetProcessGroupStatus.GetCondition(fdbv1beta2.NodeTaintReplacing).ProcessGroupConditionType).To(Equal(fdbv1beta2.NodeTaintReplacing))
 
 			Eventually(func() *requeue {
-				return replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster)
+				return replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster, nil)
 			}).WithTimeout(time.Duration(cluster.GetTaintReplacementTimeSeconds()*3) * time.Second).WithPolling(1 * time.Second).ShouldNot(BeNil())
 
 			Expect(getRemovedProcessGroupIDs(cluster)).To(Equal([]fdbv1beta2.ProcessGroupID{targetPodProcessGroupID}))
@@ -293,7 +293,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 
 			// cluster won't replace the process
 			time.Sleep(time.Second * time.Duration(cluster.GetTaintReplacementTimeSeconds()+1))
-			Expect(replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster)).To(BeNil())
+			Expect(replaceFailedProcessGroups{}.reconcile(ctx.TODO(), clusterReconciler, cluster, nil)).To(BeNil())
 			Expect(getRemovedProcessGroupIDs(cluster)).To(Equal([]fdbv1beta2.ProcessGroupID{}))
 		})
 

--- a/controllers/replace_misconfigured_process_groups.go
+++ b/controllers/replace_misconfigured_process_groups.go
@@ -36,7 +36,7 @@ import (
 type replaceMisconfiguredProcessGroups struct{}
 
 // reconcile runs the reconciler's work.
-func (c replaceMisconfiguredProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (c replaceMisconfiguredProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "replaceMisconfiguredProcessGroups")
 
 	// TODO(johscheuer): Remove the pvc map an make direct calls.

--- a/controllers/update_config_map.go
+++ b/controllers/update_config_map.go
@@ -39,7 +39,7 @@ import (
 type updateConfigMap struct{}
 
 // reconcile runs the reconciler's work.
-func (u updateConfigMap) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster) *requeue {
+func (u updateConfigMap) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster, _ *fdbtypes.FoundationDBStatus) *requeue {
 	configMap, err := internal.GetConfigMap(cluster)
 	if err != nil {
 		return &requeue{curError: err}

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -23,6 +23,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+
 	"k8s.io/utils/pointer"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"

--- a/controllers/update_lock_configuration.go
+++ b/controllers/update_lock_configuration.go
@@ -31,7 +31,7 @@ import (
 type updateLockConfiguration struct{}
 
 // reconcile runs the reconciler's work.
-func (updateLockConfiguration) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (updateLockConfiguration) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	if len(cluster.Spec.LockOptions.DenyList) == 0 || !cluster.ShouldUseLocks() || !cluster.Status.Configured {
 		return nil
 	}

--- a/controllers/update_lock_configuration_test.go
+++ b/controllers/update_lock_configuration_test.go
@@ -61,7 +61,7 @@ var _ = Describe("update_lock_configuration", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = updateLockConfiguration{}.reconcile(context.TODO(), clusterReconciler, cluster)
+		requeue = updateLockConfiguration{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 		if requeue != nil {
 			Expect(requeue.curError).NotTo(HaveOccurred())
 		}

--- a/controllers/update_metadata.go
+++ b/controllers/update_metadata.go
@@ -34,7 +34,7 @@ import (
 type updateMetadata struct{}
 
 // reconcile runs the reconciler's work.
-func (updateMetadata) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (updateMetadata) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updateMetadata")
 	// TODO(johscheuer): Remove the use of the pvc map and directly make a get request.
 	pvcs := &corev1.PersistentVolumeClaimList{}

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -38,7 +38,7 @@ import (
 type updatePodConfig struct{}
 
 // reconcile runs the reconciler's work.
-func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updatePodConfig")
 	configMap, err := internal.GetConfigMap(cluster)
 	if err != nil {

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -23,8 +23,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
 

--- a/controllers/update_pod_config_test.go
+++ b/controllers/update_pod_config_test.go
@@ -52,7 +52,7 @@ var _ = Describe("updatePodConfig", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = updatePodConfig{}.reconcile(context.TODO(), clusterReconciler, cluster)
+		requeue = updatePodConfig{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -25,9 +25,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal/statuschecks"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
-	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -38,7 +39,7 @@ import (
 type updatePods struct{}
 
 // reconcile runs the reconciler's work.
-func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
+func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updatePods")
 
 	updates, err := getPodsToUpdate(ctx, logger, r, cluster)
@@ -68,13 +69,7 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 		return nil
 	}
 
-	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r.Client)
-	if err != nil {
-		return &requeue{curError: err, delayedRequeue: true}
-	}
-	defer adminClient.Close()
-
-	return deletePodsForUpdates(ctx, r, cluster, adminClient, updates, logger)
+	return deletePodsForUpdates(ctx, r, cluster, updates, logger, status)
 }
 
 // getPodsToUpdate returns a map of Zone to Pods mapping. The map has the fault domain as key and all Pods in that fault domain will be present as a slice of *corev1.Pod.
@@ -225,14 +220,25 @@ func getPodsToDelete(deletionMode fdbv1beta2.PodUpdateMode, updates map[string][
 }
 
 // deletePodsForUpdates will delete Pods with the specified deletion mode
-func deletePodsForUpdates(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, adminClient fdbadminclient.AdminClient, updates map[string][]*corev1.Pod, logger logr.Logger) *requeue {
+func deletePodsForUpdates(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, updates map[string][]*corev1.Pod, logger logr.Logger, status *fdbv1beta2.FoundationDBStatus) *requeue {
 	deletionMode := r.PodLifecycleManager.GetDeletionMode(cluster)
 	zone, deletions, err := getPodsToDelete(deletionMode, updates)
 	if err != nil {
 		return &requeue{curError: err}
 	}
 
-	ready, err := r.PodLifecycleManager.CanDeletePods(logr.NewContext(ctx, logger), adminClient, cluster)
+	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r.Client)
+	if err != nil {
+		return &requeue{curError: err, delayedRequeue: true}
+	}
+	defer adminClient.Close()
+
+	newContext := logr.NewContext(ctx, logger)
+	if status != nil {
+		newContext = context.WithValue(ctx, statuschecks.StatusContextKey{}, status)
+	}
+
+	ready, err := r.PodLifecycleManager.CanDeletePods(newContext, adminClient, cluster)
 	if err != nil {
 		return &requeue{curError: err}
 	}

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -38,7 +38,7 @@ import (
 type updatePods struct{}
 
 // reconcile runs the reconciler's work.
-func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updatePods")
 
 	updates, err := getPodsToUpdate(ctx, logger, r, cluster)

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -38,7 +38,7 @@ import (
 type updateSidecarVersions struct{}
 
 // reconcile runs the reconciler's work.
-func (updateSidecarVersions) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (updateSidecarVersions) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updateSidecarVersions")
 	// We don't need to upgrade the sidecar if no upgrade is in progress, we can skip any further work here.
 	if !cluster.IsBeingUpgradedWithVersionIncompatibleVersion() {

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -49,55 +49,25 @@ import (
 type updateStatus struct{}
 
 // reconcile runs the reconciler's work.
-func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) *requeue {
+func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, databaseStatus *fdbv1beta2.FoundationDBStatus) *requeue {
 	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "updateStatus")
 	originalStatus := cluster.Status.DeepCopy()
-	status := fdbv1beta2.FoundationDBClusterStatus{}
+	clusterStatus := fdbv1beta2.FoundationDBClusterStatus{}
 	// Pass through Maintenance Mode Info as the maintenance_mode_checker reconciler takes care of updating it
-	originalStatus.MaintenanceModeInfo.DeepCopyInto(&status.MaintenanceModeInfo)
-	status.Generations.Reconciled = cluster.Status.Generations.Reconciled
+	originalStatus.MaintenanceModeInfo.DeepCopyInto(&clusterStatus.MaintenanceModeInfo)
+	clusterStatus.Generations.Reconciled = cluster.Status.Generations.Reconciled
 
 	// Initialize with the current desired storage servers per Pod
-	status.StorageServersPerDisk = []int{cluster.GetStorageServersPerPod()}
-	status.ImageTypes = []fdbv1beta2.ImageType{fdbv1beta2.ImageType(internal.GetDesiredImageType(cluster))}
+	clusterStatus.StorageServersPerDisk = []int{cluster.GetStorageServersPerPod()}
+	clusterStatus.ImageTypes = []fdbv1beta2.ImageType{fdbv1beta2.ImageType(internal.GetDesiredImageType(cluster))}
 
-	var databaseStatus *fdbv1beta2.FoundationDBStatus
 	processMap := make(map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessInfo)
 
-	if cluster.Status.ConnectionString == "" {
-		databaseStatus = &fdbv1beta2.FoundationDBStatus{
-			Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
-				Layers: fdbv1beta2.FoundationDBStatusLayerInfo{
-					Error: "configurationMissing",
-				},
-			},
-		}
-	} else {
-		connectionString, err := tryConnectionOptions(logger, cluster, r)
+	if databaseStatus == nil {
+		var err error
+		databaseStatus, err = r.getStatusFromClusterOrDummyStatus(logger, cluster)
 		if err != nil {
-			return &requeue{curError: err}
-		}
-		cluster.Status.ConnectionString = connectionString
-
-		adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
-		if err != nil {
-			return &requeue{curError: err}
-		}
-
-		databaseStatus, err = adminClient.GetStatus()
-		_ = adminClient.Close()
-
-		if err != nil {
-			if cluster.Status.Configured {
-				return &requeue{curError: err, delayedRequeue: true}
-			}
-			databaseStatus = &fdbv1beta2.FoundationDBStatus{
-				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
-					Layers: fdbv1beta2.FoundationDBStatusLayerInfo{
-						Error: "configurationMissing",
-					},
-				},
-			}
+			return &requeue{curError: fmt.Errorf("update_status error fetching status: %w", err)}
 		}
 	}
 
@@ -119,17 +89,17 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	}
 	cluster.Status.RunningVersion = version
 
-	status.HasListenIPsForAllPods = cluster.NeedsExplicitListenAddress()
-	status.DatabaseConfiguration = databaseStatus.Cluster.DatabaseConfiguration.NormalizeConfigurationWithSeparatedProxies(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())
+	clusterStatus.HasListenIPsForAllPods = cluster.NeedsExplicitListenAddress()
+	clusterStatus.DatabaseConfiguration = databaseStatus.Cluster.DatabaseConfiguration.NormalizeConfigurationWithSeparatedProxies(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())
 	// Removing excluded servers as we don't want them during comparison.
-	status.DatabaseConfiguration.ExcludedServers = nil
-	cluster.ClearMissingVersionFlags(&status.DatabaseConfiguration)
-	status.Configured = cluster.Status.Configured || (databaseStatus.Client.DatabaseStatus.Available && databaseStatus.Cluster.Layers.Error != "configurationMissing")
+	clusterStatus.DatabaseConfiguration.ExcludedServers = nil
+	cluster.ClearMissingVersionFlags(&clusterStatus.DatabaseConfiguration)
+	clusterStatus.Configured = cluster.Status.Configured || (databaseStatus.Client.DatabaseStatus.Available && databaseStatus.Cluster.Layers.Error != "configurationMissing")
 
 	if cluster.Spec.MainContainer.EnableTLS {
-		status.RequiredAddresses.TLS = true
+		clusterStatus.RequiredAddresses.TLS = true
 	} else {
-		status.RequiredAddresses.NonTLS = true
+		clusterStatus.RequiredAddresses.NonTLS = true
 	}
 
 	if databaseStatus != nil {
@@ -140,41 +110,41 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 			}
 
 			if address.Flags["tls"] {
-				status.RequiredAddresses.TLS = true
+				clusterStatus.RequiredAddresses.TLS = true
 			} else {
-				status.RequiredAddresses.NonTLS = true
+				clusterStatus.RequiredAddresses.NonTLS = true
 			}
 		}
 
-		status.Health.Available = databaseStatus.Client.DatabaseStatus.Available
-		status.Health.Healthy = databaseStatus.Client.DatabaseStatus.Healthy
-		status.Health.FullReplication = databaseStatus.Cluster.FullReplication
-		status.Health.DataMovementPriority = databaseStatus.Cluster.Data.MovingData.HighestPriority
-		status.MaintenanceModeInfo.ZoneID = databaseStatus.Cluster.MaintenanceZone
+		clusterStatus.Health.Available = databaseStatus.Client.DatabaseStatus.Available
+		clusterStatus.Health.Healthy = databaseStatus.Client.DatabaseStatus.Healthy
+		clusterStatus.Health.FullReplication = databaseStatus.Cluster.FullReplication
+		clusterStatus.Health.DataMovementPriority = databaseStatus.Cluster.Data.MovingData.HighestPriority
+		clusterStatus.MaintenanceModeInfo.ZoneID = databaseStatus.Cluster.MaintenanceZone
 	}
 
-	cluster.Status.RequiredAddresses = status.RequiredAddresses
+	cluster.Status.RequiredAddresses = clusterStatus.RequiredAddresses
 
 	configMap, err := internal.GetConfigMap(cluster)
 	if err != nil {
 		return &requeue{curError: fmt.Errorf("update_status skipped due to error in GetConfigMap: %w", err)}
 	}
 
-	status.ProcessGroups = make([]*fdbv1beta2.ProcessGroupStatus, 0, len(cluster.Status.ProcessGroups))
+	clusterStatus.ProcessGroups = make([]*fdbv1beta2.ProcessGroupStatus, 0, len(cluster.Status.ProcessGroups))
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup != nil && processGroup.ProcessGroupID != "" {
-			status.ProcessGroups = append(status.ProcessGroups, processGroup)
+			clusterStatus.ProcessGroups = append(clusterStatus.ProcessGroups, processGroup)
 		}
 	}
 
-	updateFaultDomains(logger, processMap, &status)
+	updateFaultDomains(logger, processMap, &clusterStatus)
 
-	pvcs, err := refreshProcessGroupStatus(ctx, r, cluster, &status)
+	pvcs, err := refreshProcessGroupStatus(ctx, r, cluster, &clusterStatus)
 	if err != nil {
 		return &requeue{curError: fmt.Errorf("update_status skipped due to error in refreshProcessGroupStatus: %w", err)}
 	}
 
-	status.ProcessGroups, err = validateProcessGroups(ctx, r, cluster, &status, processMap, configMap, pvcs, logger)
+	clusterStatus.ProcessGroups, err = validateProcessGroups(ctx, r, cluster, &clusterStatus, processMap, configMap, pvcs, logger)
 	if err != nil {
 		return &requeue{curError: fmt.Errorf("update_status skipped due to error in validateProcessGroups: %w", err)}
 	}
@@ -182,34 +152,34 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	existingConfigMap := &corev1.ConfigMap{}
 	err = r.Get(ctx, types.NamespacedName{Namespace: configMap.Namespace, Name: configMap.Name}, existingConfigMap)
 	if err != nil && k8serrors.IsNotFound(err) {
-		status.HasIncorrectConfigMap = true
+		clusterStatus.HasIncorrectConfigMap = true
 	} else if err != nil {
 		return &requeue{curError: err}
 	}
 
-	status.RunningVersion = cluster.Status.RunningVersion
+	clusterStatus.RunningVersion = cluster.Status.RunningVersion
 
-	if status.RunningVersion == "" {
+	if clusterStatus.RunningVersion == "" {
 		version, present := existingConfigMap.Data["running-version"]
 		if present {
-			status.RunningVersion = version
+			clusterStatus.RunningVersion = version
 		}
 	}
 
-	if status.RunningVersion == "" {
-		status.RunningVersion = cluster.Spec.Version
+	if clusterStatus.RunningVersion == "" {
+		clusterStatus.RunningVersion = cluster.Spec.Version
 	}
 
-	status.ConnectionString = cluster.Status.ConnectionString
-	if status.ConnectionString == "" {
-		status.ConnectionString = existingConfigMap.Data[internal.ClusterFileKey]
+	clusterStatus.ConnectionString = cluster.Status.ConnectionString
+	if clusterStatus.ConnectionString == "" {
+		clusterStatus.ConnectionString = existingConfigMap.Data[internal.ClusterFileKey]
 	}
 
-	if status.ConnectionString == "" {
-		status.ConnectionString = cluster.Spec.SeedConnectionString
+	if clusterStatus.ConnectionString == "" {
+		clusterStatus.ConnectionString = cluster.Spec.SeedConnectionString
 	}
 
-	status.HasIncorrectConfigMap = status.HasIncorrectConfigMap || !equality.Semantic.DeepEqual(existingConfigMap.Data, configMap.Data) || !metadataMatches(existingConfigMap.ObjectMeta, configMap.ObjectMeta)
+	clusterStatus.HasIncorrectConfigMap = clusterStatus.HasIncorrectConfigMap || !equality.Semantic.DeepEqual(existingConfigMap.Data, configMap.Data) || !metadataMatches(existingConfigMap.ObjectMeta, configMap.ObjectMeta)
 
 	service := internal.GetHeadlessService(cluster)
 	existingService := &corev1.Service{}
@@ -220,9 +190,9 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 		return &requeue{curError: err}
 	}
 
-	status.HasIncorrectServiceConfig = (service == nil) != (existingService == nil)
+	clusterStatus.HasIncorrectServiceConfig = (service == nil) != (existingService == nil)
 
-	if status.Configured && cluster.Status.ConnectionString != "" {
+	if clusterStatus.Configured && cluster.Status.ConnectionString != "" {
 		coordinatorStatus := make(map[string]bool, len(databaseStatus.Client.Coordinators.Coordinators))
 		for _, coordinator := range databaseStatus.Client.Coordinators.Coordinators {
 			coordinatorStatus[coordinator.Address.String()] = false
@@ -233,10 +203,10 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 			return &requeue{curError: err, delayedRequeue: true}
 		}
 
-		status.NeedsNewCoordinators = !coordinatorsValid
+		clusterStatus.NeedsNewCoordinators = !coordinatorsValid
 	}
 
-	if len(cluster.Spec.LockOptions.DenyList) > 0 && cluster.ShouldUseLocks() && status.Configured {
+	if len(cluster.Spec.LockOptions.DenyList) > 0 && cluster.ShouldUseLocks() && clusterStatus.Configured {
 		lockClient, err := r.getLockClient(cluster)
 		if err != nil {
 			return &requeue{curError: err}
@@ -248,23 +218,23 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 		if len(denyList) == 0 {
 			denyList = nil
 		}
-		status.Locks.DenyList = denyList
+		clusterStatus.Locks.DenyList = denyList
 	}
 
 	// Sort slices that are assembled based on pods to prevent a reordering from
 	// issuing a new reconcile loop.
-	sort.Ints(status.StorageServersPerDisk)
-	sort.Slice(status.ImageTypes, func(i int, j int) bool {
-		return string(status.ImageTypes[i]) < string(status.ImageTypes[j])
+	sort.Ints(clusterStatus.StorageServersPerDisk)
+	sort.Slice(clusterStatus.ImageTypes, func(i int, j int) bool {
+		return string(clusterStatus.ImageTypes[i]) < string(clusterStatus.ImageTypes[j])
 	})
 
 	// Sort ProcessGroups by ProcessGroupID otherwise this can result in an endless loop when the
 	// order changes.
-	sort.SliceStable(status.ProcessGroups, func(i, j int) bool {
-		return status.ProcessGroups[i].ProcessGroupID < status.ProcessGroups[j].ProcessGroupID
+	sort.SliceStable(clusterStatus.ProcessGroups, func(i, j int) bool {
+		return clusterStatus.ProcessGroups[i].ProcessGroupID < clusterStatus.ProcessGroups[j].ProcessGroupID
 	})
 
-	cluster.Status = status
+	cluster.Status = clusterStatus
 
 	_, err = cluster.CheckReconciliation(log)
 	if err != nil {
@@ -273,11 +243,11 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 
 	// See: https://github.com/kubernetes-sigs/kubebuilder/issues/592
 	// If we use the default reflect.DeepEqual method it will be recreating the
-	// status multiple times because the pointers are different.
+	// clusterStatus multiple times because the pointers are different.
 	if !equality.Semantic.DeepEqual(cluster.Status, *originalStatus) {
 		err = r.updateOrApply(ctx, cluster)
 		if err != nil {
-			logger.Error(err, "Error updating cluster status")
+			logger.Error(err, "Error updating cluster clusterStatus")
 			return &requeue{curError: err}
 		}
 	}

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -694,7 +694,7 @@ var _ = Describe("update_status", func() {
 		JustBeforeEach(func() {
 			err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			requeue = updateStatus{}.reconcile(context.TODO(), clusterReconciler, cluster)
+			requeue = updateStatus{}.reconcile(context.TODO(), clusterReconciler, cluster, nil)
 			if requeue != nil {
 				Expect(requeue.curError).NotTo(HaveOccurred())
 			}

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -173,6 +173,7 @@ FoundationDBClusterAutomationOptions provides flags for enabling or disabling op
 | ----- | ----------- | ------ | -------- |
 | configureDatabase | ConfigureDatabase defines whether the operator is allowed to reconfigure the database. | *bool | false |
 | killProcesses | KillProcesses defines whether the operator is allowed to bounce fdbserver processes. | *bool | false |
+| cacheDatabaseStatusForReconciliation | CacheDatabaseStatusForReconciliation defines whether the operator is using the same FoundationDB machine-readable status for all sub-reconcilers or if the machine-readable status should be fetched by ever sub-reconciler if required. Enabling this setting might improve the operator reconciliation speed for large clusters. | *bool | false |
 | replacements | Replacements contains options for automatically replacing failed processes. | [AutomaticReplacementOptions](#automaticreplacementoptions) | false |
 | ignorePendingPodsDuration | IgnorePendingPodsDuration defines how long a Pod has to be in the Pending Phase before ignore it during reconciliation. This prevents Pod that are stuck in Pending to block further reconciliation. | time.Duration | false |
 | useNonBlockingExcludes | UseNonBlockingExcludes defines whether the operator is allowed to use non blocking exclude commands. The default is false. | *bool | false |

--- a/docs/manual/technical_design.md
+++ b/docs/manual/technical_design.md
@@ -43,7 +43,15 @@ There are important constraints on how reconciliation has to work within this mo
 * Any local state that is not saved in a Kubernetes resource or the database may be lost at any time.
 * We cannot compare the new spec to the previous spec to know what has changed. We can only compare the new spec to the live state, or to the information we store in the resource status or in other resources that we create.
 
-In our operator, we add an additional abstraction to help structure the reconciliation loop, which we call a **Subreconciler**. A subreconciler represents a self-contained chunk of work that brings the running state closer to the spec. Each subreconciler receives the latest custom resource, and is responsible for determining what actions if any need to be run for the activity in its scope. We run every subreconciler for every reconciliation, with the subreconcilers taking care of logic to exit early if they do not have any work to do.
+In our operator, we add an additional abstraction to help structure the reconciliation loop, which we call a **Subreconciler**.
+A subreconciler represents a self-contained chunk of work that brings the running state closer to the spec.
+Each subreconciler receives the latest custom resource, and is responsible for determining what actions if any need to be run for the activity in its scope.
+We run every subreconciler for every reconciliation, with the subreconcilers taking care of logic to exit early if they do not have any work to do.
+
+Per default, since `v1.19.0`, the operator will fetch the [machine-readable status](https://apple.github.io/foundationdb/mr-status.html) at the start of a reconciliation loop and pass down the parsed status to all subreconcilers.
+This reduces the need for fetching the `machine-readable status` multiple times in a single reconcile loop, for large clusters this has a significant performance improvement.
+The risk for using the same `machine-readable status` for a single reconciliation loop is minimal, as a reconciliation loop normal takes only a few milliseconds to seconds.
+Users can deactivate the caching per reconciliation loop by passing `--cache-database-status=false` as an argument to the operator.
 
 ## Locking Operations
 

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -34,6 +34,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal/statuschecks"
+
 	"github.com/go-logr/logr"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
@@ -463,118 +465,7 @@ func (client *cliAdminClient) GetExclusions() ([]fdbv1beta2.ProcessAddress, erro
 		return nil, err
 	}
 
-	return client.GetExclusionsFromStatus(status)
-}
-
-// GetExclusionsFromStatus gets a list of the addresses currently excluded from the
-// database, based on the provided status.
-func (client *cliAdminClient) GetExclusionsFromStatus(status *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error) {
-	excludedServers := status.Cluster.DatabaseConfiguration.ExcludedServers
-	exclusions := make([]fdbv1beta2.ProcessAddress, 0, len(excludedServers))
-	for _, excludedServer := range excludedServers {
-		if excludedServer.Address != "" {
-			pAddr, err := fdbv1beta2.ParseProcessAddress(excludedServer.Address)
-			if err != nil {
-				return nil, err
-			}
-			exclusions = append(exclusions, pAddr)
-		} else {
-			exclusions = append(exclusions, fdbv1beta2.ProcessAddress{StringAddress: excludedServer.Locality})
-		}
-	}
-
-	return exclusions, nil
-}
-
-// exclusionStatus represents the current status of processes that should be excluded.
-// This can include processes that are currently in the progress of being excluded (data movement),
-// processes that are fully excluded and don't serve any roles and processes that are not marked for
-// exclusion.
-type exclusionStatus struct {
-	// inProgress contains all addresses that are excluded in the cluster and the exclude command can be used to verify if it's safe to remove this address.
-	inProgress []fdbv1beta2.ProcessAddress
-	// fullyExcluded contains all addresses that are excluded and don't have any roles assigned, this is a sign that the process is "fully" excluded and safe to remove.
-	fullyExcluded []fdbv1beta2.ProcessAddress
-	// notExcluded contains all addresses that are part of the input list and are not marked as excluded in the cluster, those addresses are not safe to remove.
-	notExcluded []fdbv1beta2.ProcessAddress
-	// missingInStatus contains all addresses that are part of the input list but are not appearing in the cluster status json.
-	missingInStatus []fdbv1beta2.ProcessAddress
-}
-
-// getRemainingAndExcludedFromStatus checks which processes of the input address list are excluded in the cluster and which are not.
-func getRemainingAndExcludedFromStatus(status *fdbv1beta2.FoundationDBStatus, addresses []fdbv1beta2.ProcessAddress) exclusionStatus {
-	notExcludedAddresses := map[string]fdbv1beta2.None{}
-	fullyExcludedAddresses := map[string]fdbv1beta2.None{}
-	visitedAddresses := map[string]fdbv1beta2.None{}
-
-	// If there are more than 1 active generations we can not handout any information about excluded processes based on
-	// the cluster status information as only the latest log processes will have the log process role. If we don't check
-	// for the active generations we have the risk to remove a log process that still has mutations on it that must be
-	// popped.
-	if status.Cluster.RecoveryState.ActiveGenerations > 1 {
-		return exclusionStatus{
-			inProgress:      nil,
-			fullyExcluded:   nil,
-			notExcluded:     addresses,
-			missingInStatus: nil,
-		}
-	}
-
-	for _, addr := range addresses {
-		notExcludedAddresses[addr.MachineAddress()] = fdbv1beta2.None{}
-	}
-
-	// Check in the status output which processes are already marked for exclusion in the cluster
-	for _, process := range status.Cluster.Processes {
-		if _, ok := notExcludedAddresses[process.Address.MachineAddress()]; !ok {
-			continue
-		}
-
-		visitedAddresses[process.Address.MachineAddress()] = fdbv1beta2.None{}
-		if !process.Excluded {
-			continue
-		}
-
-		if len(process.Roles) == 0 {
-			fullyExcludedAddresses[process.Address.MachineAddress()] = fdbv1beta2.None{}
-		}
-
-		delete(notExcludedAddresses, process.Address.MachineAddress())
-	}
-
-	exclusions := exclusionStatus{
-		inProgress:      make([]fdbv1beta2.ProcessAddress, 0, len(addresses)-len(notExcludedAddresses)-len(fullyExcludedAddresses)),
-		fullyExcluded:   make([]fdbv1beta2.ProcessAddress, 0, len(fullyExcludedAddresses)),
-		notExcluded:     make([]fdbv1beta2.ProcessAddress, 0, len(notExcludedAddresses)),
-		missingInStatus: make([]fdbv1beta2.ProcessAddress, 0, len(notExcludedAddresses)),
-	}
-
-	for _, addr := range addresses {
-		// If we didn't visit that address (absent in the cluster status) we assume it's safe to run the exclude command against it.
-		// We have to run the exclude command against those addresses, to make sure they are not serving any roles.
-		if _, ok := visitedAddresses[addr.MachineAddress()]; !ok {
-			exclusions.missingInStatus = append(exclusions.missingInStatus, addr)
-			continue
-		}
-
-		// Those addresses are not excluded, so it's not safe to start the exclude command to check if they are fully excluded.
-		if _, ok := notExcludedAddresses[addr.MachineAddress()]; ok {
-			exclusions.notExcluded = append(exclusions.notExcluded, addr)
-			continue
-		}
-
-		// Those are the processes that are marked as excluded and are not serving any roles. It's safe to delete Pods
-		// that host those processes.
-		if _, ok := fullyExcludedAddresses[addr.MachineAddress()]; ok {
-			exclusions.fullyExcluded = append(exclusions.fullyExcluded, addr)
-			continue
-		}
-
-		// Those are the processes that are marked as excluded but still serve at least one role.
-		exclusions.inProgress = append(exclusions.inProgress, addr)
-	}
-
-	return exclusions
+	return statuschecks.GetExclusions(status)
 }
 
 // CanSafelyRemove checks whether it is safe to remove processes from the cluster
@@ -586,40 +477,7 @@ func (client *cliAdminClient) CanSafelyRemove(addresses []fdbv1beta2.ProcessAddr
 		return nil, err
 	}
 
-	return client.CanSafelyRemoveFromStatus(addresses, status)
-}
-
-// CanSafelyRemoveFromStatus checks whether it is safe to remove processes from the cluster, based on the provided status.
-//
-// The list returned by this method will be the addresses that are *not* safe to remove.
-func (client *cliAdminClient) CanSafelyRemoveFromStatus(addresses []fdbv1beta2.ProcessAddress, status *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error) {
-	exclusions := getRemainingAndExcludedFromStatus(status, addresses)
-	client.log.Info("Filtering excluded processes",
-		"inProgress", exclusions.inProgress,
-		"fullyExcluded", exclusions.fullyExcluded,
-		"notExcluded", exclusions.notExcluded,
-		"missingInStatus", exclusions.missingInStatus)
-
-	notSafeToDelete := append(exclusions.notExcluded, exclusions.inProgress...)
-	// When we have at least one process that is missing in the status, we have to issue the exclude command to make sure, that those
-	// missing processes can be removed or not.
-	if len(exclusions.missingInStatus) > 0 {
-		err := client.ExcludeProcesses(exclusions.missingInStatus)
-		// When we hit a timeout error here we know that at least one of the missingInStatus is still not fully excluded for safety
-		// we just return the whole slice and don't do any further distinction. We have to return all addresses that are not excluded
-		// and are still in progress, but we don't want to return an error to block further actions on the successfully excluded
-		// addresses.
-		if err != nil {
-			if internal.IsTimeoutError(err) {
-				return append(exclusions.notExcluded, exclusions.missingInStatus...), nil
-			}
-
-			return nil, err
-		}
-	}
-
-	// All processes that are either not yet marked as excluded or still serving at least one role, cannot be removed safely.
-	return notSafeToDelete, nil
+	return statuschecks.CanSafelyRemoveFromStatus(client.log, client, addresses, status)
 }
 
 // KillProcesses restarts processes

--- a/fdbclient/command_runner.go
+++ b/fdbclient/command_runner.go
@@ -22,11 +22,12 @@ package fdbclient
 
 import (
 	"context"
-	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
-	"github.com/go-logr/logr"
 	"os"
 	"os/exec"
 	"strings"
+
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/go-logr/logr"
 )
 
 // commandRunner is an interface to run commands.

--- a/fdbclient/command_runner_test.go
+++ b/fdbclient/command_runner_test.go
@@ -22,10 +22,11 @@ package fdbclient
 
 import (
 	"context"
+	"strings"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"strings"
 )
 
 var _ = Describe("command_runner", func() {

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -23,15 +23,16 @@ package fdbclient
 import (
 	"encoding/json"
 	"errors"
+	"io/fs"
+	"os"
+	"path"
+	"time"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/go-logr/logr"
-	"io/fs"
-	"os"
-	"path"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 // DefaultCLITimeout is the default timeout for CLI commands.

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -23,10 +23,11 @@ package fdbclient
 import (
 	"errors"
 	"fmt"
+	"time"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/go-logr/logr"
-	"time"
 )
 
 // fdbLibClient is an interface to interact with FDB over the client libraries

--- a/internal/fault_tolerance.go
+++ b/internal/fault_tolerance.go
@@ -22,7 +22,6 @@ package internal
 
 import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
-	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
 	"github.com/go-logr/logr"
 )
 
@@ -30,16 +29,6 @@ func hasDesiredFaultTolerance(expectedFaultTolerance int, maxZoneFailuresWithout
 	// Only if both max zone failures for availability and data loss are greater or equal to the expected fault tolerance we know that we meet
 	// our fault tolerance requirements.
 	return maxZoneFailuresWithoutLosingData >= expectedFaultTolerance && maxZoneFailuresWithoutLosingAvailability >= expectedFaultTolerance
-}
-
-// HasDesiredFaultTolerance checks if the cluster has the desired fault tolerance.
-func HasDesiredFaultTolerance(log logr.Logger, adminClient fdbadminclient.AdminClient, cluster *fdbv1beta2.FoundationDBCluster) (bool, error) {
-	status, err := adminClient.GetStatus()
-	if err != nil {
-		return false, err
-	}
-
-	return HasDesiredFaultToleranceFromStatus(log, status, cluster), nil
 }
 
 // HasDesiredFaultToleranceFromStatus checks if the cluster has the desired fault tolerance based on the provided status.

--- a/internal/fdb_status_helper_test.go
+++ b/internal/fdb_status_helper_test.go
@@ -22,6 +22,7 @@ package internal
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/internal/foundationdb_status.go
+++ b/internal/foundationdb_status.go
@@ -21,8 +21,9 @@
 package internal
 
 import (
-	"github.com/go-logr/logr"
 	"math"
+
+	"github.com/go-logr/logr"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 )

--- a/internal/foundationdb_status_test.go
+++ b/internal/foundationdb_status_test.go
@@ -21,8 +21,9 @@
 package internal
 
 import (
-	"github.com/go-logr/logr"
 	"net"
+
+	"github.com/go-logr/logr"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"

--- a/internal/removals/remove.go
+++ b/internal/removals/remove.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal/statuschecks"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
 	"github.com/go-logr/logr"
 	"k8s.io/utils/pointer"
@@ -141,7 +143,7 @@ func GetRemainingMap(logger logr.Logger, adminClient fdbadminclient.AdminClient,
 
 	var remaining []fdbv1beta2.ProcessAddress
 	if len(addresses) > 0 {
-		remaining, err = adminClient.CanSafelyRemoveFromStatus(addresses, status)
+		remaining, err = statuschecks.CanSafelyRemoveFromStatus(logger, adminClient, addresses, status)
 		if err != nil {
 			return map[string]bool{}, err
 		}

--- a/internal/removals/remove.go
+++ b/internal/removals/remove.go
@@ -118,7 +118,7 @@ func GetZonedRemovals(status *fdbv1beta2.FoundationDBStatus, processGroupsToRemo
 }
 
 // GetRemainingMap returns a map that indicates if a process group is fully excluded in the cluster.
-func GetRemainingMap(logger logr.Logger, adminClient fdbadminclient.AdminClient, cluster *fdbv1beta2.FoundationDBCluster) (map[string]bool, error) {
+func GetRemainingMap(logger logr.Logger, adminClient fdbadminclient.AdminClient, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus) (map[string]bool, error) {
 	var err error
 	addresses := make([]fdbv1beta2.ProcessAddress, 0, len(cluster.Status.ProcessGroups))
 	for _, processGroup := range cluster.Status.ProcessGroups {
@@ -141,7 +141,7 @@ func GetRemainingMap(logger logr.Logger, adminClient fdbadminclient.AdminClient,
 
 	var remaining []fdbv1beta2.ProcessAddress
 	if len(addresses) > 0 {
-		remaining, err = adminClient.CanSafelyRemove(addresses)
+		remaining, err = adminClient.CanSafelyRemoveFromStatus(addresses, status)
 		if err != nil {
 			return map[string]bool{}, err
 		}

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -23,6 +23,7 @@ package replacements
 import (
 	"context"
 	"fmt"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -23,6 +23,7 @@ package replacements
 import (
 	"context"
 	"fmt"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/internal/replacements/suite_test.go
+++ b/internal/replacements/suite_test.go
@@ -1,12 +1,13 @@
 package replacements
 
 import (
+	"testing"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	mockclient "github.com/FoundationDB/fdb-kubernetes-operator/mock-kubernetes-client/client"
 	"k8s.io/client-go/kubernetes/scheme"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/internal/statuschecks/status_checks.go
+++ b/internal/statuschecks/status_checks.go
@@ -1,0 +1,175 @@
+/*
+ * status_checks.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package statuschecks
+
+import (
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
+	"github.com/go-logr/logr"
+)
+
+// StatusContextKey will be used as a key in a context to pass down the cached status.
+type StatusContextKey struct{}
+
+// exclusionStatus represents the current status of processes that should be excluded.
+// This can include processes that are currently in the progress of being excluded (data movement),
+// processes that are fully excluded and don't serve any roles and processes that are not marked for
+// exclusion.
+type exclusionStatus struct {
+	// inProgress contains all addresses that are excluded in the cluster and the exclude command can be used to verify if it's safe to remove this address.
+	inProgress []fdbv1beta2.ProcessAddress
+	// fullyExcluded contains all addresses that are excluded and don't have any roles assigned, this is a sign that the process is "fully" excluded and safe to remove.
+	fullyExcluded []fdbv1beta2.ProcessAddress
+	// notExcluded contains all addresses that are part of the input list and are not marked as excluded in the cluster, those addresses are not safe to remove.
+	notExcluded []fdbv1beta2.ProcessAddress
+	// missingInStatus contains all addresses that are part of the input list but are not appearing in the cluster status json.
+	missingInStatus []fdbv1beta2.ProcessAddress
+}
+
+// getRemainingAndExcludedFromStatus checks which processes of the input address list are excluded in the cluster and which are not.
+func getRemainingAndExcludedFromStatus(status *fdbv1beta2.FoundationDBStatus, addresses []fdbv1beta2.ProcessAddress) exclusionStatus {
+	notExcludedAddresses := map[string]fdbv1beta2.None{}
+	fullyExcludedAddresses := map[string]fdbv1beta2.None{}
+	visitedAddresses := map[string]fdbv1beta2.None{}
+
+	// If there are more than 1 active generations we can not handout any information about excluded processes based on
+	// the cluster status information as only the latest log processes will have the log process role. If we don't check
+	// for the active generations we have the risk to remove a log process that still has mutations on it that must be
+	// popped.
+	if status.Cluster.RecoveryState.ActiveGenerations > 1 {
+		return exclusionStatus{
+			inProgress:      nil,
+			fullyExcluded:   nil,
+			notExcluded:     addresses,
+			missingInStatus: nil,
+		}
+	}
+
+	for _, addr := range addresses {
+		notExcludedAddresses[addr.MachineAddress()] = fdbv1beta2.None{}
+	}
+
+	// Check in the status output which processes are already marked for exclusion in the cluster
+	for _, process := range status.Cluster.Processes {
+		if _, ok := notExcludedAddresses[process.Address.MachineAddress()]; !ok {
+			continue
+		}
+
+		visitedAddresses[process.Address.MachineAddress()] = fdbv1beta2.None{}
+		if !process.Excluded {
+			continue
+		}
+
+		if len(process.Roles) == 0 {
+			fullyExcludedAddresses[process.Address.MachineAddress()] = fdbv1beta2.None{}
+		}
+
+		delete(notExcludedAddresses, process.Address.MachineAddress())
+	}
+
+	exclusions := exclusionStatus{
+		inProgress:      make([]fdbv1beta2.ProcessAddress, 0, len(addresses)-len(notExcludedAddresses)-len(fullyExcludedAddresses)),
+		fullyExcluded:   make([]fdbv1beta2.ProcessAddress, 0, len(fullyExcludedAddresses)),
+		notExcluded:     make([]fdbv1beta2.ProcessAddress, 0, len(notExcludedAddresses)),
+		missingInStatus: make([]fdbv1beta2.ProcessAddress, 0, len(notExcludedAddresses)),
+	}
+
+	for _, addr := range addresses {
+		// If we didn't visit that address (absent in the cluster status) we assume it's safe to run the exclude command against it.
+		// We have to run the exclude command against those addresses, to make sure they are not serving any roles.
+		if _, ok := visitedAddresses[addr.MachineAddress()]; !ok {
+			exclusions.missingInStatus = append(exclusions.missingInStatus, addr)
+			continue
+		}
+
+		// Those addresses are not excluded, so it's not safe to start the exclude command to check if they are fully excluded.
+		if _, ok := notExcludedAddresses[addr.MachineAddress()]; ok {
+			exclusions.notExcluded = append(exclusions.notExcluded, addr)
+			continue
+		}
+
+		// Those are the processes that are marked as excluded and are not serving any roles. It's safe to delete Pods
+		// that host those processes.
+		if _, ok := fullyExcludedAddresses[addr.MachineAddress()]; ok {
+			exclusions.fullyExcluded = append(exclusions.fullyExcluded, addr)
+			continue
+		}
+
+		// Those are the processes that are marked as excluded but still serve at least one role.
+		exclusions.inProgress = append(exclusions.inProgress, addr)
+	}
+
+	return exclusions
+}
+
+// CanSafelyRemoveFromStatus checks whether it is safe to remove processes from the cluster, based on the provided status.
+//
+// The list returned by this method will be the addresses that are *not* safe to remove.
+func CanSafelyRemoveFromStatus(logger logr.Logger, client fdbadminclient.AdminClient, addresses []fdbv1beta2.ProcessAddress, status *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error) {
+	exclusions := getRemainingAndExcludedFromStatus(status, addresses)
+	logger.Info("Filtering excluded processes",
+		"inProgress", exclusions.inProgress,
+		"fullyExcluded", exclusions.fullyExcluded,
+		"notExcluded", exclusions.notExcluded,
+		"missingInStatus", exclusions.missingInStatus)
+
+	notSafeToDelete := append(exclusions.notExcluded, exclusions.inProgress...)
+	// When we have at least one process that is missing in the status, we have to issue the exclude command to make sure, that those
+	// missing processes can be removed or not.
+	if len(exclusions.missingInStatus) > 0 {
+		err := client.ExcludeProcesses(exclusions.missingInStatus)
+		// When we hit a timeout error here we know that at least one of the missingInStatus is still not fully excluded for safety
+		// we just return the whole slice and don't do any further distinction. We have to return all addresses that are not excluded
+		// and are still in progress, but we don't want to return an error to block further actions on the successfully excluded
+		// addresses.
+		if err != nil {
+			if internal.IsTimeoutError(err) {
+				return append(exclusions.notExcluded, exclusions.missingInStatus...), nil
+			}
+
+			return nil, err
+		}
+	}
+
+	// All processes that are either not yet marked as excluded or still serving at least one role, cannot be removed safely.
+	return notSafeToDelete, nil
+}
+
+// GetExclusions gets a list of the addresses currently excluded from the
+// database, based on the provided status.
+func GetExclusions(status *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error) {
+	excludedServers := status.Cluster.DatabaseConfiguration.ExcludedServers
+	exclusions := make([]fdbv1beta2.ProcessAddress, 0, len(excludedServers))
+	for _, excludedServer := range excludedServers {
+		if excludedServer.Address != "" {
+			pAddr, err := fdbv1beta2.ParseProcessAddress(excludedServer.Address)
+			if err != nil {
+				return nil, err
+			}
+			exclusions = append(exclusions, pAddr)
+		} else {
+			exclusions = append(exclusions, fdbv1beta2.ProcessAddress{StringAddress: excludedServer.Locality})
+		}
+	}
+
+	return exclusions, nil
+}

--- a/internal/statuschecks/status_checks_test.go
+++ b/internal/statuschecks/status_checks_test.go
@@ -1,0 +1,257 @@
+/*
+ * status_checks_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package statuschecks
+
+import (
+	"net"
+
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("status_checks", func() {
+	When("getting the excluded and remaining processes", func() {
+		addr1 := fdbv1beta2.NewProcessAddress(net.ParseIP("127.0.0.1"), "", 0, nil)
+		addr2 := fdbv1beta2.NewProcessAddress(net.ParseIP("127.0.0.2"), "", 0, nil)
+		addr3 := fdbv1beta2.NewProcessAddress(net.ParseIP("127.0.0.3"), "", 0, nil)
+		addr4 := fdbv1beta2.NewProcessAddress(net.ParseIP("127.0.0.4"), "", 0, nil)
+		addr5 := fdbv1beta2.NewProcessAddress(net.ParseIP("127.0.0.5"), "", 0, nil)
+		status := &fdbv1beta2.FoundationDBStatus{
+			Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+				Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+					"1": {
+						Address:  addr1,
+						Excluded: true,
+					},
+					"2": {
+						Address: addr2,
+					},
+					"3": {
+						Address: addr3,
+					},
+					"4": {
+						Address:  addr4,
+						Excluded: true,
+						Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+							{
+								Role: "tester",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		DescribeTable("fetching the excluded and remaining processes from the status",
+			func(status *fdbv1beta2.FoundationDBStatus, addresses []fdbv1beta2.ProcessAddress, expectedExcluded []fdbv1beta2.ProcessAddress, expectedRemaining []fdbv1beta2.ProcessAddress, expectedFullyExcluded []fdbv1beta2.ProcessAddress, expectedMissing []fdbv1beta2.ProcessAddress) {
+				exclusions := getRemainingAndExcludedFromStatus(status, addresses)
+				Expect(expectedExcluded).To(ConsistOf(exclusions.inProgress))
+				Expect(expectedRemaining).To(ConsistOf(exclusions.notExcluded))
+				Expect(expectedFullyExcluded).To(ConsistOf(exclusions.fullyExcluded))
+				Expect(expectedMissing).To(ConsistOf(exclusions.missingInStatus))
+			},
+			Entry("with an empty input address slice",
+				status,
+				[]fdbv1beta2.ProcessAddress{},
+				nil,
+				nil,
+				nil,
+				nil,
+			),
+			Entry("when the process is excluded",
+				status,
+				[]fdbv1beta2.ProcessAddress{addr4},
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				nil,
+				nil,
+			),
+			Entry("when the process is not excluded",
+				status,
+				[]fdbv1beta2.ProcessAddress{addr3},
+				nil,
+				[]fdbv1beta2.ProcessAddress{addr3},
+				nil,
+				nil,
+			),
+			Entry("when some processes are excluded and some not",
+				status,
+				[]fdbv1beta2.ProcessAddress{addr1, addr2, addr3, addr4},
+				[]fdbv1beta2.ProcessAddress{addr4},
+				[]fdbv1beta2.ProcessAddress{addr2, addr3},
+				[]fdbv1beta2.ProcessAddress{addr1},
+				nil,
+			),
+			Entry("when a process is missing",
+				status,
+				[]fdbv1beta2.ProcessAddress{addr5},
+				nil,
+				[]fdbv1beta2.ProcessAddress{},
+				nil,
+				[]fdbv1beta2.ProcessAddress{addr5},
+			),
+			Entry("when the process is excluded but the cluster status has multiple generations",
+				&fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						RecoveryState: fdbv1beta2.RecoveryState{
+							ActiveGenerations: 2,
+						},
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"1": {
+								Address:  addr1,
+								Excluded: true,
+							},
+							"2": {
+								Address: addr2,
+							},
+							"3": {
+								Address: addr3,
+							},
+							"4": {
+								Address:  addr4,
+								Excluded: true,
+								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+									{
+										Role: "tester",
+									},
+								},
+							},
+						},
+					},
+				},
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				nil,
+			),
+		)
+	})
+
+	When("getting the exclusions from the status", func() {
+		var status *fdbv1beta2.FoundationDBStatus
+		var exclusions []fdbv1beta2.ProcessAddress
+
+		JustBeforeEach(func() {
+			var err error
+			exclusions, err = GetExclusions(status)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		When("the status contains no exclusions", func() {
+			BeforeEach(func() {
+				status = &fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						DatabaseConfiguration: fdbv1beta2.DatabaseConfiguration{
+							ExcludedServers: []fdbv1beta2.ExcludedServers{},
+						},
+					},
+				}
+			})
+
+			It("should return an empty list", func() {
+				Expect(exclusions).To(BeEmpty())
+			})
+		})
+
+		When("the status contains exclusions with IP addresses", func() {
+			BeforeEach(func() {
+				status = &fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						DatabaseConfiguration: fdbv1beta2.DatabaseConfiguration{
+							ExcludedServers: []fdbv1beta2.ExcludedServers{
+								{
+									Address: "192.168.0.1",
+								},
+								{
+									Address: "192.168.0.2",
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("should return the excluded servers", func() {
+				Expect(exclusions).To(HaveLen(2))
+				Expect(exclusions).To(ConsistOf(
+					fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP("192.168.0.1")},
+					fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP("192.168.0.2")},
+				))
+			})
+		})
+
+		When("the status contains exclusions with localities", func() {
+			BeforeEach(func() {
+				status = &fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						DatabaseConfiguration: fdbv1beta2.DatabaseConfiguration{
+							ExcludedServers: []fdbv1beta2.ExcludedServers{
+								{
+									Locality: "test1",
+								},
+								{
+									Locality: "test2",
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("should return the excluded servers", func() {
+				Expect(exclusions).To(HaveLen(2))
+				Expect(exclusions).To(ConsistOf(
+					fdbv1beta2.ProcessAddress{StringAddress: "test1"},
+					fdbv1beta2.ProcessAddress{StringAddress: "test2"},
+				))
+			})
+		})
+
+		When("the status contains exclusions with localities and IP addresses", func() {
+			BeforeEach(func() {
+				status = &fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						DatabaseConfiguration: fdbv1beta2.DatabaseConfiguration{
+							ExcludedServers: []fdbv1beta2.ExcludedServers{
+								{
+									Locality: "test1",
+								},
+								{
+									Address: "192.168.0.2",
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("should return the excluded servers", func() {
+				Expect(exclusions).To(HaveLen(2))
+				Expect(exclusions).To(ConsistOf(
+					fdbv1beta2.ProcessAddress{StringAddress: "test1"},
+					fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP("192.168.0.2")},
+				))
+			})
+		})
+	})
+})

--- a/internal/statuschecks/suite_test.go
+++ b/internal/statuschecks/suite_test.go
@@ -1,0 +1,33 @@
+/*
+ * suite_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package statuschecks
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FDB status checks")
+}

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -45,21 +45,12 @@ type AdminClient interface {
 	// database.
 	GetExclusions() ([]fdbv1beta2.ProcessAddress, error)
 
-	// GetExclusionsFromStatus gets a list of the addresses currently excluded from the
-	// database, based on the provided status.
-	GetExclusionsFromStatus(status *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error)
-
 	// CanSafelyRemove checks whether it is safe to remove processes from the
 	// cluster.
 	//
 	// The list returned by this method will be the addresses that are *not*
 	// safe to remove.
 	CanSafelyRemove(addresses []fdbv1beta2.ProcessAddress) ([]fdbv1beta2.ProcessAddress, error)
-
-	// CanSafelyRemoveFromStatus checks whether it is safe to remove processes from the cluster, based on the provided status.
-	//
-	// The list returned by this method will be the addresses that are *not* safe to remove.
-	CanSafelyRemoveFromStatus(addresses []fdbv1beta2.ProcessAddress, status *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error)
 
 	// KillProcesses restarts processes
 	KillProcesses(addresses []fdbv1beta2.ProcessAddress) error

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -45,12 +45,21 @@ type AdminClient interface {
 	// database.
 	GetExclusions() ([]fdbv1beta2.ProcessAddress, error)
 
+	// GetExclusionsFromStatus gets a list of the addresses currently excluded from the
+	// database, based on the provided status.
+	GetExclusionsFromStatus(status *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error)
+
 	// CanSafelyRemove checks whether it is safe to remove processes from the
 	// cluster.
 	//
 	// The list returned by this method will be the addresses that are *not*
 	// safe to remove.
 	CanSafelyRemove(addresses []fdbv1beta2.ProcessAddress) ([]fdbv1beta2.ProcessAddress, error)
+
+	// CanSafelyRemoveFromStatus checks whether it is safe to remove processes from the cluster, based on the provided status.
+	//
+	// The list returned by this method will be the addresses that are *not* safe to remove.
+	CanSafelyRemoveFromStatus(addresses []fdbv1beta2.ProcessAddress, status *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error)
 
 	// KillProcesses restarts processes
 	KillProcesses(addresses []fdbv1beta2.ProcessAddress) error

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -476,6 +476,13 @@ func (client *AdminClient) CanSafelyRemove(addresses []fdbv1beta2.ProcessAddress
 	return remaining, nil
 }
 
+// CanSafelyRemoveFromStatus checks whether it is safe to remove processes from the cluster, based on the provided status.
+//
+// The list returned by this method will be the addresses that are *not* safe to remove.
+func (client *AdminClient) CanSafelyRemoveFromStatus(addresses []fdbv1beta2.ProcessAddress, _ *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error) {
+	return client.CanSafelyRemove(addresses)
+}
+
 // GetExclusions gets a list of the addresses currently excluded from the
 // database.
 func (client *AdminClient) GetExclusions() ([]fdbv1beta2.ProcessAddress, error) {
@@ -492,6 +499,12 @@ func (client *AdminClient) GetExclusions() ([]fdbv1beta2.ProcessAddress, error) 
 	}
 
 	return pAddrs, nil
+}
+
+// GetExclusionsFromStatus gets a list of the addresses currently excluded from the
+// database, based on the provided status.
+func (client *AdminClient) GetExclusionsFromStatus(_ *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error) {
+	return client.GetExclusions()
 }
 
 // KillProcesses restarts processes

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -476,13 +476,6 @@ func (client *AdminClient) CanSafelyRemove(addresses []fdbv1beta2.ProcessAddress
 	return remaining, nil
 }
 
-// CanSafelyRemoveFromStatus checks whether it is safe to remove processes from the cluster, based on the provided status.
-//
-// The list returned by this method will be the addresses that are *not* safe to remove.
-func (client *AdminClient) CanSafelyRemoveFromStatus(addresses []fdbv1beta2.ProcessAddress, _ *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error) {
-	return client.CanSafelyRemove(addresses)
-}
-
 // GetExclusions gets a list of the addresses currently excluded from the
 // database.
 func (client *AdminClient) GetExclusions() ([]fdbv1beta2.ProcessAddress, error) {
@@ -499,12 +492,6 @@ func (client *AdminClient) GetExclusions() ([]fdbv1beta2.ProcessAddress, error) 
 	}
 
 	return pAddrs, nil
-}
-
-// GetExclusionsFromStatus gets a list of the addresses currently excluded from the
-// database, based on the provided status.
-func (client *AdminClient) GetExclusionsFromStatus(_ *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, error) {
-	return client.GetExclusions()
 }
 
 // KillProcesses restarts processes

--- a/pkg/podmanager/pod_lifecycle_manager.go
+++ b/pkg/podmanager/pod_lifecycle_manager.go
@@ -123,6 +123,7 @@ func (manager StandardPodLifecycleManager) DeletePod(ctx context.Context, r clie
 
 // CanDeletePods checks whether it is safe to delete Pods.
 func (manager StandardPodLifecycleManager) CanDeletePods(ctx context.Context, adminClient fdbadminclient.AdminClient, cluster *fdbv1beta2.FoundationDBCluster) (bool, error) {
+	// TODO(j-scheuermann): Can we pass down a cached status here?
 	return internal.HasDesiredFaultTolerance(logr.FromContextOrDiscard(ctx), adminClient, cluster)
 }
 

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -59,6 +59,7 @@ type Options struct {
 	EnableRestartIncompatibleProcesses bool
 	ServerSideApply                    bool
 	EnableRecoveryState                bool
+	CacheDatabaseStatus                bool
 	MetricsAddr                        string
 	LeaderElectionID                   string
 	LogFile                            string
@@ -105,6 +106,8 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&o.EnableRestartIncompatibleProcesses, "enable-restart-incompatible-processes", true, "This flag enables/disables in the operator to restart incompatible fdbserver processes.")
 	fs.BoolVar(&o.ServerSideApply, "server-side-apply", false, "This flag enables server side apply.")
 	fs.BoolVar(&o.EnableRecoveryState, "enable-recovery-state", true, "This flag enables the use of the recovery state for the minimum uptime between bounced if the FDB version supports it.")
+	// TODO (johscheuer): Set this to false as a default after testing.
+	fs.BoolVar(&o.CacheDatabaseStatus, "cache-database-status", true, "Defines the default value for caching the database status.")
 }
 
 // StartManager will start the FoundationDB operator manager.
@@ -183,6 +186,7 @@ func StartManager(
 		clusterReconciler.EnableRestartIncompatibleProcesses = operatorOpts.EnableRestartIncompatibleProcesses
 		clusterReconciler.ServerSideApply = operatorOpts.ServerSideApply
 		clusterReconciler.EnableRecoveryState = operatorOpts.EnableRecoveryState
+		clusterReconciler.CacheDatabaseStatusForReconciliationDefault = operatorOpts.CacheDatabaseStatus
 
 		if err := clusterReconciler.SetupWithManager(mgr, operatorOpts.MaxConcurrentReconciles, *labelSelector, watchedObjects...); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "FoundationDBCluster")

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -106,7 +106,6 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&o.EnableRestartIncompatibleProcesses, "enable-restart-incompatible-processes", true, "This flag enables/disables in the operator to restart incompatible fdbserver processes.")
 	fs.BoolVar(&o.ServerSideApply, "server-side-apply", false, "This flag enables server side apply.")
 	fs.BoolVar(&o.EnableRecoveryState, "enable-recovery-state", true, "This flag enables the use of the recovery state for the minimum uptime between bounced if the FDB version supports it.")
-	// TODO (johscheuer): Set this to false as a default after testing.
 	fs.BoolVar(&o.CacheDatabaseStatus, "cache-database-status", true, "Defines the default value for caching the database status.")
 }
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1615. The caching mechanism can be enabled or disabled per `FoundationDBCluster` config, and the default value (if unset) can be configured per command line flag. The idea is to fetch the machine-readable status only once per reconciliation loop instead of multiple times. This should improve the performance of the operator for large clusters (and many), as the operator has to spend less time fetching the machine-readable status and parsing it.

A reconciliation loop should end pretty fast (a few seconds), therefore the risk should be minimal, but a user can decide if they want to enable this feature or not.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

For the testing I set the default value to true, I will change that to false before merging.

## Testing

Unit tests and e2e tests will be running.

## Documentation

Will be added before merging.

## Follow-up

-