### PR TITLE
Remove the MissingPVC condition for stateless processes

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -594,17 +594,20 @@ func (processGroupStatus *ProcessGroupStatus) AllAddressesExcluded(logger logr.L
 
 // NewProcessGroupStatus returns a new GroupStatus for the given processGroupID and processClass.
 func NewProcessGroupStatus(processGroupID ProcessGroupID, processClass ProcessClass, addresses []string) *ProcessGroupStatus {
+	initialConditions := []*ProcessGroupCondition{
+		NewProcessGroupCondition(MissingProcesses),
+		NewProcessGroupCondition(MissingPod),
+	}
+
+	if processClass.IsStateful() {
+		initialConditions = append(initialConditions, NewProcessGroupCondition(MissingPVC))
+	}
+
 	return &ProcessGroupStatus{
-		ProcessGroupID: processGroupID,
-		ProcessClass:   processClass,
-		Addresses:      addresses,
-		ProcessGroupConditions: []*ProcessGroupCondition{
-			NewProcessGroupCondition(MissingProcesses),
-			NewProcessGroupCondition(MissingPod),
-			NewProcessGroupCondition(MissingPVC),
-			// TODO(johscheuer): currently we never set this condition
-			// NewProcessGroupCondition(MissingService),
-		},
+		ProcessGroupID:         processGroupID,
+		ProcessClass:           processClass,
+		Addresses:              addresses,
+		ProcessGroupConditions: initialConditions,
 	}
 }
 

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -5547,4 +5547,42 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				},
 			}, "testing"),
 	)
+
+	When("creating a new ProcessGroup", func() {
+		var processGroupID ProcessGroupID
+		var processClass ProcessClass
+		var processGroup *ProcessGroupStatus
+
+		JustBeforeEach(func() {
+			processGroup = NewProcessGroupStatus(processGroupID, processClass, nil)
+		})
+
+		When("the ProcessGroup is stateful", func() {
+			BeforeEach(func() {
+				processGroupID = "storage-1"
+				processClass = ProcessClassStorage
+			})
+
+			It("should create the new ProcessGroup with the initial conditions", func() {
+				Expect(processGroup).NotTo(BeNil())
+				Expect(processGroup.ProcessGroupConditions).To(HaveLen(3))
+				Expect(processGroup.ProcessClass).To(Equal(processClass))
+				Expect(processGroup.ProcessGroupID).To(Equal(processGroupID))
+			})
+		})
+
+		When("the ProcessGroup is stateless", func() {
+			BeforeEach(func() {
+				processGroupID = "stateless-1"
+				processClass = ProcessClassStateless
+			})
+
+			It("should create the new ProcessGroup with the initial conditions", func() {
+				Expect(processGroup).NotTo(BeNil())
+				Expect(processGroup.ProcessGroupConditions).To(HaveLen(2))
+				Expect(processGroup.ProcessClass).To(Equal(processClass))
+				Expect(processGroup.ProcessGroupID).To(Equal(processGroupID))
+			})
+		})
+	})
 })


### PR DESCRIPTION
# Description

Small bug fix to remove the `MissingPVC` condition for stateless processes. This condition doesn't make sense for stateless processes, as those are not using any PVC.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Unit test.

## Documentation

-

## Follow-up

-
