### PR TITLE
Replacement logic should ignore process groups that are in maintenance mode

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -746,6 +746,11 @@ func (processGroupStatus *ProcessGroupStatus) GetConditionTime(conditionType Pro
 	return nil
 }
 
+// IsUnderMaintenance checks if the process is in maintenance zone.
+func (processGroupStatus *ProcessGroupStatus) IsUnderMaintenance(maintenanceZone FaultDomain) bool {
+	return processGroupStatus.FaultDomain == maintenanceZone
+}
+
 // GetCondition returns the ProcessGroupStatus's ProcessGroupCondition that matches the conditionType;
 // It returns nil if the ProcessGroupStatus doesn't have a matching condition
 func (processGroupStatus *ProcessGroupStatus) GetCondition(conditionType ProcessGroupConditionType) *ProcessGroupCondition {

--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -59,7 +59,7 @@ func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *Foundation
 
 	// Only replace process groups without an address, if the cluster has the desired fault tolerance and is available.
 	hasDesiredFaultTolerance := fdbstatus.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
-	if replacements.ReplaceFailedProcessGroups(logger, cluster, hasDesiredFaultTolerance) {
+	if replacements.ReplaceFailedProcessGroups(logger, cluster, status, hasDesiredFaultTolerance) {
 		err := r.updateOrApply(ctx, cluster)
 		if err != nil {
 			return &requeue{curError: err}

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -920,7 +920,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			})
 
 			It("should not mark the process group for removal", func() {
-				Expect(getRemovedProcessGroupIDs(cluster)).To(Equal([]fdbv1beta2.ProcessGroupID{}))
+				Expect(getRemovedProcessGroupIDs(cluster)).To(Equal(BeEmpty()))
 			})
 		})
 	})

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -911,6 +911,18 @@ var _ = Describe("replace_failed_process_groups", func() {
 				})
 			})
 		})
+
+		Context("with maintenance mode enabled", func() {
+			BeforeEach(func() {
+				adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(adminClient.SetMaintenanceZone("operator-test-1-storage-2", 0)).NotTo(HaveOccurred())
+			})
+
+			It("should not mark the process group for removal", func() {
+				Expect(getRemovedProcessGroupIDs(cluster)).To(Equal([]fdbv1beta2.ProcessGroupID{}))
+			})
+		})
 	})
 
 	Context("with a process that has been missing for a brief time", func() {

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -920,7 +920,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 			})
 
 			It("should not mark the process group for removal", func() {
-				Expect(getRemovedProcessGroupIDs(cluster)).To(Equal(BeEmpty()))
+				Expect(getRemovedProcessGroupIDs(cluster)).To(BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION
# Description

Modify operator replacement logic to ignore process groups that are in maintenance mode.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion


## Testing

Manual testing.

## Documentation


## Follow-up

