### PR TITLE
Reduce the update calls for the FoundationDB resource

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1508,7 +1508,7 @@ func (cluster *FoundationDBCluster) CheckReconciliation(log logr.Logger) (bool, 
 			for _, condition := range processGroup.ProcessGroupConditions {
 				// If there is at least one process with an incorrect command line, that means the operator has to restart
 				// processes.
-				if condition.ProcessGroupConditionType == IncorrectCommandLine {
+				if condition.ProcessGroupConditionType == IncorrectCommandLine && cluster.Status.Generations.NeedsBounce == 0 {
 					logger.V(1).Info("Pending restart of fdbserver processes", "state", "NeedsBounce")
 					cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
 				}

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -105,7 +105,8 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 		cluster.ClearMissingVersionFlags(&clusterStatus.DatabaseConfiguration)
 	}
 
-	clusterStatus.Configured = databaseStatus.Client.DatabaseStatus.Available && databaseStatus.Cluster.Layers.Error != "configurationMissing"
+	// If we saw at least once that the cluster was configured, we assume that the cluster is always configured.
+	clusterStatus.Configured = cluster.Status.Configured || (databaseStatus.Client.DatabaseStatus.Available && databaseStatus.Cluster.Layers.Error != "configurationMissing")
 
 	if cluster.Spec.MainContainer.EnableTLS {
 		clusterStatus.RequiredAddresses.TLS = true

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -105,7 +105,7 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 		cluster.ClearMissingVersionFlags(&clusterStatus.DatabaseConfiguration)
 	}
 
-	clusterStatus.Configured = cluster.Status.Configured || (databaseStatus.Client.DatabaseStatus.Available && databaseStatus.Cluster.Layers.Error != "configurationMissing")
+	clusterStatus.Configured = databaseStatus.Client.DatabaseStatus.Available && databaseStatus.Cluster.Layers.Error != "configurationMissing"
 
 	if cluster.Spec.MainContainer.EnableTLS {
 		clusterStatus.RequiredAddresses.TLS = true


### PR DESCRIPTION
# Description

Remove the update calls from the `BounceProcesses` reconciler and the `UpdateDatabaseConfiguration` reconciler. Those updates are done in the `UpdateStatus` reconciler already. This should reduce some conflicts and simplifies the code.

## Type of change

*Please select one of the options below.*

- Other (code cleanup).

## Discussion

There are other places that can be reviewed to try to update the `FoundationDBCluster` resource in a single place.

## Testing

Ran unit tests and e2e tests are running with CI.

## Documentation

-

## Follow-up

-
