### PR TITLE
Add label watch perdicate

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -273,6 +273,7 @@ func (r *FoundationDBClusterReconciler) SetupWithManager(mgr ctrl.Manager, maxCo
 			predicate.And(
 				labelSelectorPredicate,
 				predicate.Or(
+					predicate.LabelChangedPredicate{},
 					predicate.GenerationChangedPredicate{},
 					predicate.AnnotationChangedPredicate{},
 				),


### PR DESCRIPTION
# Description

When providing label selector for operator I expect to have following behaviour:
1. Adding label that match label selector to existing foundationdbcluster should reconcile cluster
2. Removing label that match label selector to foundationdbcluster should reconcile cluster

Right now I have following scenario which do not match this expectation:
1. Running fdbcluster with label that matches label selector of operator
2. Remove label above from fdbcluster
3. Remove bunch of pods from fdbcluster
4. Add label back
5. It's not reconcile (I expect this to be reconciled)

It happens due to fdb operator filtering events when such thing happens, so the cluster will stay drifted from expected state and operator won't do reconcilation.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

No

## Testing

Built and tested scenario with foundationdbcluster.

Don't think there is need for additional testing.

## Documentation

No need

## Follow-up

No
