### PR TITLE
add ProcessGroupIdPrefix to testing generateClusterStruct and correct test cases

### DIFF
--- a/kubectl-fdb/cmd/buggify_crash_loop_test.go
+++ b/kubectl-fdb/cmd/buggify_crash_loop_test.go
@@ -60,12 +60,12 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 					Entry("Adding single process group.",
 						testCase{
 							ProcessGroups:                    []string{"test-storage-1"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"storage-1"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
 						}),
 					Entry("Adding multiple process groups.",
 						testCase{
 							ProcessGroups:                    []string{"test-storage-1", "test-storage-2"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2"},
 						}),
 				)
 
@@ -75,7 +75,7 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 				BeforeEach(func() {
 					crashLoopContainerObj := fdbv1beta2.CrashLoopContainerObject{
 						ContainerName: fdbv1beta2.MainContainerName,
-						Targets:       []fdbv1beta2.ProcessGroupID{"storage-1"},
+						Targets:       []fdbv1beta2.ProcessGroupID{"test-storage-1"},
 					}
 					cluster.Spec.Buggify.CrashLoopContainers = append(cluster.Spec.Buggify.CrashLoopContainers, crashLoopContainerObj)
 				})
@@ -102,17 +102,17 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 					Entry("Adding same process group.",
 						testCase{
 							ProcessGroups:                    []string{"test-storage-1"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"storage-1"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
 						}),
 					Entry("Adding single but different process group.",
 						testCase{
 							ProcessGroups:                    []string{"test-storage-2"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2"},
 						}),
 					Entry("Adding multiple process groups.",
 						testCase{
 							ProcessGroups:                    []string{"test-storage-1", "test-storage-2", "test-storage-3"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2", "storage-3"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-storage-3"},
 						}),
 				)
 			})
@@ -121,7 +121,7 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 				BeforeEach(func() {
 					crashLoopContainerObj := fdbv1beta2.CrashLoopContainerObject{
 						ContainerName: fdbv1beta2.SidecarContainerName,
-						Targets:       []fdbv1beta2.ProcessGroupID{"storage-1"},
+						Targets:       []fdbv1beta2.ProcessGroupID{"should-be-ignored-storage-1"},
 					}
 					cluster.Spec.Buggify.CrashLoopContainers = append(cluster.Spec.Buggify.CrashLoopContainers, crashLoopContainerObj)
 				})
@@ -148,12 +148,12 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 					Entry("Adding single process group.",
 						testCase{
 							ProcessGroups:                    []string{"test-storage-1"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"storage-1"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
 						}),
 					Entry("Adding multiple process group.",
 						testCase{
 							ProcessGroups:                    []string{"test-storage-1", "test-storage-2", "test-storage-3"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2", "storage-3"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-storage-3"},
 						}),
 				)
 
@@ -169,7 +169,7 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 			BeforeEach(func() {
 				crashLoopContainerObj := fdbv1beta2.CrashLoopContainerObject{
 					ContainerName: fdbv1beta2.MainContainerName,
-					Targets:       []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2", "storage-3"},
+					Targets:       []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-storage-3"},
 				}
 				cluster.Spec.Buggify.CrashLoopContainers = append(cluster.Spec.Buggify.CrashLoopContainers, crashLoopContainerObj)
 			})
