### PR TITLE
Add indexer to fix exec command

### DIFF
--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -96,6 +96,16 @@ func getKubeClient(ctx context.Context, o *fdbBOptions) (client.Client, error) {
 		return nil, err
 	}
 
+	// Setup index field to allow access to the status phase of a Pod more efficiently. The indexer must be created before the
+	// informer is started.
+	err = internalCache.IndexField(ctx, &corev1.Pod{}, "status.phase", func(object client.Object) []string {
+		return []string{string(object.(*corev1.Pod).Status.Phase)}
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
 	// Make sure the internal cache is started.
 	go func() {
 		_ = internalCache.Start(ctx)


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1916

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Manually ran the command with a manual build:

```bash
$ ./dist/kubectl-fdb_darwin_arm64/kubectl-fdb -n dev  exec -c test-cluster --version-check=false -- bas
[fdb@test-cluster-storage-6 /]$ exit
exit
```

## Documentation

N/A

## Follow-up

I checked for other fields we use and we should be covering all now.
