### PR TITLE
Explanation for the number of recoveries that happen during an upgrade

### DIFF
--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -262,9 +262,10 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 			// Verify that the cluster generation number didn't increase by more
 			// than 80 (in an ideal case the number of recoveries that should happen
-			// during an upgrade is 9, but in reality that number could be higher
-			// because different server processes may get bounced at different times).
-			// See: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1607
+			// during an upgrade, because of bouncing of server processes, is 9, but
+			// in reality that number could be higher because different server processes
+			// may get bounced at different times and also because of cluster controller
+			// change, which happens a number of times, during an upgrade).
 			Expect(finalGeneration).To(BeNumerically("<=", initialGeneration+80))
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),


### PR DESCRIPTION

# Description

Add an explanation for the number of recoveries that happen during an upgrade.
Resolves issue: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1607

## Type of change

*Please select one of the options below.*

- Other

## Discussion

*Are there any design details that you would like to discuss further?*

No.

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

None.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No.

## Documentation

*Did you update relevant documentation within this repository?*

Yes (updated a test related comment)

*If this change is adding new functionality, do we need to describe it in our user manual?*

N/A

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

N/A

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

N/A

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

It is probably worth investigating more test results to confirm the explanation that has been added here.

*Does this introduce new defaults that we should re-evaluate in the future?*

No.
