### PR TITLE
Remove the global admin mutex for the admin client

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -32,7 +32,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -48,8 +47,6 @@ const (
 	fdbbackupStr  = "fdbbackup"
 	fdbrestoreStr = "fdbrestore"
 )
-
-var adminClientMutex sync.Mutex
 
 var maxCommandOutput = parseMaxCommandOutput()
 
@@ -313,9 +310,6 @@ func (client *cliAdminClient) getStatus() (*fdbv1beta2.FoundationDBStatus, error
 
 // GetStatus gets the database's status
 func (client *cliAdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
-	adminClientMutex.Lock()
-	defer adminClientMutex.Unlock()
-
 	startTime := time.Now()
 	// This will call directly the database and fetch the status information from the system key space.
 	status, err := getStatusFromDB(client.fdbLibClient, client.log, client.getTimeout())


### PR DESCRIPTION
# Description

Having the mutex as it is will block the concurrency for the `GetStatus` method and limit it to be one request at a time.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

I'm not sure about the historical reason why we added it, but that mutex shouldn't be required as the operator and users will probably create a new admin client any way. If we want to keep the mutex for ? reasons, we should be thinking about making that mutex cluster aware. But it's also interesting that only the `GetStatus` uses the mutex and no other method.

## Testing

Ran unit tests and e2e tests will be running.

## Documentation

-

## Follow-up

-
