### PR TITLE
Document the maintenance mode feature

### DIFF
--- a/docs/manual/replacements_and_deletions.md
+++ b/docs/manual/replacements_and_deletions.md
@@ -27,6 +27,23 @@ The following changes can only be rolled out through replacement:
 The number of inflight replacements can be configured by setting `maxConcurrentReplacements`, per default the operator will replace all misconfigured process groups.
 Depending on the cluster size this can require a quota that is has double the capacity of the actual required resources.
 
+## Using The Maintenance Mode
+
+The FoundationDB Kubernetes operator supports to make use of the [maintenance mode](https://github.com/apple/foundationdb/wiki/Maintenance-mode) in FoundationDB.
+Using the maintenance mode in FoundationDB will reduce the data distribution and disruption when Storage Pods must be updated.
+The following addition to the `FoundationDBCluster` resource will enable the maintenance mode for this cluster:
+
+```yaml
+spec:
+    automationOptions:
+      maintenanceModeOptions:
+        UseMaintenanceModeChecker: true
+```
+
+Only Pods that are updated (deleted and recreated) will be considered during the maintenance mode.
+
+**NOTE** The maintenance mode feature is relatively new and has limited e2e test coverage and should therefore used with care.
+
 ## Automatic Replacements for ProcessGroups in Undesired State
 
 The operator has an option to automatically replace pods that are in a bad state. This behavior is disabled by default, but you can enable it by setting the field `automationOptions.replacements.enabled` in the cluster spec.

--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -70,6 +70,8 @@ type ClusterConfig struct {
 	Performance bool
 	// If enabled the debug images will be used for this test case.
 	DebugSymbols bool
+	// UseMaintenanceMode if enabled the FoundationDBCluster resource will enable the maintenance mode.
+	UseMaintenanceMode bool
 	// CreationTracker if specified will be used to log the time between the creations steps.
 	CreationTracker CreationTrackerLogger
 	// Number of machines, this is used for calculating the number of Pods and is not correlated to the actual number
@@ -488,4 +490,27 @@ func calculateProxies(proxies int) (int, int) {
 
 	// Ensure we create at least 1 process of each proxy type
 	return max(grv, 1), max(commit, 1)
+}
+
+// Copy will return a new struct of the ClusterConfig.
+func (config *ClusterConfig) Copy() *ClusterConfig {
+	return &ClusterConfig{
+		Performance:         config.Performance,
+		DebugSymbols:        config.DebugSymbols,
+		UseMaintenanceMode:  config.UseMaintenanceMode,
+		CreationTracker:     config.CreationTracker,
+		MachineCount:        config.MachineCount,
+		DisksPerMachine:     config.DisksPerMachine,
+		StorageServerPerPod: config.StorageServerPerPod,
+		LogServersPerPod:    config.LogServersPerPod,
+		VolumeSize:          config.VolumeSize,
+		Namespace:           config.Namespace,
+		Name:                config.Name,
+		cloudProvider:       config.cloudProvider,
+		StorageEngine:       config.StorageEngine,
+		NodeSelector:        config.NodeSelector,
+		HaMode:              config.HaMode,
+		CustomParameters:    config.CustomParameters,
+		CreationCallback:    config.CreationCallback,
+	}
 }

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -178,19 +178,7 @@ func (factory *Factory) CreateFdbHaCluster(
 ) *HaFdbCluster {
 	config.SetDefaults(factory)
 
-	mainOverrides, sidecarOverrides := factory.getContainerOverrides(
-		config.DebugSymbols,
-	)
-
-	dbConfig := config.CreateDatabaseConfiguration()
-	dcIDs := GetDcIDsFromConfig(dbConfig)
 	cluster, err := factory.ensureHAFdbClusterExists(
-		dcIDs,
-		factory.MultipleNamespaces(dcIDs),
-		factory.createProcesses(config),
-		dbConfig,
-		mainOverrides,
-		sidecarOverrides,
 		config,
 		options,
 	)

--- a/e2e/fixtures/ha_fdb_cluster.go
+++ b/e2e/fixtures/ha_fdb_cluster.go
@@ -208,25 +208,14 @@ func (haFDBCluster *HaFdbCluster) WaitForReconciliation(
 }
 
 func (factory Factory) createHaFdbClusterSpec(
-	clusterName string,
-	namespace string,
+	config *ClusterConfig,
 	dcID string,
 	seedConnection string,
 	databaseConfiguration *fdbv1beta2.DatabaseConfiguration,
-	processes map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings,
-	mainContainerOverrides fdbv1beta2.ContainerOverrides,
-	sidecarContainerOverrides fdbv1beta2.ContainerOverrides,
 ) *fdbv1beta2.FoundationDBCluster {
 	cluster := factory.createFDBClusterSpec(
-		clusterName,
-		namespace,
-		processes,
+		config,
 		*databaseConfiguration,
-		// TODO(johscheuer): make this configurable.
-		1,
-		1,
-		mainContainerOverrides,
-		sidecarContainerOverrides,
 	)
 
 	cluster.Spec.ProcessGroupIDPrefix = dcID


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1648
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1648

## Type of change

- Documentation
- Other

## Discussion

-

## Testing

Added a minimal upgrade test with the maintenance mode enabled.

## Documentation

Added documentation on how to use it and the current limitations.

## Follow-up

We have a few radars around the maintenance mode.
