### PR TITLE
Add coordinator fault tolerance check

### DIFF
--- a/api/v1beta2/foundationdb_process_address.go
+++ b/api/v1beta2/foundationdb_process_address.go
@@ -256,7 +256,6 @@ func (address ProcessAddress) String() string {
 	sb.WriteString(net.JoinHostPort(address.MachineAddress(), strconv.Itoa(address.Port)))
 
 	flags := address.SortedFlags()
-
 	if len(flags) > 0 {
 		sb.WriteString(":" + strings.Join(flags, ":"))
 	}

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -331,8 +331,7 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should update the pods", func() {
 				pods := &corev1.PodList{}
-				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
 				for _, pod := range pods.Items {
 					env := make(map[string]string)
 					for _, envVar := range pod.Spec.InitContainers[0].Env {
@@ -342,6 +341,7 @@ var _ = Describe("cluster_controller", func() {
 				}
 			})
 		})
+
 		Context("when buggifying a pod to make it crash loop", func() {
 			BeforeEach(func() {
 				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{"storage-1"}

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -43,8 +43,7 @@ var _ = Describe("remove_process_groups", func() {
 	Context("validating process removal", func() {
 		BeforeEach(func() {
 			cluster = internal.CreateDefaultCluster()
-			err := k8sClient.Create(context.TODO(), cluster)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(context.TODO(), cluster)).NotTo(HaveOccurred())
 
 			result, err := reconcileCluster(cluster)
 			Expect(err).NotTo(HaveOccurred())
@@ -193,7 +192,7 @@ var _ = Describe("remove_process_groups", func() {
 				})
 			})
 
-			When("Removing multiple process groups", func() {
+			When("removing multiple process groups", func() {
 				var initialCnt int
 				var secondRemovedProcessGroup *fdbv1beta2.ProcessGroupStatus
 
@@ -201,7 +200,7 @@ var _ = Describe("remove_process_groups", func() {
 					BeforeEach(func() {
 						Expect(cluster.Spec.AutomationOptions.RemovalMode).To(BeEmpty())
 						initialCnt = len(cluster.Status.ProcessGroups)
-						secondRemovedProcessGroup = cluster.Status.ProcessGroups[1]
+						secondRemovedProcessGroup = cluster.Status.ProcessGroups[6]
 						marked, processGroup := fdbv1beta2.MarkProcessGroupForRemoval(cluster.Status.ProcessGroups, secondRemovedProcessGroup.ProcessGroupID, secondRemovedProcessGroup.ProcessClass, removedProcessGroup.Addresses[0])
 						Expect(marked).To(BeTrue())
 						Expect(processGroup).To(BeNil())
@@ -303,7 +302,7 @@ var _ = Describe("remove_process_groups", func() {
 						Expect(err).NotTo(HaveOccurred())
 
 						initialCnt = len(cluster.Status.ProcessGroups)
-						secondRemovedProcessGroup = cluster.Status.ProcessGroups[1]
+						secondRemovedProcessGroup = cluster.Status.ProcessGroups[6]
 						marked, processGroup := fdbv1beta2.MarkProcessGroupForRemoval(cluster.Status.ProcessGroups, secondRemovedProcessGroup.ProcessGroupID, secondRemovedProcessGroup.ProcessClass, removedProcessGroup.Addresses[0])
 						Expect(marked).To(BeTrue())
 						Expect(processGroup).To(BeNil())

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -350,6 +350,7 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 		status.Cluster.Clients.SupportedVersions = supportedVersions
 	}
 
+	var countReachableCoordinators int
 	for address, reachable := range coordinators {
 		pAddr, err := fdbv1beta2.ParseProcessAddress(address)
 		if err != nil {
@@ -360,8 +361,14 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 			Address:   pAddr,
 			Reachable: reachable,
 		})
+
+		if reachable {
+			countReachableCoordinators++
+		}
 	}
 
+	minReachableCoordinators := (client.Cluster.DesiredCoordinatorCount() + 1) / 2
+	status.Client.Coordinators.QuorumReachable = countReachableCoordinators >= minReachableCoordinators
 	status.Client.DatabaseStatus.Available = true
 	status.Client.DatabaseStatus.Healthy = true
 

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -228,6 +228,13 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 					for _, envVar := range container.Env {
 						if envVar.Name == "FDB_DNS_NAME" {
 							locality[fdbv1beta2.FDBLocalityDNSNameKey] = envVar.Value
+
+							if client.Cluster.UseDNSInClusterFile() {
+								fullAddress.StringAddress = envVar.Value
+							}
+							// TODO (johscheuer): This should be set to true. This will add additional information to the
+							// return address and needs some additional refactoring in the mock code.
+							// fullAddress.FromHostname = true
 						}
 					}
 				}


### PR DESCRIPTION
# Description

Adding a fault tolerance check for coordinators and only allow operations if all coordinators are up and running. In a fallow up we could use those fault tolerances and only validate them for affected Pods, e.g. only validate the coordinator fault tolerance for coordinator changes.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

Currently the requirement is that all coordinators are up and running. This is the most strict policy.

## Testing

I added new unit tests. Some of the existing tests are broken and they need some modification (or the mock setup).

## Documentation

-

## Follow-up

-
