### PR TITLE
Handle large exclusions better

### DIFF
--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -44,8 +44,7 @@ var _ = Describe("admin_client_test", func() {
 
 	BeforeEach(func() {
 		cluster = internal.CreateDefaultCluster()
-		err = k8sClient.Create(context.TODO(), cluster)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(context.TODO(), cluster)).NotTo(HaveOccurred())
 
 		result, err := reconcileCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())
@@ -71,8 +70,7 @@ var _ = Describe("admin_client_test", func() {
 			When("the version supports grv and commit proxies", func() {
 				BeforeEach(func() {
 					cluster.Spec.Version = fdbv1beta2.Versions.NextMajorVersion.String()
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 
 					result, err := reconcileCluster(cluster)
 					Expect(err).NotTo(HaveOccurred())
@@ -173,8 +171,7 @@ var _ = Describe("admin_client_test", func() {
 		Context("with the DNS names enabled", func() {
 			BeforeEach(func() {
 				cluster.Spec.Routing.DefineDNSLocalityFields = pointer.Bool(true)
-				err = k8sClient.Update(context.TODO(), cluster)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 			})
 
 			When("the cluster has not been reconciled", func() {

--- a/controllers/exclude_processes_test.go
+++ b/controllers/exclude_processes_test.go
@@ -23,9 +23,8 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"net"
-
 	"k8s.io/utils/pointer"
+	"net"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 
@@ -38,11 +37,10 @@ var _ = Describe("exclude_processes", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
 	var err error
 
-	Describe("canExcludeNewProcesses", func() {
+	When("validating if processes can be excluded", func() {
 		BeforeEach(func() {
 			cluster = internal.CreateDefaultCluster()
-			err = k8sClient.Create(context.TODO(), cluster)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(context.TODO(), cluster)).NotTo(HaveOccurred())
 
 			result, err := reconcileCluster(cluster)
 			Expect(err).NotTo(HaveOccurred())
@@ -180,9 +178,8 @@ var _ = Describe("exclude_processes", func() {
 
 			When("there are no exclusions", func() {
 				It("should not exclude anything", func() {
-					fdbProcessesToExclude, processClassesToExclude := getProcessesToExclude(exclusions, cluster, 0)
-					Expect(len(processClassesToExclude)).To(Equal(0))
-					Expect(len(fdbProcessesToExclude)).To(Equal(0))
+					fdbProcessesToExcludeByClass := getProcessesToExclude(exclusions, cluster)
+					Expect(fdbProcessesToExcludeByClass).To(HaveLen(0))
 				})
 			})
 
@@ -195,11 +192,11 @@ var _ = Describe("exclude_processes", func() {
 				})
 
 				It("should report the excluded process", func() {
-					fdbProcessesToExclude, processClassesToExclude := getProcessesToExclude(exclusions, cluster, 0)
-					Expect(len(processClassesToExclude)).To(Equal(1))
-					Expect(processClassesToExclude).To(Equal(map[fdbv1beta2.ProcessClass]fdbv1beta2.None{fdbv1beta2.ProcessClassStorage: {}}))
-					Expect(len(fdbProcessesToExclude)).To(Equal(1))
-					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExclude, " ")).To(Equal("1.1.1.1"))
+					fdbProcessesToExcludeByClass := getProcessesToExclude(exclusions, cluster)
+					Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
+					Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+					Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage], " ")).To(Equal("1.1.1.1"))
 				})
 			})
 
@@ -217,11 +214,11 @@ var _ = Describe("exclude_processes", func() {
 				})
 
 				It("should report the excluded process", func() {
-					fdbProcessesToExclude, processClassesToExclude := getProcessesToExclude(exclusions, cluster, 0)
-					Expect(len(processClassesToExclude)).To(Equal(1))
-					Expect(processClassesToExclude).To(Equal(map[fdbv1beta2.ProcessClass]fdbv1beta2.None{fdbv1beta2.ProcessClassStorage: {}}))
-					Expect(len(fdbProcessesToExclude)).To(Equal(2))
-					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExclude, " ")).To(Equal("1.1.1.1 1.1.1.2"))
+					fdbProcessesToExcludeByClass := getProcessesToExclude(exclusions, cluster)
+					Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
+					Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+					Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(2))
+					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage], " ")).To(Equal("1.1.1.1 1.1.1.2"))
 				})
 			})
 
@@ -241,11 +238,11 @@ var _ = Describe("exclude_processes", func() {
 				})
 
 				It("should report the excluded process", func() {
-					fdbProcessesToExclude, processClassesToExclude := getProcessesToExclude(exclusions, cluster, 1)
-					Expect(len(processClassesToExclude)).To(Equal(1))
-					Expect(processClassesToExclude).To(Equal(map[fdbv1beta2.ProcessClass]fdbv1beta2.None{fdbv1beta2.ProcessClassStorage: {}}))
-					Expect(len(fdbProcessesToExclude)).To(Equal(1))
-					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExclude, " ")).To(Equal("1.1.1.1"))
+					fdbProcessesToExcludeByClass := getProcessesToExclude(exclusions, cluster)
+					Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
+					Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+					Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage], " ")).To(Equal("1.1.1.1"))
 				})
 			})
 		})
