### PR TITLE
Improve verbosity of cordon and remove process commands

### DIFF
--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -403,7 +403,14 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1
 		confirmed := false
 
 		if len(failedProcessGroups) > 0 {
-			err := replaceProcessGroups(kubeClient, cluster.Name, failedProcessGroups, cluster.Namespace, "", "", true, wait, false, true)
+			err := replaceProcessGroups(cmd, kubeClient, cluster.Name, failedProcessGroups, cluster.Namespace, replaceProcessGroupsOptions{
+				clusterLabel:      "",
+				processClass:      "",
+				withExclusion:     true,
+				wait:              wait,
+				removeAllFailed:   false,
+				useProcessGroupID: true,
+			})
 			if err != nil {
 				return err
 			}

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -403,7 +403,7 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1
 		confirmed := false
 
 		if len(failedProcessGroups) > 0 {
-			err := replaceProcessGroups(cmd, kubeClient, cluster.Name, failedProcessGroups, cluster.Namespace, replaceProcessGroupsOptions{
+			_, err := replaceProcessGroups(cmd, kubeClient, cluster.Name, failedProcessGroups, cluster.Namespace, replaceProcessGroupsOptions{
 				clusterLabel:      "",
 				processClass:      "",
 				withExclusion:     true,

--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -137,7 +137,7 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 	for _, node := range nodes {
 		pods, err := fetchPodsOnNode(kubeClient, inputClusterName, namespace, node, clusterLabel)
 		if err != nil {
-			return fmt.Errorf("Issue fetching Pods running on node %s. Error: %s\n", node, err)
+			return fmt.Errorf("issue fetching Pods running on node %s. Error: %s", node, err)
 		}
 		var podNames []string
 		for _, pod := range pods.Items {
@@ -154,7 +154,7 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 			useProcessGroupID: false,
 		})
 		if err != nil {
-			return fmt.Errorf("Unable to cordon all Pods running on node %s. Error: %s\n", node, err.Error())
+			return fmt.Errorf("unable to cordon all Pods running on node %s. Error: %s", node, err.Error())
 		}
 		totalRemoved += removedFromNode
 	}

--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -137,7 +137,7 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 	for _, node := range nodes {
 		pods, err := fetchPodsOnNode(kubeClient, inputClusterName, namespace, node, clusterLabel)
 		if err != nil {
-			return fmt.Errorf("issue fetching Pods running on node %s. Error: %s", node, err)
+			return fmt.Errorf("issue fetching Pods running on node %s. Error: %w", node, err)
 		}
 		var podNames []string
 		for _, pod := range pods.Items {

--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -196,21 +196,3 @@ func fetchPodsOnNode(kubeClient client.Client, clusterName string, namespace str
 
 	return pods, nil
 }
-
-func getClusterNames(cmd *cobra.Command, clusterName string, pods corev1.PodList, clusterLabel string) map[string]fdbv1beta2.None {
-	if clusterName != "" {
-		return map[string]fdbv1beta2.None{clusterName: {}}
-	}
-
-	clusterNames := make(map[string]fdbv1beta2.None)
-	for _, pod := range pods.Items {
-		clusterName, ok := pod.Labels[clusterLabel]
-		if !ok {
-			cmd.PrintErrf("could not fetch cluster name from Pod: %s\n", pod.Name)
-			continue
-		}
-		clusterNames[clusterName] = fdbv1beta2.None{}
-	}
-
-	return clusterNames
-}

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -21,7 +21,6 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
@@ -57,12 +56,7 @@ var _ = Describe("[plugin] cordon command", func() {
 
 		DescribeTable("should cordon all targeted processes",
 			func(input testCase) {
-				// We use these buffers to check the input/output
-				outBuffer := bytes.Buffer{}
-				errBuffer := bytes.Buffer{}
-				inBuffer := bytes.Buffer{}
-
-				cmd := newCordonCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer})
+				cmd := newCordonCmd(genericclioptions.IOStreams{})
 				err := cordonNode(cmd, k8sClient, input.clusterName, input.nodes, namespace, input.WithExclusion, false, input.clusterLabel)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -297,7 +297,7 @@ func getProcessGroupIDsFromPodName(cluster *fdbv1beta2.FoundationDBCluster, podN
 
 // getProcessGroupIdsWithClass returns a list of ProcessGroupIDs in the given cluster which are of the given processClass
 func getProcessGroupIdsWithClass(cluster *fdbv1beta2.FoundationDBCluster, processClass string) []fdbv1beta2.ProcessGroupID {
-	var matchingProcessGroupIDs []fdbv1beta2.ProcessGroupID
+	matchingProcessGroupIDs := []fdbv1beta2.ProcessGroupID{}
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.ProcessClass != fdbv1beta2.ProcessClass(processClass) {
 			continue

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -297,7 +297,7 @@ func getProcessGroupIDsFromPodName(cluster *fdbv1beta2.FoundationDBCluster, podN
 
 // getProcessGroupIdsWithClass returns a list of ProcessGroupIDs in the given cluster which are of the given processClass
 func getProcessGroupIdsWithClass(cluster *fdbv1beta2.FoundationDBCluster, processClass string) []fdbv1beta2.ProcessGroupID {
-	matchingProcessGroupIDs := []fdbv1beta2.ProcessGroupID{}
+	var matchingProcessGroupIDs []fdbv1beta2.ProcessGroupID
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.ProcessClass != fdbv1beta2.ProcessClass(processClass) {
 			continue

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -90,23 +90,23 @@ func newRemoveProcessGroupCmd(streams genericclioptions.IOStreams) *cobra.Comman
 		},
 		Example: `
 # Remove process groups for a cluster in the current namespace
-kubectl fdb remove process-group -c cluster pod-1 pod-2
+kubectl fdb remove process-groups -c cluster pod-1 pod-2
 
 # Remove process groups across clusters in the current namespace
-kubectl fdb remove process-group pod-1-cluster-A pod-2-cluster-B -l your-cluster-label
+kubectl fdb remove process-groups pod-1-cluster-A pod-2-cluster-B -l your-cluster-label
 
 # Remove process groups for a cluster in the namespace default
-kubectl fdb -n default remove process-group -c cluster pod-1 pod-2
+kubectl fdb -n default remove process-groups -c cluster pod-1 pod-2
 
 # Remove process groups for a cluster with the process group ID.
 # The process group ID of a Pod can be fetched with "kubectl get po -L foundationdb.org/fdb-process-group-id"
-kubectl fdb -n default remove process-group --use-process-group-id -c cluster storage-1 storage-2
+kubectl fdb -n default remove process-groups --use-process-group-id -c cluster storage-1 storage-2
 
 # Remove all failed process groups for a cluster (all process groups that have a missing process)
-kubectl fdb -n default remove process-group -c cluster --remove-all-failed
+kubectl fdb -n default remove process-groups -c cluster --remove-all-failed
 
 # Remove all processes in the cluster that have the given process-class (incompatible with passing pod names or process group IDs)
-kubectl fdb -n default remove process-group -c cluster --process-class="stateless"
+kubectl fdb -n default remove process-groups -c cluster --process-class="stateless"
 `,
 	}
 

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -27,6 +27,7 @@ import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -62,7 +63,15 @@ var _ = Describe("[plugin] remove process groups command", func() {
 
 			DescribeTable("should cordon all targeted processes",
 				func(tc testCase) {
-					err := replaceProcessGroups(k8sClient, clusterName, tc.Instances, namespace, "", "", tc.WithExclusion, false, tc.RemoveAllFailed, false)
+					cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
+					err := replaceProcessGroups(cmd, k8sClient, clusterName, tc.Instances, namespace, replaceProcessGroupsOptions{
+						clusterLabel:      "",
+						processClass:      "",
+						withExclusion:     tc.WithExclusion,
+						wait:              false,
+						removeAllFailed:   tc.RemoveAllFailed,
+						useProcessGroupID: false,
+					})
 					Expect(err).NotTo(HaveOccurred())
 
 					var resCluster fdbv1beta2.FoundationDBCluster
@@ -119,7 +128,15 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				When("adding the same process group to the removal list without exclusion", func() {
 					It("should add the process group to the removal without exclusion list", func() {
 						removals := []string{"test-storage-1"}
-						err := replaceProcessGroups(k8sClient, clusterName, removals, namespace, "", "", false, false, false, false)
+						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
+						err := replaceProcessGroups(cmd, k8sClient, clusterName, removals, namespace, replaceProcessGroupsOptions{
+							clusterLabel:      "",
+							processClass:      "",
+							withExclusion:     false,
+							wait:              false,
+							removeAllFailed:   false,
+							useProcessGroupID: false,
+						})
 						Expect(err).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster
@@ -139,7 +156,15 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				When("adding the same process group to the removal list", func() {
 					It("should add the process group to the removal without exclusion list", func() {
 						removals := []string{"test-storage-1"}
-						err := replaceProcessGroups(k8sClient, clusterName, removals, namespace, "", "", true, false, false, false)
+						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
+						err := replaceProcessGroups(cmd, k8sClient, clusterName, removals, namespace, replaceProcessGroupsOptions{
+							clusterLabel:      "",
+							processClass:      "",
+							withExclusion:     true,
+							wait:              false,
+							removeAllFailed:   false,
+							useProcessGroupID: false,
+						})
 						Expect(err).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster
@@ -184,7 +209,15 @@ var _ = Describe("[plugin] remove process groups command", func() {
 
 				DescribeTable("should remove specified processes via clusterLabel and podName(s)",
 					func(tc testCase) {
-						err := replaceProcessGroups(k8sClient, tc.clusterNameFilter, tc.podNames, namespace, tc.clusterLabel, "", true, false, false, false)
+						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
+						err := replaceProcessGroups(cmd, k8sClient, tc.clusterNameFilter, tc.podNames, namespace, replaceProcessGroupsOptions{
+							clusterLabel:      tc.clusterLabel,
+							processClass:      "",
+							withExclusion:     true,
+							wait:              false,
+							removeAllFailed:   false,
+							useProcessGroupID: false,
+						})
 						if tc.wantErrorContains != "" {
 							Expect(err).To(Not(BeNil()))
 							Expect(err.Error()).To(ContainSubstring(tc.wantErrorContains))
@@ -350,7 +383,15 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				}
 				DescribeTable("should remove specified processes via clusterLabel and podName(s)",
 					func(tc testCase) {
-						err := replaceProcessGroups(k8sClient, tc.clusterName, tc.ids, namespace, "", tc.processClass, true, false, false, false)
+						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
+						err := replaceProcessGroups(cmd, k8sClient, tc.clusterName, tc.ids, namespace, replaceProcessGroupsOptions{
+							clusterLabel:      "",
+							processClass:      tc.processClass,
+							withExclusion:     true,
+							wait:              false,
+							removeAllFailed:   false,
+							useProcessGroupID: false,
+						})
 						if tc.wantErrorContains != "" {
 							Expect(err).To(Not(BeNil()))
 							Expect(err.Error()).To(ContainSubstring(tc.wantErrorContains))

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -64,7 +64,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 			DescribeTable("should cordon all targeted processes",
 				func(tc testCase) {
 					cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-					err := replaceProcessGroups(cmd, k8sClient, clusterName, tc.Instances, namespace, replaceProcessGroupsOptions{
+					_, err := replaceProcessGroups(cmd, k8sClient, clusterName, tc.Instances, namespace, replaceProcessGroupsOptions{
 						clusterLabel:      "",
 						processClass:      "",
 						withExclusion:     tc.WithExclusion,
@@ -129,7 +129,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					It("should add the process group to the removal without exclusion list", func() {
 						removals := []string{"test-storage-1"}
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-						err := replaceProcessGroups(cmd, k8sClient, clusterName, removals, namespace, replaceProcessGroupsOptions{
+						_, err := replaceProcessGroups(cmd, k8sClient, clusterName, removals, namespace, replaceProcessGroupsOptions{
 							clusterLabel:      "",
 							processClass:      "",
 							withExclusion:     false,
@@ -157,7 +157,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					It("should add the process group to the removal without exclusion list", func() {
 						removals := []string{"test-storage-1"}
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-						err := replaceProcessGroups(cmd, k8sClient, clusterName, removals, namespace, replaceProcessGroupsOptions{
+						_, err := replaceProcessGroups(cmd, k8sClient, clusterName, removals, namespace, replaceProcessGroupsOptions{
 							clusterLabel:      "",
 							processClass:      "",
 							withExclusion:     true,
@@ -210,7 +210,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				DescribeTable("should remove specified processes via clusterLabel and podName(s)",
 					func(tc testCase) {
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-						err := replaceProcessGroups(cmd, k8sClient, tc.clusterNameFilter, tc.podNames, namespace, replaceProcessGroupsOptions{
+						_, err := replaceProcessGroups(cmd, k8sClient, tc.clusterNameFilter, tc.podNames, namespace, replaceProcessGroupsOptions{
 							clusterLabel:      tc.clusterLabel,
 							processClass:      "",
 							withExclusion:     true,
@@ -384,7 +384,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				DescribeTable("should remove specified processes via clusterLabel and podName(s)",
 					func(tc testCase) {
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-						err := replaceProcessGroups(cmd, k8sClient, tc.clusterName, tc.ids, namespace, replaceProcessGroupsOptions{
+						_, err := replaceProcessGroups(cmd, k8sClient, tc.clusterName, tc.ids, namespace, replaceProcessGroupsOptions{
 							clusterLabel:      "",
 							processClass:      tc.processClass,
 							withExclusion:     true,


### PR DESCRIPTION
# Description

This improves the verbosity of the cordon and remove process commands. It should address https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1602 (if not exactly as described)

Example output for cordon (no wait):
```
Starting to cordon 2 nodes

Cordoning node: node-1
Cluster test/test2:
removed [test2-instance-1] (exclude: false)
Cluster test/test:
removed [test-instance-1] (exclude: false)

Cordoning node: node-2
Cluster test/test2:
removed [test2-instance-2] (exclude: false)
Cluster test/test:
removed [test-instance-2] (exclude: false)

Completed removal of 4 Pods
```

Example output for remove process-groups by cluster-label (with wait)
```
Remove [test-instance-1] from cluster test with exclude: true [y/n]: y
Cluster test:
removed [test-instance-1] (exclude: true)

Completed removal of 1 processGroups
```

## Type of change

- New feature (non-breaking change which adds functionality)
- Cleanup

## Discussion

Error immediately or collate?

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*
No new tests, should be covered by old unit tests.  Verified with test output and on kubernetes.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*
No

## Documentation

N/A

## Follow-up

N/A
