### PR TITLE
Enable 2 Storage Servers per default in test cases

### DIFF
--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -138,7 +138,7 @@ func (config *ClusterConfig) SetDefaults(factory *Factory) {
 	}
 
 	if config.StorageServerPerPod == 0 {
-		config.StorageServerPerPod = 1
+		config.StorageServerPerPod = 2
 	}
 
 	if config.CreationCallback == nil {


### PR DESCRIPTION
# Description

Enable 2 Storage Servers per disk as the default config in our e2e tests.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

We will enable one e2e tests with 1 SS per disk.

## Testing

CI will run e21e tests.

## Documentation

Will be updated.

## Follow-up

Add dedicated test(s) for single SS per Pod.