### PR TITLE
Make sure we update the status of the FoundationDBCluster only in one place

### DIFF
--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -64,7 +64,6 @@ func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterR
 		}
 	}
 
-	hasNewProcessGroups := false
 	for _, processClass := range fdbv1beta2.ProcessClasses {
 		desiredCount := desiredCounts[processClass]
 		if desiredCount < 0 {
@@ -95,14 +94,6 @@ func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterR
 			cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(processGroupID, processClass, nil))
 
 			idNum++
-		}
-		hasNewProcessGroups = true
-	}
-
-	if hasNewProcessGroups {
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
 		}
 	}
 

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -59,10 +59,7 @@ var _ = Describe("add_process_groups", func() {
 			Expect(requeue.curError).NotTo(HaveOccurred())
 		}
 
-		_, err = reloadCluster(cluster)
-		Expect(err).NotTo(HaveOccurred())
 		newProcessCounts = fdbv1beta2.CreateProcessCountsFromProcessGroupStatus(cluster.Status.ProcessGroups, true)
-
 	})
 
 	Context("with a reconciled cluster", func() {

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -82,11 +82,6 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsBounce",
 			fmt.Sprintf("Spec require a bounce of some processes, but the cluster has only been up for %f seconds", minimumUptime))
 		cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			logger.Error(err, "Error updating cluster status")
-		}
-
 		// Retry after we waited the minimum uptime
 		return &requeue{
 			message: "Cluster needs to stabilize before bouncing",

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -100,10 +100,6 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 		return &requeue{curError: err, delayedRequeue: true}
 	}
 	cluster.Status.ConnectionString = connectionString
-	err = r.updateOrApply(ctx, cluster)
-	if err != nil {
-		return &requeue{curError: err, delayedRequeue: true}
-	}
 
 	return nil
 }

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -123,10 +123,6 @@ func (c chooseRemovals) reconcile(ctx context.Context, r *FoundationDBClusterRec
 				processGroup.MarkForRemoval()
 			}
 		}
