### PR TITLE
Verify the processes that are excluded 

### DIFF
--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -897,7 +897,7 @@ protocol fdb00b071010000`,
 			}
 
 			mockRunner = &mockCommandRunner{
-				mockedError:  fdbv1beta2.TimeoutError{Err: fmt.Errorf("timed out")},
+				mockedError:  nil,
 				mockedOutput: "",
 			}
 		})
@@ -921,8 +921,39 @@ protocol fdb00b071010000`,
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should not issue an exclude command", func() {
-				Expect(mockRunner.receivedBinary).To(BeEmpty())
+			It("should issue an exclude command to verify the exclusion", func() {
+				Expect(mockRunner.receivedBinary).To(HaveSuffix(fdbcliStr))
+				Expect(mockRunner.receivedArgs).To(ContainElements("exclude 192.168.0.1:4500 192.168.0.2:4500"))
+			})
+		})
+
+		When("all provided processes are fully excluded in the status but the exclude command returns an error", func() {
+			BeforeEach(func() {
+				addressesToCheck = []fdbv1beta2.ProcessAddress{
+					{
+						IPAddress: net.ParseIP("192.168.0.1"),
+						Port:      4500,
+					},
+					{
+						IPAddress: net.ParseIP("192.168.0.2"),
+						Port:      4500,
+					},
+				}
+
+				mockRunner = &mockCommandRunner{
+					mockedError:  fdbv1beta2.TimeoutError{Err: fmt.Errorf("timed out")},
+					mockedOutput: "",
+				}
+			})
+
+			It("should return an empty list and an error", func() {
+				Expect(result).To(HaveLen(0))
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should issue an exclude command to verify the exclusion", func() {
+				Expect(mockRunner.receivedBinary).To(HaveSuffix(fdbcliStr))
+				Expect(mockRunner.receivedArgs).To(ContainElements("exclude 192.168.0.1:4500 192.168.0.2:4500"))
 			})
 		})
 
@@ -942,6 +973,11 @@ protocol fdb00b071010000`,
 						Port:      4500,
 					},
 				}
+
+				mockRunner = &mockCommandRunner{
+					mockedError:  nil,
+					mockedOutput: "",
+				}
 			})
 
 			It("should return the one process that is not excluded", func() {
@@ -952,8 +988,8 @@ protocol fdb00b071010000`,
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should not issue an exclude command", func() {
-				Expect(mockRunner.receivedBinary).To(BeEmpty())
+			It("should issue an exclude command to verify the exclusion", func() {
+				Expect(mockRunner.receivedBinary).To(HaveSuffix(fdbcliStr))
 			})
 		})
 
@@ -983,8 +1019,8 @@ protocol fdb00b071010000`,
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should not issue an exclude command", func() {
-				Expect(mockRunner.receivedBinary).To(BeEmpty())
+			It("should issue an exclude command to verify the exclusion", func() {
+				Expect(mockRunner.receivedBinary).To(HaveSuffix(fdbcliStr))
 			})
 		})
 
@@ -1023,12 +1059,12 @@ protocol fdb00b071010000`,
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should not issue an exclude command", func() {
-				Expect(mockRunner.receivedBinary).To(BeEmpty())
+			It("should issue an exclude command to verify the exclusion", func() {
+				Expect(mockRunner.receivedBinary).To(HaveSuffix(fdbcliStr))
 			})
 		})
 
-		When("one process is missing in the cluster status", func() {
+		When("one process is missing in the cluster status and the exclude command times out", func() {
 			BeforeEach(func() {
 				addressesToCheck = []fdbv1beta2.ProcessAddress{
 					{
@@ -1043,6 +1079,11 @@ protocol fdb00b071010000`,
 						IPAddress: net.ParseIP("192.168.0.5"),
 						Port:      4500,
 					},
+				}
+
+				mockRunner = &mockCommandRunner{
+					mockedError:  fdbv1beta2.TimeoutError{Err: fmt.Errorf("timed out")},
+					mockedOutput: "",
 				}
 			})
 

--- a/pkg/fdbstatus/status_checks.go
+++ b/pkg/fdbstatus/status_checks.go
@@ -85,6 +85,7 @@ func getRemainingAndExcludedFromStatus(logger logr.Logger, status *fdbv1beta2.Fo
 		}
 
 		if len(process.Roles) == 0 {
+			logger.Info("found fully excluded process without any roles", "process", process)
 			fullyExcludedAddresses[process.Address.MachineAddress()]++
 		}
 	}


### PR DESCRIPTION
# Description

Verify the processes that are assumed to be excluded by the machine-readable status are also excluded based on the exclude command

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

This change will make sure we have a second safety net for processes that might be missing the roles sporadic in the amchine-readable status.

## Testing

Unit tests. I will see if there is a good way to reproduce a process without any roles but not excluded.

## Documentation

-

## Follow-up

-
