### PR TITLE
Allow the remove sub command to remove by process class

### DIFF
--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -403,7 +403,7 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1
 		confirmed := false
 
 		if len(failedProcessGroups) > 0 {
-			err := replaceProcessGroups(kubeClient, cluster.Name, failedProcessGroups, cluster.Namespace, "", true, wait, false, true)
+			err := replaceProcessGroups(kubeClient, cluster.Name, failedProcessGroups, cluster.Namespace, "", "", true, wait, false, true)
 			if err != nil {
 				return err
 			}

--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -171,7 +171,7 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 					processGroups = append(processGroups, processGroup)
 				}
 			}
-			err = replaceProcessGroups(kubeClient, cluster.Name, processGroups, namespace, "", withExclusion, wait, false, true)
+			err = replaceProcessGroups(kubeClient, cluster.Name, processGroups, namespace, "", "", withExclusion, wait, false, true)
 			if err != nil {
 				internalErr := fmt.Sprintf("unable to cordon all Pods for cluster %s\n", cluster.Name)
 				errors = append(errors, internalErr)

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -230,6 +230,20 @@ func createPods(clusterName string, namespace string) error {
 				NodeName: "node-2",
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-instance-3", clusterName),
+				Namespace: namespace,
+				Labels: map[string]string{
+					fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStateless),
+					fdbv1beta2.FDBClusterLabel:        clusterName,
+					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-instance-3", clusterName),
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "node-3",
+			},
+		},
 	}
 
 	for _, pod := range pods {

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -297,7 +297,7 @@ func getProcessGroupIDsFromPodName(cluster *fdbv1beta2.FoundationDBCluster, podN
 
 // getProcessGroupIdsWithClass returns a list of ProcessGroupIDs in the given cluster which are of the given processClass
 func getProcessGroupIdsWithClass(cluster *fdbv1beta2.FoundationDBCluster, processClass string) []fdbv1beta2.ProcessGroupID {
-	var matchingProcessGroupIDs []fdbv1beta2.ProcessGroupID
+	matchingProcessGroupIDs := []fdbv1beta2.ProcessGroupID{}
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.ProcessClass != fdbv1beta2.ProcessClass(processClass) {
 			continue

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -295,6 +295,18 @@ func getProcessGroupIDsFromPodName(cluster *fdbv1beta2.FoundationDBCluster, podN
 	return processGroupIDs, nil
 }
 
+// getProcessGroupIdsWithClass returns a list of ProcessGroupIDs in the given cluster which are of the given processClass
+func getProcessGroupIdsWithClass(cluster *fdbv1beta2.FoundationDBCluster, processClass string) []fdbv1beta2.ProcessGroupID {
+	var matchingProcessGroupIDs []fdbv1beta2.ProcessGroupID
+	for _, processGroup := range cluster.Status.ProcessGroups {
+		if processGroup.ProcessClass != fdbv1beta2.ProcessClass(processClass) {
+			continue
+		}
+		matchingProcessGroupIDs = append(matchingProcessGroupIDs, processGroup.ProcessGroupID)
+	}
+	return matchingProcessGroupIDs
+}
+
 // fetchProcessGroupsCrossCluster fetches the list of process groups matching the given podNames and returns the
 // processGroupIDs mapped by clusterName matching the given clusterLabel.
 func fetchProcessGroupsCrossCluster(kubeClient client.Client, namespace string, clusterLabel string, podNames ...string) (map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID, error) {

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -35,8 +35,8 @@ func newRemoveProcessGroupCmd(streams genericclioptions.IOStreams) *cobra.Comman
 
 	cmd := &cobra.Command{
 		Use:   "process-groups",
-		Short: "Adds a process group (or multiple) to the remove list of the given cluster",
-		Long:  "Adds a process group (or multiple) to the remove list field of the given cluster",
+		Short: "Adds a process group (or multiple) to the remove list of the given cluster, or matching given pod names",
+		Long:  "Adds a process group (or multiple) to the remove list field of the given cluster, or matching given pod names",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			wait, err := cmd.Root().Flags().GetBool("wait")
 			if err != nil {

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -76,9 +76,15 @@ func generateClusterStruct(name string, namespace string) *fdbv1beta2.Foundation
 			ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
 				{
 					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-instance-1"),
+					ProcessClass:   fdbv1beta2.ProcessClassStorage,
 				},
 				{
 					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-instance-2"),
+					ProcessClass:   fdbv1beta2.ProcessClassStorage,
+				},
+				{
+					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-instance-3"),
+					ProcessClass:   fdbv1beta2.ProcessClassStateless,
 				},
 			},
 		},


### PR DESCRIPTION
# Description

This addresses https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1702

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

Let me know if the error raising is undesirable, also if a struct of common options for these commands might be helpful instead of the long list of parameters/options that includes many naked bools.

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Unit tests are in the PR and I tested it on some actual pods

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*
I do not believe so, no.

## Documentation

*Did you update relevant documentation within this repository?*
I don't think this is needed beyond the docstrings

*If this change is adding new functionality, do we need to describe it in our user manual?*
I do not think so, no

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*
N/A

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*
No

*Does this introduce new defaults that we should re-evaluate in the future?*
No
