### PR TITLE
Add logging when the operator detects a new running version

### DIFF
--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -83,7 +83,7 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	}
 
 	// Update the running version based on the reported version of the FDB processes
-	version, err := getRunningVersion(versionMap, cluster.Status.RunningVersion)
+	version, err := getRunningVersion(logger, versionMap, cluster.Status.RunningVersion)
 	if err != nil {
 		return &requeue{curError: fmt.Errorf("update_status skipped due to error in getRunningVersion: %w", err)}
 	}
@@ -748,9 +748,9 @@ func refreshProcessGroupStatus(ctx context.Context, r *FoundationDBClusterReconc
 	return pvcs, nil
 }
 
-func getRunningVersion(versionMap map[string]int, fallback string) (string, error) {
+func getRunningVersion(logger logr.Logger, versionMap map[string]int, currentRunningVersion string) (string, error) {
 	if len(versionMap) == 0 {
-		return fallback, nil
+		return currentRunningVersion, nil
 	}
 
 	var currentCandidate fdbv1beta2.Version
@@ -763,7 +763,7 @@ func getRunningVersion(versionMap map[string]int, fallback string) (string, erro
 
 		parsedVersion, err := fdbv1beta2.ParseFdbVersion(version)
 		if err != nil {
-			return fallback, err
+			return currentRunningVersion, err
 		}
 		// In this case we want to ensure we always pick the newer version to have a stable return value. Otherwise,
 		// it could happen that the version will be flapping between two versions.
@@ -777,7 +777,18 @@ func getRunningVersion(versionMap map[string]int, fallback string) (string, erro
 		currentMaxCount = count
 	}
 
-	return currentCandidate.String(), nil
+	candidateString := currentCandidate.String()
+	// Only in the case of a new version detected we should log the new version and more information why the operator
+	// made this decision.
+	if candidateString != currentRunningVersion {
+		logger.Info("getting the running version from status",
+			"detectedCandidate", candidateString,
+			"previousVersion", currentCandidate,
+			"versionMap", versionMap)
+
+	}
+
+	return candidateString, nil
 }
 
 func hasExactMatchedTaintKey(taintReplacementOptions []fdbv1beta2.TaintReplacementOption, nodeTaintKey string) bool {

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -785,7 +785,6 @@ func getRunningVersion(logger logr.Logger, versionMap map[string]int, currentRun
 			"detectedCandidate", candidateString,
 			"previousVersion", currentCandidate,
 			"versionMap", versionMap)
-
 	}
 
 	return candidateString, nil

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -734,7 +734,7 @@ var _ = Describe("update_status", func() {
 	})
 
 	DescribeTable("when getting the running version from the running processes", func(versionMap map[string]int, fallback string, expected string) {
-		Expect(getRunningVersion(versionMap, fallback)).To(Equal(expected))
+		Expect(getRunningVersion(log, versionMap, fallback)).To(Equal(expected))
 	},
 		Entry("when nearly all processes running on the new version", map[string]int{
 			"7.1.11": 1,

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1185,10 +1185,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			Consistently(func() corev1.PodPhase {
 				return fdbCluster.GetPod(podName).Status.Phase
 			}).WithTimeout(2 * time.Minute).WithPolling(15 * time.Second).Should(Equal(corev1.PodPending))
-			// Clear the buggify list, this should allow the operator to move forawrd
-			Expect(fdbCluster.ClearBuggifyNoSchedule(false)).NotTo(HaveOccurred())
+			// Clear the buggify list, this should allow the operator to move forward and delete the Pod
+			Expect(fdbCluster.ClearBuggifyNoSchedule(true)).NotTo(HaveOccurred())
 			// Make sure the Pod is deleted.
-			fdbCluster.EnsurePodIsDeleted(podName)
+			Expect(fdbCluster.CheckPodIsDeleted(podName)).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
# Description

This will be helpful to detect any issues with a flapping running version.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

Unit tests.

## Documentation

-

## Follow-up

-
