### PR TITLE
Making the cluster argument optional when we are removing pods in the…

### DIFF
--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -403,7 +403,7 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1
 		confirmed := false
 
 		if len(failedProcessGroups) > 0 {
-			err := replaceProcessGroups(kubeClient, cluster.Name, failedProcessGroups, cluster.Namespace, true, wait, false, true)
+			err := replaceProcessGroups(kubeClient, cluster.Name, failedProcessGroups, cluster.Namespace, "", true, wait, false, true)
 			if err != nil {
 				return err
 			}

--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -134,7 +134,7 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 
 	var errors []string
 	for _, node := range nodes {
-		pods, err := fetchPods(kubeClient, inputClusterName, namespace, node, clusterLabel)
+		pods, err := fetchPodsOnNode(kubeClient, inputClusterName, namespace, node, clusterLabel)
 		if err != nil {
 			internalErr := fmt.Sprintf("Issue fetching Pods running on node: %s. Error: %s\n", node, err)
 			cmd.PrintErr(internalErr)
@@ -171,7 +171,7 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 					processGroups = append(processGroups, processGroup)
 				}
 			}
-			err = replaceProcessGroups(kubeClient, cluster.Name, processGroups, namespace, withExclusion, wait, false, true)
+			err = replaceProcessGroups(kubeClient, cluster.Name, processGroups, namespace, "", withExclusion, wait, false, true)
 			if err != nil {
 				internalErr := fmt.Sprintf("unable to cordon all Pods for cluster %s\n", cluster.Name)
 				errors = append(errors, internalErr)
@@ -186,7 +186,7 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 	return nil
 }
 
-func fetchPods(kubeClient client.Client, clusterName string, namespace string, node string, clusterLabel string) (corev1.PodList, error) {
+func fetchPodsOnNode(kubeClient client.Client, clusterName string, namespace string, node string, clusterLabel string) (corev1.PodList, error) {
 	var pods corev1.PodList
 	var err error
 

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -34,9 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var secondCluster *fdbv1beta2.FoundationDBCluster
-var secondClusterName = "test2"
-
 var _ = Describe("[plugin] cordon command", func() {
 	When("running cordon command", func() {
 		type testCase struct {

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -296,7 +296,7 @@ func getProcessGroupIDsFromPodName(cluster *fdbv1beta2.FoundationDBCluster, podN
 }
 
 // fetchProcessGroupsCrossCluster fetches the list of process groups matching the given podNames and returns the
-// processGroup objects mapped by clusterName matching the given clusterLabel.
+// processGroupIDs mapped by clusterName matching the given clusterLabel.
 func fetchProcessGroupsCrossCluster(kubeClient client.Client, namespace string, clusterLabel string, podNames ...string) (map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID, error) {
 	var pod corev1.Pod
 	podsByClusterName := map[string][]string{} // start with grouping by cluster-label values and load clusters later

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"github.com/go-logr/logr"
 	"io"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	"math/rand"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -292,6 +293,33 @@ func getProcessGroupIDsFromPodName(cluster *fdbv1beta2.FoundationDBCluster, podN
 	}
 
 	return processGroupIDs, nil
+}
+
+// fetchProcessGroupsCrossCluster fetches the list of process groups matching the given podNames and returns the
+// processGroup objects mapped by clusterName matching the given clusterLabel.
+func fetchProcessGroupsCrossCluster(kubeClient client.Client, namespace string, clusterLabel string, podNames ...string) (map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID, error) {
+	var pod corev1.Pod
+	pgsByCluster := map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID{}
+
+	for _, podName := range podNames {
+		err := kubeClient.Get(context.Background(), client.ObjectKey{Name: podName, Namespace: namespace}, &pod)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil, fmt.Errorf("could not get pod: %s/%s", namespace, podName)
+			}
+			return nil, err
+		}
+		clusterName := pod.Labels[clusterLabel]
+		cluster, err := loadCluster(kubeClient, namespace, clusterName)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil, fmt.Errorf("could not get cluster: %s/%s", namespace, clusterName)
+			}
+			return nil, err
+		}
+		pgsByCluster[cluster] = append(pgsByCluster[cluster], internal.GetProcessGroupIDFromPodName(cluster, podName))
+	}
+	return pgsByCluster, nil
 }
 
 func chooseRandomPod(pods *corev1.PodList) (*corev1.Pod, error) {

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/cobra"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -44,6 +43,10 @@ func newRemoveProcessGroupCmd(streams genericclioptions.IOStreams) *cobra.Comman
 				return err
 			}
 			cluster, err := cmd.Flags().GetString("fdb-cluster")
+			if err != nil {
+				return err
+			}
+			clusterLabel, err := cmd.Flags().GetString("cluster-label")
 			if err != nil {
 				return err
 			}
@@ -70,11 +73,14 @@ func newRemoveProcessGroupCmd(streams genericclioptions.IOStreams) *cobra.Comman
 				return err
 			}
 
-			return replaceProcessGroups(kubeClient, cluster, args, namespace, withExclusion, wait, removeAllFailed, useProcessGroupID)
+			return replaceProcessGroups(kubeClient, cluster, args, namespace, clusterLabel, withExclusion, wait, removeAllFailed, useProcessGroupID)
 		},
 		Example: `
 # Remove process groups for a cluster in the current namespace
 kubectl fdb remove process-group -c cluster pod-1 pod-2
+
+# Remove process groups across clusters in the current namespace
+kubectl fdb remove process-group pod-1-cluster-A pod-2-cluster-B -l your-cluster-label
 
 # Remove process groups for a cluster in the namespace default
 kubectl fdb -n default remove process-group -c cluster pod-1 pod-2
@@ -92,10 +98,8 @@ kubectl fdb -n default remove process-group -c cluster --remove-all-failed
 	cmd.Flags().BoolP("exclusion", "e", true, "define if the process groups should be removed with exclusion.")
 	cmd.Flags().Bool("remove-all-failed", false, "define if all failed processes should be replaced.")
 	cmd.Flags().Bool("use-process-group-id", false, "define if the process-group should be used instead of the Pod name.")
-	err := cmd.MarkFlagRequired("fdb-cluster")
-	if err != nil {
-		log.Fatal(err)
-	}
+	cmd.Flags().StringP("cluster-label", "l", fdbv1beta2.FDBClusterLabel, "cluster label used to identify the cluster for a requested pod")
+
 	cmd.SetOut(o.Out)
 	cmd.SetErr(o.ErrOut)
 	cmd.SetIn(o.In)
@@ -105,21 +109,36 @@ kubectl fdb -n default remove process-group -c cluster --remove-all-failed
 	return cmd
 }
 
-// replaceProcessGroups adds process groups to the removal list of the cluster
-func replaceProcessGroups(kubeClient client.Client, clusterName string, ids []string, namespace string, withExclusion bool, wait bool, removeAllFailed bool, useProcessGroupID bool) error {
+// replaceProcessGroups adds process groups to the removal list of their respective clusters
+// if a clusterName is specified, it will ONLY do so for the specified cluster
+func replaceProcessGroups(kubeClient client.Client, clusterName string, ids []string, namespace string, clusterLabel string, withExclusion bool, wait bool, removeAllFailed bool, useProcessGroupID bool) error {
 	if len(ids) == 0 && !removeAllFailed {
 		return nil
 	}
 
-	cluster, err := loadCluster(kubeClient, namespace, clusterName)
+	// cross-cluster logic: given a list of Pod names, we can look up the FDB clusters by pod label, and work across clusters
+	if !useProcessGroupID && clusterName == "" {
+		pgsByCluster, err := fetchProcessGroupsCrossCluster(kubeClient, namespace, clusterLabel, ids...)
+		if err != nil {
+			return err
+		}
+		for cluster, pgs := range pgsByCluster {
+			// TODO check over this error logic
+			err = replaceProcessGroupsFromCluster(kubeClient, cluster, pgs, namespace, withExclusion, wait, removeAllFailed)
+			if err != nil {
+				return err
+			}
+		}
+	}
 
+	// single-cluster logic
+	cluster, err := loadCluster(kubeClient, namespace, clusterName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return fmt.Errorf("could not get cluster: %s/%s", namespace, clusterName)
 		}
 		return err
 	}
-
 	// In this case the user has Pod name specified
 	var processGroupIDs []fdbv1beta2.ProcessGroupID
 	if !useProcessGroupID {
@@ -132,7 +151,11 @@ func replaceProcessGroups(kubeClient client.Client, clusterName string, ids []st
 			processGroupIDs = append(processGroupIDs, fdbv1beta2.ProcessGroupID(id))
 		}
 	}
+	return replaceProcessGroupsFromCluster(kubeClient, cluster, processGroupIDs, namespace, withExclusion, wait, removeAllFailed)
+}
 
+// replaceProcessGroupsFromCluster removes the process groups ONLY from the specified cluster
+func replaceProcessGroupsFromCluster(kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluster, processGroupIDs []fdbv1beta2.ProcessGroupID, namespace string, withExclusion bool, wait bool, removeAllFailed bool) error {
 	patch := client.MergeFrom(cluster.DeepCopy())
 
 	processGroupSet := map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None{}
@@ -155,7 +178,7 @@ func replaceProcessGroups(kubeClient client.Client, clusterName string, ids []st
 	}
 
 	if wait {
-		if !confirmAction(fmt.Sprintf("Remove %v from cluster %s/%s with exclude: %t", processGroupIDs, namespace, clusterName, withExclusion)) {
+		if !confirmAction(fmt.Sprintf("Remove %v from cluster %s/%s with exclude: %t", processGroupIDs, namespace, cluster.Name, withExclusion)) {
 			return fmt.Errorf("user aborted the removal")
 		}
 	}

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -123,12 +123,12 @@ func replaceProcessGroups(kubeClient client.Client, clusterName string, ids []st
 			return err
 		}
 		for cluster, pgs := range pgsByCluster {
-			// TODO check over this error logic
 			err = replaceProcessGroupsFromCluster(kubeClient, cluster, pgs, namespace, withExclusion, wait, removeAllFailed)
 			if err != nil {
 				return err
 			}
 		}
+		return nil
 	}
 
 	// single-cluster logic
@@ -183,6 +183,16 @@ func replaceProcessGroupsFromCluster(kubeClient client.Client, cluster *fdbv1bet
 		}
 	}
 
+	/*
+			processGroupSet: "storage-1"
+			processGroupIDs: []{"storage-1"}
+			cluster:
+				ProcessGroups: {ProcessGroupID: "storage-42"} {ProcessGroupID: "storage-1"}
+		bad:
+			cluster:
+				ProcessGroups: {ProcessGroupID: "test-instance-1"}
+
+	*/
 	if withExclusion {
 		cluster.Spec.ProcessGroupsToRemove = cluster.GetProcessGroupsToRemove(processGroupIDs)
 	} else {

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -183,16 +183,6 @@ func replaceProcessGroupsFromCluster(kubeClient client.Client, cluster *fdbv1bet
 		}
 	}
 
-	/*
-			processGroupSet: "storage-1"
-			processGroupIDs: []{"storage-1"}
-			cluster:
-				ProcessGroups: {ProcessGroupID: "storage-42"} {ProcessGroupID: "storage-1"}
-		bad:
-			cluster:
-				ProcessGroups: {ProcessGroupID: "test-instance-1"}
-
-	*/
 	if withExclusion {
 		cluster.Spec.ProcessGroupsToRemove = cluster.GetProcessGroupsToRemove(processGroupIDs)
 	} else {

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -156,7 +156,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				})
 			})
 
-			When("processes are removed by pod + clusterLabel criteria", func() {
+			When("processes are removed by pod and clusterLabel criteria", func() {
 				BeforeEach(func() {
 					// creating Pods for first cluster.
 					cluster = generateClusterStruct(clusterName, namespace) // the status is overwritten by prior tests
@@ -183,7 +183,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					wantErrorContains string
 				}
 
-				DescribeTable("should remove specified processes via clusterLabel + podName(s)",
+				DescribeTable("should remove specified processes via clusterLabel and podName(s)",
 					func(tc testCase) {
 						err := replaceProcessGroups(k8sClient, tc.clusterNameFilter, tc.podNames, namespace, tc.clusterLabel, true, false, tc.RemoveAllFailed, false)
 						if tc.wantErrorContains != "" {
@@ -192,17 +192,17 @@ var _ = Describe("[plugin] remove process groups command", func() {
 							Expect(err).NotTo(HaveOccurred())
 						}
 
-						for clusterName, cd := range tc.clusterDataMap {
+						for clusterName, clusterData := range tc.clusterDataMap {
 							var resCluster fdbv1beta2.FoundationDBCluster
 							err = k8sClient.Get(context.Background(), client.ObjectKey{
 								Namespace: namespace,
 								Name:      clusterName,
 							}, &resCluster)
 							Expect(err).NotTo(HaveOccurred())
-							Expect(cd.ExpectedInstancesToRemove).To(ContainElements(resCluster.Spec.ProcessGroupsToRemove))
-							Expect(len(cd.ExpectedInstancesToRemove)).To(BeNumerically("==", len(resCluster.Spec.ProcessGroupsToRemove)))
+							Expect(clusterData.ExpectedInstancesToRemove).To(ContainElements(resCluster.Spec.ProcessGroupsToRemove))
+							Expect(len(clusterData.ExpectedInstancesToRemove)).To(BeNumerically("==", len(resCluster.Spec.ProcessGroupsToRemove)))
 							Expect(len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion)).To(BeNumerically("==", 0))
-							Expect(cd.ExpectedProcessCounts.Storage).To(Equal(resCluster.Spec.ProcessCounts.Storage))
+							Expect(clusterData.ExpectedProcessCounts.Storage).To(Equal(resCluster.Spec.ProcessCounts.Storage))
 						}
 					},
 					Entry("errors when process group IDs are provided instead of pod names",

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -61,7 +61,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 
 			DescribeTable("should cordon all targeted processes",
 				func(tc testCase) {
-					err := replaceProcessGroups(k8sClient, clusterName, tc.Instances, namespace, tc.WithExclusion, false, tc.RemoveAllFailed, false)
+					err := replaceProcessGroups(k8sClient, clusterName, tc.Instances, namespace, "", tc.WithExclusion, false, tc.RemoveAllFailed, false)
 					Expect(err).NotTo(HaveOccurred())
 
 					var resCluster fdbv1beta2.FoundationDBCluster
@@ -118,7 +118,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				When("adding the same process group to the removal list without exclusion", func() {
 					It("should add the process group to the removal without exclusion list", func() {
 						removals := []string{"test-storage-1"}
-						err := replaceProcessGroups(k8sClient, clusterName, removals, namespace, false, false, false, false)
+						err := replaceProcessGroups(k8sClient, clusterName, removals, namespace, "", false, false, false, false)
 						Expect(err).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster
@@ -138,7 +138,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				When("adding the same process group to the removal list", func() {
 					It("should add the process group to the removal without exclusion list", func() {
 						removals := []string{"test-storage-1"}
-						err := replaceProcessGroups(k8sClient, clusterName, removals, namespace, true, false, false, false)
+						err := replaceProcessGroups(k8sClient, clusterName, removals, namespace, "", true, false, false, false)
 						Expect(err).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -22,6 +22,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
@@ -153,6 +154,186 @@ var _ = Describe("[plugin] remove process groups command", func() {
 						Expect(len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion)).To(BeNumerically("==", 0))
 					})
 				})
+			})
+
+			When("processes are removed by pod + clusterLabel criteria", func() {
+				BeforeEach(func() {
+					// creating Pods for first cluster.
+					cluster = generateClusterStruct(clusterName, namespace) // the status is overwritten by prior tests
+					Expect(createPods(clusterName, namespace)).NotTo(HaveOccurred())
+
+					// creating a second cluster
+					secondCluster = generateClusterStruct(secondClusterName, namespace)
+					Expect(k8sClient.Create(context.TODO(), secondCluster)).NotTo(HaveOccurred())
+					Expect(createPods(secondClusterName, namespace)).NotTo(HaveOccurred())
+				})
+
+				// since these tests involve multiple clusters, this allows us to more easily check expected counts on
+				// a cluster-by-cluster basis
+				type clusterData struct {
+					ExpectedInstancesToRemove []fdbv1beta2.ProcessGroupID
+					ExpectedProcessCounts     fdbv1beta2.ProcessCounts
+				}
+				type testCase struct {
+					podNames          []string
+					clusterNameFilter string // if used, then cross-cluster will not work
+					clusterLabel      string
+					RemoveAllFailed   bool
+					clusterDataMap    map[string]clusterData
+					wantErrorContains string
+				}
+
+				DescribeTable("should remove specified processes via clusterLabel + podName(s)",
+					func(tc testCase) {
+						err := replaceProcessGroups(k8sClient, tc.clusterNameFilter, tc.podNames, namespace, tc.clusterLabel, true, false, tc.RemoveAllFailed, false)
+						if tc.wantErrorContains != "" {
+							Expect(err.Error()).To(ContainSubstring(tc.wantErrorContains))
+						} else {
+							Expect(err).NotTo(HaveOccurred())
+						}
+
+						for clusterName, cd := range tc.clusterDataMap {
+							var resCluster fdbv1beta2.FoundationDBCluster
+							err = k8sClient.Get(context.Background(), client.ObjectKey{
+								Namespace: namespace,
+								Name:      clusterName,
+							}, &resCluster)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(cd.ExpectedInstancesToRemove).To(ContainElements(resCluster.Spec.ProcessGroupsToRemove))
+							Expect(len(cd.ExpectedInstancesToRemove)).To(BeNumerically("==", len(resCluster.Spec.ProcessGroupsToRemove)))
+							Expect(len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion)).To(BeNumerically("==", 0))
+							Expect(cd.ExpectedProcessCounts.Storage).To(Equal(resCluster.Spec.ProcessCounts.Storage))
+						}
+					},
+					Entry("errors when process group IDs are provided instead of pod names",
+						testCase{
+							podNames:          []string{"instance-1"},
+							clusterLabel:      fdbv1beta2.FDBClusterLabel,
+							wantErrorContains: "could not get pod: test/instance-1",
+							clusterDataMap: map[string]clusterData{
+								clusterName: {
+									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
+									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
+										Storage: 1,
+									},
+								},
+							},
+						},
+					),
+					Entry("errors when no cluster found with given label",
+						testCase{
+							podNames:          []string{fmt.Sprintf("%s-instance-1", clusterName)},
+							clusterLabel:      "invalid-cluster-label",
+							wantErrorContains: fmt.Sprintf("no cluster-label 'invalid-cluster-label' found for pod '%s-instance-1'", clusterName),
+							clusterDataMap: map[string]clusterData{
+								clusterName: {
+									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
+									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
+										Storage: 1,
+									},
+								},
+							},
+						},
+					),
+					Entry("removes valid 1 process group referred to by pod name and cluster-label",
+						testCase{
+							podNames:     []string{fmt.Sprintf("%s-instance-1", clusterName)},
+							clusterLabel: fdbv1beta2.FDBClusterLabel,
+							clusterDataMap: map[string]clusterData{
+								clusterName: {
+									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
+									},
+									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
+										Storage: 1,
+									},
+								},
+								secondClusterName: {
+									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
+									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
+										Storage: 1,
+									},
+								},
+							},
+						},
+					),
+					Entry("removes two process groups, each on a different cluster",
+						testCase{
+							podNames:     []string{fmt.Sprintf("%s-instance-1", clusterName), fmt.Sprintf("%s-instance-1", secondClusterName)},
+							clusterLabel: fdbv1beta2.FDBClusterLabel,
+							clusterDataMap: map[string]clusterData{
+								clusterName: {
+									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
+									},
+									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
+										Storage: 1,
+									},
+								},
+								secondClusterName: {
+									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", secondClusterName)),
+									},
+									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
+										Storage: 1,
+									},
+								},
+							},
+						},
+					),
+					Entry("removes 3 process groups, on 2 different clusters",
+						testCase{
+							podNames:     []string{fmt.Sprintf("%s-instance-1", clusterName), fmt.Sprintf("%s-instance-1", secondClusterName), fmt.Sprintf("%s-instance-2", secondClusterName)},
+							clusterLabel: fdbv1beta2.FDBClusterLabel,
+							clusterDataMap: map[string]clusterData{
+								clusterName: {
+									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
+									},
+									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
+										Storage: 1,
+									},
+								},
+								secondClusterName: {
+									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", secondClusterName)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", secondClusterName)),
+									},
+									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
+										Storage: 1,
+									},
+								},
+							},
+						},
+					),
+					Entry("removes 4 process groups, on 2 different clusters",
+						testCase{
+							podNames: []string{fmt.Sprintf("%s-instance-1", clusterName), fmt.Sprintf("%s-instance-2", clusterName),
+								fmt.Sprintf("%s-instance-1", secondClusterName), fmt.Sprintf("%s-instance-2", secondClusterName)},
+							clusterLabel: fdbv1beta2.FDBClusterLabel,
+							clusterDataMap: map[string]clusterData{
+								clusterName: {
+									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+									},
+									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
+										Storage: 1,
+									},
+								},
+								secondClusterName: {
+									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", secondClusterName)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", secondClusterName)),
+									},
+									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
+										Storage: 1,
+									},
+								},
+							},
+						},
+					),
+				)
 			})
 		})
 	})

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -14,10 +14,14 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var k8sClient *mockclient.MockClient
-var cluster *fdbv1beta2.FoundationDBCluster
-var clusterName = "test"
-var namespace = "test"
+var (
+	k8sClient         *mockclient.MockClient
+	cluster           *fdbv1beta2.FoundationDBCluster
+	secondCluster     *fdbv1beta2.FoundationDBCluster
+	clusterName       = "test"
+	secondClusterName = "test2"
+	namespace         = "test"
+)
 
 // MockVersionChecker will help to mock the calls to GitHub API to get 'latest' version in tests
 type MockVersionChecker struct {


### PR DESCRIPTION
… remove process-groups command

# Description

Addresses https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1537 by allowing the user to specify a cluster-label to grab the cluster-name from.  This does mean that those with non-default-value cluster-labels will not be saving much typing, but this does enable cross-cluster removal of processes.

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

see follow-up

## Testing

I added additional unit tests to verify this change, and tested it on some pods.

## Documentation

*Did you update relevant documentation within this repository?*
I updated the help text, but otherwise did not update other documentation as this is an addition of a cli option.

*If this change is adding new functionality, do we need to describe it in our user manual?*
I do not think so

## Follow-up

For those with non-default cluster labels, perhaps we could consider adding some way to save a default cluster label with kubectl-fdb so that they can avoid typing it in for commands which require it?