### PR TITLE
Allow to use max timeout for get status and allow to specify the max timeout

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -136,7 +136,7 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 		clusterLog.Info("Fetch machine-readable status for reconcilitation loop", "cacheStatus", cacheStatus)
 		status, err = r.getStatusFromClusterOrDummyStatus(clusterLog, cluster)
 		if err != nil {
-			return ctrl.Result{Requeue: true}, err
+			return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, err
 		}
 	}
 
@@ -481,14 +481,6 @@ func (r *FoundationDBClusterReconciler) getStatusFromClusterOrDummyStatus(logger
 
 	status, err := adminClient.GetStatus()
 	if err == nil {
-		if len(status.Client.Messages) > 0 {
-			logger.Info("found client message(s) in the machine-readable status", "messages", status.Client.Messages)
-		}
-
-		if len(status.Cluster.Messages) > 0 {
-			logger.Info("found cluster message(s) in the machine-readable status", "messages", status.Cluster.Messages)
-		}
-
 		return status, nil
 	}
 

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -693,6 +693,11 @@ protocol fdb00b071010000`,
 		When("the old version returns the correct result", func() {
 			BeforeEach(func() {
 				inputStatus := &fdbv1beta2.FoundationDBStatus{
+					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+							Available: true,
+						},
+					},
 					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 							"1": {},
@@ -709,7 +714,7 @@ protocol fdb00b071010000`,
 				}
 			})
 
-			It("should the correct status", func() {
+			It("should return the correct status", func() {
 				Expect(status).NotTo(BeNil())
 				Expect(status.Cluster.Processes).To(HaveLen(1))
 				Expect(err).NotTo(HaveOccurred())
@@ -723,6 +728,11 @@ protocol fdb00b071010000`,
 			Expect(err).NotTo(HaveOccurred())
 
 			inputStatus := &fdbv1beta2.FoundationDBStatus{
+				Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+					DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+						Available: true,
+					},
+				},
 				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 					Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 						"1": {},
@@ -743,7 +753,7 @@ protocol fdb00b071010000`,
 				}
 			})
 
-			It("should the correct status", func() {
+			It("should return the correct status", func() {
 				Expect(status).NotTo(BeNil())
 				Expect(status.Cluster.Processes).To(HaveLen(1))
 				Expect(err).NotTo(HaveOccurred())

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -38,6 +38,9 @@ import (
 // DefaultCLITimeout is the default timeout for CLI commands.
 var DefaultCLITimeout = 10 * time.Second
 
+// MaxCliTimeout is the maximum CLI timeout that will be used for requests that might be slower to respond.
+var MaxCliTimeout = 60 * time.Second
+
 const (
 	defaultTransactionTimeout = 5 * time.Second
 )
@@ -89,13 +92,13 @@ func ensureClusterFileIsPresent(dir string, uid string, connectionString string)
 }
 
 // getConnectionStringFromDB gets the database's connection string directly from the system key
-func getConnectionStringFromDB(libClient fdbLibClient) ([]byte, error) {
-	return libClient.getValueFromDBUsingKey("\xff/coordinators", DefaultCLITimeout)
+func getConnectionStringFromDB(libClient fdbLibClient, timeout time.Duration) ([]byte, error) {
+	return libClient.getValueFromDBUsingKey("\xff/coordinators", timeout)
 }
 
 // getStatusFromDB gets the database's status directly from the system key
-func getStatusFromDB(libClient fdbLibClient) (*fdbv1beta2.FoundationDBStatus, error) {
-	contents, err := libClient.getValueFromDBUsingKey("\xff\xff/status/json", DefaultCLITimeout)
+func getStatusFromDB(libClient fdbLibClient, timeout time.Duration) (*fdbv1beta2.FoundationDBStatus, error) {
+	contents, err := libClient.getValueFromDBUsingKey("\xff\xff/status/json", timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -68,6 +68,7 @@ type Options struct {
 	LabelSelector                      string
 	WatchNamespace                     string
 	CliTimeout                         int
+	MaxCliTimeout                      int
 	MaxConcurrentReconciles            int
 	LogFileMaxSize                     int
 	LogFileMaxAge                      int
@@ -90,6 +91,7 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 	)
 	fs.StringVar(&o.LogFile, "log-file", "", "The path to a file to write logs to.")
 	fs.IntVar(&o.CliTimeout, "cli-timeout", 10, "The timeout to use for CLI commands in seconds.")
+	fs.IntVar(&o.MaxCliTimeout, "max-cli-timeout", 60, "The maximum timeout to use for CLI commands in seconds. This timeout is used for CLI requests that are known to be potentially slow like get status or exclude.")
 	fs.IntVar(&o.MaxConcurrentReconciles, "max-concurrent-reconciles", 1, "Defines the maximum number of concurrent reconciles for all controllers.")
 	fs.BoolVar(&o.CleanUpOldLogFile, "cleanup-old-cli-logs", true, "Defines if the operator should delete old fdbcli log files.")
 	fs.DurationVar(&o.LogFileMinAge, "log-file-min-age", 5*time.Minute, "Defines the minimum age of fdbcli log files before removing when \"--cleanup-old-cli-logs\" is set.")
@@ -143,6 +145,7 @@ func StartManager(
 
 	setupLog := logger.WithName("setup")
 	fdbclient.DefaultCLITimeout = time.Duration(operatorOpts.CliTimeout) * time.Second
+	fdbclient.MaxCliTimeout = time.Duration(operatorOpts.MaxCliTimeout) * time.Second
 
 	options := ctrl.Options{
 		Scheme:             scheme,


### PR DESCRIPTION
# Description

Instead of retrying to fetch the status with multiple different timeouts, we should fetch the status directly with the maximum timeout. This reduced the amount of retries if the cluster is not responsive. I create a follow up for a better retry mechanism.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

e2e tests will be running.

## Documentation

-

## Follow-up

-
