### PR TITLE
Remove the list call in the remove process groups reconciler and use the get method instead.

### DIFF
--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -152,7 +152,7 @@ func removeProcessGroup(ctx context.Context, r *FoundationDBClusterReconciler, c
 	}
 
 	if err == nil && pod.DeletionTimestamp.IsZero() {
-		deletionError = r.PodLifecycleManager.DeletePod(ctx, r, pod)
+		err = r.PodLifecycleManager.DeletePod(ctx, r, pod)
 		if err != nil {
 			deletionError = fmt.Errorf("could not delete Pod: %w", err)
 		}

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -26,6 +26,9 @@ import (
 	"net"
 	"time"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbstatus"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal/buggify"
@@ -104,7 +107,7 @@ func (u removeProcessGroups) reconcile(ctx context.Context, r *FoundationDBClust
 
 	// In addition to that we should add the same logic as in the exclude step
 	// to ensure we never exclude/remove more process groups than desired.
-	zonedRemovals, lastDeletion, err := removals.GetZonedRemovals(status, processGroupsToRemove)
+	zonedRemovals, lastDeletion, err := removals.GetZonedRemovals(processGroupsToRemove)
 	if err != nil {
 		return &requeue{curError: err}
 	}
@@ -138,24 +141,21 @@ func (u removeProcessGroups) reconcile(ctx context.Context, r *FoundationDBClust
 	return nil
 }
 
-func removeProcessGroup(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, processGroupID fdbv1beta2.ProcessGroupID) error {
-	listOptions := internal.GetSinglePodListOptions(cluster, processGroupID)
-	pods, err := r.PodLifecycleManager.GetPods(ctx, r, cluster, listOptions...)
-	if err != nil {
-		return err
-	}
+func removeProcessGroup(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus) error {
+	podName := processGroup.GetPodName(cluster)
+	var deletionError error
 
-	if len(pods) == 1 && pods[0].DeletionTimestamp.IsZero() {
-		err = r.PodLifecycleManager.DeletePod(ctx, r, pods[0])
+	pod, err := r.PodLifecycleManager.GetPod(ctx, r, cluster, podName)
+	if err == nil && pod.DeletionTimestamp.IsZero() {
+		deletionError = r.PodLifecycleManager.DeletePod(ctx, r, pod)
 		if err != nil {
-			return err
+			deletionError = fmt.Errorf("could not delete Pod: %w", err)
 		}
-	} else if len(pods) > 1 {
-		return fmt.Errorf("multiple pods found for cluster %s, processGroupID %s", cluster.Name, processGroupID)
 	}
 
+	// TODO(johscheuer): https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1638
 	pvcs := &corev1.PersistentVolumeClaimList{}
-	err = r.List(ctx, pvcs, listOptions...)
+	err = r.List(ctx, pvcs, internal.GetSinglePodListOptions(cluster, processGroup.ProcessGroupID)...)
 	if err != nil {
 		return err
 	}
@@ -163,83 +163,90 @@ func removeProcessGroup(ctx context.Context, r *FoundationDBClusterReconciler, c
 		logr.FromContextOrDiscard(ctx).V(1).Info("Deleting pvc", "name", pvcs.Items[0].Name)
 		err = r.Delete(ctx, &pvcs.Items[0])
 		if err != nil {
-			return err
+			pvcError := fmt.Errorf("could not delete PVC: %w", err)
+			if deletionError == nil {
+				deletionError = pvcError
+			} else {
+				deletionError = fmt.Errorf("previous error: %w, %w", deletionError, pvcError)
+			}
 		}
 	} else if len(pvcs.Items) > 1 {
-		return fmt.Errorf("multiple PVCs found for cluster %s, processGroupID %s", cluster.Name, processGroupID)
+		return fmt.Errorf("multiple PVCs found for cluster %s, processGroupID %s", cluster.Name, processGroup.ProcessGroupID)
 	}
 
-	services := &corev1.ServiceList{}
-	err = r.List(ctx, services, listOptions...)
-	if err != nil {
-		return err
-	}
-	if len(services.Items) == 1 && services.Items[0].DeletionTimestamp.IsZero() {
-		logr.FromContextOrDiscard(ctx).V(1).Info("Deleting service", "name", services.Items[0].Name)
-		err = r.Delete(ctx, &services.Items[0])
+	service := &corev1.Service{}
+	err = r.Get(ctx, client.ObjectKey{Name: podName, Namespace: cluster.Namespace}, service)
+	if err == nil && service.DeletionTimestamp.IsZero() {
+		err = r.Delete(ctx, service)
 		if err != nil {
-			return err
+			serviceError := fmt.Errorf("could not delete Service: %w", err)
+			if deletionError == nil {
+				deletionError = serviceError
+			} else {
+				deletionError = fmt.Errorf("previous error: %w, %w", deletionError, serviceError)
+			}
 		}
-	} else if len(services.Items) > 1 {
-		return fmt.Errorf("multiple services found for cluster %s, processGroupID %s", cluster.Name, processGroupID)
 	}
 
-	return nil
+	return deletionError
 }
 
-func confirmRemoval(ctx context.Context, logger logr.Logger, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, processGroupID fdbv1beta2.ProcessGroupID) (bool, bool, error) {
+func confirmRemoval(ctx context.Context, logger logr.Logger, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus) (bool, bool, error) {
 	canBeIncluded := true
-	listOptions := internal.GetSinglePodListOptions(cluster, processGroupID)
 
-	pods, err := r.PodLifecycleManager.GetPods(ctx, r, cluster, listOptions...)
-	if err != nil {
+	podName := processGroup.GetPodName(cluster)
+	pod, err := r.PodLifecycleManager.GetPod(ctx, r, cluster, podName)
+	// If we get an error different from not found we will return the error.
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return false, false, err
 	}
 
-	if len(pods) == 1 {
-		// If the Pod is already in a terminating state we don't have to care for it
-		if pods[0] != nil && pods[0].ObjectMeta.DeletionTimestamp == nil {
-			logger.Info("Waiting for process group to get torn down", "processGroupID", processGroupID, "pod", pods[0].Name)
+	// The Pod resource still exists, so we have to validate the deletion timestamp.
+	if err == nil {
+		if pod.DeletionTimestamp.IsZero() {
+			logger.Info("Waiting for process group to get torn down", "processGroupID", processGroup.ProcessGroupID, "pod", podName)
 			return false, false, nil
 		}
+
 		// Pod is in terminating state so we don't want to block but we also don't want to include it
 		canBeIncluded = false
-	} else if len(pods) > 1 {
-		return false, false, fmt.Errorf("multiple pods found for cluster %s, processGroupID %s", cluster.Name, processGroupID)
 	}
 
+	// TODO(johscheuer): https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1638
 	pvcs := &corev1.PersistentVolumeClaimList{}
-	err = r.List(ctx, pvcs, listOptions...)
+	err = r.List(ctx, pvcs, internal.GetSinglePodListOptions(cluster, processGroup.ProcessGroupID)...)
 	if err != nil {
 		return false, canBeIncluded, err
 	}
 
 	if len(pvcs.Items) == 1 {
 		if pvcs.Items[0].DeletionTimestamp == nil {
-			logger.Info("Waiting for volume claim to get torn down", "processGroupID", processGroupID, "pvc", pvcs.Items[0].Name)
-			return false, canBeIncluded, nil
+			logger.Info("Waiting for volume claim to get torn down", "processGroupID", processGroup.ProcessGroupID, "pvc", pvcs.Items[0].Name)
+			return false, false, nil
 		}
+
 		// PVC is in terminating state so we don't want to block but we also don't want to include it
 		canBeIncluded = false
 	} else if len(pvcs.Items) > 1 {
-		return false, canBeIncluded, fmt.Errorf("multiple PVCs found for cluster %s, processGroupID %s", cluster.Name, processGroupID)
+		return false, false, fmt.Errorf("multiple PVCs found for cluster %s, processGroupID %s", cluster.Name, processGroup.ProcessGroupID)
 	}
 
-	services := &corev1.ServiceList{}
-	err = r.List(ctx, services, listOptions...)
-	if err != nil {
-		return false, canBeIncluded, err
+	service := &corev1.Service{}
+	err = r.Get(ctx, client.ObjectKey{Name: podName, Namespace: cluster.Namespace}, service)
+	// If we get an error different from not found we will return the error.
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return false, false, err
 	}
 
-	if len(services.Items) == 1 {
-		if services.Items[0].DeletionTimestamp == nil {
-			logger.Info("Waiting for service to get torn down", "processGroupID", processGroupID, "service", services.Items[0].Name)
-			return false, canBeIncluded, nil
+	// The Pod resource still exists, so we have to validate the deletion timestamp.
+	if err == nil {
+		if service.DeletionTimestamp.IsZero() {
+			logger.Info("Waiting for process group to get torn down", "processGroupID", processGroup.ProcessGroupID, "service", podName)
+			return false, false, nil
 		}
-		// service is in terminating state so we don't want to block but we also don't want to include it
+
+		// Service is in terminating state so we don't want to block but we also don't want to include it
 		canBeIncluded = false
-	} else if len(services.Items) > 1 {
-		return false, canBeIncluded, fmt.Errorf("multiple services found for cluster %s, processGroupID %s", cluster.Name, processGroupID)
 	}
 
 	return true, canBeIncluded, nil
@@ -337,15 +344,14 @@ func (r *FoundationDBClusterReconciler) getProcessGroupsToRemove(logger logr.Log
 	return allExcluded, newExclusions, processGroupsToRemove
 }
 
-func (r *FoundationDBClusterReconciler) removeProcessGroups(ctx context.Context, logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, processGroupsToRemove []fdbv1beta2.ProcessGroupID, terminatingProcessGroups []fdbv1beta2.ProcessGroupID) map[fdbv1beta2.ProcessGroupID]bool {
+func (r *FoundationDBClusterReconciler) removeProcessGroups(ctx context.Context, logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, processGroupsToRemove []*fdbv1beta2.ProcessGroupStatus, terminatingProcessGroups []*fdbv1beta2.ProcessGroupStatus) map[fdbv1beta2.ProcessGroupID]bool {
 	r.Recorder.Event(cluster, corev1.EventTypeNormal, "RemovingProcesses", fmt.Sprintf("Removing pods: %v", processGroupsToRemove))
 
 	processGroups := append(processGroupsToRemove, terminatingProcessGroups...)
-
-	for _, id := range processGroups {
-		err := removeProcessGroup(logr.NewContext(ctx, logger), r, cluster, id)
+	for _, processGroup := range processGroups {
+		err := removeProcessGroup(logr.NewContext(ctx, logger), r, cluster, processGroup)
 		if err != nil {
-			logger.Error(err, "Error during remove process group", "processGroupID", id)
+			logger.Error(err, "Error during remove process group", "processGroupID", processGroup.ProcessGroupID)
 			continue
 		}
 	}
@@ -353,17 +359,17 @@ func (r *FoundationDBClusterReconciler) removeProcessGroups(ctx context.Context,
 	removedProcessGroups := make(map[fdbv1beta2.ProcessGroupID]bool)
 	// We have to check if the currently removed process groups are completely removed.
 	// In addition, we have to check if one of the terminating process groups has been cleaned up.
-	for _, id := range processGroups {
-		removed, include, err := confirmRemoval(ctx, logger, r, cluster, id)
+	for _, processGroup := range processGroups {
+		removed, include, err := confirmRemoval(ctx, logger, r, cluster, processGroup)
 		if err != nil {
-			logger.Error(err, "Error during confirm process group removal", "processGroupID", id)
+			logger.Error(err, "Error during confirm process group removal", "processGroupID", processGroup.ProcessGroupID)
 			continue
 		}
 
 		if removed {
 			// Pods that are stuck in terminating shouldn't block reconciliation, but we also
 			// don't want to include them since they have an unknown state.
-			removedProcessGroups[id] = include
+			removedProcessGroups[processGroup.ProcessGroupID] = include
 			continue
 		}
 	}

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -110,7 +110,7 @@ var _ = Describe("remove_process_groups", func() {
 					It("should successfully remove that process group", func() {
 						Expect(result).To(BeNil())
 						// Ensure resources are deleted
-						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 						Expect(err).To(BeNil())
 						Expect(removed).To(BeTrue())
 						Expect(include).To(BeTrue())
@@ -136,7 +136,7 @@ var _ = Describe("remove_process_groups", func() {
 						Expect(result).NotTo(BeNil())
 						Expect(result.message).To(Equal("Removals cannot proceed because cluster has degraded fault tolerance"))
 						// Ensure resources are not deleted
-						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 						Expect(err).To(BeNil())
 						Expect(removed).To(BeFalse())
 						Expect(include).To(BeFalse())
@@ -160,7 +160,7 @@ var _ = Describe("remove_process_groups", func() {
 						Expect(result).NotTo(BeNil())
 						Expect(result.message).To(Equal("Removals cannot proceed because cluster has degraded fault tolerance"))
 						// Ensure resources are not deleted
-						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 						Expect(err).To(BeNil())
 						Expect(removed).To(BeFalse())
 						Expect(include).To(BeFalse())
@@ -184,7 +184,7 @@ var _ = Describe("remove_process_groups", func() {
 						Expect(result).NotTo(BeNil())
 						Expect(result.message).To(Equal("Reconciliation needs to exclude more processes"))
 						// Ensure resources are not deleted
-						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 						Expect(err).To(BeNil())
 						Expect(removed).To(BeFalse())
 						Expect(include).To(BeFalse())
@@ -216,10 +216,10 @@ var _ = Describe("remove_process_groups", func() {
 						Expect(result).To(BeNil())
 						Expect(initialCnt - len(cluster.Status.ProcessGroups)).To(BeNumerically("==", 1))
 						// Check if resources are deleted
-						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 						Expect(err).To(BeNil())
 						// Check if resources are deleted
-						removedSecondary, includeSecondary, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup.ProcessGroupID)
+						removedSecondary, includeSecondary, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup)
 						Expect(err).To(BeNil())
 						// Make sure only one of the process groups was deleted.
 						Expect(removed).NotTo(Equal(removedSecondary))
@@ -229,19 +229,19 @@ var _ = Describe("remove_process_groups", func() {
 					When("a process group is marked as terminating and all resources are removed it should be removed", func() {
 						BeforeEach(func() {
 							secondRemovedProcessGroup.ProcessGroupConditions = append(secondRemovedProcessGroup.ProcessGroupConditions, fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.ResourcesTerminating))
-							Expect(removeProcessGroup(context.Background(), clusterReconciler, cluster, secondRemovedProcessGroup.ProcessGroupID)).NotTo(HaveOccurred())
+							Expect(removeProcessGroup(context.Background(), clusterReconciler, cluster, secondRemovedProcessGroup)).NotTo(HaveOccurred())
 						})
 
 						It("should remove the process group and the terminated process group", func() {
 							Expect(result).To(BeNil())
 							Expect(initialCnt - len(cluster.Status.ProcessGroups)).To(BeNumerically("==", 2))
 							// Ensure resources are deleted
-							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup.ProcessGroupID)
+							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeTrue())
 							Expect(include).To(BeTrue())
 							// Ensure resources are deleted
-							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeTrue())
 							Expect(include).To(BeTrue())
@@ -257,12 +257,12 @@ var _ = Describe("remove_process_groups", func() {
 							Expect(result).To(BeNil())
 							Expect(initialCnt - len(cluster.Status.ProcessGroups)).To(BeNumerically("==", 2))
 							// Ensure resources are deleted
-							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup.ProcessGroupID)
+							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeTrue())
 							Expect(include).To(BeTrue())
 							// Ensure resources are deleted
-							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeTrue())
 							Expect(include).To(BeTrue())
@@ -281,12 +281,12 @@ var _ = Describe("remove_process_groups", func() {
 							Expect(result.message).To(HavePrefix("not allowed to remove process groups, waiting:"))
 							Expect(initialCnt - len(cluster.Status.ProcessGroups)).To(BeNumerically("==", 0))
 							// Ensure resources are not deleted
-							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeFalse())
 							Expect(include).To(BeFalse())
 							// Ensure resources are deleted
-							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup.ProcessGroupID)
+							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeFalse())
 							Expect(include).To(BeFalse())
@@ -318,12 +318,12 @@ var _ = Describe("remove_process_groups", func() {
 						Expect(result).To(BeNil())
 						Expect(initialCnt - len(cluster.Status.ProcessGroups)).To(BeNumerically("==", 2))
 						// Ensure resources are deleted
-						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 						Expect(err).To(BeNil())
 						Expect(removed).To(BeTrue())
 						Expect(include).To(BeTrue())
 						// Ensure resources are deleted as the RemovalMode is PodUpdateModeAll
-						removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup.ProcessGroupID)
+						removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup)
 						Expect(err).To(BeNil())
 						Expect(removed).To(BeTrue())
 						Expect(include).To(BeTrue())
@@ -332,7 +332,7 @@ var _ = Describe("remove_process_groups", func() {
 					When("a process group is marked as terminating and all resources are removed it should be removed", func() {
 						BeforeEach(func() {
 							secondRemovedProcessGroup.ProcessGroupConditions = append(secondRemovedProcessGroup.ProcessGroupConditions, fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.ResourcesTerminating))
-							err := removeProcessGroup(context.Background(), clusterReconciler, cluster, secondRemovedProcessGroup.ProcessGroupID)
+							err := removeProcessGroup(context.Background(), clusterReconciler, cluster, secondRemovedProcessGroup)
 							Expect(err).NotTo(HaveOccurred())
 						})
 
@@ -340,12 +340,12 @@ var _ = Describe("remove_process_groups", func() {
 							Expect(result).To(BeNil())
 							Expect(initialCnt - len(cluster.Status.ProcessGroups)).To(BeNumerically("==", 2))
 							// Ensure resources are deleted
-							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup.ProcessGroupID)
+							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeTrue())
 							Expect(include).To(BeTrue())
 							// Ensure resources are deleted
-							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeTrue())
 							Expect(include).To(BeTrue())
@@ -361,12 +361,12 @@ var _ = Describe("remove_process_groups", func() {
 							Expect(result).To(BeNil())
 							Expect(initialCnt - len(cluster.Status.ProcessGroups)).To(BeNumerically("==", 2))
 							// Ensure resources are deleted
-							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup.ProcessGroupID)
+							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeTrue())
 							Expect(include).To(BeTrue())
 							// Ensure resources are deleted
-							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeTrue())
 							Expect(include).To(BeTrue())
@@ -384,12 +384,12 @@ var _ = Describe("remove_process_groups", func() {
 							Expect(result).To(BeNil())
 							Expect(initialCnt - len(cluster.Status.ProcessGroups)).To(BeNumerically("==", 2))
 							// Ensure resources are not deleted
-							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+							removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeTrue())
 							Expect(include).To(BeTrue())
 							// Ensure resources are deleted
-							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup.ProcessGroupID)
+							removed, include, err = confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, secondRemovedProcessGroup)
 							Expect(err).To(BeNil())
 							Expect(removed).To(BeTrue())
 							Expect(include).To(BeTrue())

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -708,9 +708,12 @@ func updateTaintCondition(ctx context.Context, r *FoundationDBClusterReconciler,
 
 func refreshProcessGroupStatus(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBClusterStatus) (*corev1.PersistentVolumeClaimList, error) {
 	status.ProcessGroups = make([]*fdbv1beta2.ProcessGroupStatus, 0, len(cluster.Status.ProcessGroups))
+	knownProcessGroups := map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None{}
+
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup != nil && processGroup.ProcessGroupID != "" {
 			status.ProcessGroups = append(status.ProcessGroups, processGroup)
+			knownProcessGroups[processGroup.ProcessGroupID] = fdbv1beta2.None{}
 		}
 	}
 
@@ -723,10 +726,12 @@ func refreshProcessGroupStatus(ctx context.Context, r *FoundationDBClusterReconc
 
 	for _, pod := range pods {
 		processGroupID := fdbv1beta2.ProcessGroupID(pod.Labels[cluster.GetProcessGroupIDLabel()])
-		if fdbv1beta2.ContainsProcessGroupID(status.ProcessGroups, processGroupID) {
+		if _, ok := knownProcessGroups[processGroupID]; ok {
 			continue
 		}
 
+		// Since we found a new process group we have to add it to our map.
+		knownProcessGroups[processGroupID] = fdbv1beta2.None{}
 		status.ProcessGroups = append(status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(processGroupID, internal.ProcessClassFromLabels(cluster, pod.Labels), nil))
 	}
 
@@ -738,10 +743,12 @@ func refreshProcessGroupStatus(ctx context.Context, r *FoundationDBClusterReconc
 
 	for _, pvc := range pvcs.Items {
 		processGroupID := fdbv1beta2.ProcessGroupID(pvc.Labels[cluster.GetProcessGroupIDLabel()])
-		if fdbv1beta2.ContainsProcessGroupID(status.ProcessGroups, processGroupID) {
+		if _, ok := knownProcessGroups[processGroupID]; ok {
 			continue
 		}
 
+		// Since we found a new process group we have to add it to our map.
+		knownProcessGroups[processGroupID] = fdbv1beta2.None{}
 		status.ProcessGroups = append(status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(processGroupID, internal.ProcessClassFromLabels(cluster, pvc.Labels), nil))
 	}
 
@@ -753,10 +760,16 @@ func refreshProcessGroupStatus(ctx context.Context, r *FoundationDBClusterReconc
 
 	for _, service := range services.Items {
 		processGroupID := fdbv1beta2.ProcessGroupID(service.Labels[cluster.GetProcessGroupIDLabel()])
-		if processGroupID == "" || fdbv1beta2.ContainsProcessGroupID(status.ProcessGroups, processGroupID) {
+		if processGroupID == "" {
 			continue
 		}
 
+		if _, ok := knownProcessGroups[processGroupID]; ok {
+			continue
+		}
+
+		// Since we found a new process group we have to add it to our map.
+		knownProcessGroups[processGroupID] = fdbv1beta2.None{}
 		status.ProcessGroups = append(status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(processGroupID, internal.ProcessClassFromLabels(cluster, service.Labels), nil))
 	}
 

--- a/internal/removals/remove_test.go
+++ b/internal/removals/remove_test.go
@@ -142,17 +142,17 @@ var _ = Describe("remove", func() {
 			"zone3": {
 				{
 					ProcessGroupID: "3",
-					FaultDomain:    "zone1",
+					FaultDomain:    "zone3",
 				},
 				{
 					ProcessGroupID: "4",
-					FaultDomain:    "zone1",
+					FaultDomain:    "zone3",
 				},
 			},
 			UnknownZone: {
 				{
 					ProcessGroupID: "5",
-					FaultDomain:    "zone1",
+					FaultDomain:    UnknownZone,
 				},
 			},
 		}


### PR DESCRIPTION
# Description

Using the get method is more efficient than doing a List, especially if the operator is managing a large amount of resources.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

Once https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1638 is fixed we are rid of all List command except the once in `update_status`, but those are intended to catch resources that are missing in the status.

## Testing

Ran unit tests, CI will run e2e test.

## Documentation

-

## Follow-up

- https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1638