-		err := r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
-		}
 	}
 
 	return nil

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -58,8 +58,6 @@ var _ = Describe("choose_removals", func() {
 	JustBeforeEach(func() {
 		requeue = chooseRemovals{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = reloadCluster(cluster)
-		Expect(err).NotTo(HaveOccurred())
 
 		removals = nil
 		for _, processGroup := range cluster.Status.ProcessGroups {
@@ -67,7 +65,6 @@ var _ = Describe("choose_removals", func() {
 				removals = append(removals, processGroup.ProcessGroupID)
 			}
 		}
-
 	})
 
 	Context("with a reconciled cluster", func() {

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -196,7 +196,7 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 			continue
 		}
 
-		err = r.updateClusterStatusIfNeeded(ctx, cluster, originalStatus)
+		err = r.updateClusterStatusIfNeeded(ctx, clusterLog, cluster, originalStatus)
 		if err != nil {
 			clusterLog.Error(err, "could not update cluster status")
 			return ctrl.Result{Requeue: true}, err
@@ -205,7 +205,7 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 		return processRequeue(requeue, subReconciler, cluster, r.Recorder, clusterLog)
 	}
 
-	err = r.updateClusterStatusIfNeeded(ctx, cluster, originalStatus)
+	err = r.updateClusterStatusIfNeeded(ctx, clusterLog, cluster, originalStatus)
 	if err != nil {
 		clusterLog.Error(err, "could not update cluster status")
 		return ctrl.Result{Requeue: true}, err
@@ -226,11 +226,12 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 }
 
 // updateClusterStatusIfNeeded will update the cluster status if any changes are detected, otherwise this method will be a no-op.
-func (r *FoundationDBClusterReconciler) updateClusterStatusIfNeeded(ctx context.Context, cluster *fdbv1beta2.FoundationDBCluster, originalStatus *fdbv1beta2.FoundationDBClusterStatus) error {
+func (r *FoundationDBClusterReconciler) updateClusterStatusIfNeeded(ctx context.Context, logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, originalStatus *fdbv1beta2.FoundationDBClusterStatus) error {
 	// See: https://github.com/kubernetes-sigs/kubebuilder/issues/592
 	// If we use the default reflect.DeepEqual method it will be recreating the
 	// clusterStatus multiple times because the pointers are different.
 	if !equality.Semantic.DeepEqual(cluster.Status, *originalStatus) {
+		logger.V(1).Info("Updating FoundationDBClusterStatus", "newStatus", cluster.Status, "originalStatus", *originalStatus)
 		return r.updateOrApply(ctx, cluster)
 	}
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2962,6 +2962,7 @@ var _ = Describe("cluster_controller", func() {
 						err := k8sClient.Update(context.TODO(), cluster)
 						Expect(err).NotTo(HaveOccurred())
 					})
+
 					It("generations are matching", func() {
 						generations, err := reloadClusterGenerations(cluster)
 						Expect(err).NotTo(HaveOccurred())
@@ -2975,12 +2976,14 @@ var _ = Describe("cluster_controller", func() {
 						err := k8sClient.Update(context.TODO(), cluster)
 						Expect(err).NotTo(HaveOccurred())
 					})
+
 					It("generations are matching", func() {
 						generations, err := reloadClusterGenerations(cluster)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(generations.Reconciled).To(Equal(cluster.ObjectMeta.Generation))
 					})
 				})
+
 				When("using 7.0.0", func() {
 					BeforeEach(func() {
 						cluster.Spec.DatabaseConfiguration.StorageEngine = fdbv1beta2.StorageEngineRedwood1Experimental
@@ -2994,6 +2997,7 @@ var _ = Describe("cluster_controller", func() {
 						Expect(generations.Reconciled).To(Equal(cluster.ObjectMeta.Generation))
 					})
 				})
+
 				When("using 6.3.24", func() {
 					BeforeEach(func() {
 						cluster.Spec.DatabaseConfiguration.StorageEngine = fdbv1beta2.StorageEngineRedwood1Experimental
@@ -3009,7 +3013,6 @@ var _ = Describe("cluster_controller", func() {
 					})
 				})
 			})
-
 		})
 
 		When("When a process have an incorrect commandline", func() {

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -138,10 +138,5 @@ func (g generateInitialClusterFile) reconcile(ctx context.Context, r *Foundation
 
 	cluster.Status.ConnectionString = connectionString.String()
 
-	err = r.updateOrApply(ctx, cluster)
-	if err != nil {
-		return &requeue{curError: err}
-	}
-
 	return nil
 }

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -87,10 +87,6 @@ func (maintenanceModeChecker) reconcile(ctx context.Context, r *FoundationDBClus
 		return &requeue{curError: err, delayedRequeue: true}
 	}
 	cluster.Status.MaintenanceModeInfo = fdbv1beta2.MaintenanceModeInfo{}
-	err = r.updateOrApply(ctx, cluster)
-	if err != nil {
-		return &requeue{curError: err, delayedRequeue: true}
-	}
 
 	return nil
 }

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -33,7 +33,7 @@ import (
 type maintenanceModeChecker struct{}
 
 // reconcile runs the reconciler's work.
-func (maintenanceModeChecker) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	if !cluster.UseMaintenaceMode() {
 		return nil
 	}

--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -60,11 +60,6 @@ func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *Foundation
 	// Only replace process groups without an address, if the cluster has the desired fault tolerance and is available.
 	hasDesiredFaultTolerance := fdbstatus.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
 	if replacements.ReplaceFailedProcessGroups(logger, cluster, status, hasDesiredFaultTolerance) {
-		err := r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
-		}
-
 		return &requeue{message: "Removals have been updated in the cluster status"}
 	}
 

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -58,6 +58,8 @@ var _ = Describe("replace_failed_process_groups", func() {
 		generation, err := reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(generation).To(Equal(int64(1)))
+
+		Expect(internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})).NotTo(HaveOccurred())
 	})
 
 	JustBeforeEach(func() {

--- a/controllers/replace_misconfigured_process_groups.go
+++ b/controllers/replace_misconfigured_process_groups.go
@@ -46,18 +46,9 @@ func (c replaceMisconfiguredProcessGroups) reconcile(ctx context.Context, r *Fou
 		return &requeue{curError: err}
 	}
 
-	hasReplacements, err := replacements.ReplaceMisconfiguredProcessGroups(ctx, r.PodLifecycleManager, r, logger, cluster, internal.CreatePVCMap(cluster, pvcs))
+	_, err = replacements.ReplaceMisconfiguredProcessGroups(ctx, r.PodLifecycleManager, r, logger, cluster, internal.CreatePVCMap(cluster, pvcs))
 	if err != nil {
 		return &requeue{curError: err}
-	}
-
-	if hasReplacements {
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
-		}
-
-		logger.Info("Removals have been updated in the cluster status")
 	}
 
 	return nil

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -106,10 +106,6 @@ func (u updateDatabaseConfiguration) reconcile(ctx context.Context, r *Foundatio
 		}
 		if initialConfig {
 			cluster.Status.Configured = true
-			err = r.updateOrApply(ctx, cluster)
-			if err != nil {
-				return &requeue{curError: err, delayedRequeue: true}
-			}
 			return nil
 		}
 		logger.Info("Configured database")

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -63,15 +63,6 @@ func (u updateDatabaseConfiguration) reconcile(_ context.Context, r *FoundationD
 		return nil
 	}
 
-	// Make sure we reset the status here if the configuration changes where not successful.
-	originalStatus := cluster.Status.DeepCopy()
-	defer func() {
-		if err != nil {
-			logger.V(1).Info("Resetting status to previous changes because an error occurred", "current", cluster.Status, "originalStatus", originalStatus)
-			cluster.Status = *originalStatus
-		}
-	}()
-
 	desiredConfiguration := cluster.DesiredDatabaseConfiguration()
 	desiredConfiguration.RoleCounts.Storage = 0
 	currentConfiguration := status.Cluster.DatabaseConfiguration.NormalizeConfigurationWithSeparatedProxies(cluster.Spec.Version, cluster.Spec.DatabaseConfiguration.AreSeparatedProxiesConfigured())

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"k8s.io/apimachinery/pkg/api/equality"
-
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
@@ -47,7 +45,6 @@ func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		return &requeue{curError: err}
 	}
 
-	originalStatus := cluster.Status.DeepCopy()
 	allSynced := true
 	delayedRequeue := true
 	var errs []error
@@ -140,13 +137,6 @@ func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		}
 
 		processGroup.UpdateCondition(fdbv1beta2.SidecarUnreachable, false)
-	}
-
-	if !equality.Semantic.DeepEqual(cluster.Status, *originalStatus) {
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
-		}
 	}
 
 	// If any error has happened requeue.

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -54,10 +54,6 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 			r.Recorder.Event(cluster, corev1.EventTypeNormal,
 				"NeedsPodsDeletion", "Spec require deleting some pods, but deleting pods is disabled")
 			cluster.Status.Generations.NeedsPodDeletion = cluster.ObjectMeta.Generation
-			err = r.updateOrApply(ctx, cluster)
-			if err != nil {
-				logger.Error(err, "Error updating cluster status")
-			}
 			return &requeue{message: "Pod deletion is disabled"}
 		}
 	}

--- a/controllers/update_pods_test.go
+++ b/controllers/update_pods_test.go
@@ -306,6 +306,7 @@ var _ = Describe("update_pods", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
 			Expect(k8sClient.Get(context.TODO(), ctrlClient.ObjectKeyFromObject(cluster), cluster)).NotTo(HaveOccurred())
+			Expect(internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})).NotTo(HaveOccurred())
 		})
 
 		JustBeforeEach(func() {

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -253,17 +253,6 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 		return &requeue{curError: err}
 	}
 
-	// See: https://github.com/kubernetes-sigs/kubebuilder/issues/592
-	// If we use the default reflect.DeepEqual method it will be recreating the
-	// clusterStatus multiple times because the pointers are different.
-	if !equality.Semantic.DeepEqual(cluster.Status, *originalStatus) {
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			logger.Error(err, "Error updating cluster clusterStatus")
-			return &requeue{curError: err}
-		}
-	}
-
 	return nil
 }
 

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -693,8 +693,6 @@ var _ = Describe("update_status", func() {
 			if requeue != nil {
 				Expect(requeue.curError).NotTo(HaveOccurred())
 			}
-			_, err = reloadCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should mark the cluster as reconciled", func() {
@@ -716,11 +714,12 @@ var _ = Describe("update_status", func() {
 			})
 		})
 
-		Context("testing maintenance mode functionality", func() {
+		When("testing maintenance mode functionality", func() {
 			When("maintenance mode is on", func() {
 				BeforeEach(func() {
 					Expect(adminClient.SetMaintenanceZone("operator-test-1-storage-4", 0)).NotTo(HaveOccurred())
 				})
+
 				It("status maintenance zone should match", func() {
 					Expect(cluster.Status.MaintenanceModeInfo).To(Equal(fdbv1beta2.MaintenanceModeInfo{ZoneID: "operator-test-1-storage-4"}))
 				})


### PR DESCRIPTION
# Description

The goal of those changes is to reduce the number of conflicts when the operator is updating the `FoundationDBCluster` resource in Kubernetes.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

This will make it easier to debug issues, as the noise for the conflicts will be reduced.

## Testing

Unit tests and e2e tests.

## Documentation

N/A

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
