### PR TITLE
Make use of errgroup and simplify some testing code

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -354,6 +354,45 @@ type ProcessGroupStatus struct {
 	FaultDomain FaultDomain `json:"faultDomain,omitempty"`
 }
 
+// String returns string representation.
+func (processGroupStatus *ProcessGroupStatus) String() string {
+	var sb strings.Builder
+
+	sb.WriteString("ID: ")
+	sb.WriteString(string(processGroupStatus.ProcessGroupID))
+	sb.WriteString(", Class: ")
+	sb.WriteString(string(processGroupStatus.ProcessClass))
+	sb.WriteString(", Addresses: ")
+	sb.WriteString(strings.Join(processGroupStatus.Addresses, ","))
+
+	sb.WriteString(", RemovalTimestamp: ")
+	if processGroupStatus.RemovalTimestamp.IsZero() {
+		sb.WriteString("-")
+	} else {
+		sb.WriteString(processGroupStatus.RemovalTimestamp.String())
+	}
+
+	sb.WriteString(", ExclusionTimestamp: ")
+	if processGroupStatus.ExclusionTimestamp.IsZero() {
+		sb.WriteString("-")
+	} else {
+		sb.WriteString(processGroupStatus.ExclusionTimestamp.String())
+	}
+
+	sb.WriteString(", ExclusionSkipped: ")
+	sb.WriteString(strconv.FormatBool(processGroupStatus.ExclusionSkipped))
+
+	sb.WriteString(", ProcessGroupConditions: ")
+	for _, condition := range processGroupStatus.ProcessGroupConditions {
+		sb.WriteString(condition.String())
+	}
+
+	sb.WriteString(", FaultDomain: ")
+	sb.WriteString(string(processGroupStatus.FaultDomain))
+
+	return sb.String()
+}
+
 // FaultDomain represents the FaultDomain of a process group
 // +kubebuilder:validation:MaxLength=512
 type FaultDomain string
