### PR TITLE
Improve operator lock handling by releasing locks once cluster is reconciled

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -217,7 +217,7 @@ func getProcessesReadyForRestart(logger logr.Logger, cluster *fdbv1beta2.Foundat
 			continue
 		}
 
-		// If any of the processes that should not be skipped are not having an updated ConfigMap, we should we waiting
+		// If any of the processes that should not be skipped are not having an updated ConfigMap, we should be waiting
 		// for the config to be propagated.
 		if processGroup.GetConditionTime(fdbv1beta2.IncorrectConfigMap) != nil {
 			allSynced = false

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -387,6 +387,17 @@ func (r *FoundationDBClusterReconciler) takeLock(logger logr.Logger, cluster *fd
 	return hasLock, nil
 }
 
+// releaseLock attempts to release a lock.
+func (r *FoundationDBClusterReconciler) releaseLock(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster) error {
+	logger.Info("Release lock on cluster", "namespace", cluster.Namespace, "cluster", cluster.Name)
+	lockClient, err := r.getLockClient(cluster)
+	if err != nil {
+		return err
+	}
+
+	return lockClient.ReleaseLock()
+}
+
 var connectionStringNameRegex, _ = regexp.Compile("[^A-Za-z0-9_]")
 
 // clusterSubReconciler describes a class that does part of the work of

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -254,7 +254,7 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	}
 
 	if reconciled {
-		// Once the cluster is reconciled the operator will release any pending locks.
+		// Once the cluster is reconciled the operator will release any pending locks for this cluster.
 		lockErr := r.releaseLock(logger, cluster)
 		if lockErr != nil {
 			return &requeue{curError: lockErr}

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -313,8 +313,8 @@ func (client *realLockClient) getDenyListKey(id string) fdb.Key {
 	return fdb.Key(fmt.Sprintf("%s/denyList/%s", client.cluster.GetLockPrefix(), id))
 }
 
-// ReleaseLock will release the current lock. The method will only succeed if the current operator
-// is the lock holder.
+// ReleaseLock will release the current lock. The method will only release the lock if the current
+// operator is the lock holder.
 func (client *realLockClient) ReleaseLock() error {
 	if client.disableLocks {
 		return nil
@@ -330,7 +330,7 @@ func (client *realLockClient) ReleaseLock() error {
 		lockValue := transaction.Get(lockKey).MustGet()
 		// The lock value is not set, so no action is required.
 		if len(lockValue) == 0 {
-			return true, nil
+			return false, nil
 		}
 
 		lockTuple, err := tuple.Unpack(lockValue)

--- a/pkg/fdbadminclient/lock_client.go
+++ b/pkg/fdbadminclient/lock_client.go
@@ -32,8 +32,8 @@ type LockClient interface {
 	// TakeLock attempts to acquire a lock.
 	TakeLock() (bool, error)
 
-	// ReleaseLock will release the current lock. The method will only succeed if the current operator
-	// is the lock holder.
+	// ReleaseLock will release the current lock. The method will only release the lock if the current
+	// operator is the lock holder.
 	ReleaseLock() error
 
 	// AddPendingUpgrades registers information about which process groups are

--- a/pkg/fdbadminclient/lock_client.go
+++ b/pkg/fdbadminclient/lock_client.go
@@ -32,6 +32,10 @@ type LockClient interface {
 	// TakeLock attempts to acquire a lock.
 	TakeLock() (bool, error)
 
+	// ReleaseLock will release the current lock. The method will only succeed if the current operator
+	// is the lock holder.
+	ReleaseLock() error
+
 	// AddPendingUpgrades registers information about which process groups are
 	// pending an upgrade to a new version.
 	AddPendingUpgrades(version fdbv1beta2.Version, processGroupIDs []fdbv1beta2.ProcessGroupID) error

--- a/pkg/fdbadminclient/mock/lock_client.go
+++ b/pkg/fdbadminclient/mock/lock_client.go
@@ -107,6 +107,12 @@ func (client *LockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntry) e
 	return nil
 }
 
+// ReleaseLock will release the current lock. The method will only succeed if the current operator
+// is the lock holder.
+func (client *LockClient) ReleaseLock() error {
+	return nil
+}
+
 // lockClientCache provides a cache of mock lock clients.
 var lockClientCache = make(map[string]*LockClient)
 var lockClientMutex sync.Mutex

--- a/pkg/fdbadminclient/mock/lock_client.go
+++ b/pkg/fdbadminclient/mock/lock_client.go
@@ -107,8 +107,8 @@ func (client *LockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntry) e
 	return nil
 }
 
-// ReleaseLock will release the current lock. The method will only succeed if the current operator
-// is the lock holder.
+// ReleaseLock will release the current lock. The method will only release the lock if the current
+// operator is the lock holder.
 func (client *LockClient) ReleaseLock() error {
 	return nil
 }


### PR DESCRIPTION
# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

Otherwise we have wait until the current lock expires. The default lock duration is 10 minutes, so waiting until the lock expires will slow down operations for HA clusters.

## Testing

Ran the unit tests (but they are not yet traversing the code path) and ran some e2e tests.

I will try to see if we can add some additional unit tests for this.

## Documentation

Will be updated once the changes look good (to make sure we document the right approach).

## Follow-up

-
