### PR TITLE
Correct the way an empty result is interpreted

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -352,6 +352,7 @@ func (client *cliAdminClient) GetMaintenanceZone() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return string(mode), nil
 }
 

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -63,8 +63,9 @@ func (fdbClient *realFdbLibClient) getValueFromDBUsingKey(fdbKey string, timeout
 		}
 
 		rawResult := transaction.Get(fdb.Key(fdbKey)).MustGet()
+		// If the value is empty return an empty byte slice. Otherwise, an error will be thrown.
 		if len(rawResult) == 0 {
-			return nil, err
+			return []byte{}, err
 		}
 
 		return rawResult, err


### PR DESCRIPTION
# Description

Fixes a bug in the admin client if the key has not value.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

Without this change if the value is empty we get an error like this: `could not cast result into byte slice`

## Testing

Ran a manual test.

## Documentation

-

## Follow-up

-