### PR TITLE
Update the way the operator deployment is created and verified

### DIFF
--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -514,9 +514,9 @@ func (factory *Factory) WaitUntilOperatorPodsRunning(namespace string) {
 				continue
 			}
 
-			// If the Pod is not running after 60 seconds we delete it and let the Deployment controller create a new Pod.
+			// If the Pod is not running after 120 seconds we delete it and let the Deployment controller create a new Pod.
 			if time.Since(pod.CreationTimestamp.Time).Seconds() > 120.0 {
-				log.Println("operator Pod", pod.Name, "not running after 60 seconds, going to delete this Pod, status:", pod.Status)
+				log.Println("operator Pod", pod.Name, "not running after 120 seconds, going to delete this Pod, status:", pod.Status)
 				err := factory.GetControllerRuntimeClient().Delete(ctx.TODO(), &pod)
 				if k8serrors.IsNotFound(err) {
 					continue


### PR DESCRIPTION
# Description

We have seen cases where it took longer than the expected 60 seconds for the Pods to get scheduled and into a running state, so this PR increases the threshold to 120 seconds and the overall wait time. I removed some duplication code in `RecreateOperatorPods`. 

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

CI will run tests.

## Documentation

-

## Follow-up

-