@@ -257,9 +254,8 @@ var _ = Describe("exclude_processes", func() {
 
 			When("there are no exclusions", func() {
 				It("should not exclude anything", func() {
-					fdbProcessesToExclude, processClassesToExclude := getProcessesToExclude(exclusions, cluster, 0)
-					Expect(len(processClassesToExclude)).To(Equal(0))
-					Expect(len(fdbProcessesToExclude)).To(Equal(0))
+					fdbProcessesToExcludeByClass := getProcessesToExclude(exclusions, cluster)
+					Expect(fdbProcessesToExcludeByClass).To(HaveLen(0))
 				})
 			})
 
@@ -272,11 +268,11 @@ var _ = Describe("exclude_processes", func() {
 				})
 
 				It("should report the excluded process", func() {
-					fdbProcessesToExclude, processClassesToExclude := getProcessesToExclude(exclusions, cluster, 0)
-					Expect(len(processClassesToExclude)).To(Equal(1))
-					Expect(processClassesToExclude).To(Equal(map[fdbv1beta2.ProcessClass]fdbv1beta2.None{fdbv1beta2.ProcessClassStorage: {}}))
-					Expect(len(fdbProcessesToExclude)).To(Equal(1))
-					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExclude, " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
+					fdbProcessesToExcludeByClass := getProcessesToExclude(exclusions, cluster)
+					Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
+					Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+					Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage], " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
 				})
 			})
 
@@ -294,11 +290,11 @@ var _ = Describe("exclude_processes", func() {
 				})
 
 				It("should report the excluded process", func() {
-					fdbProcessesToExclude, processClassesToExclude := getProcessesToExclude(exclusions, cluster, 0)
-					Expect(len(processClassesToExclude)).To(Equal(1))
-					Expect(processClassesToExclude).To(Equal(map[fdbv1beta2.ProcessClass]fdbv1beta2.None{fdbv1beta2.ProcessClassStorage: {}}))
-					Expect(len(fdbProcessesToExclude)).To(Equal(2))
-					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExclude, " ")).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
+					fdbProcessesToExcludeByClass := getProcessesToExclude(exclusions, cluster)
+					Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
+					Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+					Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(2))
+					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage], " ")).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
 				})
 			})
 
@@ -318,11 +314,11 @@ var _ = Describe("exclude_processes", func() {
 				})
 
 				It("should report the excluded process", func() {
-					fdbProcessesToExclude, processClassesToExclude := getProcessesToExclude(exclusions, cluster, 1)
-					Expect(len(processClassesToExclude)).To(Equal(1))
-					Expect(processClassesToExclude).To(Equal(map[fdbv1beta2.ProcessClass]fdbv1beta2.None{fdbv1beta2.ProcessClassStorage: {}}))
-					Expect(len(fdbProcessesToExclude)).To(Equal(2))
-					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExclude, " ")).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
+					fdbProcessesToExcludeByClass := getProcessesToExclude(exclusions, cluster)
+					Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
+					Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+					Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(2))
+					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage], " ")).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
 				})
 			})
 
@@ -340,12 +336,13 @@ var _ = Describe("exclude_processes", func() {
 
 					exclusions = append(exclusions, fdbv1beta2.ProcessAddress{StringAddress: processGroup2.GetExclusionString()})
 				})
+
 				It("should report the excluded process", func() {
-					fdbProcessesToExclude, processClassesToExclude := getProcessesToExclude(exclusions, cluster, 1)
-					Expect(len(processClassesToExclude)).To(Equal(1))
-					Expect(processClassesToExclude).To(Equal(map[fdbv1beta2.ProcessClass]fdbv1beta2.None{fdbv1beta2.ProcessClassStorage: {}}))
-					Expect(len(fdbProcessesToExclude)).To(Equal(1))
-					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExclude, " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
+					fdbProcessesToExcludeByClass := getProcessesToExclude(exclusions, cluster)
+					Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
+					Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+					Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage], " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
 				})
 			})
 		})

