### PR TITLE
Check if the database is available before doing any exclusion checks

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -411,16 +411,6 @@ func (r *FoundationDBClusterReconciler) newFdbPodClient(cluster *fdbv1beta2.Foun
 	return internal.NewFdbPodClient(cluster, pod, globalControllerLogger.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "pod", pod.Name), r.GetTimeout, r.PostTimeout)
 }
 
-func (r *FoundationDBClusterReconciler) getCoordinatorSet(cluster *fdbv1beta2.FoundationDBCluster) (map[string]fdbv1beta2.None, error) {
-	adminClient, err := r.DatabaseClientProvider.GetAdminClient(cluster, r)
-	if err != nil {
-		return map[string]fdbv1beta2.None{}, err
-	}
-	defer adminClient.Close()
-
-	return adminClient.GetCoordinatorSet()
-}
-
 // updateOrApply updates the status either with server-side apply or if disabled with the normal update call.
 func (r *FoundationDBClusterReconciler) updateOrApply(ctx context.Context, cluster *fdbv1beta2.FoundationDBCluster) error {
 	if r.ServerSideApply {

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -411,6 +411,16 @@ func (r *FoundationDBClusterReconciler) newFdbPodClient(cluster *fdbv1beta2.Foun
 	return internal.NewFdbPodClient(cluster, pod, globalControllerLogger.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "pod", pod.Name), r.GetTimeout, r.PostTimeout)
 }
 
+func (r *FoundationDBClusterReconciler) getCoordinatorSet(cluster *fdbv1beta2.FoundationDBCluster) (map[string]fdbv1beta2.None, error) {
+	adminClient, err := r.DatabaseClientProvider.GetAdminClient(cluster, r)
+	if err != nil {
+		return map[string]fdbv1beta2.None{}, err
+	}
+	defer adminClient.Close()
+
+	return adminClient.GetCoordinatorSet()
+}
+
 // updateOrApply updates the status either with server-side apply or if disabled with the normal update call.
 func (r *FoundationDBClusterReconciler) updateOrApply(ctx context.Context, cluster *fdbv1beta2.FoundationDBCluster) error {
 	if r.ServerSideApply {

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -314,8 +314,7 @@ func (r *FoundationDBClusterReconciler) getProcessGroupsToRemove(logger logr.Log
 			continue
 		}
 
-		// ProcessGroup is already marked as excluded we can add it to the processGroupsToRemove and skip further
-		// checks.
+		// ProcessGroup is already marked as excluded we can add it to the processGroupsToRemove and skip further checks.
 		if processGroup.IsExcluded() {
 			processGroupsToRemove = append(processGroupsToRemove, processGroup)
 			continue

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -64,7 +64,8 @@ func (u removeProcessGroups) reconcile(ctx context.Context, r *FoundationDBClust
 		return &requeue{curError: err}
 	}
 
-	allExcluded, newExclusions, processGroupsToRemove := r.getProcessGroupsToRemove(logger, cluster, remainingMap)
+	coordinators := fdbstatus.GetCoordinatorsFromStatus(status)
+	allExcluded, newExclusions, processGroupsToRemove := r.getProcessGroupsToRemove(logger, cluster, remainingMap, coordinators)
 	// If no process groups are marked to remove we have to check if all process groups are excluded.
 	if len(processGroupsToRemove) == 0 {
 		if !allExcluded {
@@ -297,8 +298,7 @@ func getProcessesToInclude(cluster *fdbv1beta2.FoundationDBCluster, removedProce
 	return fdbProcessesToInclude
 }
 
-func (r *FoundationDBClusterReconciler) getProcessGroupsToRemove(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, remainingMap map[string]bool) (bool, bool, []*fdbv1beta2.ProcessGroupStatus) {
-	var cordSet map[string]fdbv1beta2.None
+func (r *FoundationDBClusterReconciler) getProcessGroupsToRemove(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, remainingMap map[string]bool, cordSet map[string]fdbv1beta2.None) (bool, bool, []*fdbv1beta2.ProcessGroupStatus) {
 	allExcluded := true
 	newExclusions := false
 	processGroupsToRemove := make([]*fdbv1beta2.ProcessGroupStatus, 0, len(cluster.Status.ProcessGroups))
@@ -306,17 +306,6 @@ func (r *FoundationDBClusterReconciler) getProcessGroupsToRemove(logger logr.Log
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if !processGroup.IsMarkedForRemoval() {
 			continue
-		}
-
-		// Only query FDB if we have a pending removal otherwise don't query FDB
-		if len(cordSet) == 0 {
-			var err error
-			cordSet, err = r.getCoordinatorSet(cluster)
-
-			if err != nil {
-				logger.Error(err, "Fetching coordinator set for removal")
-				return false, false, nil
-			}
 		}
 
 		if _, ok := cordSet[string(processGroup.ProcessGroupID)]; ok {

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -64,8 +64,7 @@ func (u removeProcessGroups) reconcile(ctx context.Context, r *FoundationDBClust
 		return &requeue{curError: err}
 	}
 
-	coordinators := fdbstatus.GetCoordinatorsFromStatus(status)
-	allExcluded, newExclusions, processGroupsToRemove := r.getProcessGroupsToRemove(logger, cluster, remainingMap, coordinators)
+	allExcluded, newExclusions, processGroupsToRemove := r.getProcessGroupsToRemove(logger, cluster, remainingMap)
 	// If no process groups are marked to remove we have to check if all process groups are excluded.
 	if len(processGroupsToRemove) == 0 {
 		if !allExcluded {
@@ -298,7 +297,8 @@ func getProcessesToInclude(cluster *fdbv1beta2.FoundationDBCluster, removedProce
 	return fdbProcessesToInclude
 }
 
-func (r *FoundationDBClusterReconciler) getProcessGroupsToRemove(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, remainingMap map[string]bool, cordSet map[string]fdbv1beta2.None) (bool, bool, []*fdbv1beta2.ProcessGroupStatus) {
+func (r *FoundationDBClusterReconciler) getProcessGroupsToRemove(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, remainingMap map[string]bool) (bool, bool, []*fdbv1beta2.ProcessGroupStatus) {
+	var cordSet map[string]fdbv1beta2.None
 	allExcluded := true
 	newExclusions := false
 	processGroupsToRemove := make([]*fdbv1beta2.ProcessGroupStatus, 0, len(cluster.Status.ProcessGroups))
@@ -306,6 +306,17 @@ func (r *FoundationDBClusterReconciler) getProcessGroupsToRemove(logger logr.Log
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if !processGroup.IsMarkedForRemoval() {
 			continue
+		}
+
+		// Only query FDB if we have a pending removal otherwise don't query FDB
+		if len(cordSet) == 0 {
+			var err error
+			cordSet, err = r.getCoordinatorSet(cluster)
+
+			if err != nil {
+				logger.Error(err, "Fetching coordinator set for removal")
+				return false, false, nil
+			}
 		}
 
 		if _, ok := cordSet[string(processGroup.ProcessGroupID)]; ok {

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -167,9 +167,9 @@ var _ = Describe("remove_process_groups", func() {
 						}
 					})
 
-					It("should not remove that process group", func() {
+					It("should not remove the process group and should not exclude processes", func() {
 						Expect(result).NotTo(BeNil())
-						Expect(result.message).To(Equal("Removals cannot proceed because cluster has degraded fault tolerance"))
+						Expect(result.message).To(Equal("Reconciliation needs to exclude more processes"))
 						// Ensure resources are not deleted
 						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
 						Expect(err).To(BeNil())

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -79,11 +79,7 @@ var _ = Describe("remove_process_groups", func() {
 					coordinatorIP: false,
 				}
 
-				coordSet := map[string]fdbv1beta2.None{
-					coordinatorIP: {},
-				}
-
-				allExcluded, newExclusions, processes := clusterReconciler.getProcessGroupsToRemove(globalControllerLogger, cluster, remaining, coordSet)
+				allExcluded, newExclusions, processes := clusterReconciler.getProcessGroupsToRemove(globalControllerLogger, cluster, remaining)
 				Expect(allExcluded).To(BeFalse())
 				Expect(processes).To(BeEmpty())
 				Expect(newExclusions).To(BeFalse())

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -79,7 +79,11 @@ var _ = Describe("remove_process_groups", func() {
 					coordinatorIP: false,
 				}
 
-				allExcluded, newExclusions, processes := clusterReconciler.getProcessGroupsToRemove(globalControllerLogger, cluster, remaining)
+				coordSet := map[string]fdbv1beta2.None{
+					coordinatorIP: {},
+				}
+
+				allExcluded, newExclusions, processes := clusterReconciler.getProcessGroupsToRemove(globalControllerLogger, cluster, remaining, coordSet)
 				Expect(allExcluded).To(BeFalse())
 				Expect(processes).To(BeEmpty())
 				Expect(newExclusions).To(BeFalse())

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -301,6 +301,7 @@ func tryConnectionOptions(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCl
 	originalConnectionString := cluster.Status.ConnectionString
 	defer func() { cluster.Status.ConnectionString = originalConnectionString }()
 
+	var err error
 	for _, connectionString := range connectionStrings {
 		logger.Info("Attempting to get connection string from cluster", "connectionString", connectionString)
 		cluster.Status.ConnectionString = connectionString
@@ -309,7 +310,8 @@ func tryConnectionOptions(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCl
 			return originalConnectionString, clientErr
 		}
 
-		activeConnectionString, err := adminClient.GetConnectionString()
+		var activeConnectionString string
+		activeConnectionString, err = adminClient.GetConnectionString()
 
 		closeErr := adminClient.Close()
 		if closeErr != nil {
@@ -323,7 +325,7 @@ func tryConnectionOptions(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCl
 		logger.Error(err, "Error getting connection string from cluster", "connectionString", connectionString)
 	}
 
-	return originalConnectionString, nil
+	return originalConnectionString, err
 }
 
 // checkAndSetProcessStatus checks the status of the Process and if missing or incorrect add it to the related status field

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -325,7 +325,7 @@ func tryConnectionOptions(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCl
 		logger.Error(err, "Error getting connection string from cluster", "connectionString", connectionString)
 	}
 
-	return originalConnectionString, err
+	return originalConnectionString, nil
 }
 
 // checkAndSetProcessStatus checks the status of the Process and if missing or incorrect add it to the related status field

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -846,6 +846,11 @@ protocol fdb00b071010000`,
 			Expect(err).NotTo(HaveOccurred())
 
 			status := &fdbv1beta2.FoundationDBStatus{
+				Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+					DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+						Available: true,
+					},
+				},
 				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 					Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 						"1": { // This process is fully excluded

--- a/pkg/fdbstatus/status_checks.go
+++ b/pkg/fdbstatus/status_checks.go
@@ -36,14 +36,10 @@ import (
 // We don't want to block the exclusion check for all messages, as some messages also indicate client issues or issues
 // with a specific transaction priority.
 var forbiddenStatusMessages = map[string]fdbv1beta2.None{
-	"storage_servers_error":              {},
-	"status_incomplete":                  {},
-	"unreachable_master_worker":          {},
-	"unreachable_dataDistributor_worker": {},
-	"unreachable_ratekeeper_worker":      {},
-	"unreadable_configuration":           {},
-	"unreachable_processes":              {},
-	"log_servers_error":                  {},
+	"unreadable_configuration": {},
+	"full_replication_timeout": {},
+	"storage_servers_error":    {},
+	"log_servers_error":        {},
 }
 
 // StatusContextKey will be used as a key in a context to pass down the cached status.

--- a/pkg/fdbstatus/status_checks.go
+++ b/pkg/fdbstatus/status_checks.go
@@ -94,7 +94,9 @@ func getRemainingAndExcludedFromStatus(logger logr.Logger, status *fdbv1beta2.Fo
 		}
 	}
 
-	// ...
+	// We have to make sure that the provided machine-readable status contains the required information, if any of the
+	// forbiddenStatusMessages is present, the operator is not able to make a decision if a set of processes is fully excluded
+	// or not.
 	if !clusterStatusHasValidRoleInformation(logger, status) {
 		return exclusionStatus{
 			inProgress:      nil,

--- a/pkg/fdbstatus/status_checks_test.go
+++ b/pkg/fdbstatus/status_checks_test.go
@@ -418,6 +418,98 @@ var _ = Describe("status_checks", func() {
 				nil,
 				nil,
 			),
+			Entry("when the machine-readable status contains the \"unreadable_configuration\" message",
+				&fdbv1beta2.FoundationDBStatus{
+					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+							Available: true,
+						},
+					},
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						Messages: []fdbv1beta2.FoundationDBStatusMessage{
+							{
+								Name:        "unreadable_configuration",
+								Description: "...",
+							},
+						},
+						RecoveryState: fdbv1beta2.RecoveryState{
+							ActiveGenerations: 1,
+						},
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"1": {
+								Address:  addr1,
+								Excluded: true,
+							},
+							"2": {
+								Address: addr2,
+							},
+							"3": {
+								Address: addr3,
+							},
+							"4": {
+								Address:  addr4,
+								Excluded: true,
+								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+									{
+										Role: "tester",
+									},
+								},
+							},
+						},
+					},
+				},
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				nil,
+			),
+			Entry("when the machine-readable status contains the \"full_replication_timeout\" message",
+				&fdbv1beta2.FoundationDBStatus{
+					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+							Available: true,
+						},
+					},
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						Messages: []fdbv1beta2.FoundationDBStatusMessage{
+							{
+								Name:        "full_replication_timeout",
+								Description: "...",
+							},
+						},
+						RecoveryState: fdbv1beta2.RecoveryState{
+							ActiveGenerations: 1,
+						},
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"1": {
+								Address:  addr1,
+								Excluded: true,
+							},
+							"2": {
+								Address: addr2,
+							},
+							"3": {
+								Address: addr3,
+							},
+							"4": {
+								Address:  addr4,
+								Excluded: true,
+								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+									{
+										Role: "tester",
+									},
+								},
+							},
+						},
+					},
+				},
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				nil,
+			),
 			Entry("when the machine-readable status contains the \"client_issues\" message",
 				&fdbv1beta2.FoundationDBStatus{
 					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{

--- a/pkg/fdbstatus/status_checks_test.go
+++ b/pkg/fdbstatus/status_checks_test.go
@@ -286,7 +286,7 @@ var _ = Describe("status_checks", func() {
 				nil,
 				nil,
 			),
-			Entry("when the process is excluded but the cluster is unavilable",
+			Entry("when the process is excluded but the cluster is unavailable",
 				&fdbv1beta2.FoundationDBStatus{
 					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
 						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
@@ -323,6 +323,144 @@ var _ = Describe("status_checks", func() {
 				[]fdbv1beta2.ProcessAddress{addr4},
 				nil,
 				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				nil,
+			),
+			Entry("when the machine-readable status contains the \"storage_servers_error\" message",
+				&fdbv1beta2.FoundationDBStatus{
+					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+							Available: true,
+						},
+					},
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						Messages: []fdbv1beta2.FoundationDBStatusMessage{
+							{
+								Name:        "storage_servers_error",
+								Description: "...",
+							},
+						},
+						RecoveryState: fdbv1beta2.RecoveryState{
+							ActiveGenerations: 1,
+						},
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"1": {
+								Address:  addr1,
+								Excluded: true,
+							},
+							"2": {
+								Address: addr2,
+							},
+							"3": {
+								Address: addr3,
+							},
+							"4": {
+								Address:  addr4,
+								Excluded: true,
+								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+									{
+										Role: "tester",
+									},
+								},
+							},
+						},
+					},
+				},
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				nil,
+			),
+			Entry("when the machine-readable status contains the \"log_servers_error\" message",
+				&fdbv1beta2.FoundationDBStatus{
+					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+							Available: true,
+						},
+					},
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						Messages: []fdbv1beta2.FoundationDBStatusMessage{
+							{
+								Name:        "log_servers_error",
+								Description: "...",
+							},
+						},
+						RecoveryState: fdbv1beta2.RecoveryState{
+							ActiveGenerations: 1,
+						},
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"1": {
+								Address:  addr1,
+								Excluded: true,
+							},
+							"2": {
+								Address: addr2,
+							},
+							"3": {
+								Address: addr3,
+							},
+							"4": {
+								Address:  addr4,
+								Excluded: true,
+								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+									{
+										Role: "tester",
+									},
+								},
+							},
+						},
+					},
+				},
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				nil,
+			),
+			Entry("when the machine-readable status contains the \"client_issues\" message",
+				&fdbv1beta2.FoundationDBStatus{
+					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+							Available: true,
+						},
+					},
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						Messages: []fdbv1beta2.FoundationDBStatusMessage{
+							{
+								Name:        "client_issues",
+								Description: "...",
+							},
+						},
+						RecoveryState: fdbv1beta2.RecoveryState{
+							ActiveGenerations: 1,
+						},
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"1": {
+								Address:  addr1,
+								Excluded: true,
+							},
+							"2": {
+								Address: addr2,
+							},
+							"3": {
+								Address: addr3,
+							},
+							"4": {
+								Address:  addr4,
+								Excluded: true,
+								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+									{
+										Role: "tester",
+									},
+								},
+							},
+						},
+					},
+				},
+				[]fdbv1beta2.ProcessAddress{addr4},
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
 				nil,
 				nil,
 			),

--- a/pkg/fdbstatus/status_checks_test.go
+++ b/pkg/fdbstatus/status_checks_test.go
@@ -38,6 +38,11 @@ var _ = Describe("status_checks", func() {
 		addr4 := fdbv1beta2.NewProcessAddress(net.ParseIP("127.0.0.4"), "", 0, nil)
 		addr5 := fdbv1beta2.NewProcessAddress(net.ParseIP("127.0.0.5"), "", 0, nil)
 		status := &fdbv1beta2.FoundationDBStatus{
+			Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+				DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+					Available: true,
+				},
+			},
 			Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 				Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 					"1": {
@@ -119,6 +124,11 @@ var _ = Describe("status_checks", func() {
 			),
 			Entry("when the process is excluded but the cluster status has multiple generations",
 				&fdbv1beta2.FoundationDBStatus{
+					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+							Available: true,
+						},
+					},
 					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 						RecoveryState: fdbv1beta2.RecoveryState{
 							ActiveGenerations: 2,
@@ -154,6 +164,11 @@ var _ = Describe("status_checks", func() {
 			),
 			Entry("when the process group has multiple processes and only one is fully excluded",
 				&fdbv1beta2.FoundationDBStatus{
+					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+							Available: true,
+						},
+					},
 					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 							"1": {
@@ -196,6 +211,11 @@ var _ = Describe("status_checks", func() {
 			),
 			Entry("when the process group has multiple processes and both are fully excluded",
 				&fdbv1beta2.FoundationDBStatus{
+					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+							Available: true,
+						},
+					},
 					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 							"1": {
@@ -227,6 +247,11 @@ var _ = Describe("status_checks", func() {
 			),
 			Entry("when the process group has multiple processes and only one is excluded",
 				&fdbv1beta2.FoundationDBStatus{
+					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+							Available: true,
+						},
+					},
 					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 							"1": {
@@ -249,6 +274,46 @@ var _ = Describe("status_checks", func() {
 								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
 									{
 										Role: string(fdbv1beta2.ProcessRoleStorage),
+									},
+								},
+							},
+						},
+					},
+				},
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				[]fdbv1beta2.ProcessAddress{addr4},
+				nil,
+				nil,
+			),
+			Entry("when the process is excluded but the cluster is unavilable",
+				&fdbv1beta2.FoundationDBStatus{
+					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+							Available: false,
+						},
+					},
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						RecoveryState: fdbv1beta2.RecoveryState{
+							ActiveGenerations: 1,
+						},
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"1": {
+								Address:  addr1,
+								Excluded: true,
+							},
+							"2": {
+								Address: addr2,
+							},
+							"3": {
+								Address: addr3,
+							},
+							"4": {
+								Address:  addr4,
+								Excluded: true,
+								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+									{
+										Role: "tester",
 									},
 								},
 							},


### PR DESCRIPTION
# Description

We want to make sure that the database is available if we do any checks for the exclusion status based on the machine-readable status. If the database is unavailable we could hit a case were processes are reported but not the roles for them. In this case it will be better to wait until the database is available again.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

I decided to return all processes as "not excluded" to prevent the operator doing any additional checks with the exclude command, as the exclude command could make the unavailable database state even worse.

## Testing

Unit tests.

## Documentation

-

## Follow-up

-
