### PR TITLE
Correct the namespace creation for e2e tests

### DIFF
--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -124,7 +124,8 @@ func (config *ClusterConfig) SetDefaults(factory *Factory) {
 		config.Name = factory.getClusterPrefix()
 	}
 
-	if config.Namespace == "" {
+	// Only create the namespace for non HA clusters, otherwise the namespaces will be created in a different way.
+	if config.Namespace == "" && config.HaMode == HaModeNone {
 		config.Namespace = factory.SingleNamespace()
 	}
 

--- a/e2e/fixtures/kubernetes_fixtures.go
+++ b/e2e/fixtures/kubernetes_fixtures.go
@@ -39,8 +39,17 @@ const (
 	namespaceRegEx = `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 )
 
+// factory.getRandomizedNamespaceName() checks if the username is valid to be used in the namespace name. If so this
+// method will return the namespace name as the username a hyphen and 8 random chars.
+func (factory *Factory) getRandomizedNamespaceName() string {
+	gomega.Expect(factory.singleton.userName).To(gomega.MatchRegexp(namespaceRegEx), "user name contains invalid characters")
+	return factory.singleton.userName + "-" + RandStringRunes(8)
+}
+
 // MultipleNamespaces creates multiple namespaces for HA testing.
 func (factory *Factory) MultipleNamespaces(dcIDs []string) []string {
+	factory.options.namespace = factory.getRandomizedNamespaceName()
+
 	res := make([]string, len(dcIDs))
 	for idx, dcID := range dcIDs {
 		namespace := factory.createNamespace(dcID)
@@ -71,8 +80,7 @@ func (factory *Factory) createNamespace(suffix string) string {
 	namespace := factory.options.namespace
 
 	if namespace == "" {
-		gomega.Expect(factory.singleton.userName).To(gomega.MatchRegexp(namespaceRegEx), "user name contains invalid characters")
-		namespace = factory.singleton.userName + "-" + RandStringRunes(8)
+		namespace = factory.getRandomizedNamespaceName()
 	}
 
 	if suffix != "" {


### PR DESCRIPTION
# Description

Before this change the prefix for the namespaces of an HA cluster were different and the e2e test suite would always create an empty namespace running the operator deployment. With this change the prefix for HA cluster namespaces will be constant and only create the single namespace per default for non HA clusters.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran the e2e tests.

## Documentation

-

## Follow-up

-
