### PR TITLE
Make sure we wait some time before checking the incompatible connections

### DIFF
--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -530,8 +530,10 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			// The cluster should still be able to upgrade.
 			Expect(fdbCluster.UpgradeCluster(targetVersion, true)).NotTo(HaveOccurred())
 
-			status := fdbCluster.GetStatus()
-			Expect(len(status.Cluster.IncompatibleConnections)).To(Equal(0))
+			// Make sure that the incompatible connections are cleaned up after some time.
+			Eventually(func() []string {
+				return fdbCluster.GetStatus().Cluster.IncompatibleConnections
+			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).MustPassRepeatedly(5).Should(HaveLen(0))
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s with one coordinator not being restarted"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -533,7 +533,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			// Make sure that the incompatible connections are cleaned up after some time.
 			Eventually(func() []string {
 				return fdbCluster.GetStatus().Cluster.IncompatibleConnections
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).MustPassRepeatedly(5).Should(HaveLen(0))
+			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).MustPassRepeatedly(5).Should(BeEmpty())
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s with one coordinator not being restarted"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),


### PR DESCRIPTION
# Description

Wait for 5 minutes before failing if the incompatible connections are not 0. This makes sure we give the FDB cluster some time to clean up the incompatible connections as this information is cached for some time.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Manual run.

## Documentation

-

## Follow-up

-