### PR TITLE
Make sure that the PVC and service gets created if a process group gets quickly marked as removal

### DIFF
--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -89,9 +89,7 @@ func (a addPods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler
 			return &requeue{curError: err}
 		}
 
-		imageType := internal.GetImageType(pod)
-
-		configMapHash, err := internal.GetDynamicConfHash(configMap, processGroup.ProcessClass, imageType, serverPerPod)
+		configMapHash, err := internal.GetDynamicConfHash(configMap, processGroup.ProcessClass, internal.GetImageType(pod), serverPerPod)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/add_pvcs.go
+++ b/controllers/add_pvcs.go
@@ -39,7 +39,7 @@ type addPVCs struct{}
 // reconcile runs the reconciler's work.
 func (a addPVCs) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.IsMarkedForRemoval() {
+		if processGroup.IsMarkedForRemoval() && processGroup.IsExcluded() {
 			continue
 		}
 

--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -63,7 +63,7 @@ func (a addServices) reconcile(ctx context.Context, r *FoundationDBClusterReconc
 
 	if cluster.GetPublicIPSource() == fdbv1beta2.PublicIPSourceService {
 		for _, processGroup := range cluster.Status.ProcessGroups {
-			if processGroup.IsMarkedForRemoval() {
+			if processGroup.IsMarkedForRemoval() && processGroup.IsExcluded() {
 				continue
 			}
 

--- a/controllers/add_services_test.go
+++ b/controllers/add_services_test.go
@@ -108,6 +108,7 @@ var _ = Describe("add_services", func() {
 					Expect(service.Spec.Selector).To(Equal(labels))
 				}
 			})
+
 			It("should set the metadata on the services", func() {
 				for _, service := range newServices.Items {
 					Expect(service.Labels["fdb-test-label"]).To(Equal("true"))
@@ -150,7 +151,7 @@ var _ = Describe("add_services", func() {
 			})
 		})
 
-		Context("when the process group is being removed", func() {
+		When("the process group is being removed", func() {
 			BeforeEach(func() {
 				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].MarkForRemoval()
 			})
@@ -159,8 +160,22 @@ var _ = Describe("add_services", func() {
 				Expect(requeue).To(BeNil())
 			})
 
-			It("should not create any services", func() {
-				Expect(newServices.Items).To(HaveLen(len(initialServices.Items)))
+			It("should create the services", func() {
+				Expect(newServices.Items).To(HaveLen(len(initialServices.Items) + 1))
+			})
+
+			When("the process group is fully excluded", func() {
+				BeforeEach(func() {
+					cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].SetExclude()
+				})
+
+				It("should not requeue", func() {
+					Expect(requeue).To(BeNil())
+				})
+
+				It("should not create any services", func() {
+					Expect(newServices.Items).To(HaveLen(len(initialServices.Items)))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
# Description

Otherwise the operator might get in a deadlock where it doesn't create the PVC and therefore the Pod is stuck in pending forever. Since the Pod might have never received an IP address, the operator is currently not allowed/able to remove the process group. This issue can happen when migrations are triggered in a rapid manner or resource limitations are hit.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Updated the unit tests to handle the new behaviour.

## Documentation

N/A

## Follow-up

-
