### PR TITLE
Fixes issue #1640

### DIFF
--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -192,7 +192,7 @@ func getAllPodsFromClusterWithCondition(stdErr io.Writer, kubeClient client.Clie
 
 	for process := range processesSet {
 		if _, ok := podMap[string(process)]; !ok {
-			fmt.Fprintf(stdErr, "Process Group: %s, is missing pods.", process)
+			fmt.Fprintf(stdErr, "Process Group: %s, is missing pods.\n", process)
 			continue
 		}
 		pod := podMap[string(process)]
@@ -201,7 +201,7 @@ func getAllPodsFromClusterWithCondition(stdErr io.Writer, kubeClient client.Clie
 			continue
 		}
 		if pod.Status.Phase != corev1.PodRunning {
-			fmt.Fprintf(stdErr, "Skipping Process Group: %s, Pod is not running, current phase: %s", process, pod.Status.Phase)
+			fmt.Fprintf(stdErr, "Skipping Process Group: %s, Pod is not running, current phase: %s\n", process, pod.Status.Phase)
 			continue
 		}
 

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -192,7 +192,7 @@ func getAllPodsFromClusterWithCondition(stdErr io.Writer, kubeClient client.Clie
 	var warnings []string
 	for process := range processesSet {
 		if _, ok := podMap[string(process)]; !ok {
-			warnings = append(warnings, fmt.Sprintf("Process Group: %s, is missing pods.", process))
+			fmt.Fprintln(stdErr, ("Process Group: %s, is missing pods.", process)
 			continue
 		}
 		if podMap[string(process)].Labels[cluster.GetProcessGroupIDLabel()] != string(process) {

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -193,7 +193,7 @@ func getAllPodsFromClusterWithCondition(stdErr io.Writer, kubeClient client.Clie
 	for process := range processesSet {
 
 		if _, ok := podMap[string(process)]; !ok {
-			fmt.Fprintln(stdErr, "Process Group: %s, is missing pods.", process)
+			fmt.Fprintf(stdErr, "Process Group: %s, is missing pods.", process)
 			continue
 		}
 		pod := podMap[string(process)]
@@ -202,7 +202,7 @@ func getAllPodsFromClusterWithCondition(stdErr io.Writer, kubeClient client.Clie
 			continue
 		}
 		if pod.Status.Phase != corev1.PodRunning {
-			fmt.Fprintln(stdErr, "Skipping Process Group: %s, Pod is not running, current phase: %s", process, pod.Status.Phase)
+			fmt.Fprintf(stdErr, "Skipping Process Group: %s, Pod is not running, current phase: %s", process, pod.Status.Phase)
 			continue
 		}
 

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -192,7 +192,7 @@ func getAllPodsFromClusterWithCondition(stdErr io.Writer, kubeClient client.Clie
 
 	for process := range processesSet {
 		if _, ok := podMap[string(process)]; !ok {
-			fmt.Fprintf(stdErr, "Process Group: %s, is missing pods.\n", process)
+			fmt.Fprintf(stdErr, "Skipping Process Group: %s, because it does not have a corresponding Pod.\n", process)
 			continue
 		}
 		pod := podMap[string(process)]

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -191,7 +191,6 @@ func getAllPodsFromClusterWithCondition(stdErr io.Writer, kubeClient client.Clie
 	}
 
 	for process := range processesSet {
-
 		if _, ok := podMap[string(process)]; !ok {
 			fmt.Fprintf(stdErr, "Process Group: %s, is missing pods.", process)
 			continue

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -160,7 +160,7 @@ func executeCmd(restConfig *rest.Config, kubeClient *kubernetes.Clientset, podNa
 	return &stdout, &stderr, err
 }
 
-func getAllPodsFromClusterWithCondition(kubeClient client.Client, clusterName string, namespace string, conditions []fdbv1beta2.ProcessGroupConditionType) ([]string, []string, error) {
+func getAllPodsFromClusterWithCondition(stdErr io.Writer, kubeClient client.Client, clusterName string, namespace string, conditions []fdbv1beta2.ProcessGroupConditionType) ([]string, error) {
 	cluster, err := loadCluster(kubeClient, namespace, clusterName)
 	if err != nil {
 		return []string{}, nil, err

--- a/kubectl-fdb/cmd/k8s_client_test.go
+++ b/kubectl-fdb/cmd/k8s_client_test.go
@@ -151,7 +151,7 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 
 		DescribeTable("should show all deprecations",
 			func(tc testCase) {
-				pods, err := getAllPodsFromClusterWithCondition(k8sClient, clusterName, namespace, tc.conditions)
+				pods, _, err := getAllPodsFromClusterWithCondition(k8sClient, clusterName, namespace, tc.conditions)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pods).To(Equal(tc.expected))
 			},

--- a/kubectl-fdb/cmd/k8s_client_test.go
+++ b/kubectl-fdb/cmd/k8s_client_test.go
@@ -158,6 +158,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 			expectedOutputBuffer string
 		}
 
+		expectedPodNamesMultipleConditions := make([]string, 0, 3)
+		expectedPodNamesMultipleConditions = append(expectedPodNamesMultipleConditions, "instance-1", "instance-2")
+
 		DescribeTable("should show all deprecations",
 			func(tc testCase) {
 				outBuffer := bytes.Buffer{}
@@ -181,7 +184,7 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 			Entry("Multiple conditions",
 				testCase{
 					conditions:           []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses, fdbv1beta2.IncorrectCommandLine},
-					expected:             []string{"instance-1", "instance-2"},
+					expected:             expectedPodNamesMultipleConditions,
 					expectedOutputBuffer: "",
 				}),
 			Entry("Single condition and missing pod",

--- a/kubectl-fdb/cmd/k8s_client_test.go
+++ b/kubectl-fdb/cmd/k8s_client_test.go
@@ -194,13 +194,13 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				testCase{
 					conditions:           []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.SidecarUnreachable},
 					expected:             []string{},
-					expectedOutputBuffer: "Process Group: instance-5, is missing pods.\n",
+					expectedOutputBuffer: "Skipping Process Group: instance-5, because it does not have a corresponding Pod.\n",
 				}),
 			Entry("Multiple conditions and missing pod",
 				testCase{
 					conditions:           []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses, fdbv1beta2.SidecarUnreachable},
 					expected:             append(expectedPodNamesMultipleConditionsMissingPods, "instance-1"),
-					expectedOutputBuffer: "Process Group: instance-5, is missing pods.\nSkipping Process Group: instance-3, Pod is not running, current phase: Failed\n",
+					expectedOutputBuffer: "Skipping Process Group: instance-5, because it does not have a corresponding Pod.\nSkipping Process Group: instance-3, Pod is not running, current phase: Failed\n",
 				}),
 		)
 	})

--- a/kubectl-fdb/cmd/k8s_client_test.go
+++ b/kubectl-fdb/cmd/k8s_client_test.go
@@ -158,8 +158,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 			expectedOutputBuffer string
 		}
 
+		// The length of the expectedPodNamesMultipleConditions should be equal to the number of processes with the given conditions
+		// and not marked for removal
 		expectedPodNamesMultipleConditions := make([]string, 0, 3)
-		expectedPodNamesMultipleConditions = append(expectedPodNamesMultipleConditions, "instance-1", "instance-2")
 
 		DescribeTable("should show all deprecations",
 			func(tc testCase) {
@@ -184,8 +185,8 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 			Entry("Multiple conditions",
 				testCase{
 					conditions:           []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses, fdbv1beta2.IncorrectCommandLine},
-					expected:             expectedPodNamesMultipleConditions,
-					expectedOutputBuffer: "",
+					expected:             append(expectedPodNamesMultipleConditions, "instance-2", "instance-1"),
+					expectedOutputBuffer: "Skipping Process Group: instance-3, Pod is not running, current phase: Failed",
 				}),
 			Entry("Single condition and missing pod",
 				testCase{

--- a/kubectl-fdb/cmd/restart.go
+++ b/kubectl-fdb/cmd/restart.go
@@ -23,7 +23,6 @@ package cmd
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
@@ -106,13 +105,9 @@ func newRestartCmd(streams genericclioptions.IOStreams) *cobra.Command {
 					processes = append(processes, pod.Name)
 				}
 			} else if len(conditions) > 0 {
-				var warn []string
-				processes, warn, err = getAllPodsFromClusterWithCondition(cmd.ErrOrStderr(), kubeClient, clusterName, namespace, conditions)
+				processes, err = getAllPodsFromClusterWithCondition(cmd.ErrOrStderr(), kubeClient, clusterName, namespace, conditions)
 				if err != nil {
 					return err
-				}
-				if warn != nil {
-					cmd.PrintErrln("< Warning: The following Process Groups cannot be restarted \n" + strings.Join(warn, "\n") + " />\n")
 				}
 			} else {
 				processes = args

--- a/kubectl-fdb/cmd/restart.go
+++ b/kubectl-fdb/cmd/restart.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
@@ -105,9 +106,13 @@ func newRestartCmd(streams genericclioptions.IOStreams) *cobra.Command {
 					processes = append(processes, pod.Name)
 				}
 			} else if len(conditions) > 0 {
-				processes, err = getAllPodsFromClusterWithCondition(kubeClient, clusterName, namespace, conditions)
+				var warn []string
+				processes, warn, err = getAllPodsFromClusterWithCondition(kubeClient, clusterName, namespace, conditions)
 				if err != nil {
 					return err
+				}
+				if warn != nil {
+					cmd.PrintErrln("< Warning: The following Process Groups cannot be restarted \n" + strings.Join(warn, "\n") + " />\n")
 				}
 			} else {
 				processes = args

--- a/kubectl-fdb/cmd/restart.go
+++ b/kubectl-fdb/cmd/restart.go
@@ -107,7 +107,7 @@ func newRestartCmd(streams genericclioptions.IOStreams) *cobra.Command {
 				}
 			} else if len(conditions) > 0 {
 				var warn []string
-				processes, warn, err = getAllPodsFromClusterWithCondition(kubeClient, clusterName, namespace, conditions)
+				processes, warn, err = getAllPodsFromClusterWithCondition(cmd.ErrOrStderr(), kubeClient, clusterName, namespace, conditions)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
# Description

Fixes #1640 

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*
- Unit tests added 
- Manual testing: 
```
$ kubectl-fdb restart -c fdb-cluster --context fdb-dev  --process-condition=MissingProcesses 
Skipping Process Group: test, because it does not have a corresponding Pod.
Skipping Process Group: test2, because it does not have a corresponding Pod.
Restart [] in cluster timeseries/foundationdb-cluster [y/n]: 
```

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?* No

## Documentation

*Did you update relevant documentation within this repository?* No

*If this change is adding new functionality, do we need to describe it in our user manual?* No

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?* N/A

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?* N/A

## Follow-up

*Are there any follow-up issues that we should pursue in the future?* No

*Does this introduce new defaults that we should re-evaluate in the future?* No
