### PR TITLE
Add e2e test to make sure operator can handle Pods that are stuck in pending

### DIFF
--- a/api/v1beta2/foundationdb_process_class.go
+++ b/api/v1beta2/foundationdb_process_class.go
@@ -73,3 +73,9 @@ func (pClass ProcessClass) SupportsMultipleLogServers() bool {
 func (pClass ProcessClass) GetServersPerPodEnvName() string {
 	return strings.ToUpper(string(pClass)) + "_SERVERS_PER_POD"
 }
+
+// GetProcessClassForPodName will return the process class name where the underscore is replaced with a hyphen, as
+// underscores are not allowed in Kubernetes resources names.
+func (pClass ProcessClass) GetProcessClassForPodName() string {
+	return strings.ReplaceAll(string(pClass), "_", "-")
+}

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -761,6 +761,11 @@ func (processGroupStatus *ProcessGroupStatus) GetConditionTime(conditionType Pro
 
 // IsUnderMaintenance checks if the process is in maintenance zone.
 func (processGroupStatus *ProcessGroupStatus) IsUnderMaintenance(maintenanceZone FaultDomain) bool {
+	// If the maintenanceZone is not set or the Process Group has not fault domain set, return false.gs
+	if maintenanceZone == "" || processGroupStatus.FaultDomain == "" {
+		return false
+	}
+
 	return processGroupStatus.FaultDomain == maintenanceZone
 }
 

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -761,7 +761,7 @@ func (processGroupStatus *ProcessGroupStatus) GetConditionTime(conditionType Pro
 
 // IsUnderMaintenance checks if the process is in maintenance zone.
 func (processGroupStatus *ProcessGroupStatus) IsUnderMaintenance(maintenanceZone FaultDomain) bool {
-	// If the maintenanceZone is not set or the Process Group has not fault domain set, return false.gs
+	// If the maintenanceZone is not set or the Process Group has not fault domain set, return false.
 	if maintenanceZone == "" || processGroupStatus.FaultDomain == "" {
 		return false
 	}

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -108,7 +108,7 @@ var _ = Describe("add_process_groups", func() {
 		})
 	})
 
-	FContext("when replacing a process with a different process group ID prefix", func() {
+	Context("when replacing a process with a different process group ID prefix", func() {
 		BeforeEach(func() {
 			for _, processGroup := range cluster.Status.ProcessGroups {
 				if processGroup.ProcessGroupID == "storage-4" {

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -98,8 +98,7 @@ var _ = Describe("add_process_groups", func() {
 				"storage-4",
 				"storage-5",
 			}
-			Expect(len(storageProcesses)).To(BeNumerically("==", len(expectedStorageProcesses)))
-			Expect(storageProcesses).To(ContainElements(expectedStorageProcesses))
+			Expect(storageProcesses).To(ConsistOf(expectedStorageProcesses))
 		})
 
 		It("should not change the log or stateless processes", func() {
@@ -132,8 +131,7 @@ var _ = Describe("add_process_groups", func() {
 				"storage-3",
 				"storage-5",
 			}
-			Expect(len(storageProcesses)).To(BeNumerically("==", len(expectedStorageProcesses)))
-			Expect(storageProcesses).To(ContainElements(expectedStorageProcesses))
+			Expect(storageProcesses).To(ConsistOf(expectedStorageProcesses))
 		})
 
 		It("should not change the log or stateless processes", func() {
@@ -166,8 +164,7 @@ var _ = Describe("add_process_groups", func() {
 				"storage-5",
 				"storage-6",
 			}
-			Expect(len(storageProcesses)).To(BeNumerically("==", len(expectedStorageProcesses)))
-			Expect(storageProcesses).To(ContainElements(expectedStorageProcesses))
+			Expect(storageProcesses).To(ConsistOf(expectedStorageProcesses))
 		})
 
 		It("should not change the log or stateless processes", func() {
@@ -199,8 +196,7 @@ var _ = Describe("add_process_groups", func() {
 					"storage-5",
 					"storage-7",
 				}
-				Expect(len(storageProcesses)).To(BeNumerically("==", len(expectedStorageProcesses)))
-				Expect(storageProcesses).To(ContainElements(expectedStorageProcesses))
+				Expect(storageProcesses).To(ConsistOf(expectedStorageProcesses))
 			})
 		})
 	})

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -87,7 +87,7 @@ var _ = Describe("add_process_groups", func() {
 		It("should add a storage process", func() {
 			storageProcesses := make([]fdbv1beta2.ProcessGroupID, 0, newProcessCounts.Storage)
 			for _, processGroup := range cluster.Status.ProcessGroups {
-				if processGroup.ProcessClass == "storage" {
+				if processGroup.ProcessClass == fdbv1beta2.ProcessClassStorage {
 					storageProcesses = append(storageProcesses, processGroup.ProcessGroupID)
 				}
 			}
@@ -108,7 +108,7 @@ var _ = Describe("add_process_groups", func() {
 		})
 	})
 
-	Context("when replacing a process with a different process group ID prefix", func() {
+	FContext("when replacing a process with a different process group ID prefix", func() {
 		BeforeEach(func() {
 			for _, processGroup := range cluster.Status.ProcessGroups {
 				if processGroup.ProcessGroupID == "storage-4" {
@@ -121,7 +121,7 @@ var _ = Describe("add_process_groups", func() {
 		It("should add a storage process", func() {
 			storageProcesses := make([]fdbv1beta2.ProcessGroupID, 0, newProcessCounts.Storage)
 			for _, processGroup := range cluster.Status.ProcessGroups {
-				if processGroup.ProcessClass == "storage" {
+				if processGroup.ProcessClass == fdbv1beta2.ProcessClassStorage {
 					storageProcesses = append(storageProcesses, processGroup.ProcessGroupID)
 				}
 			}
@@ -154,7 +154,7 @@ var _ = Describe("add_process_groups", func() {
 		It("should add storage processes", func() {
 			storageProcesses := make([]fdbv1beta2.ProcessGroupID, 0, newProcessCounts.Storage)
 			for _, processGroup := range cluster.Status.ProcessGroups {
-				if processGroup.ProcessClass == "storage" {
+				if processGroup.ProcessClass == fdbv1beta2.ProcessClassStorage {
 					storageProcesses = append(storageProcesses, processGroup.ProcessGroupID)
 				}
 			}
@@ -187,7 +187,7 @@ var _ = Describe("add_process_groups", func() {
 			It("should fill in the gap", func() {
 				storageProcesses := make([]fdbv1beta2.ProcessGroupID, 0, newProcessCounts.Storage)
 				for _, processGroup := range cluster.Status.ProcessGroups {
-					if processGroup.ProcessClass == "storage" {
+					if processGroup.ProcessClass == fdbv1beta2.ProcessClassStorage {
 						storageProcesses = append(storageProcesses, processGroup.ProcessGroupID)
 					}
 				}

--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -75,7 +75,7 @@ func (a addServices) reconcile(ctx context.Context, r *FoundationDBClusterReconc
 				return &requeue{curError: err}
 			}
 
-			serviceName, _ := internal.GetProcessGroupID(cluster, processGroup.ProcessClass, idNum)
+			serviceName, _ := cluster.GetProcessGroupID(processGroup.ProcessClass, idNum)
 			service, err := internal.GetService(cluster, processGroup.ProcessClass, idNum)
 			if err != nil {
 				return &requeue{curError: err}

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -579,6 +579,7 @@ func writePodInformation(pod corev1.Pod) string {
 
 			// If the Pod is scheduled we can ignore this condition.
 			if condition.Status == corev1.ConditionTrue {
+				buffer.WriteString("\t-")
 				continue
 			}
 

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -1101,7 +1101,6 @@ func (fdbCluster *FdbCluster) CheckPodIsDeleted(podName string) bool {
 	err := fdbCluster.getClient().
 		Get(ctx.TODO(), client.ObjectKey{Namespace: fdbCluster.Namespace(), Name: podName}, pod)
 
-	log.Println("error: ", err, "pod", pod.ObjectMeta)
 	if err != nil {
 		if kubeErrors.IsNotFound(err) {
 			return true

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -487,7 +487,7 @@ func (factory *Factory) CreateFDBOperatorIfAbsent(namespace string) error {
 	return nil
 }
 
-// GetOperatorPods returs the operator Pods in the provided namespace.
+// GetOperatorPods returns the operator Pods in the provided namespace.
 func (factory *Factory) GetOperatorPods(namespace string) *corev1.PodList {
 	pods := &corev1.PodList{}
 	gomega.Eventually(func() error {

--- a/e2e/fixtures/test_runner.go
+++ b/e2e/fixtures/test_runner.go
@@ -37,8 +37,7 @@ import (
 func RunGinkgoTests(t *testing.T, name string) {
 	// Setup logging
 	log.SetFlags(log.LstdFlags)
-	// Below line makes log cached in GinkgoWriter even with --vv option enabled.
-	// log.SetOutput(GinkgoWriter)
+	log.SetOutput(ginkgo.GinkgoWriter)
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, name)
 }

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1248,35 +1248,22 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	When("a process group has no address assigned and should be removed", func() {
 		var processGroupID fdbv1beta2.ProcessGroupID
 		var podName string
+		var initialReplacementDuration time.Duration
 
 		BeforeEach(func() {
-			initialPods := fdbCluster.GetStatelessPods()
-			processGroupIDs := map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None{}
+			initialReplacementDuration = time.Duration(pointer.IntDeref(fdbCluster.GetCachedCluster().Spec.AutomationOptions.Replacements.TaintReplacementTimeSeconds, 600)) * time.Second
+			// Get the current Process Group ID numbers that are in use.
+			_, processGroupIDs, err := fdbCluster.GetCluster().GetCurrentProcessGroupsAndProcessCounts()
+			Expect(err).NotTo(HaveOccurred())
 
-			for _, pod := range initialPods.Items {
-				processGroupIDs[fixtures.GetProcessGroupID(pod)] = fdbv1beta2.None{}
-			}
-
-			idNum := 1
-			for {
-				_, processGroupID = internal.GetProcessGroupID(fdbCluster.GetCachedCluster(), fdbv1beta2.ProcessClassStateless, idNum)
-				if fdbCluster.GetCachedCluster().ProcessGroupIsBeingRemoved(processGroupID) {
-					idNum++
-					continue
-				}
-
-				// If the process group is not present use this one.
-				if _, ok := processGroupIDs[processGroupID]; !ok {
-					break
-				}
-
-				idNum++
-			}
+			// The the next free ProcessGroupID and mark this one as unschedulable.
+			processGroupID, _ = fdbCluster.GetCluster().GetNextProcessGroupID(fdbv1beta2.ProcessClassStateless, processGroupIDs[fdbv1beta2.ProcessClassStateless], 1)
+			log.Println("Next process group ID", processGroupID, "current processGroupIDs for stateless processes", processGroupIDs[fdbv1beta2.ProcessClassStateless])
 
 			// Make sure the new Pod will be stuck in unschedulable.
 			fdbCluster.SetProcessGroupsAsUnschedulable([]fdbv1beta2.ProcessGroupID{processGroupID})
 			// Now replace a random Pod for replacement to force the cluster to create a new Pod.
-			fdbCluster.ReplacePod(fixtures.RandomPickOnePod(initialPods.Items), false)
+			fdbCluster.ReplacePod(fixtures.RandomPickOnePod(fdbCluster.GetStatelessPods().Items), false)
 
 			// Wait until the new Pod is actually created.
 			Eventually(func() bool {
@@ -1289,24 +1276,76 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 				return false
 			}).WithPolling(2 * time.Second).WithTimeout(5 * time.Minute).Should(BeTrue())
-
-			fdbCluster.ReplacePod(fixtures.RandomPickOnePod(initialPods.Items), false)
-
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
-			spec.ProcessGroupsToRemove = append(spec.ProcessGroupsToRemove, processGroupID)
-			// Add the new pending Pod to the removal list.
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
 		})
 
-		It("should not remove the Pod as long as it is unschedulable", func() {
-			// Make sure the Pod is stuck in pending for 2 minutes
-			Consistently(func() corev1.PodPhase {
-				return fdbCluster.GetPod(podName).Status.Phase
-			}).WithTimeout(2 * time.Minute).WithPolling(15 * time.Second).Should(Equal(corev1.PodPending))
+		AfterEach(func() {
 			// Clear the buggify list, this should allow the operator to move forward and delete the Pod
 			Expect(fdbCluster.ClearBuggifyNoSchedule(true)).NotTo(HaveOccurred())
 			// Make sure the Pod is deleted.
 			Expect(fdbCluster.CheckPodIsDeleted(podName)).To(BeTrue())
+			// Make sure we cleaned up the process groups to remove.
+			Expect(fdbCluster.ClearProcessGroupsToRemove())
+			Expect(fdbCluster.SetAutoReplacements(true, initialReplacementDuration)).NotTo(HaveOccurred())
+		})
+
+		When("automatic replacements are disabled", func() {
+			BeforeEach(func() {
+				// Disable automatic replacements
+				Expect(fdbCluster.SetAutoReplacementsWithWait(false, 10*time.Hour, false)).NotTo(HaveOccurred())
+				// Add the pending Process group to the removal list.
+				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				spec.ProcessGroupsToRemove = append(spec.ProcessGroupsToRemove, processGroupID)
+				// Add the new pending Pod to the removal list.
+				fdbCluster.UpdateClusterSpecWithSpec(spec)
+			})
+
+			It("should not remove the Pod as long as it is unschedulable", func() {
+				log.Println("Make sure process group", processGroupID, "is stuck in Pending state with Pod", podName)
+				// Make sure the Pod is stuck in pending for 2 minutes
+				Consistently(func() corev1.PodPhase {
+					return fdbCluster.GetPod(podName).Status.Phase
+				}).WithTimeout(2 * time.Minute).WithPolling(15 * time.Second).Should(Equal(corev1.PodPending))
+			})
+		})
+
+		When("automatic replacements are enabled", func() {
+			BeforeEach(func() {
+				// Enable automatic replacements
+				Expect(fdbCluster.SetAutoReplacementsWithWait(true, 1*time.Minute, false)).NotTo(HaveOccurred())
+			})
+
+			It("should remove the Pod", func() {
+				log.Println("Make sure process group", processGroupID, "gets replaced with Pod", podName)
+				// Make sure the process group is marked fore removal after some time.
+				Eventually(func() bool {
+					for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+						if processGroup.ProcessGroupID != processGroupID {
+							continue
+						}
+
+						return processGroup.IsMarkedForRemoval()
+					}
+
+					return false
+				}).WithTimeout(2 * time.Minute).WithPolling(15 * time.Second).Should(BeTrue())
+
+				// Make sure the exclusion step is skipped, as the Process Group is missing addresses
+				var exclusionSkipped bool
+				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+					if processGroup.ProcessGroupID != processGroupID {
+						continue
+					}
+
+					exclusionSkipped = processGroup.ExclusionSkipped
+				}
+
+				Expect(exclusionSkipped).To(BeTrue())
+
+				// Make sure the Pod is actually deleted after some time.
+				Eventually(func() bool {
+					return fdbCluster.CheckPodIsDeleted(podName)
+				}).WithTimeout(2 * time.Minute).WithPolling(15 * time.Second).Should(BeTrue())
+			})
 		})
 	})
 })

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1316,7 +1316,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			It("should remove the Pod", func() {
 				log.Println("Make sure process group", processGroupID, "gets replaced with Pod", podName)
-				// Make sure the process group is marked fore removal after some time.
+				// Make sure the process group is marked for removal after some time.
 				Eventually(func() bool {
 					for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
 						if processGroup.ProcessGroupID != processGroupID {
@@ -1325,6 +1325,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 						return processGroup.IsMarkedForRemoval()
 					}
+
+					// Make sure the operator is reconciling again and detecting, that this process group is in a bad
+					// state.
+					fdbCluster.ForceReconcile()
 
 					return false
 				}).WithTimeout(2 * time.Minute).WithPolling(15 * time.Second).Should(BeTrue())

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -156,7 +156,7 @@ func processGroupNeedsRemoval(cluster *fdbv1beta2.FoundationDBCluster, pod *core
 		return false, err
 	}
 
-	_, desiredProcessGroupID := internal.GetProcessGroupID(cluster, processGroupStatus.ProcessClass, idNum)
+	_, desiredProcessGroupID := cluster.GetProcessGroupID(processGroupStatus.ProcessClass, idNum)
 	if processGroupStatus.ProcessGroupID != desiredProcessGroupID {
 		logger.Info("Replace process group",
 			"reason", fmt.Sprintf("expect process group ID: %s", desiredProcessGroupID))

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -597,7 +597,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			pvcMap = map[fdbv1beta2.ProcessGroupID]corev1.PersistentVolumeClaim{}
 
 			for i := 0; i < 10; i++ {
-				_, id := internal.GetProcessGroupID(cluster, fdbv1beta2.ProcessClassStorage, i)
+				_, id := cluster.GetProcessGroupID(fdbv1beta2.ProcessClassStorage, i)
 				newPVC, err := internal.GetPvc(cluster, fdbv1beta2.ProcessClassStorage, i)
 				Expect(err).NotTo(HaveOccurred())
 				pvcMap[id] = *newPVC
@@ -609,7 +609,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			}
 
 			for i := 0; i < 1; i++ {
-				_, id := internal.GetProcessGroupID(cluster, fdbv1beta2.ProcessClassTransaction, i)
+				_, id := cluster.GetProcessGroupID(fdbv1beta2.ProcessClassTransaction, i)
 				newPVC, err := internal.GetPvc(cluster, fdbv1beta2.ProcessClassTransaction, i)
 				Expect(err).NotTo(HaveOccurred())
 				pvcMap[id] = *newPVC
@@ -698,7 +698,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 			When("the process is a storage process", func() {
 				BeforeEach(func() {
-					podName, _ := internal.GetProcessGroupID(cluster, fdbv1beta2.ProcessClassStorage, 0)
+					podName, _ := cluster.GetProcessGroupID(fdbv1beta2.ProcessClassStorage, 0)
 					currentPod := &corev1.Pod{}
 					Expect(k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: podName, Namespace: cluster.Namespace}, currentPod)).NotTo(HaveOccurred())
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1764 (by adding an e2e test and verify this behaviour).
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1748

## Type of change

*Please select one of the options below.*

- Other

## Discussion

I refactored the way how the new ProcessGroupID is generated to make it usable by the e2e tests.

## Testing

Added a new e2e test and ran it manually.

## Documentation

-

## Follow-up

-
