### PR TITLE
Make sure we exclude the FDB_NETWORK_OPTION_CLIENT_THREADS_PER_VERSION env variable and don't pass it down to fdbcli

### DIFF
--- a/fdbclient/command_runner.go
+++ b/fdbclient/command_runner.go
@@ -48,6 +48,7 @@ func getEnvironmentVariablesWithoutExcludedFdbEnv() []string {
 	excludedEnvironmentVariables := map[string]fdbv1beta2.None{
 		"FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY":       {},
 		"FDB_NETWORK_OPTION_IGNORE_EXTERNAL_CLIENT_FAILURES": {},
+		"FDB_NETWORK_OPTION_CLIENT_THREADS_PER_VERSION":      {},
 	}
 
 	osVariables := os.Environ()

--- a/fdbclient/command_runner_test.go
+++ b/fdbclient/command_runner_test.go
@@ -54,6 +54,8 @@ var _ = Describe("command_runner", func() {
 		BeforeEach(func() {
 			GinkgoT().Setenv("FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY", "")
 			GinkgoT().Setenv("FDB_NETWORK_OPTION_IGNORE_EXTERNAL_CLIENT_FAILURES", "")
+			GinkgoT().Setenv("FDB_NETWORK_OPTION_CLIENT_THREADS_PER_VERSION", "")
+
 			GinkgoT().Setenv("FDB_TLS_CERTIFICATE_FILE", "")
 
 			for _, env := range getEnvironmentVariablesWithoutExcludedFdbEnv() {
@@ -64,6 +66,7 @@ var _ = Describe("command_runner", func() {
 		It("should exclude the listed FDB variables but include all others", func() {
 			Expect(envVariablesKeys).NotTo(ContainElement("FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY"))
 			Expect(envVariablesKeys).NotTo(ContainElement("FDB_NETWORK_OPTION_IGNORE_EXTERNAL_CLIENT_FAILURES"))
+			Expect(envVariablesKeys).NotTo(ContainElement("FDB_NETWORK_OPTION_CLIENT_THREADS_PER_VERSION"))
 			Expect(envVariablesKeys).To(ContainElement("FDB_TLS_CERTIFICATE_FILE"))
 		})
 	})


### PR DESCRIPTION
# Description

The fdb client has the option to set the environment variable `FDB_NETWORK_OPTION_CLIENT_THREADS_PER_VERSION` to make use of multiple threads, see: https://apple.github.io/foundationdb/api-general.html#multi-threaded-client. If this environment variable is set all `fdbcli` call will fail because of this variable. In order to fix this we have to exclude this variable when calling fdbcli. Setting this variable doesn't make any sense for fdbcli, as fdbcli can only connect to a single cluster anyway.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran a manual e2e test where I set `FDB_NETWORK_OPTION_CLIENT_THREADS_PER_VERSION`.

## Documentation

-

## Follow-up

-
