### PR TITLE
Make sure we retry the maintenance commands if they fail once

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1111,13 +1111,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		When("maintenance mode is on", func() {
 			BeforeEach(func() {
 				command := fmt.Sprintf("maintenance on %s %s", "operator-test-1-storage-4", "40000")
-				_, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(command, false, 40)
-				Expect(err).ShouldNot(HaveOccurred())
+				_, _ = fdbCluster.RunFdbCliCommandInOperator(command, false, 40)
 			})
 
 			AfterEach(func() {
-				_, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry("maintenance off", false, 40)
-				Expect(err).ShouldNot(HaveOccurred())
+				_, _ = fdbCluster.RunFdbCliCommandInOperator("maintenance off", false, 40)
 			})
 
 			It("status maintenance zone should match", func() {


### PR DESCRIPTION
# Description

We've seen a few failures where the e2e test framework was not able to connect to the operator Pod, e.g. because it was just killed by the Pod chaos. In order to make the tests more reliable we should retry the command(s).

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Manual test.

## Documentation

-
## Follow-up

-
