### PR TITLE
Remove the update status calls in the sub-reconcilers and unify them to a single call

### DIFF
--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -34,7 +34,7 @@ import (
 type addProcessGroups struct{}
 
 // reconcile runs the reconciler's work.
-func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (a addProcessGroups) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	desiredCountStruct, err := cluster.GetProcessCountsWithDefaults()
 	if err != nil {
 		return &requeue{curError: err}
@@ -45,7 +45,6 @@ func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterR
 		return &requeue{curError: err}
 	}
 
-	hasNewProcessGroups := false
 	for _, processClass := range fdbv1beta2.ProcessClasses {
 		desiredCount := desiredCounts[processClass]
 		if desiredCount < 0 {
@@ -66,14 +65,6 @@ func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterR
 			cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(processGroupID, processClass, nil))
 			// Increase the idNum here, since we just added a Process Group with this ID number.
 			idNum++
-		}
-		hasNewProcessGroups = true
-	}
-
-	if hasNewProcessGroups {
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
 		}
 	}
 

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -59,8 +59,6 @@ var _ = Describe("add_process_groups", func() {
 			Expect(requeue.curError).NotTo(HaveOccurred())
 		}
 
-		_, err = reloadCluster(cluster)
-		Expect(err).NotTo(HaveOccurred())
 		newProcessCounts = fdbv1beta2.CreateProcessCountsFromProcessGroupStatus(cluster.Status.ProcessGroups, true)
 
 	})

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -43,7 +43,7 @@ import (
 type bounceProcesses struct{}
 
 // reconcile runs the reconciler's work.
-func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (bounceProcesses) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	if !pointer.BoolDeref(cluster.Spec.AutomationOptions.KillProcesses, true) {
 		return nil
 	}
@@ -82,10 +82,6 @@ func (bounceProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsBounce",
 			fmt.Sprintf("Spec require a bounce of some processes, but the cluster has only been up for %f seconds", minimumUptime))
 		cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			logger.Error(err, "Error updating cluster status")
-		}
 
 		// Retry after we waited the minimum uptime
 		return &requeue{

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -37,7 +37,7 @@ import (
 type changeCoordinators struct{}
 
 // reconcile runs the reconciler's work.
-func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (c changeCoordinators) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	if !cluster.Status.Configured {
 		return nil
 	}
@@ -100,10 +100,6 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 		return &requeue{curError: err, delayedRequeue: true}
 	}
 	cluster.Status.ConnectionString = connectionString
-	err = r.updateOrApply(ctx, cluster)
-	if err != nil {
-		return &requeue{curError: err, delayedRequeue: true}
-	}
 
 	return nil
 }

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -37,7 +37,7 @@ import (
 type chooseRemovals struct{}
 
 // reconcile runs the reconciler's work.
-func (c chooseRemovals) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (c chooseRemovals) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	hasNewRemovals := false
 
 	var removals = make(map[fdbv1beta2.ProcessGroupID]bool)
@@ -122,10 +122,6 @@ func (c chooseRemovals) reconcile(ctx context.Context, r *FoundationDBClusterRec
 			if !remainingProcessMap[string(processGroup.ProcessGroupID)] {
 				processGroup.MarkForRemoval()
 			}
-		}
-		err := r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err, delayedRequeue: true}
 		}
 	}
 

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -58,8 +58,6 @@ var _ = Describe("choose_removals", func() {
 	JustBeforeEach(func() {
 		requeue = chooseRemovals{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = reloadCluster(cluster)
-		Expect(err).NotTo(HaveOccurred())
 
 		removals = nil
 		for _, processGroup := range cluster.Status.ProcessGroups {

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2018-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2018-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,13 +136,11 @@ var _ = Describe("cluster_controller", func() {
 
 		JustBeforeEach(func() {
 			result, err := reconcileCluster(cluster)
-
 			if err != nil && !shouldCompleteReconciliation {
 				return
 			}
 
 			Expect(err).NotTo(HaveOccurred())
-
 			Expect(result.Requeue).To(Equal(!shouldCompleteReconciliation))
 
 			if shouldCompleteReconciliation {
@@ -1603,14 +1601,12 @@ var _ = Describe("cluster_controller", func() {
 				})
 			})
 
-			Context("with deletion disabled", func() {
+			When("Pod deletions are disabled", func() {
 				BeforeEach(func() {
 					cluster.Spec.AutomationOptions.DeletionMode = fdbv1beta2.PodUpdateModeNone
 					cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyDelete
 					shouldCompleteReconciliation = false
-
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
 				JustBeforeEach(func() {

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -138,10 +138,5 @@ func (g generateInitialClusterFile) reconcile(ctx context.Context, r *Foundation
 
 	cluster.Status.ConnectionString = connectionString.String()
 
-	err = r.updateOrApply(ctx, cluster)
-	if err != nil {
-		return &requeue{curError: err}
-	}
-
 	return nil
 }

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -33,7 +33,7 @@ import (
 type maintenanceModeChecker struct{}
 
 // reconcile runs the reconciler's work.
-func (maintenanceModeChecker) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	if !cluster.UseMaintenaceMode() {
 		return nil
 	}
@@ -87,10 +87,6 @@ func (maintenanceModeChecker) reconcile(ctx context.Context, r *FoundationDBClus
 		return &requeue{curError: err, delayedRequeue: true}
 	}
 	cluster.Status.MaintenanceModeInfo = fdbv1beta2.MaintenanceModeInfo{}
-	err = r.updateOrApply(ctx, cluster)
-	if err != nil {
-		return &requeue{curError: err, delayedRequeue: true}
-	}
 
 	return nil
 }

--- a/controllers/maintenance_mode_checker_test.go
+++ b/controllers/maintenance_mode_checker_test.go
@@ -58,8 +58,6 @@ var _ = Describe("maintenance_mode_checker", func() {
 	JustBeforeEach(func() {
 		requeue = maintenanceModeChecker{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = reloadCluster(cluster)
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Context("maintenance mode is off", func() {
@@ -77,7 +75,7 @@ var _ = Describe("maintenance_mode_checker", func() {
 
 			It("should not be requeued", func() {
 				Expect(requeue).To(BeNil())
-				Expect(cluster.Status.MaintenanceModeInfo).To(Equal(fdbv1beta2.MaintenanceModeInfo{}))
+				Expect(cluster.Status.MaintenanceModeInfo).To(Equal(fdbv1beta2.MaintenanceModeInfo{ZoneID: "storage-4"}))
 			})
 		})
 	})

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -83,10 +83,9 @@ var _ = Describe("remove_process_groups", func() {
 					coordinatorIP: {},
 				}
 
-				allExcluded, newExclusions, processes := clusterReconciler.getProcessGroupsToRemove(globalControllerLogger, cluster, remaining, coordSet)
+				allExcluded, processes := clusterReconciler.getProcessGroupsToRemove(globalControllerLogger, cluster, remaining, coordSet)
 				Expect(allExcluded).To(BeFalse())
 				Expect(processes).To(BeEmpty())
-				Expect(newExclusions).To(BeFalse())
 			})
 		})
 

--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -35,7 +35,7 @@ import (
 type replaceFailedProcessGroups struct{}
 
 // return non-nil requeue if a process has been replaced
-func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (c replaceFailedProcessGroups) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	// If the EmptyMonitorConf setting is set we expect that all fdb processes in this part of the cluster are missing. In order
 	// to prevent the operator from replacing any process groups we skip this reconciliation here.
 	if cluster.Spec.Buggify.EmptyMonitorConf {
@@ -60,11 +60,6 @@ func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *Foundation
 	// Only replace process groups without an address, if the cluster has the desired fault tolerance and is available.
 	hasDesiredFaultTolerance := fdbstatus.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
 	if replacements.ReplaceFailedProcessGroups(logger, cluster, status, hasDesiredFaultTolerance) {
-		err := r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
-		}
-
 		return &requeue{message: "Removals have been updated in the cluster status"}
 	}
 

--- a/controllers/replace_misconfigured_process_groups.go
+++ b/controllers/replace_misconfigured_process_groups.go
@@ -46,18 +46,9 @@ func (c replaceMisconfiguredProcessGroups) reconcile(ctx context.Context, r *Fou
 		return &requeue{curError: err}
 	}
 
-	hasReplacements, err := replacements.ReplaceMisconfiguredProcessGroups(ctx, r.PodLifecycleManager, r, logger, cluster, internal.CreatePVCMap(cluster, pvcs))
+	_, err = replacements.ReplaceMisconfiguredProcessGroups(ctx, r.PodLifecycleManager, r, logger, cluster, internal.CreatePVCMap(cluster, pvcs))
 	if err != nil {
 		return &requeue{curError: err}
-	}
-
-	if hasReplacements {
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
-		}
-
-		logger.Info("Removals have been updated in the cluster status")
 	}
 
 	return nil

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"k8s.io/apimachinery/pkg/api/equality"
-
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
@@ -47,7 +45,6 @@ func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		return &requeue{curError: err}
 	}
 
-	originalStatus := cluster.Status.DeepCopy()
 	allSynced := true
 	delayedRequeue := true
 	var errs []error
@@ -145,13 +142,6 @@ func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		}
 
 		processGroup.UpdateCondition(fdbv1beta2.SidecarUnreachable, false)
-	}
-
-	if !equality.Semantic.DeepEqual(cluster.Status, *originalStatus) {
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
-		}
 	}
 
 	// If any error has happened requeue.

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -54,7 +54,7 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 			r.Recorder.Event(cluster, corev1.EventTypeNormal,
 				"NeedsPodsDeletion", "Spec require deleting some pods, but deleting pods is disabled")
 			cluster.Status.Generations.NeedsPodDeletion = cluster.ObjectMeta.Generation
-			return &requeue{message: "Pod deletion is disabled", delayedRequeue: true}
+			return &requeue{message: "Pod deletion is disabled"}
 		}
 	}
 

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -54,11 +54,7 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 			r.Recorder.Event(cluster, corev1.EventTypeNormal,
 				"NeedsPodsDeletion", "Spec require deleting some pods, but deleting pods is disabled")
 			cluster.Status.Generations.NeedsPodDeletion = cluster.ObjectMeta.Generation
-			err = r.updateOrApply(ctx, cluster)
-			if err != nil {
-				logger.Error(err, "Error updating cluster status")
-			}
-			return &requeue{message: "Pod deletion is disabled"}
+			return &requeue{message: "Pod deletion is disabled", delayedRequeue: true}
 		}
 	}
 

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -261,17 +261,6 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 		}
 	}
 
-	// See: https://github.com/kubernetes-sigs/kubebuilder/issues/592
-	// If we use the default reflect.DeepEqual method it will be recreating the
-	// clusterStatus multiple times because the pointers are different.
-	if !equality.Semantic.DeepEqual(cluster.Status, *originalStatus) {
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			logger.Error(err, "Error updating cluster clusterStatus")
-			return &requeue{curError: err}
-		}
-	}
-
 	return nil
 }
 

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -689,14 +689,12 @@ var _ = Describe("update_status", func() {
 
 	Describe("Reconcile", func() {
 		var cluster *fdbv1beta2.FoundationDBCluster
-		var err error
 		var requeue *requeue
 		var adminClient *mock.AdminClient
 
 		BeforeEach(func() {
 			cluster = internal.CreateDefaultCluster()
-			err = k8sClient.Create(context.TODO(), cluster)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Create(context.TODO(), cluster)).NotTo(HaveOccurred())
 
 			result, err := reconcileCluster(cluster)
 			Expect(err).NotTo(HaveOccurred())
@@ -711,14 +709,11 @@ var _ = Describe("update_status", func() {
 		})
 
 		JustBeforeEach(func() {
-			err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})).NotTo(HaveOccurred())
 			requeue = updateStatus{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
 			if requeue != nil {
 				Expect(requeue.curError).NotTo(HaveOccurred())
 			}
-			_, err = reloadCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should mark the cluster as reconciled", func() {


### PR DESCRIPTION
# Description

Instead of having different code logic for the different sub-reconcilers we should update the status only once after the reconciliation. This should also reduce the seen conflict errors. Those changes will make it easier in the future to write new sub-reconcilers that change/update the status.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Manual e2e test run.

## Documentation

-

## Follow-up

-
