### PR TITLE
Fix Issue #1739

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,9 +23,9 @@ issues:
       - stylecheck
     text: "ST1003: const StorageEngineRocksDbV1"
   # TODO (johscheuer): Fix all go imports to make this check happy, https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1739.
-  - linters:
-      - depguard
-    text: "is not allowed from list 'Main'"
+  # - linters:
+  #     - depguard
+  #   text: "is not allowed from list 'Main'"
 
 linters:
   disable-all: true
@@ -76,7 +76,33 @@ linters-settings:
     go: "1.20"
   stylecheck:
     go: "1.20"
-
+  depguard:
+    rules:
+      main:
+        allow:
+          - $gostd
+          - github.com/FoundationDB/fdb-kubernetes-operator
+          - github.com/apple/foundationdb
+          - github.com/google/go-cmp/cmp
+          - sigs.k8s.io/controller-runtime
+          - sigs.k8s.io/yaml
+          - k8s.io/kubectl
+          - k8s.io/apimachinery
+          - k8s.io/client-go
+          - k8s.io/cli-runtim
+          - k8s.io/api
+          - k8s.io/klog
+          - k8s.io/utils
+          - github.com/onsi/gomega
+          - github.com/onsi/ginkgo
+          - github.com/hashicorp
+          - github.com/spf13/cobra
+          - github.com/spf13/viper
+          - github.com/spf13/pflag
+          - github.com/fatih/color
+          - github.com/chaos-mesh
+          - github.com/prometheus
+          - github.com/go-logr
 run:
   timeout: 10m
   skip-files:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,10 +22,6 @@ issues:
   - linters:
       - stylecheck
     text: "ST1003: const StorageEngineRocksDbV1"
-  # TODO (johscheuer): Fix all go imports to make this check happy, https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1739.
-  # - linters:
-  #     - depguard
-  #   text: "is not allowed from list 'Main'"
 
 linters:
   disable-all: true


### PR DESCRIPTION
# Description
Fixes #1739 

This PR updates golangcli-lint `depgard` configuration to allow the packages currently used by the operator.

## Type of change

- Bug fix 

## Discussion

*Are there any design details that you would like to discuss further? No

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing? <<<
```
$ make lint
/home/manufog/go/bin/golangci-lint run ./...
```

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment? No

## Documentation

*Did you update relevant documentation within this repository? No

*If this change is adding new functionality, do we need to describe it in our user manual? No

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that? N/A

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues? 
Developers will need to update the golangci-lint config when adding new packages.

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*
This changes introduces new package checks through lint. In the future it would be required to update the golangci-lint configuration when importing new go packages to allow them.

*Does this introduce new defaults that we should re-evaluate in the future? Yes the new depgard main rule allows all the packages currently used by the operator. Actually some paths are relaxed and allow all packages from a repo for example `github.com/prometheus` or `github.com/chaos-mesh`
