### PR TITLE
Ignore Pods in the Pod config update when the Pod is terminating

### DIFF
--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -71,6 +71,11 @@ func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReco
 			continue
 		}
 
+		if !pod.DeletionTimestamp.IsZero() {
+			logger.V(1).Info("ignore Pod that has a deletion timestamp for config updates")
+			continue
+		}
+
 		serverPerPod, err := internal.GetServersPerPodForPod(pod, processGroup.ProcessClass)
 		if err != nil {
 			curLogger.Error(err, "Error when receiving storage server per Pod")


### PR DESCRIPTION
# Description

Ignore Pods in the Pod config update when the Pod is terminating. If the Pod is already in terminating state the containers will probably be shutdown anyway and this would only lead to a  wrong signal that the sidecar is unreachable.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

Added unit tests.

## Documentation

-

## Follow-up

-
