### PR TITLE
Remove logServersPerDisk from v1beta1 API

### DIFF
--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -452,10 +452,6 @@ type FoundationDBClusterStatus struct {
 	// If there are more than one value in the slice the reconcile phase is not finished.
 	StorageServersPerDisk []int `json:"storageServersPerDisk,omitempty"`
 
-	// LogServersPerDisk defines the LogServersPerDisk observed in the cluster.
-	// If there are more than one value in the slice the reconcile phase is not finished.
-	LogServersPerDisk []int `json:"logServersPerDisk,omitempty"`
-
 	// ImageTypes defines the kinds of images that are in use in the cluster.
 	// If there is more than one value in the slice the reconcile phase is not
 	// finished.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -771,11 +771,6 @@ func (in *FoundationDBClusterStatus) DeepCopyInto(out *FoundationDBClusterStatus
 		*out = make([]int, len(*in))
 		copy(*out, *in)
 	}
-	if in.LogServersPerDisk != nil {
-		in, out := &in.LogServersPerDisk, &out.LogServersPerDisk
-		*out = make([]int, len(*in))
-		copy(*out, *in)
-	}
 	if in.ImageTypes != nil {
 		in, out := &in.ImageTypes, &out.ImageTypes
 		*out = make([]ImageType, len(*in))

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -9966,10 +9966,6 @@ spec:
                       type: string
                     type: array
                 type: object
-              logServersPerDisk:
-                items:
-                  type: integer
-                type: array
               missingProcesses:
                 additionalProperties:
                   format: int64


### PR DESCRIPTION
# Description

Remove this setting from the v1beta1 API as the setting has no affect here.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

Clean up from the previous log server PR.

## Testing

N/A

## Documentation

-

## Follow-up

-
