### PR TITLE
Allow to reduce debugging information in operator test framework

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -22,6 +22,7 @@ TEST_USERNAME?=$(USER)
 ENABLE_CHAOS_TESTS?=true
 CHAOS_NAMESPACE?=chaos-testing
 STORAGE_CLASS?=
+DUMP_OPERATOR_STATE?=true
 # Defines the cloud provider used for the underlying Kubernetes cluster. Currently only kind is support, other cloud providers
 # should still work but this test framework has no special cases for those.
 CLOUD_PROVIDER?=
@@ -126,4 +127,5 @@ nightly-tests: run
 	  --feature-localities=$(FEATURE_LOCALITIES) \
 	  --feature-dns=$(FEATURE_DNS) \
 	  --cloud-provider=$(CLOUD_PROVIDER) \
+	  --dump-operator-state=$(DUMP_OPERATOR_STATE) \
 	  | grep -v 'constructing many client instances from the same exec auth config can cause performance problems during cert rotation' &> $(BASE_DIR)/../logs/$<.log

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -638,7 +638,7 @@ func writePodInformation(pod corev1.Pod) string {
 
 // DumpState writes the state of the cluster to the log output. Useful for debugging test failures.
 func (factory *Factory) DumpState(fdbCluster *FdbCluster) {
-	if fdbCluster == nil {
+	if fdbCluster == nil || !factory.options.dumpOperatorState {
 		return
 	}
 

--- a/e2e/fixtures/options.go
+++ b/e2e/fixtures/options.go
@@ -49,6 +49,7 @@ type FactoryOptions struct {
 	featureOperatorDNS          bool
 	featureOperatorLocalities   bool
 	featureOperatorUnifiedImage bool
+	dumpOperatorState           bool
 }
 
 // BindFlags binds the FactoryOptions flags to the provided FlagSet. This can be used to extend the current test setup
@@ -161,6 +162,12 @@ func (options *FactoryOptions) BindFlags(fs *flag.FlagSet) {
 		"feature-dns",
 		false,
 		"defines if the operator tests should make use of DNS in cluster files.",
+	)
+	fs.BoolVar(
+		&options.dumpOperatorState,
+		"dump-operator-state",
+		true,
+		"defines if the operator tests should print the state of the cluster and the according Pods for better debugging.",
 	)
 }
 


### PR DESCRIPTION
# Description

Allow to reduce the verbosity of the operator test framework.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

Local e2e test run and it didn't printout the dump statements.

## Documentation

Added in the Makefile.

## Follow-up

-
