### PR TITLE
Make sure we update the sidecar images too for patch upgrades

### DIFF
--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -415,12 +415,12 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2
 	}
 
 	podName, processGroupID := GetProcessGroupID(cluster, processClass, idNum)
-	mainVersion := cluster.GetRunningVersion()
+	desiredVersion := cluster.GetRunningVersion()
 	if cluster.VersionCompatibleUpgradeInProgress() {
-		mainVersion = cluster.Spec.Version
+		desiredVersion = cluster.Spec.Version
 	}
 
-	image, err := GetImage(mainContainer.Image, cluster.Spec.MainContainer.ImageConfigs, mainVersion, false)
+	image, err := GetImage(mainContainer.Image, cluster.Spec.MainContainer.ImageConfigs, desiredVersion, false)
 	if err != nil {
 		return nil, err
 	}
@@ -466,12 +466,12 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2
 			corev1.VolumeMount{Name: "fdb-trace-logs", MountPath: "/var/log/fdb-trace-logs"},
 		)
 
-		err = configureSidecarContainerForCluster(cluster, podName, initContainer, true, processGroupID)
+		err = configureSidecarContainerForCluster(cluster, podName, initContainer, true, processGroupID, desiredVersion)
 		if err != nil {
 			return nil, err
 		}
 
-		err = configureSidecarContainerForCluster(cluster, podName, sidecarContainer, false, processGroupID)
+		err = configureSidecarContainerForCluster(cluster, podName, sidecarContainer, false, processGroupID, desiredVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -504,8 +504,8 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2
 
 // configureSidecarContainerForCluster sets up a sidecar container for a sidecar
 // in the FDB cluster.
-func configureSidecarContainerForCluster(cluster *fdbv1beta2.FoundationDBCluster, podName string, container *corev1.Container, initMode bool, processGroupID fdbv1beta2.ProcessGroupID) error {
-	return configureSidecarContainer(container, initMode, processGroupID, podName, cluster.GetRunningVersion(), cluster, cluster.Spec.SidecarContainer.ImageConfigs, false)
+func configureSidecarContainerForCluster(cluster *fdbv1beta2.FoundationDBCluster, podName string, container *corev1.Container, initMode bool, processGroupID fdbv1beta2.ProcessGroupID, fdbVersion string) error {
+	return configureSidecarContainer(container, initMode, processGroupID, podName, fdbVersion, cluster, cluster.Spec.SidecarContainer.ImageConfigs, false)
 }
 
 // configureSidecarContainerForBackup sets up a sidecar container for the init

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -185,11 +185,12 @@ var _ = Describe("pod_models", func() {
 
 			It("should use the image tag defined in the desired version", func() {
 				for _, container := range spec.Containers {
-					if container.Name != fdbv1beta2.MainContainerName {
+					if container.Name == fdbv1beta2.MainContainerName {
+						Expect(container.Image).To(HaveSuffix(fdbv1beta2.Versions.NextPatchVersion.String()))
 						continue
 					}
 
-					Expect(container.Image).To(HaveSuffix(fdbv1beta2.Versions.NextPatchVersion.String()))
+					Expect(container.Image).To(HaveSuffix(fdbv1beta2.Versions.NextPatchVersion.String() + "-1"))
 				}
 			})
 		})
@@ -203,11 +204,12 @@ var _ = Describe("pod_models", func() {
 
 			It("should use the image tag defined in the running version", func() {
 				for _, container := range spec.Containers {
-					if container.Name != fdbv1beta2.MainContainerName {
+					if container.Name == fdbv1beta2.MainContainerName {
+						Expect(container.Image).To(HaveSuffix(cluster.Status.RunningVersion))
 						continue
 					}
 
-					Expect(container.Image).To(HaveSuffix(cluster.Status.RunningVersion))
+					Expect(container.Image).To(HaveSuffix(cluster.Status.RunningVersion + "-1"))
 				}
 			})
 		})
@@ -3285,7 +3287,7 @@ var _ = Describe("pod_models", func() {
 
 			DescribeTable("should return the correct image",
 				func(input testCase, expected string) {
-					err = configureSidecarContainerForCluster(cluster, "operator-test-storage-1", input.container, input.initMode, input.processGroupID)
+					err = configureSidecarContainerForCluster(cluster, "operator-test-storage-1", input.container, input.initMode, input.processGroupID, "6.2.21")
 					if input.hasError {
 						Expect(err).To(HaveOccurred())
 					} else {


### PR DESCRIPTION
# Description

The result of this bug was that the transaction system Pods were replaced more often than required e.g. twice instead of once.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Unit test and I will adjust an e2e test to check this behaviour.

## Documentation

-

## Follow-up

-