@@ -795,6 +834,18 @@ type ProcessGroupCondition struct {
 	ProcessGroupConditionType ProcessGroupConditionType `json:"type,omitempty"`
 	// Timestamp when the Condition was observed
 	Timestamp int64 `json:"timestamp,omitempty"`
+}
+
+// String returns the string representation for the condition.
+func (condition *ProcessGroupCondition) String() string {
+	var sb strings.Builder
+
+	sb.WriteString("Condition: ")
+	sb.WriteString(string(condition.ProcessGroupConditionType))
+	sb.WriteString(" Timestamp: ")
+	sb.WriteString(time.Unix(condition.Timestamp, 0).String())
+
+	return sb.String()
 }
 
 // ProcessGroupConditionType represents a concrete ProcessGroupCondition.

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -664,13 +664,14 @@ func (factory *Factory) DumpState(fdbCluster *FdbCluster) {
 
 	buffer.WriteString(
 		fmt.Sprintf(
-			"%s\tGENERATION: %d\tRECONCILED: %d\tAVAILABLE: %t\tFULLREPLICATION: %t\tVERSION: %s\t Age: %s\nConnection String: %s\n",
+			"%s\tGENERATION: %d\tRECONCILED: %d\tAVAILABLE: %t\tFULLREPLICATION: %t\tRUNNING_VERSION: %s\tDESIRED_VERSION: %s\t Age: %s\nConnection String: %s\n",
 			cluster.GetName(),
 			cluster.Generation,
 			cluster.Status.Generations.Reconciled,
 			cluster.Status.Health.Available,
 			cluster.Status.Health.FullReplication,
 			cluster.Status.RunningVersion,
+			cluster.Spec.Version,
 			duration.HumanDuration(time.Since(cluster.CreationTimestamp.Time)),
 			cluster.Status.ConnectionString,
 		),

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -280,7 +280,7 @@ func (fdbCluster *FdbCluster) WaitUntilWithForceReconcile(pollTimeInSeconds int,
 	fdbCluster.factory.DumpState(fdbCluster)
 
 	lastForcedReconciliationTime := time.Now()
-	forceReconcileDuration := 5 * time.Minute
+	forceReconcileDuration := 4 * time.Minute
 
 	return wait.PollImmediate(
 		time.Duration(pollTimeInSeconds)*time.Second,
@@ -297,6 +297,7 @@ func (fdbCluster *FdbCluster) WaitUntilWithForceReconcile(pollTimeInSeconds int,
 				fdbCluster.ForceReconcile()
 				lastForcedReconciliationTime = time.Now()
 			}
+
 			return false, nil
 		},
 	)
@@ -305,6 +306,7 @@ func (fdbCluster *FdbCluster) WaitUntilWithForceReconcile(pollTimeInSeconds int,
 // ForceReconcile will add an annotation with the current timestamp on the FoundationDBCluster resource to make sure
 // the operator reconciliation loop is triggered. This is used to speed up some test cases.
 func (fdbCluster *FdbCluster) ForceReconcile() {
+	log.Println("ForceReconcile")
 	log.Printf("Status Generations=%s",
 		ToJSON(fdbCluster.cluster.Status.Generations))
 	log.Printf(

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -23,6 +23,7 @@ package fixtures
 import (
 	ctx "context"
 	"fmt"
+	"golang.org/x/sync/errgroup"
 	"log"
 	"strconv"
 	"strings"
@@ -279,10 +280,10 @@ func (fdbCluster *FdbCluster) WaitUntilWithForceReconcile(pollTimeInSeconds int,
 	fdbCluster.factory.DumpState(fdbCluster)
 
 	counter := 0
-	// We want to force reconcile every 5 minutes, otherwise we update the cluster spec to often and we
+	// We want to force reconcile every 2:30 minutes, otherwise we update the cluster spec to often and we
 	// introduce to many conflicts. This will be resolved once we move to server side apply see:
 	// https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1278
-	forceReconcile := 300 / pollTimeInSeconds
+	forceReconcile := 150 / pollTimeInSeconds
 
 	return wait.PollImmediate(
 		time.Duration(pollTimeInSeconds)*time.Second,
@@ -989,22 +990,18 @@ func (fdbCluster *FdbCluster) SetEmptyMonitorConf(enable bool) error {
 		return nil
 	}
 	// Don't wait for reconciliation when we set empty monitor config to true since the cluster won't reconcile
-
-	waitGroup := sync.WaitGroup{}
 	pods := fdbCluster.GetPods().Items
-	waitGroup.Add(len(pods))
-	podMap := make(map[string]struct{})
-	var mu sync.Mutex
-	var errorList []string
-	for i := range pods {
-		go func(i int) {
-			defer waitGroup.Done()
-			mu.Lock()
-			podMap[pods[i].Name] = struct{}{}
-			mu.Unlock()
+	podMap := sync.Map{}
+
+	g := new(errgroup.Group)
+	for _, pod := range pods {
+		targetPod := pod // https://golang.org/doc/faq#closures_and_goroutines
+		podMap.Store(targetPod.Name, struct{}{})
+
+		g.Go(func() error {
 			err := wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
 				output, _, err := fdbCluster.ExecuteCmdOnPod(
-					pods[i],
+					targetPod,
 					fdbv1beta2.MainContainerName,
 					"ps -e | grep fdbserver | wc -l",
 					false,
@@ -1012,45 +1009,47 @@ func (fdbCluster *FdbCluster) SetEmptyMonitorConf(enable bool) error {
 				if err != nil {
 					log.Printf(
 						"error executing command on %s, error: %s\n",
-						pods[i].Name,
+						targetPod.Name,
 						err.Error(),
 					)
 					return false, nil
 				}
-				fdbserver := strings.TrimSpace(output)
+
 				// If EmptyMonitor is enabled, each pod should has no fdbserver running
-				if fdbserver == "0" {
-					mu.Lock()
-					delete(podMap, pods[i].Name)
-					mu.Unlock()
+				if strings.TrimSpace(output) == "0" {
+					podMap.Delete(targetPod.Name)
 					return true, nil
 				}
+
 				return false, nil
 			})
-			if err != nil {
-				mu.Lock()
-				errorList = append(
-					errorList,
-					fmt.Sprintf("pod: %s, error: %s\n", pods[i].Name, err.Error()),
-				)
-				mu.Unlock()
-			}
-		}(i)
+
+			return err
+		})
 	}
-	waitGroup.Wait()
-	if len(errorList) > 0 {
-		log.Printf("Issue running command on the pods: %v", errorList)
+
+	err := g.Wait()
+	if err != nil {
+		return err
 	}
 
 	var failedPods strings.Builder
-	if len(podMap) != 0 {
-		for pod := range podMap {
-			failedPods.WriteString(pod)
-			failedPods.WriteString(" ")
+	podMap.Range(func(key any, value any) bool {
+		podName, ok := key.(string)
+		if !ok {
+			return false
 		}
+		failedPods.WriteString(podName)
+		failedPods.WriteString(" ")
+
+		return true
+	})
+	if failedPods.Len() > 0 {
 		return fmt.Errorf("enabling empty monitor failed on pods: %s", failedPods.String())
 	}
+
 	log.Printf("Enabling empty monitor succeeded in cluster: %s", fdbCluster.Name())
+
 	return nil
 }
 

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -752,6 +752,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		BeforeEach(func() {
 			Expect(fdbCluster.SetProcessGroupPrefix(prefix)).NotTo(HaveOccurred())
+			Expect(fdbCluster.WaitForReconciliation())
 		})
 
 		It("should add the prefix to all instances", func() {

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+require golang.org/x/sync v0.3.0
+
 require (
 	github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -493,6 +493,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
# Description

Make use of [errgroup ](https://pkg.go.dev/golang.org/x/sync/errgroup) inlaces where we implemented that by ourself. This reduces some complexity in our testing code.

## Type of change

*Please select one of the options below.*

- Other (code clean up).

## Discussion

-

## Testing

Ran local/manual tests.

## Documentation

-

## Follow-up

-
