### PR TITLE
Make the verification of the coordinators more flexible and use the hard limits to validate the locality distribution

### DIFF
--- a/internal/locality/locality_test.go
+++ b/internal/locality/locality_test.go
@@ -22,12 +22,10 @@ package locality
 
 import (
 	"fmt"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podclient/mock"
 	"math"
 	"net"
 	"strings"
-	"time"
-
-	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podclient/mock"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -648,38 +646,6 @@ var _ = Describe("Change coordinators", func() {
 				Expect(coordinatorsValid).To(BeFalse())
 				Expect(addressesValid).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-
-		When("a process has a process group status with a pending Pod", func() {
-			BeforeEach(func() {
-				status.Cluster.Processes["4"] = fdbv1beta2.FoundationDBStatusProcessInfo{
-					Address: fdbv1beta2.ProcessAddress{
-						IPAddress: net.ParseIP("1.1.1.4"),
-						Port:      4501,
-					},
-					Locality: map[string]string{
-						fdbv1beta2.FDBLocalityInstanceIDKey: "test-4",
-					},
-				}
-
-				cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups,
-					&fdbv1beta2.ProcessGroupStatus{
-						ProcessGroupID: "test-4",
-						ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
-							{
-								ProcessGroupConditionType: fdbv1beta2.PodPending,
-								Timestamp:                 time.Now().Add(-45 * time.Minute).Unix(),
-							},
-						},
-					})
-			})
-
-			It("should ignore the process", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
-				Expect(coordinatorsValid).To(BeTrue())
-				Expect(addressesValid).To(BeTrue())
-				Expect(err).To(BeNil())
 			})
 		})
 


### PR DESCRIPTION
# Description

Follow up of: https://github.com/FoundationDB/fdb-kubernetes-operator/pull/1651#pullrequestreview-1673608381

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

This change makes sure we validate the coordinators localties based on the hard limits of the configuration and not based on a hardcoded rule.

## Testing

Modified unit tests and CI will run e2e tests.

## Documentation

-

## Follow-up

-
