### PR TITLE
Add estimates and pretty printing to exclusion status check

### DIFF
--- a/kubectl-fdb/cmd/exclusion_status_test.go
+++ b/kubectl-fdb/cmd/exclusion_status_test.go
@@ -1,0 +1,41 @@
+/*
+ * exclusion_status_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("[plugin] exclustion stats command", func() {
+	DescribeTable("pretty printing the stored bytes", func(storedByes int, expected string) {
+		Expect(prettyPrintStoredBytes(storedByes)).To(Equal(expected))
+	},
+		Entry("a few bytes", 1023, "1023.00"),
+		Entry("two KiB", 2*1024, "2.00Ki"),
+		Entry("two and a half KiB", 2*1024+512, "2.50Ki"),
+		Entry("three MiB", 3*1024*1024, "3.00Mi"),
+		Entry("four GiB", 4*1024*1024*1024, "4.00Gi"),
+		Entry("five TiB", 5*1024*1024*1024*1024, "5.00Ti"),
+		Entry("six Pib", 6*1024*1024*1024*1024*1024, "6.00Pi"),
+	)
+
+})


### PR DESCRIPTION
# Description

Add estimates and pretty printing to exclusion status check.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

The estimates are not that accurate and we have to revisit that logic later.

## Testing

I ran the command manually against a testing cluster:

```bash
$ ./dist/kubectl-fdb_darwin_arm64/kubectl-fdb get exclusion-status testing --version-check=false
testingstorage-88-1:    119.34Gi are left - estimate: N/A
testingstorage-88-2:    61.72Gi are left - estimate: N/A
There are 2 processes that are not fully excluded.
======================================================================================================
testingstorage-88-1:    116.14Gi are left - estimate: 19m36.960677976s
testingstorage-88-2:    56.67Gi are left - estimate: 5m59.626873826s
There are 2 processes that are not fully excluded.
======================================================================================================
testingstorage-88-1:    103.23Gi are left - estimate: 6m35.942526875s
testingstorage-88-2:    45.62Gi are left - estimate: 3m46.2528725s
There are 2 processes that are not fully excluded.
======================================================================================================
testingstorage-88-1:    89.11Gi are left - estimate: 6m39.385221504s
testingstorage-88-2:    30.28Gi are left - estimate: 1m6.564203584s
There are 2 processes that are not fully excluded.
testingstorage-88-1:    74.58Gi are left - estimate: 7m4.777066455s
testingstorage-88-2:    17.76Gi are left - estimate: 1m24.955413291s
There are 2 processes that are not fully excluded.
======================================================================================================
testingstorage-88-1:    70.04Gi are left - estimate: 6m12.807613755s
testingstorage-88-2:    15.11Gi are left - estimate: 2m4.269204585s
There are 2 processes that are not fully excluded.
======================================================================================================
```

## Documentation

-

## Follow-up

Revisit the estimate logic and add more tests for this command.
