### PR TITLE
Fix test case for version compatible upgrades

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1342,6 +1342,7 @@ func (cluster *FoundationDBCluster) CheckReconciliation(log logr.Logger) (bool, 
 	logger := log.WithValues("method", "CheckReconciliation", "namespace", cluster.Namespace, "cluster", cluster.Name)
 	var reconciled = true
 	if !cluster.Status.Configured {
+		logger.Info("Pending initial database configuration", "state", "NeedsConfigurationChange")
 		cluster.Status.Generations.NeedsConfigurationChange = cluster.ObjectMeta.Generation
 		return false, nil
 	}


### PR DESCRIPTION
# Description

Added some more description in the test case. TLDR: the test case was not working properly for version compatible upgrades as the Pod was recreated by the operator and then the network partition was lost (as chaos-mesh is not re-injecting chaos).

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Manual run with a version compatible upgrade.

## Documentation

Added in code.

## Follow-up

-