### PR TITLE
Let operator replace processes that are excluded but not yet marked as removed

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -64,7 +64,7 @@ type FoundationDBClusterList struct {
 }
 
 var conditionsThatNeedReplacement = []ProcessGroupConditionType{MissingProcesses, PodFailing, MissingPod, MissingPVC,
-	MissingService, PodPending, NodeTaintReplacing}
+	MissingService, PodPending, NodeTaintReplacing, ProcessIsMarkedAsExcluded}
 
 func init() {
 	SchemeBuilder.Register(&FoundationDBCluster{}, &FoundationDBClusterList{})
@@ -892,6 +892,8 @@ const (
 	NodeTaintDetected ProcessGroupConditionType = "NodeTaintDetected"
 	// NodeTaintReplacing represents a Pod whose node has been tainted and the operator should replace the Pod
 	NodeTaintReplacing ProcessGroupConditionType = "NodeTaintReplacing"
+	// ProcessIsMarkedAsExcluded represents a process group where at least one process is excluded.
+	ProcessIsMarkedAsExcluded ProcessGroupConditionType = "ProcessIsMarkedAsExcluded"
 )
 
 // AllProcessGroupConditionTypes returns all ProcessGroupConditionType
@@ -910,6 +912,7 @@ func AllProcessGroupConditionTypes() []ProcessGroupConditionType {
 		ReadyCondition,
 		NodeTaintDetected,
 		NodeTaintReplacing,
+		ProcessIsMarkedAsExcluded,
 	}
 }
 
@@ -940,6 +943,8 @@ func GetProcessGroupConditionType(processGroupConditionType string) (ProcessGrou
 		return NodeTaintDetected, nil
 	case "NodeTaintReplacing":
 		return NodeTaintReplacing, nil
+	case "ProcessIsMarkedAsExcluded":
+		return ProcessIsMarkedAsExcluded, nil
 	}
 
 	return "", fmt.Errorf("unknown process group condition type: %s", processGroupConditionType)

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -373,6 +373,22 @@ var _ = Describe("update_status", func() {
 			})
 		})
 
+		When("a process group has a process that is excluded", func() {
+			BeforeEach(func() {
+				adminClient.ExcludedAddresses[storagePod.Status.PodIP] = fdbv1beta2.None{}
+			})
+
+			It("should get the ProcessIsMarkedAsExcluded condition", func() {
+				processGroupStatus, err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPvcs, logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(processGroupStatus)).To(BeNumerically(">", 4))
+				processGroup := processGroupStatus[len(processGroupStatus)-4]
+				Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
+				Expect(processGroup.ProcessGroupConditions).To(HaveLen(1))
+				Expect(processGroup.ProcessGroupConditions[0].ProcessGroupConditionType).To(Equal(fdbv1beta2.ProcessIsMarkedAsExcluded))
+			})
+		})
+
 		When("a process group has the wrong command line", func() {
 			BeforeEach(func() {
 				adminClient.MockIncorrectCommandLine(storageOneProcessGroupID, true)

--- a/docs/manual/replacements_and_deletions.md
+++ b/docs/manual/replacements_and_deletions.md
@@ -61,6 +61,7 @@ The following conditions are currently eligible for replacement:
 * `MissingService`: This indicates that a process group that doesn't have a Service assigned.
 * `PodPending`: This indicates that a process group where the Pod is in a pending state.
 * `NodeTaintReplacing`: This indicates a process group where the Pod has been running on a tainted Node for at least the configured duration. If a ProcessGroup has the `NodeTaintReplacing` condition, the replacement cannot be stopped, even after the Node taint was removed.
+* `ProcessIsMarkedAsExcluded`: This indicates a process group where at least on process is excluded. If the process group is not marked as removal, the operator will replace this process group to make sure the cluster runs at the right capacity.
 
 Process groups that are set into the crash loop state with the `Buggify` setting won't be replaced by the operator.
 If the `cluster.Spec.Buggify.EmptyMonitorConf` setting is active the operator won't replace any process groups.

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1431,4 +1431,39 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}).WithPolling(4 * time.Second).WithTimeout(2 * time.Minute).MustPassRepeatedly(10).Should(BeTrue())
 		})
 	})
+
+	When("a process is excluded without being marked for removal", func() {
+		var initialReplaceTime time.Duration
+		var pod *corev1.Pod
+
+		BeforeEach(func() {
+			availabilityCheck = false
+			initialReplaceTime = time.Duration(pointer.IntDeref(
+				fdbCluster.GetClusterSpec().AutomationOptions.Replacements.FailureDetectionTimeSeconds,
+				90,
+			)) * time.Second
+			Expect(fdbCluster.SetAutoReplacements(true, 30*time.Second)).ShouldNot(HaveOccurred())
+
+			pod = fixtures.ChooseRandomPod(fdbCluster.GetStatelessPods())
+			log.Printf("exclude Pod: %s", pod.Name)
+			Expect(pod.Status.PodIP).NotTo(BeEmpty())
+			_, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(fmt.Sprintf("exclude %s", pod.Status.PodIP), false, 30)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Make sure we trigger a reconciliation to speed up the exclusion detection.
+			fdbCluster.ForceReconcile()
+		})
+
+		It("should replace the excluded Pod", func() {
+			log.Printf("waiting for pod removal: %s", pod.Name)
+			Expect(fdbCluster.WaitForPodRemoval(pod)).ShouldNot(HaveOccurred())
+			exists, err := factory.DoesPodExist(*pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+
+		AfterEach(func() {
+			Expect(fdbCluster.SetAutoReplacements(true, initialReplaceTime)).ShouldNot(HaveOccurred())
+		})
+	})
 })


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1674

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

I added units tests and a new e2e test that I ran manually:

```text
Ran 1 of 40 Specs in 1070.055 seconds
SUCCESS! -- 1 Passed | 0 Failed | 9 Pending | 30 Skipped
PASS | FOCUSED
```
## Documentation

Updated.

## Follow-up

N/A
