### PR TITLE
Increase timeout for default single cluster upgrade

### DIFF
--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 			transactionSystemProcessGroups := make(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None)
 			// Wait until the cluster is upgraded and fully reconciled.
-			Expect(fdbCluster.WaitUntilWithForceReconcile(2, 600, func(cluster *fdbv1beta2.FoundationDBCluster) bool {
+			Expect(fdbCluster.WaitUntilWithForceReconcile(2, 1200, func(cluster *fdbv1beta2.FoundationDBCluster) bool {
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					if processGroup.ProcessClass == fdbv1beta2.ProcessClassStorage {
 						continue


### PR DESCRIPTION
# Description

Increase the timeout for the default single cluster upgrade. This should make sure that the operator has enough time to replace any process that might not be coming up correctly.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

I ran those test manually.

## Documentation

-

## Follow-up

-
