### PR TITLE
Add failure condition to logging in automatic replacements

### DIFF
--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -293,9 +293,11 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1
 			printStatement(cmd, statement, errorMessage)
 		}
 
-		needsReplacement, _ := processGroup.NeedsReplacement(0, 0)
-		if needsReplacement && autoFix {
-			failedProcessGroups = append(failedProcessGroups, string(processGroup.ProcessGroupID))
+		if autoFix {
+			_, failureTime := processGroup.NeedsReplacement(0, 0)
+			if failureTime > 0 {
+				failedProcessGroups = append(failedProcessGroups, string(processGroup.ProcessGroupID))
+			}
 		}
 	}
 

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -88,7 +88,7 @@ kubectl fdb -n default remove process-group -c cluster --remove-all-failed
 `,
 	}
 
-	cmd.Flags().StringP("fdb-cluster", "c", "", "remove process groupss from the provided cluster.")
+	cmd.Flags().StringP("fdb-cluster", "c", "", "remove process groups from the provided cluster.")
 	cmd.Flags().BoolP("exclusion", "e", true, "define if the process groups should be removed with exclusion.")
 	cmd.Flags().Bool("remove-all-failed", false, "define if all failed processes should be replaced.")
 	cmd.Flags().Bool("use-process-group-id", false, "define if the process-group should be used instead of the Pod name.")
@@ -147,8 +147,8 @@ func replaceProcessGroups(kubeClient client.Client, clusterName string, ids []st
 				continue
 			}
 
-			needsReplacement, _ := processGroupStatus.NeedsReplacement(0, 0)
-			if needsReplacement {
+			_, failureTime := processGroupStatus.NeedsReplacement(0, 0)
+			if failureTime > 0 {
 				processGroupIDs = append(processGroupIDs, processGroupStatus.ProcessGroupID)
 			}
 		}


### PR DESCRIPTION
# Description

This change adds additional information to the replacement logic for failed process groups. Historically we only replaced processes based on one condition, but now in the current implementation we have multiple reasons that could lead to an automatic replacement. Adding this information to the logging output, makes it easier to understand why the operator started the replacement.

## Type of change

*Please select one of the options below.*

- Other (improve logging)

## Discussion

-

## Testing

Updated unit tests + CI will run e2e tests.

## Documentation

-

## Follow-up

-
