### PR TITLE
Update the FDB versions used for e2e tests

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -10,9 +10,9 @@ TIMEOUT?=168h
 NAMESPACE?=
 PREFIX?=
 CONTEXT?=
-FDB_VERSION?=7.1.43
+FDB_VERSION?=7.1.53
 # This will be the version used for upgrade tests.
-NEXT_FDB_VERSION?=7.3.25
+NEXT_FDB_VERSION?=7.3.29
 ## Expectation is that you are running standard build image which generates both regular and debug (Symbols) images.
 FDB_IMAGE?=foundationdb/foundationdb:$(FDB_VERSION)
 SIDECAR_IMAGE?=foundationdb/foundationdb-kubernetes-sidecar:$(FDB_VERSION)-1


### PR DESCRIPTION
# Description

Update the FDB versions to match the latest released FDB versions.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

CI will be running tests.

## Documentation

-

## Follow-up

-
