### PR TITLE
Make sure the exclusion is tried again

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1533,9 +1533,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			pod = fixtures.ChooseRandomPod(fdbCluster.GetStatelessPods())
 			log.Printf("exclude Pod: %s", pod.Name)
 			Expect(pod.Status.PodIP).NotTo(BeEmpty())
-			_, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(fmt.Sprintf("exclude %s", pod.Status.PodIP), false, 30)
-			Expect(err).NotTo(HaveOccurred())
-
+			_, _ = fdbCluster.RunFdbCliCommandInOperator(fmt.Sprintf("exclude %s", pod.Status.PodIP), false, 30)
 			// Make sure we trigger a reconciliation to speed up the exclusion detection.
 			fdbCluster.ForceReconcile()
 		})


### PR DESCRIPTION
# Description

Fixes the failure in: https://github.com/FoundationDB/fdb-kubernetes-operator/pull/1873#issuecomment-1802442002 where the operator Pod was removed during the exclude command execution.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Manual run of this test case.

## Documentation

-

## Follow-up

-
