### PR TITLE
Refactor code to make use of the process group directly without passing the class and id number down

### DIFF
--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -78,14 +78,9 @@ func (a addPods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler
 			continue
 		}
 
-		idNum, err := processGroup.ProcessGroupID.GetIDNumber()
+		pod, err := internal.GetPod(cluster, processGroup)
 		if err != nil {
-			return &requeue{curError: err}
-		}
-
-		pod, err := internal.GetPod(cluster, processGroup.ProcessClass, idNum)
-		if err != nil {
-			r.Recorder.Event(cluster, corev1.EventTypeWarning, "GetPod", fmt.Sprintf("failed to get the PodSpec for %s/%d with error: %s", processGroup.ProcessClass, idNum, err))
+			r.Recorder.Event(cluster, corev1.EventTypeWarning, "GetPod", fmt.Sprintf("failed to get the PodSpec for %s with error: %s", processGroup.ProcessGroupID, err))
 			return &requeue{curError: err}
 		}
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1336,10 +1336,10 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, item := range pods.Items {
-					id, err := fdbv1beta2.ProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel]).GetIDNumber()
-					Expect(err).NotTo(HaveOccurred())
-
-					hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(cluster, item.Labels), id, nil)
+					hash, err := internal.GetPodSpecHash(cluster, &fdbv1beta2.ProcessGroupStatus{
+						ProcessGroupID: fdbv1beta2.ProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
+						ProcessClass:   internal.ProcessClassFromLabels(cluster, item.Labels),
+					}, nil)
 					Expect(err).NotTo(HaveOccurred())
 
 					configMapHash, err := getConfigMapHash(cluster, internal.GetProcessClassFromMeta(cluster, item.ObjectMeta), &item)
@@ -1477,10 +1477,10 @@ var _ = Describe("cluster_controller", func() {
 					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 					Expect(err).NotTo(HaveOccurred())
 					for _, item := range pods.Items {
-						id, err := fdbv1beta2.ProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel]).GetIDNumber()
-						Expect(err).NotTo(HaveOccurred())
-
-						hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(cluster, item.Labels), id, nil)
+						hash, err := internal.GetPodSpecHash(cluster, &fdbv1beta2.ProcessGroupStatus{
+							ProcessGroupID: fdbv1beta2.ProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
+							ProcessClass:   internal.ProcessClassFromLabels(cluster, item.Labels),
+						}, nil)
 						Expect(err).NotTo(HaveOccurred())
 
 						configMapHash, err := getConfigMapHash(cluster, internal.GetProcessClassFromMeta(cluster, item.ObjectMeta), &item)
@@ -1586,10 +1586,10 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, item := range pods.Items {
-					id, err := fdbv1beta2.ProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel]).GetIDNumber()
-					Expect(err).NotTo(HaveOccurred())
-
-					hash, err := internal.GetPodSpecHash(cluster, internal.ProcessClassFromLabels(cluster, item.Labels), id, nil)
+					hash, err := internal.GetPodSpecHash(cluster, &fdbv1beta2.ProcessGroupStatus{
+						ProcessGroupID: fdbv1beta2.ProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
+						ProcessClass:   internal.ProcessClassFromLabels(cluster, item.Labels),
+					}, nil)
 					Expect(err).NotTo(HaveOccurred())
 
 					configMapHash, err := getConfigMapHash(cluster, internal.GetProcessClassFromMeta(cluster, item.ObjectMeta), &item)
