### PR TITLE
Fix flaky migration test setup

### DIFF
--- a/e2e/fixtures/cluster_config_test.go
+++ b/e2e/fixtures/cluster_config_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-var _ = FDescribe("Cluster configuration", func() {
+var _ = Describe("Cluster configuration", func() {
 	DescribeTable("when generating the Pod resources", func(config *ClusterConfig, processClass fdbv1beta2.ProcessClass, expected corev1.ResourceList) {
 		Expect(config.generatePodResources(processClass)).To(Equal(expected))
 	},

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -276,7 +276,6 @@ func (fdbCluster *FdbCluster) waitForReconciliationToGeneration(
 	}
 
 	err := fdbCluster.WaitUntilWithForceReconcile(pollTimeInSeconds, timeOutInSeconds, checkIfReconciliationIsDone)
-
 	if creationTracker != nil {
 		creationTracker.report()
 	}

--- a/e2e/fixtures/fdb_cluster_test.go
+++ b/e2e/fixtures/fdb_cluster_test.go
@@ -1,0 +1,58 @@
+/*
+ * fdb_cluster_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FDB Cluster", func() {
+	DescribeTable("when generating the reconciliation options", func(expected *ReconciliationOptions, options ...func(*ReconciliationOptions)) {
+		reconciliationOptions := MakeReconciliationOptionsStruct(options...)
+		Expect(reconciliationOptions).To(Equal(expected))
+	},
+		Entry("No options provided",
+			&ReconciliationOptions{
+				timeOutInSeconds:  1800,
+				pollTimeInSeconds: 10,
+			},
+		),
+		Entry("Minimum generation option provided",
+			&ReconciliationOptions{
+				timeOutInSeconds:  1800,
+				pollTimeInSeconds: 10,
+				minimumGeneration: 2,
+			},
+			MinimumGenerationOption(2),
+		),
+		Entry("Minimum generation option provided",
+			&ReconciliationOptions{
+				timeOutInSeconds:        1800,
+				pollTimeInSeconds:       10,
+				minimumGeneration:       2,
+				allowSoftReconciliation: true,
+			},
+			MinimumGenerationOption(2),
+			SoftReconcileOption(true),
+		),
+	)
+})

--- a/e2e/fixtures/fdb_data_loader.go
+++ b/e2e/fixtures/fdb_data_loader.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
@@ -224,6 +225,14 @@ func (factory *Factory) CreateDataLoaderIfAbsent(cluster *FdbCluster) {
 	}
 
 	factory.WaitUntilDataLoaderIsDone(cluster)
+
+	// Remove data loader Pods again, as the loading was done.
+	gomega.Expect(factory.controllerRuntimeClient.Delete(context.Background(), &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dataLoaderName,
+			Namespace: cluster.Namespace(),
+		},
+	})).NotTo(gomega.HaveOccurred())
 }
 
 // WaitUntilDataLoaderIsDone will wait until the data loader Job has finished.

--- a/e2e/fixtures/fdb_data_loader.go
+++ b/e2e/fixtures/fdb_data_loader.go
@@ -233,6 +233,11 @@ func (factory *Factory) CreateDataLoaderIfAbsent(cluster *FdbCluster) {
 			Namespace: cluster.Namespace(),
 		},
 	})).NotTo(gomega.HaveOccurred())
+
+	gomega.Expect(factory.controllerRuntimeClient.DeleteAllOf(context.Background(), &corev1.Pod{},
+		client.InNamespace(cluster.Namespace()),
+		client.MatchingLabels(map[string]string{"job-name": dataLoaderName}),
+	)).NotTo(gomega.HaveOccurred())
 }
 
 // WaitUntilDataLoaderIsDone will wait until the data loader Job has finished.

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -795,6 +795,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		It("should add the prefix to all instances", func() {
 			Eventually(func(g Gomega) bool {
 				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+					if processGroup.IsMarkedForRemoval() && processGroup.IsExcluded() {
+						continue
+					}
 					g.Expect(string(processGroup.ProcessGroupID)).To(HavePrefix(prefix))
 				}
 
@@ -804,6 +807,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			Eventually(func(g Gomega) bool {
 				pods := fdbCluster.GetPods()
 				for _, pod := range pods.Items {
+					if !pod.DeletionTimestamp.IsZero() {
+						continue
+					}
 					g.Expect(string(fixtures.GetProcessGroupID(pod))).To(HavePrefix(prefix))
 				}
 

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -789,11 +789,6 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		BeforeEach(func() {
 			currentGeneration := fdbCluster.GetCluster().Generation
 			Expect(fdbCluster.SetProcessGroupPrefix(prefix)).NotTo(HaveOccurred())
-			// Make sure that the operator started the migration.
-			Eventually(func() int64 {
-				fdbCluster.ForceReconcile()
-				return fdbCluster.GetCluster().Status.Generations.Reconciled
-			}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(BeZero())
 			Expect(fdbCluster.WaitForReconciliation(fixtures.MinimumGenerationOption(currentGeneration+1), fixtures.SoftReconcileOption(false)))
 		})
 

--- a/e2e/test_operator_migrations/operator_migration_test.go
+++ b/e2e/test_operator_migrations/operator_migration_test.go
@@ -101,6 +101,9 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 		It("should add the prefix to all instances", func() {
 			Eventually(func(g Gomega) bool {
 				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+					if processGroup.IsMarkedForRemoval() && processGroup.IsExcluded() {
+						continue
+					}
 					g.Expect(string(processGroup.ProcessGroupID)).To(HavePrefix(prefix))
 				}
 
@@ -110,6 +113,9 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 			Eventually(func(g Gomega) bool {
 				pods := fdbCluster.GetPods()
 				for _, pod := range pods.Items {
+					if !pod.DeletionTimestamp.IsZero() {
+						continue
+					}
 					g.Expect(string(fixtures.GetProcessGroupID(pod))).To(HavePrefix(prefix))
 				}
 

--- a/e2e/test_operator_migrations/operator_migration_test.go
+++ b/e2e/test_operator_migrations/operator_migration_test.go
@@ -54,6 +54,8 @@ var _ = BeforeSuite(func() {
 		fixtures.DefaultClusterConfig(false),
 		factory.GetClusterOptions()...,
 	)
+	// Load some data into the cluster.
+	factory.CreateDataLoaderIfAbsent(fdbCluster)
 })
 
 var _ = AfterSuite(func() {
@@ -93,11 +95,6 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 
 			currentGeneration := fdbCluster.GetCluster().Generation
 			Expect(fdbCluster.SetProcessGroupPrefix(prefix)).NotTo(HaveOccurred())
-			// Make sure that the operator started the migration.
-			Eventually(func() int64 {
-				fdbCluster.ForceReconcile()
-				return fdbCluster.GetCluster().Status.Generations.Reconciled
-			}).WithTimeout(10 * time.Minute).WithPolling(30 * time.Second).Should(BeZero())
 			Expect(fdbCluster.WaitForReconciliation(fixtures.MinimumGenerationOption(currentGeneration+1), fixtures.SoftReconcileOption(false)))
 		})
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1835

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

The flakiness was in the test, depending on the test behaviour there was a race condition in the Eventually statement.

## Testing

Ran the e2e test manually.

## Documentation

-

## Follow-up

-