### PR TITLE
update goreleaser version, and remove invalid config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,14 +17,9 @@ builds:
 archives:
   - id: kubectl-fdb
     builds:
-    - kubectl-fdb
+      - kubectl-fdb
     format: binary
     name_template: "{{ .Binary }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ KUSTOMIZE_PKG?=sigs.k8s.io/kustomize/kustomize/v4@v4.5.2
 KUSTOMIZE=$(GOBIN)/kustomize
 GOLANGCI_LINT_PKG=github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
 GOLANGCI_LINT=$(GOBIN)/golangci-lint
-GORELEASER_PKG=github.com/goreleaser/goreleaser@v1.9.2
+GORELEASER_PKG=github.com/goreleaser/goreleaser@v1.20.0
 GORELEASER=$(GOBIN)/goreleaser
 GO_LINES_PKG=github.com/segmentio/golines@v0.11.0
 GO_LINES=$(GOBIN)/golines
@@ -251,7 +251,7 @@ release: bin/release
 
 bin/release: ${GO_SRC} $(GORELEASER)
 	$(GORELEASER) check
-	$(GORELEASER) release --rm-dist
+	$(GORELEASER) release --clean
 	@mkdir -p bin
 	@touch $@
 


### PR DESCRIPTION
attempt to fix release failing to build `macos` and `windows` `arm64` artifacts