### PR TITLE
Make sure the operator can proceed with exclusions even if multiple pods are failing

### DIFF
--- a/e2e/fixtures/chaos_common.go
+++ b/e2e/fixtures/chaos_common.go
@@ -92,6 +92,10 @@ func (factory *Factory) DeleteChaosMeshExperimentSafe(experiment *ChaosMeshExper
 }
 
 func (factory *Factory) deleteChaosMeshExperiment(experiment *ChaosMeshExperiment) error {
+	if experiment == nil {
+		return nil
+	}
+
 	log.Println("Start deleting", experiment.name)
 	err := factory.getChaosExperiment(experiment.name, experiment.namespace, experiment.chaosObject)
 	if err != nil {


### PR DESCRIPTION
# Description

This PR contains a bug fix in the operator logic, if multiple pods are failing and the automatic replacements are not allowed to replace all pods at once.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Added unit and e2e tests.

## Documentation

-

## Follow-up

-