### PR TITLE
Allow to set additional fields for the admin client logger

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -728,3 +728,23 @@ func (client *cliAdminClient) GetCoordinatorSet() (map[string]fdbv1beta2.None, e
 func (client *cliAdminClient) SetKnobs(knobs []string) {
 	client.knobs = knobs
 }
+
+// WithValues will update the logger used by the current AdminClient to contain the provided key value pairs. The provided
+// arguments must be even.
+func (client *cliAdminClient) WithValues(keysAndValues ...interface{}) {
+	newLogger := client.log.WithValues(keysAndValues...)
+	client.log = newLogger
+
+	// Update the FDB library client logger
+	realFdbClient, ok := client.fdbLibClient.(*realFdbLibClient)
+	if ok {
+		realFdbClient.logger = newLogger
+	}
+
+	// Update the command runner logger
+	cmdRunner, ok := client.cmdRunner.(*realCommandRunner)
+	if !ok {
+		return
+	}
+	cmdRunner.log = newLogger
+}

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -27,10 +27,10 @@ import (
 // AdminClient describes an interface for running administrative commands on a
 // cluster
 type AdminClient interface {
-	// GetStatus gets the database's status
+	// GetStatus gets the database's status.
 	GetStatus() (*fdbv1beta2.FoundationDBStatus, error)
 
-	// ConfigureDatabase sets the database configuration
+	// ConfigureDatabase sets the database configuration.
 	ConfigureDatabase(configuration fdbv1beta2.DatabaseConfiguration, newDatabase bool, version string) error
 
 	// ExcludeProcesses starts evacuating processes so that they can be removed
@@ -103,12 +103,16 @@ type AdminClient interface {
 	// SetKnobs sets the Knobs that should be used for the commandline call.
 	SetKnobs([]string)
 
-	// GetMaintenanceZone gets current maintenance zone, if any
+	// GetMaintenanceZone gets current maintenance zone, if any.
 	GetMaintenanceZone() (string, error)
 
-	// SetMaintenanceZone places zone into maintenance mode
+	// SetMaintenanceZone places zone into maintenance mode.
 	SetMaintenanceZone(zone string, timeoutSeconds int) error
 
-	// Reset maintenance mode
+	// ResetMaintenanceMode resets the maintenance mode.
 	ResetMaintenanceMode() error
+
+	// WithValues will update the logger used by the current AdminClient to contain the provided key value pairs. The provided
+	// arguments must be even.
+	WithValues(keysAndValues ...interface{})
 }

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -1018,3 +1018,7 @@ func (client *AdminClient) GetWorstDurabilityLag() (fdbv1beta2.FoundationDBStatu
 	lagInfo, ok := client.LagInfo["worstDurabilityLag"]
 	return lagInfo, ok
 }
+
+// WithValues will update the logger used by the current AdminClient to contain the provided key value pairs. The provided
+// arguments must be even.
+func (client *AdminClient) WithValues(_ ...interface{}) {}


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1710

## Type of change

*Please select one of the options below.*

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Discussion

-

## Testing

Manual e2e test run:

```text
fdb-kubernetes-operator-controller-manager-7695576797-vk9vr manager {"level":"info","ts":"2023-06-28T12:17:11Z","logger":"fdbclient","msg":"Done fetching values from FDB","namespace":"jscheuermann-ove3b2kz","cluster":"fdb-cluster-ho1fvswm","testing":"12345","key":"\ufffd/coordinators"}
```

## Documentation

-

## Follow-up

-
