### PR TITLE
Three data hall enable locking by default

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1916,7 +1916,8 @@ func (cluster *FoundationDBCluster) ShouldUseLocks() bool {
 		return !*disabled
 	}
 
-	return cluster.Spec.FaultDomain.ZoneCount > 1 || len(cluster.Spec.DatabaseConfiguration.Regions) > 1
+	return cluster.Spec.FaultDomain.ZoneCount > 1 || len(cluster.Spec.DatabaseConfiguration.Regions) > 1 ||
+		cluster.Spec.DatabaseConfiguration.RedundancyMode == RedundancyModeThreeDataHall
 }
 
 // GetLockPrefix gets the prefix for the keys where we store locking

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -3499,6 +3499,14 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			Expect(cluster.ShouldUseLocks()).To(BeTrue())
 
 			cluster.Spec.FaultDomain.ZoneCount = 0
+			Expect(cluster.ShouldUseLocks()).To(BeFalse())
+
+			cluster.Spec.DatabaseConfiguration.RedundancyMode = RedundancyModeThreeDataHall
+			Expect(cluster.ShouldUseLocks()).To(BeTrue())
+
+			cluster.Spec.DatabaseConfiguration.RedundancyMode = RedundancyModeDouble
+			Expect(cluster.ShouldUseLocks()).To(BeFalse())
+
 			cluster.Spec.DatabaseConfiguration.Regions = []Region{
 				{},
 				{},

--- a/docs/manual/fault_domains.md
+++ b/docs/manual/fault_domains.md
@@ -253,7 +253,7 @@ spec:
 ## Coordinating Global Operations
 
 When running a FoundationDB cluster that is deployed across multiple Kubernetes clusters, each Kubernetes cluster will have its own instance of the operator working on the processes in its cluster. There will be some operations that cannot be scoped to a single Kubernetes cluster, such as changing the database configuration.
-The operator provides a locking system to ensure that only one instance of the operator can perform these operations at a time. You can enable this locking system by setting `lockOptions.disableLocks = false` in the cluster spec. The locking system is automatically enabled by default for any cluster that has multiple regions in its database configuration, or a `zoneCount` greater than 1 in its fault domain configuration.
+The operator provides a locking system to ensure that only one instance of the operator can perform these operations at a time. You can enable this locking system by setting `lockOptions.disableLocks = false` in the cluster spec. The locking system is automatically enabled by default for any cluster that has multiple regions in its database configuration, a `zoneCount` greater than 1 in its fault domain configuration, or `redundancyMode` equal to `three_data_hall`.
 
 The locking system uses the `processGroupIDPrefix` from the cluster spec to identify an process group of the operator.
 Make sure to set this to a unique value for each Kubernetes cluster, both to support the locking system and to prevent duplicate process group IDs.


### PR DESCRIPTION
# Description

Enable locking by default when `RedundancyMode` is `three_data_hall`, such that certain operations are coordinated across `foundationdb` k8s resources. [See [Coordinating Global Operations](https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/docs/manual/fault_domains.md#coordinating-global-operations)]

Enabling locking addresses https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1872.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

## Testing

Unit tests

## Documentation

Updated fault_domains.md

## Follow-up