--- a/controllers/update_metadata_test.go
+++ b/controllers/update_metadata_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = FDescribe("Update metadata", func() {
+var _ = Describe("Update metadata", func() {
 	type testCase struct {
 		pod          *corev1.Pod
 		metadata     metav1.ObjectMeta

--- a/docs/manual/replacements_and_deletions.md
+++ b/docs/manual/replacements_and_deletions.md
@@ -121,7 +121,11 @@ spec:
 
 ## Enforce Full Replication
 
-The operator only removes ProcessGroups when the cluster has the desired fault tolerance and is available. This is enforced by default in 1.0.0 without disabling.
+The operator only removes ProcessGroups when the cluster has the desired fault tolerance and is available. This is enforced by default in 1.0.0.
+
+## Exclusion strategy of the Operator
+
+See: [Technical Design: Exclude Processes](technical_design.md#excludeprocesses)
 
 ## Deletion mode
 

--- a/e2e/test_operator_migrations/operator_migration_test.go
+++ b/e2e/test_operator_migrations/operator_migration_test.go
@@ -1,0 +1,118 @@
+/*
+ * operator_migration_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package operatormigration
+
+/*
+This test suite includes test that make sure that the migrations and exclusion strategy of the operator is working as
+expected under different scenarios.
+*/
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	factory     *fixtures.Factory
+	fdbCluster  *fixtures.FdbCluster
+	testOptions *fixtures.FactoryOptions
+)
+
+func init() {
+	testOptions = fixtures.InitFlags()
+}
+
+var _ = BeforeSuite(func() {
+	factory = fixtures.CreateFactory(testOptions)
+	fdbCluster = factory.CreateFdbCluster(
+		fixtures.DefaultClusterConfig(false),
+		factory.GetClusterOptions()...,
+	)
+})
+
+var _ = AfterSuite(func() {
+	if CurrentSpecReport().Failed() {
+		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
+	}
+	factory.Shutdown()
+})
+
+var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			factory.DumpState(fdbCluster)
+		}
+		Expect(fdbCluster.WaitForReconciliation()).ToNot(HaveOccurred())
+	})
+
+	When("a migration is triggered and the namespace quota is limited", func() {
+		prefix := "banana"
+
+		BeforeEach(func() {
+			processCounts, err := fdbCluster.GetCluster().GetProcessCountsWithDefaults()
+			Expect(err).NotTo(HaveOccurred())
+			// Create Quota to limit the additional Pods that can be created to 5, the actual value here is 7 ,because we run
+			// 2 Operator Pods.
+			Expect(factory.CreateIfAbsent(&corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testing-quota",
+					Namespace: fdbCluster.Namespace(),
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: corev1.ResourceList{
+						"count/pods": resource.MustParse(strconv.Itoa(processCounts.Total() + 7)),
+					},
+				},
+			})).NotTo(HaveOccurred())
+
+			currentGeneration := fdbCluster.GetCluster().Generation
+			Expect(fdbCluster.SetProcessGroupPrefix(prefix)).NotTo(HaveOccurred())
+			Expect(fdbCluster.WaitForReconciliation(fixtures.MinimumGenerationOption(currentGeneration+1), fixtures.SoftReconcileOption(false)))
+		})
+
+		It("should add the prefix to all instances", func() {
+			Eventually(func(g Gomega) bool {
+				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+					g.Expect(string(processGroup.ProcessGroupID)).To(HavePrefix(prefix))
+				}
+
+				return true
+			}).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
+
+			Eventually(func(g Gomega) bool {
+				pods := fdbCluster.GetPods()
+				for _, pod := range pods.Items {
+					g.Expect(string(fixtures.GetProcessGroupID(pod))).To(HavePrefix(prefix))
+				}
+
+				return true
+			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
+		})
+	})
+})

--- a/e2e/test_operator_migrations/suite_test.go
+++ b/e2e/test_operator_migrations/suite_test.go
@@ -1,0 +1,34 @@
+/*
+ * suite_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package operatormigration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"
+	"github.com/onsi/gomega"
+)
+
+func TestOperatorMigrations(t *testing.T) {
+	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
+	fixtures.RunGinkgoTests(t, "Operator Migration test suite")
+}


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1639
Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1225

## Type of change

*Please select one of the options below.*

- Non breaking change.

## Discussion

-

## Testing

Created a new migration test for this and updated the existing unit tests:

```text
Ran 1 of 1 Specs in 1373.773 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestOperatorMigrations (1373.84s)
PASS
ok      github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_migrations    1374.187s
```

## Documentation

Updated the exclusion logic.

## Follow-up

-
