### PR TITLE
Three data hall fault domain storage check bug fix

### DIFF
--- a/api/v1beta2/foundationdb_database_configuration.go
+++ b/api/v1beta2/foundationdb_database_configuration.go
@@ -707,10 +707,8 @@ func MinimumFaultDomains(redundancyMode RedundancyMode) int {
 		return 1
 	case RedundancyModeDouble, RedundancyModeUnset:
 		return 2
-	case RedundancyModeTriple:
+	case RedundancyModeTriple, RedundancyModeThreeDataHall:
 		return 3
-	case RedundancyModeThreeDataHall:
-		return 4
 	default:
 		return 1
 	}

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -216,7 +216,7 @@ var _ = Describe("remove_process_groups", func() {
 					It("should successfully remove that process group", func() {
 						Expect(result).To(BeNil())
 						// Ensure resources are deleted
-						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 						Expect(err).To(BeNil())
 						Expect(removed).To(BeTrue())
 						Expect(include).To(BeTrue())
@@ -240,7 +240,7 @@ var _ = Describe("remove_process_groups", func() {
 						Expect(result).NotTo(BeNil())
 						Expect(result.message).To(Equal("Removals cannot proceed because cluster has degraded fault tolerance"))
 						// Ensure resources are not deleted
-						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup.ProcessGroupID)
+						removed, include, err := confirmRemoval(context.Background(), globalControllerLogger, clusterReconciler, cluster, removedProcessGroup)
 						Expect(err).To(BeNil())
 						Expect(removed).To(BeFalse())
 						Expect(include).To(BeFalse())


### PR DESCRIPTION
# Description

The operator should be allowed to remove processes when a cluster running with `three_data_hall` redundancy is healthy and have minimum _three_ replicas of storage data (not _four_).
Fixes https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1861
## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

## Testing

- Unit tests which checks if removals happen based on MinReplicasRemaining in the team tracker status.
- Manually verified removal of processes in a running `three_data_hall` cluster.

## Documentation

## Follow-up
