### PR TITLE
For HA e2e test with remote processes not being restarted, ignore availability check for version incompatible upgrades

### DIFF
--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -536,7 +536,11 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 				Skip("operator doesn't support feature for test case")
 			}
 
-			clusterSetup(beforeVersion, false)
+			versionsCompatible := fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion)
+			// If the versions are not protocol compatible, ignore availability issues, as the incompatible processes,
+			// can cause the database to be unavailable for a longer time period. If the versions are compatible we expect
+			// no issues.
+			clusterSetupWithHealthCheckOption(beforeVersion, false, !versionsCompatible)
 
 			// Select remote processes and use the buggify option to skip those
 			// processes during the restart command.


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1725

It's expected, that the FDB cluster will have availability issues if the remote region is not restarted.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

e2e test will be running.

## Documentation

Added a comment in the code.

## Follow-up

-