### PR TITLE
Allow to modify the leader election timeouts

### DIFF
--- a/setup/setup.go
+++ b/setup/setup.go
@@ -79,13 +79,13 @@ type Options struct {
 	// LeaseDuration is the duration that non-leader candidates will
 	// wait to force acquire leadership. This is measured against time of
 	// last observed ack. Default is 15 seconds.
-	LeaseDuration *time.Duration
+	LeaseDuration time.Duration
 	// RenewDeadline is the duration that the acting controlplane will retry
 	// refreshing leadership before giving up. Default is 10 seconds.
-	RenewDeadline *time.Duration
+	RenewDeadline time.Duration
 	// RetryPeriod is the duration the LeaderElector clients should wait
 	// between tries of actions. Default is 2 seconds.
-	RetryPeriod        *time.Duration
+	RetryPeriod        time.Duration
 	DeprecationOptions internal.DeprecationOptions
 }
 
@@ -116,9 +116,9 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.WatchNamespace, "watch-namespace", os.Getenv("WATCH_NAMESPACE"), "Defines which namespace the operator should watch.")
 	fs.DurationVar(&o.GetTimeout, "get-timeout", 5*time.Second, "http timeout for get requests to the FDB sidecar.")
 	fs.DurationVar(&o.PostTimeout, "post-timeout", 10*time.Second, "http timeout for post requests to the FDB sidecar.")
-	fs.DurationVar(o.LeaseDuration, "leader-election-lease-duration", 15*time.Second, "the duration that non-leader candidates will wait to force acquire leadership.")
-	fs.DurationVar(o.RenewDeadline, "leader-election-renew-deadline", 10*time.Second, "the duration that the acting controlplane will retry refreshing leadership before giving up.")
-	fs.DurationVar(o.RetryPeriod, "leader-election-retry-period", 2*time.Second, "the duration the LeaderElector clients should wait between tries of action.")
+	fs.DurationVar(&o.LeaseDuration, "leader-election-lease-duration", 15*time.Second, "the duration that non-leader candidates will wait to force acquire leadership.")
+	fs.DurationVar(&o.RenewDeadline, "leader-election-renew-deadline", 10*time.Second, "the duration that the acting controlplane will retry refreshing leadership before giving up.")
+	fs.DurationVar(&o.RetryPeriod, "leader-election-retry-period", 2*time.Second, "the duration the LeaderElector clients should wait between tries of action.")
 	fs.BoolVar(&o.EnableRestartIncompatibleProcesses, "enable-restart-incompatible-processes", true, "This flag enables/disables in the operator to restart incompatible fdbserver processes.")
 	fs.BoolVar(&o.ServerSideApply, "server-side-apply", false, "This flag enables server side apply.")
 	fs.BoolVar(&o.EnableRecoveryState, "enable-recovery-state", true, "This flag enables the use of the recovery state for the minimum uptime between bounced if the FDB version supports it.")
@@ -165,9 +165,9 @@ func StartManager(
 		MetricsBindAddress: operatorOpts.MetricsAddr,
 		LeaderElection:     operatorOpts.EnableLeaderElection,
 		LeaderElectionID:   operatorOpts.LeaderElectionID,
-		LeaseDuration:      operatorOpts.LeaseDuration,
-		RenewDeadline:      operatorOpts.RenewDeadline,
-		RetryPeriod:        operatorOpts.RetryPeriod,
+		LeaseDuration:      &operatorOpts.LeaseDuration,
+		RenewDeadline:      &operatorOpts.RenewDeadline,
+		RetryPeriod:        &operatorOpts.RetryPeriod,
 		Port:               9443,
 	}
 


### PR DESCRIPTION
# Description

This change allows to modify the leader election settings for the controller runtime.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

This gives some more flexibility in setting out the leader election mechanism in the operator.

## Testing

CI tests will be running.

## Documentation

-

## Follow-up

-
