### PR TITLE
Make sure we set the connection string if the status is cached

### DIFF
--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -58,17 +58,6 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 		}
 	}
 
-	if status.Cluster.ConnectionString != cluster.Status.ConnectionString {
-		logger.Info("Updating out-of-date connection string")
-		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpdatingConnectionString", fmt.Sprintf("Setting connection string to %s", status.Cluster.ConnectionString))
-		cluster.Status.ConnectionString = status.Cluster.ConnectionString
-		err = r.updateOrApply(ctx, cluster)
-
-		if err != nil {
-			return &requeue{curError: err, delayedRequeue: true}
-		}
-	}
-
 	coordinatorStatus := make(map[string]bool, len(status.Client.Coordinators.Coordinators))
 	for _, coordinator := range status.Client.Coordinators.Coordinators {
 		coordinatorStatus[coordinator.Address.String()] = false

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -447,8 +447,11 @@ func (r *FoundationDBClusterReconciler) getStatusFromClusterOrDummyStatus(logger
 		return nil, err
 	}
 
-	if cluster.Status.ConnectionString != connectionString {
-		logger.Info("Detected new connection string", "previousConnectionString", cluster.Status.ConnectionString, "newConnectionString", connectionString)
+	// Update the connection string if the newly fetched connection string is different from the current one and if the
+	// newly fetched connection string is not empty.
+	if cluster.Status.ConnectionString != connectionString && connectionString != "" {
+		logger.Info("Updating out-of-date connection string", "previousConnectionString", cluster.Status.ConnectionString, "newConnectionString", connectionString)
+		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpdatingConnectionString", fmt.Sprintf("Setting connection string to %s", connectionString))
 		cluster.Status.ConnectionString = connectionString
 	}
 

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -446,7 +446,11 @@ func (r *FoundationDBClusterReconciler) getStatusFromClusterOrDummyStatus(logger
 	if err != nil {
 		return nil, err
 	}
-	cluster.Status.ConnectionString = connectionString
+
+	if cluster.Status.ConnectionString != connectionString {
+		logger.Info("Detected new connection string", "previousConnectionString", cluster.Status.ConnectionString, "newConnectionString", connectionString)
+		cluster.Status.ConnectionString = connectionString
+	}
 
 	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
 	if err != nil {
@@ -456,9 +460,6 @@ func (r *FoundationDBClusterReconciler) getStatusFromClusterOrDummyStatus(logger
 	defer adminClient.Close()
 
 	status, err := adminClient.GetStatus()
-
-	logger.V(1).Info("connection string from getStatusFromClusterOrDummyStatus", "tryConnectionOptions", connectionString, "status", status.Cluster.ConnectionString)
-
 	if err == nil {
 		return status, nil
 	}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -456,6 +456,9 @@ func (r *FoundationDBClusterReconciler) getStatusFromClusterOrDummyStatus(logger
 	defer adminClient.Close()
 
 	status, err := adminClient.GetStatus()
+
+	logger.V(1).Info("connection string from getStatusFromClusterOrDummyStatus", "tryConnectionOptions", connectionString, "status", status.Cluster.ConnectionString)
+
 	if err == nil {
 		return status, nil
 	}

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -56,7 +56,6 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	// Pass through Maintenance Mode Info as the maintenance_mode_checker reconciler takes care of updating it
 	originalStatus.MaintenanceModeInfo.DeepCopyInto(&clusterStatus.MaintenanceModeInfo)
 	clusterStatus.Generations.Reconciled = cluster.Status.Generations.Reconciled
-	clusterStatus.ConnectionString = originalStatus.ConnectionString
 
 	// Initialize with the current desired storage servers per Pod
 	clusterStatus.StorageServersPerDisk = []int{cluster.GetStorageServersPerPod()}
@@ -290,11 +289,6 @@ func optionList(options ...string) []string {
 // returns the connection string that allows connecting to the cluster.
 func tryConnectionOptions(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, r *FoundationDBClusterReconciler) (string, error) {
 	connectionStrings := optionList(cluster.Status.ConnectionString, cluster.Spec.SeedConnectionString)
-
-	if len(connectionStrings) == 1 {
-		return cluster.Status.ConnectionString, nil
-	}
-
 	logger.Info("Trying connection options", "connectionString", connectionStrings)
 
 	originalConnectionString := cluster.Status.ConnectionString

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -56,6 +56,7 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	// Pass through Maintenance Mode Info as the maintenance_mode_checker reconciler takes care of updating it
 	originalStatus.MaintenanceModeInfo.DeepCopyInto(&clusterStatus.MaintenanceModeInfo)
 	clusterStatus.Generations.Reconciled = cluster.Status.Generations.Reconciled
+	clusterStatus.ConnectionString = originalStatus.ConnectionString
 
 	// Initialize with the current desired storage servers per Pod
 	clusterStatus.StorageServersPerDisk = []int{cluster.GetStorageServersPerPod()}

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -561,5 +561,4 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 		EntryDescription("Upgrade from %[1]s to %[2]s when no remote processes are restarted"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
-
 })


### PR DESCRIPTION
# Description

Make sure we propagate the fetched connection string only in one place and we check that the fetched connection string is not empty before assigning it.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Manuel e2e test run.

## Documentation

-

## Follow-up

-
