### PR TITLE
Allow to define creationTimestamp mock

### DIFF
--- a/mock-kubernetes-client/client/client.go
+++ b/mock-kubernetes-client/client/client.go
@@ -170,8 +170,11 @@ func (client *MockClient) generateIP() string {
 
 // Create creates a new object
 func (client *MockClient) Create(ctx context.Context, object ctrlClient.Object, options ...ctrlClient.CreateOption) error {
-	// Ensure the default values are set.
-	object.SetCreationTimestamp(metav1.Time{Time: time.Now()})
+	// Ensure the default values are set if not present.
+	if object.GetCreationTimestamp().Time.IsZero() {
+		object.SetCreationTimestamp(metav1.Time{Time: time.Now()})
+	}
+
 	object.SetGeneration(object.GetGeneration() + 1)
 	object.SetUID(uuid.NewUUID())
 


### PR DESCRIPTION
# Description

If a resource has a predefined creationTimestamp, make use of that creationTimestamp, to allow mocking resources that were created some time ago.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Added unit test.

## Documentation

-

## Follow-up

-
