### PR TITLE
Add better logging for spec hash changes

### DIFF
--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -23,6 +23,7 @@ package replacements
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
@@ -212,11 +213,16 @@ func processGroupNeedsRemoval(cluster *fdbv1beta2.FoundationDBCluster, pod *core
 		}
 
 		if pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] != specHash {
+			jsonSpec, err := json.Marshal(spec)
+			if err != nil {
+				return false, err
+			}
+
 			logger.Info("Replace process group",
 				"reason", "specHash has changed",
 				"desiredSpecHash", specHash,
 				"currentSpecHash", pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey],
-				"desiredSpec", base64.StdEncoding.EncodeToString([]byte(spec.String())),
+				"desiredSpec", base64.StdEncoding.EncodeToString(jsonSpec),
 			)
 			return true, nil
 		}


### PR DESCRIPTION
# Description

This provides better insights into the spec changes for a replacement.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

I decided to log the spec as base64 to prevent any json parsing issues.

## Testing

Locally.

## Documentation

-

## Follow-up

-
