### PR TITLE
Update the default e2e FDB versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,10 @@ COPY --chown=fdb:fdb --from=builder /var/log/fdb/.keep /var/log/fdb/.keep
 # some additional libraries that are not present in the default bookwork image. We copy those
 # libraries to make the distroless version of the operator work too, otherwise we could just install
 # the required packages.
+
+# This won't work with the current distroless image, as the image depends on debian11, but bookworm is debian12
+# see: https://github.com/GoogleContainerTools/distroless/issues/1342
+# For now we ignore this and once a debian12 based distroless image is available we can make use of that.
 COPY --from=builder /usr/lib/x86_64-linux-gnu/lib* /usr/lib/x86_64-linux-gnu/
 
 # Set to the numeric UID of fdb user to satisfy PodSecurityPolices which enforce runAsNonRoot

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,12 @@ COPY --chown=fdb:fdb --from=builder /workspace/bin/manager .
 COPY --from=builder /usr/lib/libfdb_c.so /usr/lib/
 COPY --chown=fdb:fdb --from=builder /var/log/fdb/.keep /var/log/fdb/.keep
 
+# FoundationDB versions newer than 7.1.33 are complied with the AWS SDK per default and therefore require
+# some additional libraries that are not present in the default bookwork image. We copy those
+# libraries to make the distroless version of the operator work too, otherwise we could just install
+# the required packages.
+COPY --from=builder /usr/lib/x86_64-linux-gnu/lib* /usr/lib/x86_64-linux-gnu/
+
 # Set to the numeric UID of fdb user to satisfy PodSecurityPolices which enforce runAsNonRoot
 USER 4059
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -10,8 +10,9 @@ TIMEOUT?=168h
 NAMESPACE?=
 PREFIX?=
 CONTEXT?=
-FDB_VERSION?=7.1.31
-PREVIOUS_FDB_VERSION?=6.3.25
+FDB_VERSION?=7.1.37
+# This will be the version used for upgrade tests.
+NEXT_FDB_VERSION?=7.3.15
 ## Expectation is that you are running standard build image which generates both regular and debug (Symbols) images.
 FDB_IMAGE?=foundationdb/foundationdb:$(FDB_VERSION)
 SIDECAR_IMAGE?=foundationdb/foundationdb-kubernetes-sidecar:$(FDB_VERSION)-1
@@ -27,7 +28,7 @@ DUMP_OPERATOR_STATE?=true
 # should still work but this test framework has no special cases for those.
 CLOUD_PROVIDER?=
 # Multiple versions can be specified for these upgrades by separating them with a, e.g. 6.2.25:7.1.25,7.1.23:7.1.25
-UPGRADE_VERSIONS?="$(PREVIOUS_FDB_VERSION):$(FDB_VERSION)"
+UPGRADE_VERSIONS?="$(FDB_VERSION):$(NEXT_FDB_VERSION)"
 # Those are feature flags for the operator tests. Enable a feature if you want to run the operator tests with a specific
 # feature enabled e.g. like DNS.
 FEATURE_UNIFIED_IMAGE?=false
@@ -51,7 +52,7 @@ destroy-my-namespaces:
 
 # This target can be used to create a kind cluster that can be used for e2e testing.
 kind-setup:
-	@CHAOS_NAMESPACE=$(CHAOS_NAMESPACE) FDB_VERSION=$(FDB_VERSION) UPGRADE_VERSIONS=$(UPGRADE_VERSIONS) PREVIOUS_FDB_VERSION=$(PREVIOUS_FDB_VERSION) REGISTRY=$(REGISTRY) $(shell pwd)/scripts/setup_e2e.sh
+	@CHAOS_NAMESPACE=$(CHAOS_NAMESPACE) FDB_VERSION=$(FDB_VERSION) UPGRADE_VERSIONS=$(UPGRADE_VERSIONS) PREVIOUS_FDB_VERSION=$(NEXT_FDB_VERSION) REGISTRY=$(REGISTRY) $(shell pwd)/scripts/setup_e2e.sh
 
 # This target will remove the kind cluster.
 kind-destroy:

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -52,7 +52,7 @@ destroy-my-namespaces:
 
 # This target can be used to create a kind cluster that can be used for e2e testing.
 kind-setup:
-	@CHAOS_NAMESPACE=$(CHAOS_NAMESPACE) FDB_VERSION=$(FDB_VERSION) UPGRADE_VERSIONS=$(UPGRADE_VERSIONS) PREVIOUS_FDB_VERSION=$(NEXT_FDB_VERSION) REGISTRY=$(REGISTRY) $(shell pwd)/scripts/setup_e2e.sh
+	@CHAOS_NAMESPACE=$(CHAOS_NAMESPACE) FDB_VERSION=$(FDB_VERSION) UPGRADE_VERSIONS=$(UPGRADE_VERSIONS) REGISTRY=$(REGISTRY) $(shell pwd)/scripts/setup_e2e.sh
 
 # This target will remove the kind cluster.
 kind-destroy:

--- a/e2e/scripts/setup_e2e.sh
+++ b/e2e/scripts/setup_e2e.sh
@@ -66,8 +66,6 @@ KUBE_VERSION=${KUBE_VERSION:-"v1.24.7"}
 FDB_VERSION=${FDB_VERSION:-"7.1.33"}
 # Defines the previous FDB version that should be preloaded into the Kind cluster
 UPGRADE_VERSIONS=${UPGRADE_VERSIONS:-""}
-# Defines the FDB version that are used for upgreade tests and that should be preloaded into the Kind cluster
-PREVIOUS_FDB_VERSION=${PREVIOUS_FDB_VERSION:-"6.3.25"}
 # Defines the registry to pull the images from.
 REGISTRY=${REGISTRY:-""}
 # Name for the new Kind cluster
@@ -82,7 +80,6 @@ CLUSTER=${CLUSTER} KUBE_VERSION=${KUBE_VERSION} ${SCRIPT_DIR}/start_kind_cluster
 
 # Make sure all required versions for the tests are available in the kind cluster.
 preload_foundationdb_images_for_version "${FDB_VERSION}"
-preload_foundationdb_images_for_version "${PREVIOUS_FDB_VERSION}"
 
 for version in $(echo ${UPGRADE_VERSIONS} | tr ':,' ' ');
 do


### PR DESCRIPTION
# Description

Update the default e2e test versions to 7.1 and 7.3.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

e2e test with the new versions will be triggered.

## Documentation

-

## Follow-up

-