@@ -196,12 +196,12 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 				Entry("Removing single process group.",
 					testCase{
 						ProcessGroups:                    []string{"test-storage-1"},
-						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"storage-2", "storage-3"},
+						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-2", "test-storage-3"},
 					}),
 				Entry("Removing multiple process groups.",
 					testCase{
 						ProcessGroups:                    []string{"test-storage-1", "test-storage-2"},
-						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"storage-3"},
+						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-3"},
 					}),
 				Entry("Removing all process groups.",
 					testCase{

--- a/kubectl-fdb/cmd/buggify_no_schedule.go
+++ b/kubectl-fdb/cmd/buggify_no_schedule.go
@@ -126,7 +126,7 @@ func updateNoScheduleList(kubeClient client.Client, clusterName string, pods []s
 	}
 
 	if len(processGroupIDs) == 0 {
-		return fmt.Errorf("please provide atleast one pod")
+		return fmt.Errorf("please provide at least one pod")
 	}
 
 	if wait {

--- a/kubectl-fdb/cmd/buggify_no_schedule_test.go
+++ b/kubectl-fdb/cmd/buggify_no_schedule_test.go
@@ -54,18 +54,18 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 				Entry("Adding single instance.",
 					testCase{
 						Instances:                     []string{"test-storage-1"},
-						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"storage-1"},
+						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
 					}),
 				Entry("Adding multiple instances.",
 					testCase{
 						Instances:                     []string{"test-storage-1", "test-storage-2"},
-						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2"},
+						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2"},
 					}),
 			)
 
 			When("a process group is already in no-schedule", func() {
 				BeforeEach(func() {
-					cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{"storage-1"}
+					cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{"test-storage-1"}
 				})
 
 				type testCase struct {
@@ -90,17 +90,17 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 					Entry("Adding the same instance.",
 						testCase{
 							Instances:                     []string{"test-storage-1"},
-							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"storage-1"},
+							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
 						}),
 					Entry("Adding different instance.",
 						testCase{
 							Instances:                     []string{"test-storage-2"},
-							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2"},
+							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2"},
 						}),
 					Entry("Adding multiple instances.",
 						testCase{
 							Instances:                     []string{"test-storage-2", "test-storage-3"},
-							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2", "storage-3"},
+							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-storage-3"},
 						}),
 				)
 			})
@@ -108,7 +108,7 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 
 		When("removing process group from no-schedule list from a cluster", func() {
 			BeforeEach(func() {
-				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2", "storage-3"}
+				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-storage-3"}
 			})
 
 			type testCase struct {
@@ -133,12 +133,12 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 				Entry("Removing single instance.",
 					testCase{
 						Instances:                     []string{"test-storage-1"},
-						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"storage-2", "storage-3"},
+						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-2", "test-storage-3"},
 					}),
 				Entry("Removing multiple instances.",
 					testCase{
 						Instances:                     []string{"test-storage-2", "test-storage-3"},
-						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"storage-1"},
+						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
 					}),
 			)
 

--- a/kubectl-fdb/cmd/k8s_client_test.go
+++ b/kubectl-fdb/cmd/k8s_client_test.go
@@ -207,6 +207,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 
 	When("getting the process groups IDs from Pods", func() {
 		When("the cluster doesn't have a prefix", func() {
+			BeforeEach(func() {
+				cluster.Spec.ProcessGroupIDPrefix = ""
+			})
 			DescribeTable("should get all process groups IDs",
 				func(podNames []string, expected []fdbv1beta2.ProcessGroupID) {
 					instances, err := getProcessGroupIDsFromPodName(cluster, podNames)

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -33,6 +33,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 	When("running remove process groups command", func() {
 		When("removing process groups from a cluster", func() {
 			BeforeEach(func() {
+				cluster.Spec.ProcessGroupIDPrefix = ""
 				cluster.Status = fdbv1beta2.FoundationDBClusterStatus{
 					ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
 						{

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -66,6 +66,7 @@ func generateClusterStruct(name string, namespace string) *fdbv1beta2.Foundation
 			ProcessCounts: fdbv1beta2.ProcessCounts{
 				Storage: 1,
 			},
+			ProcessGroupIDPrefix: name,
 		},
 		Status: fdbv1beta2.FoundationDBClusterStatus{
 			ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{


### PR DESCRIPTION
# Description

This PR sets `ProcessGroupIdPrefix` to the testing helper function `generateClusterStruct`, which makes it more correct for tests to refer to process group IDs with a <clustername> prefix, as they are doing right now.  This in turn makes test cases more consistent and easier to understand.

## Type of change

*Please select one of the options below.*

- Other: test bug fix?

## Discussion

*Are there any design details that you would like to discuss further?*
Nope!

## Testing

unit-test fix

## Documentation

PR only includes unit test changes, I tried to clarify comments and names as needed

## Follow-up

N/A
