### PR TITLE
Make sure we are not allowing to remove process groups if they have no addresses assigned until the exclusion is skipped

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -517,6 +517,13 @@ func (processGroupStatus *ProcessGroupStatus) AllAddressesExcluded(remainingMap 
 		return true, nil
 	}
 
+	// If the process group has no addresses assigned we cannot remove it safely and we have to set the skip exclusion.
+	if len(processGroupStatus.Addresses) == 0 {
+		return false, fmt.Errorf("process has no addresses, cannot safely determine if process can be removed")
+	}
+
+	// If a process group has more than one address we have to make sure that all the provided addresses are part
+	// of the remainingMap as excluded.
 	for _, address := range processGroupStatus.Addresses {
 		isRemaining, isPresent := remainingMap[address]
 		if !isPresent || isRemaining {

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -59,7 +59,6 @@ func (u removeProcessGroups) reconcile(ctx context.Context, r *FoundationDBClust
 	}
 
 	remainingMap, err := removals.GetRemainingMap(logger, adminClient, cluster, status)
-
 	if err != nil {
 		return &requeue{curError: err}
 	}


### PR DESCRIPTION
# Description

This should prevent any removals for process groups that have no address yet, by enforcing that a process group must have at least one address to be able to be removed. A user still can specify the skip exclusion to force this e.g. for Pods stuck in pending for a long time.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Unit tests, added an additional e2e test.

## Documentation

-

## Follow-up

-
