### PR TITLE
Add the missing list verb to Pods for testing the unified image

### DIFF
--- a/config/tests/unified_image/unified_image_role.yaml
+++ b/config/tests/unified_image/unified_image_role.yaml
@@ -17,6 +17,7 @@ rules:
       - "watch"
       - "update"
       - "patch"
+      - "list"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/e2e/fixtures/kubernetes_fixtures.go
+++ b/e2e/fixtures/kubernetes_fixtures.go
@@ -152,6 +152,7 @@ func (factory *Factory) ensureRBACSetupExists(namespace string) {
 					"watch",
 					"update",
 					"patch",
+					"list",
 				},
 			},
 		},


### PR DESCRIPTION
# Description

Otherwise the FDB kubernetes monitor is not able to list the Pod(s).

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Did a manual run.

## Documentation

-

## Follow-up

-
