### PR TITLE
Expose methods to create a cluster based on the generated spec

### DIFF
--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -155,18 +155,18 @@ func (factory *Factory) CreateFdbCluster(
 	config *ClusterConfig,
 	options ...ClusterOption,
 ) *FdbCluster {
+	spec := factory.GenerateFDBClusterSpec(config)
+	return factory.CreateFdbClusterFromSpec(spec, config, options...)
+}
+
+// CreateFdbClusterFromSpec creates a FDB cluster. This method can be used in combination with the GenerateFDBClusterSpec method.
+// In general this should only be used for special cases that are not covered by changing the ClusterOptions or the ClusterConfig.
+func (factory *Factory) CreateFdbClusterFromSpec(
+	spec *fdbv1beta2.FoundationDBCluster,
+	config *ClusterConfig,
+	options ...ClusterOption,
+) *FdbCluster {
 	config.SetDefaults(factory)
-
-	mainOverrides, sidecarOverrides := factory.getContainerOverrides(config.DebugSymbols)
-	spec := factory.createFDBClusterSpec(
-		config.Name,
-		config.Namespace,
-		factory.createProcesses(config),
-		config.CreateDatabaseConfiguration(),
-		config.StorageServerPerPod,
-		mainOverrides,
-		sidecarOverrides)
-
 	log.Printf("create cluster: %s", ToJSON(spec))
 
 	return factory.startFDBFromClusterSpec(spec, config, options...)

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -27,6 +27,21 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+// GenerateFDBClusterSpec will generate a *fdbv1beta2.FoundationDBCluster based on the input ClusterConfig.
+func (factory *Factory) GenerateFDBClusterSpec(config *ClusterConfig) *fdbv1beta2.FoundationDBCluster {
+	config.SetDefaults(factory)
+
+	mainOverrides, sidecarOverrides := factory.getContainerOverrides(config.DebugSymbols)
+	return factory.createFDBClusterSpec(
+		config.Name,
+		config.Namespace,
+		factory.createProcesses(config),
+		config.CreateDatabaseConfiguration(),
+		config.StorageServerPerPod,
+		mainOverrides,
+		sidecarOverrides)
+}
+
 // High Level Cluster Spec Supplied by Operator.
 func (factory *Factory) createFDBClusterSpec(
 	clusterName string,


### PR DESCRIPTION
# Description

Exposing those methods will be helpful for some special use cases where a modified version of the cluster spec will be used to create a cluster.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

unit test + e2e tests.

## Documentation

-

## Follow-up

-
