### PR TITLE
Enable "maintenance mode is on" test in "operator_test.go"

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -98,7 +98,6 @@ var _ = BeforeSuite(func() {
 			chaosmesh.OneMode,
 		)
 	}
-
 })
 
 var _ = AfterSuite(func() {

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -98,6 +98,7 @@ var _ = BeforeSuite(func() {
 			chaosmesh.OneMode,
 		)
 	}
+
 })
 
 var _ = AfterSuite(func() {
@@ -1108,9 +1109,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	})
 
 	Context("testing maintenance mode functionality", func() {
-		PWhen("maintenance mode is on", func() {
+		When("maintenance mode is on", func() {
 			BeforeEach(func() {
-				command := fmt.Sprintf("maintenance on %s %s", "operator-test-1-storage-4", "0")
+				command := fmt.Sprintf("maintenance on %s %s", "operator-test-1-storage-4", "40000")
 				_, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(command, false, 40)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
@@ -1122,7 +1123,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			It("status maintenance zone should match", func() {
 				status := fdbCluster.GetStatus()
-				Expect(status.Cluster.MaintenanceZone).To(Equal(fdbv1beta2.MaintenanceModeInfo{ZoneID: "operator-test-1-storage-4"}))
+				Expect(status.Cluster.MaintenanceZone).To(Equal(fdbv1beta2.FaultDomain("operator-test-1-storage-4")))
 			})
 		})
 	})


### PR DESCRIPTION
# Description

- Get "maintenance mode is on" test to succeed and enable it.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue); testing related

## Discussion

*Are there any design details that you would like to discuss further?*

No.

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

Manual testing.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

Yes, nightly regression testing.

## Documentation

*Did you update relevant documentation within this repository?*

N/A

*If this change is adding new functionality, do we need to describe it in our user manual?*

N/A

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

N/A

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

N/A

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

No.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.
