### PR TITLE
check kubectl-fdb plugin version and prevent any interaction with cluster if it is not newest release

### DIFF
--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -71,7 +71,7 @@ func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
 		Long:         `kubectl fdb plugin for the interaction with the FoundationDB operator.`,
 		SilenceUsage: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			checkKubectlFdbVersion()
+			checkPluginVersion()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -155,7 +155,7 @@ func printStatement(cmd *cobra.Command, line string, mesType messageType) {
 	color.Unset()
 }
 
-func checkKubectlFdbVersion() {
+func checkPluginVersion() {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 2
 	retryClient.RetryWaitMax = 1 * time.Second

--- a/kubectl-fdb/cmd/root_test.go
+++ b/kubectl-fdb/cmd/root_test.go
@@ -47,4 +47,26 @@ var _ = Describe("[plugin] root command", func() {
 			Expect(cmd.Execute()).NotTo(HaveOccurred())
 		})
 	})
+	When("running the root command without args", func() {
+		var outBuffer bytes.Buffer
+		var errBuffer bytes.Buffer
+		var inBuffer bytes.Buffer
+		pluginVersion = "1.15.0"
+
+		BeforeEach(func() {
+			// We use these buffers to check the input/output
+			outBuffer = bytes.Buffer{}
+			errBuffer = bytes.Buffer{}
+			inBuffer = bytes.Buffer{}
+		})
+		It("should print outdated plugin version message", func() {
+			cmd := NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer})
+			cmd.SetArgs([]string{})
+			err := cmd.Execute()
+			Expect(err).To(HaveOccurred())
+
+			Expect(outBuffer.String()).To(ContainElements(
+				"Your kubectl-fdb plugin is not up-to-date, please download latest version and try again!"))
+		})
+	})
 })

--- a/kubectl-fdb/cmd/version_test.go
+++ b/kubectl-fdb/cmd/version_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	corev1 "k8s.io/api/core/v1"
@@ -161,5 +160,32 @@ var _ = Describe("[plugin] version command", func() {
 					hasError:      true,
 				}),
 		)
+	})
+
+	When("running the version command from a client with older version", func() {
+		var outBuffer bytes.Buffer
+		var errBuffer bytes.Buffer
+		var inBuffer bytes.Buffer
+
+		BeforeEach(func() {
+			// We use these buffers to check the input/output
+			outBuffer = bytes.Buffer{}
+			errBuffer = bytes.Buffer{}
+			inBuffer = bytes.Buffer{}
+
+			pluginVersion = "1.15.0"
+			rootCmd := NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer})
+
+			args := []string{"version", "--client-only"}
+			rootCmd.SetArgs(args)
+
+			err := rootCmd.Execute()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should print outdated plugin version message", func() {
+			Expect(outBuffer.String()).To(ContainElements(
+				"Your kubectl-fdb plugin is not up-to-date, please download latest version and try again!"))
+		})
 	})
 })


### PR DESCRIPTION
# Description
-

## Type of change

*Please select one of the options below.*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Other

## Discussion

*Are there any design details that you would like to discuss further?* 
No

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*
I added unit test for both root command and also subcommand to make sure our version check is done pre-run of commands. 

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*
No 

## Documentation

*Did you update relevant documentation within this repository?*
No 

*If this change is adding new functionality, do we need to describe it in our user manual?*
No

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*
N/A 

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*
No

*Does this introduce new defaults that we should re-evaluate in the future?*
No