@@ -3671,7 +3671,10 @@ var _ = Describe("cluster_controller", func() {
 		Context("with a default pod", func() {
 			BeforeEach(func() {
 				var err error
-				pod, err = internal.GetPod(cluster, "storage", 1)
+				pod, err = internal.GetPod(cluster, &fdbv1beta2.ProcessGroupStatus{
+					ProcessClass:   fdbv1beta2.ProcessClassStorage,
+					ProcessGroupID: "storage-1",
+				})
 				Expect(err).NotTo(HaveOccurred())
 				pod.Status.PodIP = "1.1.1.1"
 				pod.Status.PodIPs = []corev1.PodIP{
@@ -3690,7 +3693,10 @@ var _ = Describe("cluster_controller", func() {
 			BeforeEach(func() {
 				var err error
 				cluster.Spec.Routing.PodIPFamily = pointer.Int(6)
-				pod, err = internal.GetPod(cluster, "storage", 1)
+				pod, err = internal.GetPod(cluster, &fdbv1beta2.ProcessGroupStatus{
+					ProcessClass:   fdbv1beta2.ProcessClassStorage,
+					ProcessGroupID: "storage-1",
+				})
 				Expect(err).NotTo(HaveOccurred())
 				pod.Status.PodIP = "1.1.1.1"
 				pod.Status.PodIPs = []corev1.PodIP{
@@ -3707,7 +3713,10 @@ var _ = Describe("cluster_controller", func() {
 			Context("with no matching IPs in the Pod IP list", func() {
 				BeforeEach(func() {
 					var err error
-					pod, err = internal.GetPod(cluster, "storage", 1)
+					pod, err = internal.GetPod(cluster, &fdbv1beta2.ProcessGroupStatus{
+						ProcessClass:   fdbv1beta2.ProcessClassStorage,
+						ProcessGroupID: "storage-1",
+					})
 					Expect(err).NotTo(HaveOccurred())
 					pod.Status.PodIPs = []corev1.PodIP{
 						{IP: "1.1.1.2"},
@@ -3725,7 +3734,10 @@ var _ = Describe("cluster_controller", func() {
 			BeforeEach(func() {
 				var err error
 				cluster.Spec.Routing.PodIPFamily = pointer.Int(4)
-				pod, err = internal.GetPod(cluster, "storage", 1)
+				pod, err = internal.GetPod(cluster, &fdbv1beta2.ProcessGroupStatus{
+					ProcessClass:   fdbv1beta2.ProcessClassStorage,
+					ProcessGroupID: "storage-1",
+				})
 				Expect(err).NotTo(HaveOccurred())
 				pod.Status.PodIP = "1.1.1.2"
 				pod.Status.PodIPs = []corev1.PodIP{

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2569,8 +2569,7 @@ var _ = Describe("cluster_controller", func() {
 		Context("with a change to the process group ID prefix", func() {
 			BeforeEach(func() {
 				cluster.Spec.ProcessGroupIDPrefix = "dev"
-				err = k8sClient.Update(context.TODO(), cluster)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 			})
 
 			It("should replace the process groups", func() {
@@ -2593,8 +2592,7 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should generate process group IDs with the new prefix", func() {
 				pods := &corev1.PodList{}
-				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
 
 				sortPodsByName(pods)
 				Expect(pods.Items[0].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("dev-cluster_controller-2"))

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -175,15 +175,7 @@ func getPodsToUpdate(ctx context.Context, logger logr.Logger, reconciler *Founda
 			return nil, fmt.Errorf("cluster has Pod %s that is pending deletion", pod.Name)
 		}
 
-		idNum, err := processGroup.ProcessGroupID.GetIDNumber()
-		if err != nil {
-			logger.Info("Skipping Pod due to error parsing Process Group ID",
-				"processGroupID", processGroup.ProcessGroupID,
-				"error", err.Error())
-			continue
-		}
-
-		specHash, err := internal.GetPodSpecHash(cluster, processGroup.ProcessClass, idNum, nil)
+		specHash, err := internal.GetPodSpecHash(cluster, processGroup, nil)
 		if err != nil {
 			logger.Info("Skipping Pod due to error generating spec hash",
 				"processGroupID", processGroup.ProcessGroupID,

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -544,12 +544,7 @@ func validateProcessGroup(ctx context.Context, r *FoundationDBClusterReconciler,
 		return nil
 	}
 
-	idNum, err := processGroupStatus.ProcessGroupID.GetIDNumber()
-	if err != nil {
-		return err
-	}
-
-	specHash, err := internal.GetPodSpecHash(cluster, processGroupStatus.ProcessClass, idNum, nil)
+	specHash, err := internal.GetPodSpecHash(cluster, processGroupStatus, nil)
 	if err != nil {
 		return err
 	}
@@ -582,7 +577,7 @@ func validateProcessGroup(ctx context.Context, r *FoundationDBClusterReconciler,
 
 	processGroupStatus.UpdateCondition(fdbv1beta2.IncorrectConfigMap, !synced)
 
-	desiredPvc, err := internal.GetPvc(cluster, processGroupStatus.ProcessClass, idNum)
+	desiredPvc, err := internal.GetPvc(cluster, processGroupStatus)
 	if err != nil {
 		return err
 	}

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -228,6 +228,14 @@ func (fdbCluster *FdbCluster) waitForReconciliationToGeneration(
 		fdbCluster.cluster.Name,
 	)
 
+	if minimumGeneration > 0 {
+		log.Printf(
+			"waiting for generation %d, current generation: %d",
+			minimumGeneration,
+			fdbCluster.cluster.Generation,
+		)
+	}
+
 	var creationTracker *fdbClusterCreationTracker
 	if creationTrackerLogger != nil {
 		creationTracker = newFdbClusterCreationTracker(

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -786,8 +786,16 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		It("should add the prefix to all instances", func() {
+			for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+				Expect(string(processGroup.ProcessGroupID)).To(HavePrefix(prefix))
+			}
+
 			pods := fdbCluster.GetPods()
 			for _, pod := range pods.Items {
+				// Ignore any old Pods that are marked for removal.
+				if !pod.DeletionTimestamp.IsZero() {
+					continue
+				}
 				Expect(string(fixtures.GetProcessGroupID(pod))).To(HavePrefix(prefix))
 			}
 		})

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -781,12 +781,14 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		prefix := "banana"
 
 		BeforeEach(func() {
+			currentGeneration := fdbCluster.GetCluster().Generation
 			Expect(fdbCluster.SetProcessGroupPrefix(prefix)).NotTo(HaveOccurred())
-			Expect(fdbCluster.WaitForReconciliation())
+			Expect(fdbCluster.WaitForReconciliation(fixtures.MinimumGenerationOption(currentGeneration), fixtures.SoftReconcileOption(false)))
 		})
 
 		It("should add the prefix to all instances", func() {
 			for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+				log.Println(processGroup.String())
 				Expect(string(processGroup.ProcessGroupID)).To(HavePrefix(prefix))
 			}
 

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -783,12 +783,17 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		BeforeEach(func() {
 			currentGeneration := fdbCluster.GetCluster().Generation
 			Expect(fdbCluster.SetProcessGroupPrefix(prefix)).NotTo(HaveOccurred())
+
+			log.Println("DEBUGGING: Wait for cluster to be reconciled, current generation:", currentGeneration)
 			Expect(fdbCluster.WaitForReconciliation(fixtures.MinimumGenerationOption(currentGeneration+1), fixtures.SoftReconcileOption(false)))
 		})
 
 		It("should add the prefix to all instances", func() {
+			log.Println("DEBUGGING: Cluster is reconciled, current generation:", fdbCluster.GetCluster().Generation)
 			Eventually(func(g Gomega) bool {
 				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+					log.Println("DEBUGGING: ProcessGroup:", processGroup.String())
+
 					g.Expect(string(processGroup.ProcessGroupID)).To(HavePrefix(prefix))
 				}
 
@@ -798,6 +803,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			Eventually(func(g Gomega) bool {
 				pods := fdbCluster.GetPods()
 				for _, pod := range pods.Items {
+					log.Println("DEBUGGING: Pod:", pod.ObjectMeta.String())
 					g.Expect(string(fixtures.GetProcessGroupID(pod))).To(HavePrefix(prefix))
 				}
 

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -788,7 +788,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		It("should add the prefix to all instances", func() {
 			for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
-				log.Println(processGroup.String())
+				log.Println("DEBUG", processGroup.String())
 				Expect(string(processGroup.ProcessGroupID)).To(HavePrefix(prefix))
 			}
 
@@ -798,6 +798,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				if !pod.DeletionTimestamp.IsZero() {
 					continue
 				}
+
+				log.Println("DEBUG", pod.GetLabels())
 				Expect(string(fixtures.GetProcessGroupID(pod))).To(HavePrefix(prefix))
 			}
 		})

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -783,8 +783,6 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		BeforeEach(func() {
 			currentGeneration := fdbCluster.GetCluster().Generation
 			Expect(fdbCluster.SetProcessGroupPrefix(prefix)).NotTo(HaveOccurred())
-
-			log.Println("DEBUGGING: Wait for cluster to be reconciled, current generation:", currentGeneration)
 			Expect(fdbCluster.WaitForReconciliation(fixtures.MinimumGenerationOption(currentGeneration+1), fixtures.SoftReconcileOption(false)))
 		})
 
@@ -792,18 +790,15 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			log.Println("DEBUGGING: Cluster is reconciled, current generation:", fdbCluster.GetCluster().Generation)
 			Eventually(func(g Gomega) bool {
 				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
-					log.Println("DEBUGGING: ProcessGroup:", processGroup.String())
-
 					g.Expect(string(processGroup.ProcessGroupID)).To(HavePrefix(prefix))
 				}
 
 				return true
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
+			}).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
 
 			Eventually(func(g Gomega) bool {
 				pods := fdbCluster.GetPods()
 				for _, pod := range pods.Items {
-					log.Println("DEBUGGING: Pod:", pod.ObjectMeta.String())
 					g.Expect(string(fixtures.GetProcessGroupID(pod))).To(HavePrefix(prefix))
 				}
 

--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -434,7 +434,10 @@ var _ = Describe("monitor_conf", func() {
 		var processGroupID = "storage-1"
 
 		BeforeEach(func() {
-			pod, err = GetPod(cluster, fdbv1beta2.ProcessClassStorage, 1)
+			pod, err = GetPod(cluster, &fdbv1beta2.ProcessGroupStatus{
+				ProcessClass:   processClass,
+				ProcessGroupID: fdbv1beta2.ProcessGroupID(processGroupID),
+			})
 			Expect(err).NotTo(HaveOccurred())
 			address = pod.Status.PodIP
 		})

--- a/internal/pod_client_test.go
+++ b/internal/pod_client_test.go
@@ -46,7 +46,7 @@ var _ = Describe("pod_client", func() {
 		})
 
 		It("should not have TLS sidecar TLS", func() {
-			pod, err := GetPod(cluster, fdbv1beta2.ProcessClassStorage, 1)
+			pod, err := GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podHasSidecarTLS(pod)).To(BeFalse())
 		})
@@ -58,7 +58,7 @@ var _ = Describe("pod_client", func() {
 		})
 
 		It("should have TLS sidecar TLS", func() {
-			pod, err := GetPod(cluster, fdbv1beta2.ProcessClassStorage, 1)
+			pod, err := GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podHasSidecarTLS(pod)).To(BeTrue())
 		})

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -99,10 +99,10 @@ func GetProcessGroupIDFromMeta(cluster *fdbv1beta2.FoundationDBCluster, metadata
 }
 
 // GetPodSpecHash builds the hash of the expected spec for a pod.
-func GetPodSpecHash(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, id int, spec *corev1.PodSpec) (string, error) {
+func GetPodSpecHash(cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus, spec *corev1.PodSpec) (string, error) {
 	var err error
 	if spec == nil {
-		spec, err = GetPodSpec(cluster, processClass, id)
+		spec, err = GetPodSpec(cluster, processGroup)
 		if err != nil {
 			return "", err
 		}
@@ -197,6 +197,7 @@ func GetPvcMetadata(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1b
 	} else {
 		customMetadata = nil
 	}
+
 	return GetObjectMetadata(cluster, customMetadata, processClass, id)
 }
 

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -47,7 +47,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("with a basic storage process group", func() {
 			BeforeEach(func() {
-				pod, err = GetPod(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pod, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -62,7 +62,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("should contain the process group's pod spec", func() {
-				spec, err := GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err := GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pod.Spec).To(Equal(*spec))
 			})
@@ -82,7 +82,7 @@ var _ = Describe("pod_models", func() {
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				pod, err = GetPod(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pod, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -101,7 +101,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("with a cluster controller process group", func() {
 			BeforeEach(func() {
-				pod, err = GetPod(cluster, fdbv1beta2.ProcessClassClusterController, 1)
+				pod, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassClusterController, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -115,7 +115,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("should contain the process group's pod spec", func() {
-				spec, err := GetPodSpec(cluster, fdbv1beta2.ProcessClassClusterController, 1)
+				spec, err := GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassClusterController, 1))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pod.Spec).To(Equal(*spec))
 			})
@@ -129,17 +129,17 @@ var _ = Describe("pod_models", func() {
 					},
 				}
 
-				pod, err = GetPod(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pod, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should add the annotations to the metadata", func() {
-				hash, err := GetPodSpecHash(cluster, ProcessClassFromLabels(cluster, pod.Labels), 1, &pod.Spec)
+				hash, err := GetPodSpecHash(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1), &pod.Spec)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
-					"fdb-annotation":                     "value1",
-					"foundationdb.org/last-applied-spec": hash,
-					"foundationdb.org/public-ip-source":  "pod",
+					"fdb-annotation":                    "value1",
+					fdbv1beta2.LastSpecKey:              hash,
+					fdbv1beta2.PublicIPSourceAnnotation: "pod",
 				}))
 			})
 		})
@@ -157,7 +157,7 @@ var _ = Describe("pod_models", func() {
 				err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				pod, err = GetPod(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pod, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -178,7 +178,7 @@ var _ = Describe("pod_models", func() {
 		Context("with a version compatible upgrade in progress", func() {
 			BeforeEach(func() {
 				cluster.Spec.Version = fdbv1beta2.Versions.NextPatchVersion.String()
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -197,7 +197,7 @@ var _ = Describe("pod_models", func() {
 		Context("with a version incompatible upgrade in progress", func() {
 			BeforeEach(func() {
 				cluster.Spec.Version = fdbv1beta2.Versions.NextMajorVersion.String()
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -215,7 +215,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("with a basic storage process group", func() {
 			BeforeEach(func() {
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -405,7 +405,7 @@ var _ = Describe("pod_models", func() {
 						Value: "",
 						Key:   "kubernetes.io/hostname",
 					}
-					spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -418,7 +418,7 @@ var _ = Describe("pod_models", func() {
 				BeforeEach(func() {
 					enabled := true
 					cluster.Spec.SidecarContainer.EnableLivenessProbe = &enabled
-					spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -439,7 +439,7 @@ var _ = Describe("pod_models", func() {
 				BeforeEach(func() {
 					enabled := false
 					cluster.Spec.SidecarContainer.EnableReadinessProbe = &enabled
-					spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -460,7 +460,7 @@ var _ = Describe("pod_models", func() {
 				BeforeEach(func() {
 					enabled := true
 					cluster.Spec.SidecarContainer.EnableReadinessProbe = &enabled
-					spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -488,7 +488,7 @@ var _ = Describe("pod_models", func() {
 			})
 			When("running one storage server per disk", func() {
 				BeforeEach(func() {
-					spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -606,7 +606,7 @@ var _ = Describe("pod_models", func() {
 			When("running multiple storage servers per disk", func() {
 				BeforeEach(func() {
 					cluster.Spec.StorageServersPerPod = 2
-					spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -662,7 +662,7 @@ var _ = Describe("pod_models", func() {
 			When("creating a log with multiple storage servers per disk", func() {
 				BeforeEach(func() {
 					cluster.Spec.StorageServersPerPod = 2
-					spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassLog, 1)
+					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassLog, 1))
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -716,7 +716,7 @@ var _ = Describe("pod_models", func() {
 			When("running multiple log servers per disk", func() {
 				BeforeEach(func() {
 					cluster.Spec.LogServersPerPod = 2
-					spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassLog, 1)
+					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassLog, 1))
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -774,7 +774,7 @@ var _ = Describe("pod_models", func() {
 					cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{"storage-1"}
 					err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 					Expect(err).NotTo(HaveOccurred())
-					spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -795,7 +795,7 @@ var _ = Describe("pod_models", func() {
 					}
 					err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 					Expect(err).NotTo(HaveOccurred())
-					spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -817,7 +817,7 @@ var _ = Describe("pod_models", func() {
 			BeforeEach(func() {
 				family := 6
 				cluster.Spec.Routing.PodIPFamily = &family
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -904,7 +904,7 @@ var _ = Describe("pod_models", func() {
 		When("enabling DNS in the cluster file", func() {
 			BeforeEach(func() {
 				cluster.Spec.Routing.UseDNSInClusterFile = pointer.Bool(true)
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 			})
 
 			It("should set an additional environment variable on the init container", func() {
@@ -988,7 +988,7 @@ var _ = Describe("pod_models", func() {
 		When("enabling DNS in the locality fields", func() {
 			BeforeEach(func() {
 				cluster.Spec.Routing.DefineDNSLocalityFields = pointer.Bool(true)
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 			})
 
 			It("should set an additional environment variable on the init container", func() {
@@ -1093,7 +1093,7 @@ var _ = Describe("pod_models", func() {
 					Value: "",
 					Key:   "kubernetes.io/hostname",
 				}
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1108,7 +1108,7 @@ var _ = Describe("pod_models", func() {
 				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{"storage-1"}
 				err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1124,7 +1124,7 @@ var _ = Describe("pod_models", func() {
 				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{"*"}
 				err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1140,7 +1140,7 @@ var _ = Describe("pod_models", func() {
 				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{"storage-2"}
 				err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1164,7 +1164,7 @@ var _ = Describe("pod_models", func() {
 						Targets:       []fdbv1beta2.ProcessGroupID{"storage-2"},
 					},
 				}
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1188,7 +1188,7 @@ var _ = Describe("pod_models", func() {
 						Targets:       []fdbv1beta2.ProcessGroupID{"storage-1"},
 					},
 				}
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1213,7 +1213,7 @@ var _ = Describe("pod_models", func() {
 						Targets:       []fdbv1beta2.ProcessGroupID{"storage-1"},
 					},
 				}
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1233,7 +1233,7 @@ var _ = Describe("pod_models", func() {
 		Context("with an process group with scheduling broken", func() {
 			BeforeEach(func() {
 				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{"storage-1"}
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1252,7 +1252,7 @@ var _ = Describe("pod_models", func() {
 		Context("with a basic storage process group with multiple storage servers per disk", func() {
 			BeforeEach(func() {
 				cluster.Spec.StorageServersPerPod = 2
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1425,7 +1425,7 @@ var _ = Describe("pod_models", func() {
 			BeforeEach(func() {
 				var source = fdbv1beta2.PublicIPSourcePod
 				cluster.Spec.Routing.PublicIPSource = &source
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1493,7 +1493,7 @@ var _ = Describe("pod_models", func() {
 				cluster.Spec.Routing.PublicIPSource = &source
 				enabled := true
 				cluster.Spec.UseExplicitListenAddress = &enabled
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1563,7 +1563,7 @@ var _ = Describe("pod_models", func() {
 			BeforeEach(func() {
 				var source = fdbv1beta2.PublicIPSourceService
 				cluster.Spec.Routing.PublicIPSource = &source
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1633,7 +1633,7 @@ var _ = Describe("pod_models", func() {
 			BeforeEach(func() {
 				var enabled = true
 				cluster.Spec.Routing.HeadlessService = &enabled
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1647,7 +1647,7 @@ var _ = Describe("pod_models", func() {
 			BeforeEach(func() {
 				var enabled = false
 				cluster.Spec.Routing.HeadlessService = &enabled
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1682,7 +1682,7 @@ var _ = Describe("pod_models", func() {
 				err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1710,7 +1710,7 @@ var _ = Describe("pod_models", func() {
 				err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1725,7 +1725,7 @@ var _ = Describe("pod_models", func() {
 		Context("with a host-based fault domain", func() {
 			BeforeEach(func() {
 				cluster.Spec.FaultDomain = fdbv1beta2.FoundationDBClusterFaultDomain{}
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 			})
 
 			It("should set the fault domain information in the sidecar environment", func() {
@@ -1781,7 +1781,7 @@ var _ = Describe("pod_models", func() {
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1815,7 +1815,7 @@ var _ = Describe("pod_models", func() {
 					Key:       "rack",
 					ValueFrom: "$RACK",
 				}
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1865,7 +1865,7 @@ var _ = Describe("pod_models", func() {
 					Key:   "foundationdb.org/kubernetes-cluster",
 					Value: "kc2",
 				}
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1912,7 +1912,7 @@ var _ = Describe("pod_models", func() {
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1970,7 +1970,7 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("should return an error since a tag is specified", func() {
-				_, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				_, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -2006,7 +2006,7 @@ var _ = Describe("pod_models", func() {
 					},
 				}}}
 
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2066,7 +2066,7 @@ var _ = Describe("pod_models", func() {
 				cluster.Spec.SidecarContainer.EnableTLS = true
 				cluster.Spec.SidecarContainer.PeerVerificationRules = "S.CN=foundationdb.org"
 
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2169,7 +2169,7 @@ var _ = Describe("pod_models", func() {
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2238,7 +2238,7 @@ var _ = Describe("pod_models", func() {
 				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2291,7 +2291,7 @@ var _ = Describe("pod_models", func() {
 					},
 				}}}
 
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2318,7 +2318,7 @@ var _ = Describe("pod_models", func() {
 		Context("with an process group ID prefix", func() {
 			BeforeEach(func() {
 				cluster.Spec.ProcessGroupIDPrefix = "dc1"
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2345,7 +2345,7 @@ var _ = Describe("pod_models", func() {
 		Context("with custom map", func() {
 			BeforeEach(func() {
 				cluster.Spec.ConfigMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "config1"}}
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2356,7 +2356,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("with no custom map", func() {
 			BeforeEach(func() {
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("adds config-map volume that refers to custom map", func() {
@@ -2370,7 +2370,7 @@ var _ = Describe("pod_models", func() {
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2381,7 +2381,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("with no custom pvc", func() {
 			BeforeEach(func() {
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("adds data volume that refers to default pvc", func() {
@@ -2392,7 +2392,7 @@ var _ = Describe("pod_models", func() {
 		Context("with a custom CA", func() {
 			BeforeEach(func() {
 				cluster.Spec.TrustedCAs = []string{"Test"}
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 			})
 
 			It("should pass the CA file to the main container", func() {
@@ -2498,7 +2498,7 @@ var _ = Describe("pod_models", func() {
 				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -2533,7 +2533,7 @@ var _ = Describe("pod_models", func() {
 				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				spec, err = GetPodSpec(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -2559,7 +2559,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("with a basic storage process group", func() {
 			BeforeEach(func() {
-				service, err = GetService(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				service, err = GetService(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2594,7 +2594,7 @@ var _ = Describe("pod_models", func() {
 		Context("with podIPFamily 6", func() {
 			BeforeEach(func() {
 				cluster.Spec.Routing.PodIPFamily = pointer.Int(6)
-				service, err = GetService(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				service, err = GetService(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2630,7 +2630,7 @@ var _ = Describe("pod_models", func() {
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				service, err = GetService(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				service, err = GetService(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2669,7 +2669,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("with a basic storage process group", func() {
 			BeforeEach(func() {
-				pvc, err = GetPvc(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2704,7 +2704,7 @@ var _ = Describe("pod_models", func() {
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				pvc, err = GetPvc(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2732,7 +2732,7 @@ var _ = Describe("pod_models", func() {
 						},
 					},
 				}}}
-				pvc, err = GetPvc(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2757,7 +2757,7 @@ var _ = Describe("pod_models", func() {
 						},
 					},
 				}}}
-				pvc, err = GetPvc(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2788,7 +2788,7 @@ var _ = Describe("pod_models", func() {
 						},
 					},
 				}}}
-				pvc, err = GetPvc(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2806,7 +2806,7 @@ var _ = Describe("pod_models", func() {
 						StorageClassName: &class,
 					},
 				}}}
-				pvc, err = GetPvc(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2817,7 +2817,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("for a stateless process group", func() {
 			BeforeEach(func() {
-				pvc, err = GetPvc(cluster, fdbv1beta2.ProcessClassStateless, 1)
+				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStateless, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2829,7 +2829,7 @@ var _ = Describe("pod_models", func() {
 		Context("with an process group ID prefix", func() {
 			BeforeEach(func() {
 				cluster.Spec.ProcessGroupIDPrefix = "dc1"
-				pvc, err = GetPvc(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2846,7 +2846,7 @@ var _ = Describe("pod_models", func() {
 		Context("with an process group ID prefix", func() {
 			BeforeEach(func() {
 				cluster.Spec.ProcessGroupIDPrefix = "dc1"
-				pvc, err = GetPvc(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2865,7 +2865,7 @@ var _ = Describe("pod_models", func() {
 				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{Name: "pvc1"},
 				}}}
-				pvc, err = GetPvc(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2876,7 +2876,7 @@ var _ = Describe("pod_models", func() {
 
 		Context("with default name in the suffix", func() {
 			BeforeEach(func() {
-				pvc, err = GetPvc(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3539,10 +3539,11 @@ var _ = Describe("pod_models", func() {
 
 	Describe("ContainsPod", func() {
 		var pod1, pod2 *corev1.Pod
+
 		BeforeEach(func() {
-			pod1, err = GetPod(cluster, fdbv1beta2.ProcessClassStorage, 1)
+			pod1, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
 			Expect(err).NotTo(HaveOccurred())
-			pod2, err = GetPod(cluster, fdbv1beta2.ProcessClassStorage, 2)
+			pod2, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 2))
 			Expect(err).NotTo(HaveOccurred())
 			pod2.Labels[fdbv1beta2.FDBClusterLabel] = "incorrect-cluster-name"
 		})

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -94,3 +94,13 @@ func CreateDefaultBackup(cluster *fdbv1beta2.FoundationDBCluster) *fdbv1beta2.Fo
 		Status: fdbv1beta2.FoundationDBBackupStatus{},
 	}
 }
+
+// GetProcessGroup is a helper method that creates a ProcessGroup based on the provided process class and id number.
+func GetProcessGroup(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, idNum int) *fdbv1beta2.ProcessGroupStatus {
+	_, processGroupID := cluster.GetProcessGroupID(processClass, idNum)
+
+	return &fdbv1beta2.ProcessGroupStatus{
+		ProcessClass:   processClass,
+		ProcessGroupID: processGroupID,
+	}
+}

--- a/pkg/podmanager/pod_lifecycle_manager.go
+++ b/pkg/podmanager/pod_lifecycle_manager.go
@@ -183,7 +183,11 @@ func (manager StandardPodLifecycleManager) PodIsUpdated(context.Context, client.
 // GetPodSpec provides an external interface for the internal GetPodSpec method
 // This is necessary for compatibility reasons.
 func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, idNum int) (*corev1.PodSpec, error) {
-	return internal.GetPodSpec(cluster, processClass, idNum)
+	_, processGroupID := cluster.GetProcessGroupID(processClass, idNum)
+	return internal.GetPodSpec(cluster, &fdbv1beta2.ProcessGroupStatus{
+		ProcessClass:   processClass,
+		ProcessGroupID: processGroupID,
+	})
 }
 
 // GetDeletionMode returns the PodUpdateMode of the cluster if set or the default value Zone.


### PR DESCRIPTION
# Description

This is a follow up to refactor the operator code and remove some old technical debts, e.g. there is no need to parse the process class and id number multiple times, we just can pass down the whole process group.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

Most of the changes are adjustments for the test cases.

## Testing

Ran unit tests and e2e tests will be running with CI.

## Documentation

-

## Follow-up

-