### PR TITLE
Create a unified process selection function and use it in removeProcessGroups

### DIFF
--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -403,14 +403,20 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1
 		confirmed := false
 
 		if len(failedProcessGroups) > 0 {
-			_, err := replaceProcessGroups(cmd, kubeClient, cluster.Name, failedProcessGroups, cluster.Namespace, replaceProcessGroupsOptions{
-				clusterLabel:      "",
-				processClass:      "",
-				withExclusion:     true,
-				wait:              wait,
-				removeAllFailed:   false,
-				useProcessGroupID: true,
-			})
+			_, err := replaceProcessGroups(cmd, kubeClient,
+				processSelectionOptions{
+					ids:               failedProcessGroups,
+					namespace:         cluster.Namespace,
+					clusterName:       cluster.Name,
+					clusterLabel:      "",
+					processClass:      "",
+					useProcessGroupID: true,
+				},
+				replaceProcessGroupsOptions{
+					withExclusion:   true,
+					wait:            wait,
+					removeAllFailed: false,
+				})
 			if err != nil {
 				return err
 			}

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -404,7 +404,7 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1
 
 		if len(failedProcessGroups) > 0 {
 			_, err := replaceProcessGroups(cmd, kubeClient,
-				processSelectionOptions{
+				processGroupSelectionOptions{
 					ids:               failedProcessGroups,
 					namespace:         cluster.Namespace,
 					clusterName:       cluster.Name,

--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -145,14 +145,20 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 		}
 
 		cmd.Printf("\nCordoning node: %s\n", node)
-		removedFromNode, err := replaceProcessGroups(cmd, kubeClient, inputClusterName, podNames, namespace, replaceProcessGroupsOptions{
-			clusterLabel:      clusterLabel,
-			processClass:      "",
-			withExclusion:     withExclusion,
-			wait:              wait,
-			removeAllFailed:   false,
-			useProcessGroupID: false,
-		})
+		removedFromNode, err := replaceProcessGroups(cmd, kubeClient,
+			processSelectionOptions{
+				ids:               podNames,
+				namespace:         namespace,
+				clusterName:       inputClusterName,
+				clusterLabel:      clusterLabel,
+				processClass:      "",
+				useProcessGroupID: false,
+			},
+			replaceProcessGroupsOptions{
+				withExclusion:   withExclusion,
+				wait:            wait,
+				removeAllFailed: false,
+			})
 		if err != nil {
 			return fmt.Errorf("unable to cordon all Pods running on node %s. Error: %s", node, err.Error())
 		}

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -42,6 +42,7 @@ var _ = Describe("[plugin] cordon command", func() {
 			ExpectedInstancesToRemoveWithoutExclusion []fdbv1beta2.ProcessGroupID
 			clusterName                               string
 			clusterLabel                              string
+			wantErrorContains                         string
 		}
 
 		BeforeEach(func() {
@@ -58,7 +59,12 @@ var _ = Describe("[plugin] cordon command", func() {
 			func(input testCase) {
 				cmd := newCordonCmd(genericclioptions.IOStreams{})
 				err := cordonNode(cmd, k8sClient, input.clusterName, input.nodes, namespace, input.WithExclusion, false, input.clusterLabel)
-				Expect(err).NotTo(HaveOccurred())
+				if input.wantErrorContains != "" {
+					Expect(err).To(Not(BeNil()))
+					Expect(err.Error()).To(ContainSubstring(input.wantErrorContains))
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
 
 				clusterNames := []string{clusterName, secondClusterName}
 				var instancesToRemove []fdbv1beta2.ProcessGroupID
@@ -101,8 +107,9 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             true,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
-					clusterName:  clusterName,
-					clusterLabel: "",
+					clusterName:       clusterName,
+					clusterLabel:      "",
+					wantErrorContains: "no processGroups could be selected with the provided options",
 				}),
 			Entry("Cordon no node nodes without exclusion",
 				testCase{
@@ -110,8 +117,9 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
-					clusterName:  clusterName,
-					clusterLabel: "",
+					clusterName:       clusterName,
+					clusterLabel:      "",
+					wantErrorContains: "no processGroups could be selected with the provided options",
 				}),
 			Entry("Cordon all nodes with exclusion",
 				testCase{
@@ -187,8 +195,9 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
-					clusterName:  "",
-					clusterLabel: fdbv1beta2.FDBClusterLabel,
+					clusterName:       "",
+					clusterLabel:      fdbv1beta2.FDBClusterLabel,
+					wantErrorContains: "no processGroups could be selected with the provided options",
 				}),
 		)
 	})

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -79,7 +79,7 @@ func newRemoveProcessGroupCmd(streams genericclioptions.IOStreams) *cobra.Comman
 			}
 
 			totalRemoved, err := replaceProcessGroups(cmd, kubeClient,
-				processSelectionOptions{
+				processGroupSelectionOptions{
 					ids:               args,
 					namespace:         namespace,
 					clusterName:       cluster,
@@ -144,25 +144,25 @@ type replaceProcessGroupsOptions struct {
 // If clusterName is specified, it will ONLY do so for the specified cluster.
 // If processClass is specified, it will ignore the given ids and remove all processes in the given cluster whose pods
 // have a processClassLabel matching the processClass.
-func replaceProcessGroups(cmd *cobra.Command, kubeClient client.Client, pgSelectOpts processSelectionOptions, opts replaceProcessGroupsOptions) (int, error) {
-	if len(pgSelectOpts.ids) == 0 && !opts.removeAllFailed && pgSelectOpts.processClass == "" {
+func replaceProcessGroups(cmd *cobra.Command, kubeClient client.Client, processGroupOpts processGroupSelectionOptions, opts replaceProcessGroupsOptions) (int, error) {
+	if len(processGroupOpts.ids) == 0 && !opts.removeAllFailed && processGroupOpts.processClass == "" {
 		return 0, errors.New("no processGroups could be selected with the provided options")
 	}
 
-	pgsByCluster, err := getProcessGroupsByCluster(kubeClient, pgSelectOpts)
+	processGroupsByCluster, err := getProcessGroupsByCluster(kubeClient, processGroupOpts)
 	if err != nil {
 		return 0, err
 	}
 
-	return replaceProcessGroupsFromCluster(cmd, kubeClient, pgsByCluster, pgSelectOpts.namespace, opts)
+	return replaceProcessGroupsFromCluster(cmd, kubeClient, processGroupsByCluster, processGroupOpts.namespace, opts)
 }
 
 // replaceProcessGroupsFromCluster removes the process groups ONLY from the specified cluster.
 // It also returns the list of processGroupIDs that it removed from the cluster.
-func replaceProcessGroupsFromCluster(cmd *cobra.Command, kubeClient client.Client, pgsByCluster map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID,
+func replaceProcessGroupsFromCluster(cmd *cobra.Command, kubeClient client.Client, processGroupsByCluster map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID,
 	namespace string, opts replaceProcessGroupsOptions) (int, error) {
 	totalRemoved := 0
-	for cluster, processGroupIDs := range pgsByCluster {
+	for cluster, processGroupIDs := range processGroupsByCluster {
 		cmd.Printf("Cluster %v/%v:\n", namespace, cluster.Name)
 		patch := client.MergeFrom(cluster.DeepCopy())
 

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -22,10 +22,11 @@ package cmd
 
 import (
 	ctx "context"
+	"errors"
 	"fmt"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/spf13/cobra"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -77,14 +78,20 @@ func newRemoveProcessGroupCmd(streams genericclioptions.IOStreams) *cobra.Comman
 				return err
 			}
 
-			totalRemoved, err := replaceProcessGroups(cmd, kubeClient, cluster, args, namespace, replaceProcessGroupsOptions{
-				clusterLabel:      clusterLabel,
-				processClass:      processClass,
-				withExclusion:     withExclusion,
-				wait:              wait,
-				removeAllFailed:   removeAllFailed,
-				useProcessGroupID: useProcessGroupID,
-			})
+			totalRemoved, err := replaceProcessGroups(cmd, kubeClient,
+				processSelectionOptions{
+					ids:               args,
+					namespace:         namespace,
+					clusterName:       cluster,
+					clusterLabel:      clusterLabel,
+					processClass:      processClass,
+					useProcessGroupID: useProcessGroupID,
+				},
+				replaceProcessGroupsOptions{
+					withExclusion:   withExclusion,
+					wait:            wait,
+					removeAllFailed: removeAllFailed,
+				})
 			cmd.Printf("\nCompleted removal of %d processGroups\n", totalRemoved)
 			return err
 		},
@@ -127,12 +134,9 @@ kubectl fdb -n default remove process-groups -c cluster --process-class="statele
 }
 
 type replaceProcessGroupsOptions struct {
-	clusterLabel      string
-	processClass      string
-	withExclusion     bool
-	wait              bool
-	removeAllFailed   bool
-	useProcessGroupID bool
+	withExclusion   bool
+	wait            bool
+	removeAllFailed bool
 }
 
 // replaceProcessGroups adds process groups to the removal list of their respective clusters, and returns a count of
@@ -140,105 +144,68 @@ type replaceProcessGroupsOptions struct {
 // If clusterName is specified, it will ONLY do so for the specified cluster.
 // If processClass is specified, it will ignore the given ids and remove all processes in the given cluster whose pods
 // have a processClassLabel matching the processClass.
-func replaceProcessGroups(cmd *cobra.Command, kubeClient client.Client, clusterName string, ids []string, namespace string, opts replaceProcessGroupsOptions) (int, error) {
-	if len(ids) == 0 && !opts.removeAllFailed && opts.processClass == "" {
-		return 0, nil
+func replaceProcessGroups(cmd *cobra.Command, kubeClient client.Client, pgSelectOpts processSelectionOptions, opts replaceProcessGroupsOptions) (int, error) {
+	if len(pgSelectOpts.ids) == 0 && !opts.removeAllFailed && pgSelectOpts.processClass == "" {
+		return 0, errors.New("no processGroups could be selected with the provided options")
 	}
 
-	// cross-cluster logic: given a list of Pod names, we can look up the FDB clusters by pod label, and work across clusters
-	if !opts.useProcessGroupID && clusterName == "" {
-		pgsByCluster, err := fetchProcessGroupsCrossCluster(kubeClient, namespace, opts.clusterLabel, ids...)
-		if err != nil {
-			return 0, err
-		}
-		totalRemoved := 0
-		for cluster, pgs := range pgsByCluster {
-			err := replaceProcessGroupsFromCluster(kubeClient, cluster, pgs, namespace, opts.withExclusion, opts.wait, opts.removeAllFailed)
-			if err != nil {
-				return 0, err
-			}
-			totalRemoved += len(pgs)
-			cmd.Printf("Cluster %v/%v:\n", namespace, cluster.Name)
-			cmd.Printf("removed %v (exclude: %t)\n", pgs, opts.withExclusion)
-		}
-		return totalRemoved, nil
-	}
-
-	// single-cluster logic
-	cluster, err := loadCluster(kubeClient, namespace, clusterName)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return 0, fmt.Errorf("could not get cluster: %s/%s", namespace, clusterName)
-		}
-		return 0, err
-	}
-
-	var processGroupIDs []fdbv1beta2.ProcessGroupID
-	if opts.processClass != "" { // match against a whole process class, ignore provided ids
-		if len(ids) != 0 {
-			return 0, fmt.Errorf("process identifiers were provided along with a processClass and would be ignored, please only provide one or the other")
-		}
-		processGroupIDs = getProcessGroupIdsWithClass(cluster, opts.processClass)
-		if len(processGroupIDs) == 0 {
-			return 0, fmt.Errorf("found no processGroups of processClass '%s' in cluster %s", opts.processClass, clusterName)
-		}
-	} else if !opts.useProcessGroupID { // match by pod name
-		processGroupIDs, err = getProcessGroupIDsFromPodName(cluster, ids)
-		if err != nil {
-			return 0, err
-		}
-	} else { // match by process group ID
-		for _, id := range ids {
-			processGroupIDs = append(processGroupIDs, fdbv1beta2.ProcessGroupID(id))
-		}
-	}
-	err = replaceProcessGroupsFromCluster(kubeClient, cluster, processGroupIDs, namespace, opts.withExclusion, opts.wait, opts.removeAllFailed)
+	pgsByCluster, err := getProcessGroupsByCluster(kubeClient, pgSelectOpts)
 	if err != nil {
 		return 0, err
 	}
-	cmd.Printf("Cluster %v/%v:\n", namespace, clusterName)
-	cmd.Printf("removed %v (exclude: %t)\n", processGroupIDs, opts.withExclusion)
-	return len(processGroupIDs), nil
+
+	return replaceProcessGroupsFromCluster(cmd, kubeClient, pgsByCluster, pgSelectOpts.namespace, opts)
 }
 
 // replaceProcessGroupsFromCluster removes the process groups ONLY from the specified cluster.
 // It also returns the list of processGroupIDs that it removed from the cluster.
-func replaceProcessGroupsFromCluster(kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluster, processGroupIDs []fdbv1beta2.ProcessGroupID, namespace string, withExclusion bool, wait bool, removeAllFailed bool) error {
-	patch := client.MergeFrom(cluster.DeepCopy())
+func replaceProcessGroupsFromCluster(cmd *cobra.Command, kubeClient client.Client, pgsByCluster map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID,
+	namespace string, opts replaceProcessGroupsOptions) (int, error) {
+	totalRemoved := 0
+	for cluster, processGroupIDs := range pgsByCluster {
+		cmd.Printf("Cluster %v/%v:\n", namespace, cluster.Name)
+		patch := client.MergeFrom(cluster.DeepCopy())
 
-	processGroupSet := map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None{}
-	for _, processGroup := range processGroupIDs {
-		processGroupSet[processGroup] = fdbv1beta2.None{}
-	}
+		processGroupSet := map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None{}
+		for _, processGroup := range processGroupIDs {
+			processGroupSet[processGroup] = fdbv1beta2.None{}
+		}
 
-	if removeAllFailed {
-		for _, processGroupStatus := range cluster.Status.ProcessGroups {
-			// Those are already included so we can skip the check and don't add duplicates
-			if _, ok := processGroupSet[processGroupStatus.ProcessGroupID]; ok {
-				continue
-			}
+		if opts.removeAllFailed {
+			for _, processGroupStatus := range cluster.Status.ProcessGroups {
+				// Those are already included so we can skip the check and don't add duplicates
+				if _, ok := processGroupSet[processGroupStatus.ProcessGroupID]; ok {
+					continue
+				}
 
-			_, failureTime := processGroupStatus.NeedsReplacement(0, 0)
-			if failureTime > 0 {
-				processGroupIDs = append(processGroupIDs, processGroupStatus.ProcessGroupID)
+				_, failureTime := processGroupStatus.NeedsReplacement(0, 0)
+				if failureTime > 0 {
+					processGroupIDs = append(processGroupIDs, processGroupStatus.ProcessGroupID)
+				}
 			}
 		}
-	}
 
-	if wait {
-		if !confirmAction(fmt.Sprintf("Remove %v from cluster %s/%s with exclude: %t", processGroupIDs, namespace, cluster.Name, withExclusion)) {
-			return fmt.Errorf("user aborted the removal")
+		if opts.wait {
+			if !confirmAction(fmt.Sprintf("Remove %v from cluster %s/%s with exclude: %t", processGroupIDs, namespace, cluster.Name, opts.withExclusion)) {
+				return totalRemoved, fmt.Errorf("user aborted the removal")
+			}
 		}
-	}
 
-	var processGroupIDsForRemoval []fdbv1beta2.ProcessGroupID
-	if withExclusion {
-		processGroupIDsForRemoval = cluster.GetProcessGroupsToRemove(processGroupIDs)
-		cluster.Spec.ProcessGroupsToRemove = processGroupIDsForRemoval
-	} else {
-		processGroupIDsForRemoval = cluster.GetProcessGroupsToRemoveWithoutExclusion(processGroupIDs)
-		cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = processGroupIDsForRemoval
-	}
+		var processGroupIDsForRemoval []fdbv1beta2.ProcessGroupID
+		if opts.withExclusion {
+			processGroupIDsForRemoval = cluster.GetProcessGroupsToRemove(processGroupIDs)
+			cluster.Spec.ProcessGroupsToRemove = processGroupIDsForRemoval
+		} else {
+			processGroupIDsForRemoval = cluster.GetProcessGroupsToRemoveWithoutExclusion(processGroupIDs)
+			cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = processGroupIDsForRemoval
+		}
 
-	return kubeClient.Patch(ctx.TODO(), cluster, patch)
+		err := kubeClient.Patch(ctx.TODO(), cluster, patch)
+		if err != nil {
+			return totalRemoved, err
+		}
+		totalRemoved += len(processGroupIDs)
+		cmd.Printf("removed %v (exclude: %t)\n", processGroupIDs, opts.withExclusion)
+	}
+	return totalRemoved, nil
 }

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -65,7 +65,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				func(tc testCase) {
 					cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
 					_, err := replaceProcessGroups(cmd, k8sClient,
-						processSelectionOptions{
+						processGroupSelectionOptions{
 							ids:               tc.Instances,
 							namespace:         namespace,
 							clusterName:       clusterName,
@@ -136,7 +136,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 						removals := []string{"test-storage-1"}
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
 						_, err := replaceProcessGroups(cmd, k8sClient,
-							processSelectionOptions{
+							processGroupSelectionOptions{
 								ids:               removals,
 								namespace:         namespace,
 								clusterName:       clusterName,
@@ -170,7 +170,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 						removals := []string{"test-storage-1"}
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
 						_, err := replaceProcessGroups(cmd, k8sClient,
-							processSelectionOptions{
+							processGroupSelectionOptions{
 								ids:               removals,
 								namespace:         namespace,
 								clusterName:       clusterName,
@@ -229,7 +229,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					func(tc testCase) {
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
 						_, err := replaceProcessGroups(cmd, k8sClient,
-							processSelectionOptions{
+							processGroupSelectionOptions{
 								ids:               tc.podNames,
 								namespace:         namespace,
 								clusterName:       tc.clusterNameFilter,
@@ -409,7 +409,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					func(tc testCase) {
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
 						_, err := replaceProcessGroups(cmd, k8sClient,
-							processSelectionOptions{
+							processGroupSelectionOptions{
 								ids:               tc.ids,
 								namespace:         namespace,
 								clusterName:       clusterName,

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -64,14 +64,20 @@ var _ = Describe("[plugin] remove process groups command", func() {
 			DescribeTable("should cordon all targeted processes",
 				func(tc testCase) {
 					cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-					_, err := replaceProcessGroups(cmd, k8sClient, clusterName, tc.Instances, namespace, replaceProcessGroupsOptions{
-						clusterLabel:      "",
-						processClass:      "",
-						withExclusion:     tc.WithExclusion,
-						wait:              false,
-						removeAllFailed:   tc.RemoveAllFailed,
-						useProcessGroupID: false,
-					})
+					_, err := replaceProcessGroups(cmd, k8sClient,
+						processSelectionOptions{
+							ids:               tc.Instances,
+							namespace:         namespace,
+							clusterName:       clusterName,
+							clusterLabel:      "",
+							processClass:      "",
+							useProcessGroupID: false,
+						},
+						replaceProcessGroupsOptions{
+							withExclusion:   tc.WithExclusion,
+							wait:            false,
+							removeAllFailed: tc.RemoveAllFailed,
+						})
 					Expect(err).NotTo(HaveOccurred())
 
 					var resCluster fdbv1beta2.FoundationDBCluster
@@ -129,14 +135,20 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					It("should add the process group to the removal without exclusion list", func() {
 						removals := []string{"test-storage-1"}
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-						_, err := replaceProcessGroups(cmd, k8sClient, clusterName, removals, namespace, replaceProcessGroupsOptions{
-							clusterLabel:      "",
-							processClass:      "",
-							withExclusion:     false,
-							wait:              false,
-							removeAllFailed:   false,
-							useProcessGroupID: false,
-						})
+						_, err := replaceProcessGroups(cmd, k8sClient,
+							processSelectionOptions{
+								ids:               removals,
+								namespace:         namespace,
+								clusterName:       clusterName,
+								clusterLabel:      "",
+								processClass:      "",
+								useProcessGroupID: false,
+							},
+							replaceProcessGroupsOptions{
+								withExclusion:   false,
+								wait:            false,
+								removeAllFailed: false,
+							})
 						Expect(err).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster
@@ -157,14 +169,20 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					It("should add the process group to the removal without exclusion list", func() {
 						removals := []string{"test-storage-1"}
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-						_, err := replaceProcessGroups(cmd, k8sClient, clusterName, removals, namespace, replaceProcessGroupsOptions{
-							clusterLabel:      "",
-							processClass:      "",
-							withExclusion:     true,
-							wait:              false,
-							removeAllFailed:   false,
-							useProcessGroupID: false,
-						})
+						_, err := replaceProcessGroups(cmd, k8sClient,
+							processSelectionOptions{
+								ids:               removals,
+								namespace:         namespace,
+								clusterName:       clusterName,
+								clusterLabel:      "",
+								processClass:      "",
+								useProcessGroupID: false,
+							},
+							replaceProcessGroupsOptions{
+								withExclusion:   true,
+								wait:            false,
+								removeAllFailed: false,
+							})
 						Expect(err).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster
@@ -210,14 +228,20 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				DescribeTable("should remove specified processes via clusterLabel and podName(s)",
 					func(tc testCase) {
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-						_, err := replaceProcessGroups(cmd, k8sClient, tc.clusterNameFilter, tc.podNames, namespace, replaceProcessGroupsOptions{
-							clusterLabel:      tc.clusterLabel,
-							processClass:      "",
-							withExclusion:     true,
-							wait:              false,
-							removeAllFailed:   false,
-							useProcessGroupID: false,
-						})
+						_, err := replaceProcessGroups(cmd, k8sClient,
+							processSelectionOptions{
+								ids:               tc.podNames,
+								namespace:         namespace,
+								clusterName:       tc.clusterNameFilter,
+								clusterLabel:      tc.clusterLabel,
+								processClass:      "",
+								useProcessGroupID: false,
+							},
+							replaceProcessGroupsOptions{
+								withExclusion:   true,
+								wait:            false,
+								removeAllFailed: false,
+							})
 						if tc.wantErrorContains != "" {
 							Expect(err).To(Not(BeNil()))
 							Expect(err.Error()).To(ContainSubstring(tc.wantErrorContains))
@@ -384,14 +408,20 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				DescribeTable("should remove specified processes via clusterLabel and podName(s)",
 					func(tc testCase) {
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-						_, err := replaceProcessGroups(cmd, k8sClient, tc.clusterName, tc.ids, namespace, replaceProcessGroupsOptions{
-							clusterLabel:      "",
-							processClass:      tc.processClass,
-							withExclusion:     true,
-							wait:              false,
-							removeAllFailed:   false,
-							useProcessGroupID: false,
-						})
+						_, err := replaceProcessGroups(cmd, k8sClient,
+							processSelectionOptions{
+								ids:               tc.ids,
+								namespace:         namespace,
+								clusterName:       clusterName,
+								clusterLabel:      "",
+								processClass:      tc.processClass,
+								useProcessGroupID: false,
+							},
+							replaceProcessGroupsOptions{
+								withExclusion:   true,
+								wait:            false,
+								removeAllFailed: false,
+							})
 						if tc.wantErrorContains != "" {
 							Expect(err).To(Not(BeNil()))
 							Expect(err.Error()).To(ContainSubstring(tc.wantErrorContains))

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -22,20 +22,21 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
 	"os"
+	"strings"
 	"time"
 
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/fatih/color"
-
-	"strings"
-
-	"github.com/spf13/viper"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // fdbBOptions provides information required to run different
@@ -174,4 +175,59 @@ func usingLatestPluginVersion(cmd *cobra.Command, pluginVersionChecker VersionCh
 	}
 
 	return nil
+}
+
+type processSelectionOptions struct {
+	ids               []string
+	namespace         string
+	clusterName       string
+	clusterLabel      string
+	processClass      string
+	useProcessGroupID bool
+}
+
+// getProcessGroupsByCluster returns a map of processGroupIDs by FDB cluster that match the criteria in the provided
+// processSelectionOptions.
+func getProcessGroupsByCluster(kubeClient client.Client, opts processSelectionOptions) (map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID, error) {
+	if opts.clusterName == "" && opts.clusterLabel == "" {
+		return nil, errors.New("processGroups will not be selected without cluster specification")
+	}
+
+	// cross-cluster logic: given a list of Pod names, we can look up the FDB clusters by pod label, and work across clusters
+	if !opts.useProcessGroupID && opts.clusterName == "" {
+		return fetchProcessGroupsCrossCluster(kubeClient, opts.namespace, opts.clusterLabel, opts.ids...)
+	}
+
+	// single-cluster logic
+	cluster, err := loadCluster(kubeClient, opts.namespace, opts.clusterName)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("could not get cluster: %s/%s", opts.namespace, opts.clusterName)
+		}
+		return nil, err
+	}
+	// find the desired process groups in the single cluster
+	var processGroupIDs []fdbv1beta2.ProcessGroupID
+	if opts.processClass != "" { // match against a whole process class, ignore provided ids
+		if len(opts.ids) != 0 {
+			return nil, fmt.Errorf("process identifiers were provided along with a processClass and would be ignored, please only provide one or the other")
+		}
+		processGroupIDs = getProcessGroupIdsWithClass(cluster, opts.processClass)
+		if len(processGroupIDs) == 0 {
+			return nil, fmt.Errorf("found no processGroups of processClass '%s' in cluster %s", opts.processClass, opts.clusterName)
+		}
+	} else if !opts.useProcessGroupID { // match by pod name
+		processGroupIDs, err = getProcessGroupIDsFromPodName(cluster, opts.ids)
+		if err != nil {
+			return nil, err
+		}
+	} else { // match by process group ID
+		for _, id := range opts.ids {
+			processGroupIDs = append(processGroupIDs, fdbv1beta2.ProcessGroupID(id))
+		}
+	}
+
+	return map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID{
+		cluster: processGroupIDs,
+	}, nil
 }

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -30,13 +29,10 @@ import (
 	"strings"
 	"time"
 
-	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // fdbBOptions provides information required to run different
@@ -177,7 +173,7 @@ func usingLatestPluginVersion(cmd *cobra.Command, pluginVersionChecker VersionCh
 	return nil
 }
 
-type processSelectionOptions struct {
+type processGroupSelectionOptions struct {
 	ids               []string
 	namespace         string
 	clusterName       string
@@ -186,48 +182,4 @@ type processSelectionOptions struct {
 	useProcessGroupID bool
 }
 
-// getProcessGroupsByCluster returns a map of processGroupIDs by FDB cluster that match the criteria in the provided
-// processSelectionOptions.
-func getProcessGroupsByCluster(kubeClient client.Client, opts processSelectionOptions) (map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID, error) {
-	if opts.clusterName == "" && opts.clusterLabel == "" {
-		return nil, errors.New("processGroups will not be selected without cluster specification")
-	}
-
-	// cross-cluster logic: given a list of Pod names, we can look up the FDB clusters by pod label, and work across clusters
-	if !opts.useProcessGroupID && opts.clusterName == "" {
-		return fetchProcessGroupsCrossCluster(kubeClient, opts.namespace, opts.clusterLabel, opts.ids...)
-	}
-
-	// single-cluster logic
-	cluster, err := loadCluster(kubeClient, opts.namespace, opts.clusterName)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil, fmt.Errorf("could not get cluster: %s/%s", opts.namespace, opts.clusterName)
-		}
-		return nil, err
-	}
-	// find the desired process groups in the single cluster
-	var processGroupIDs []fdbv1beta2.ProcessGroupID
-	if opts.processClass != "" { // match against a whole process class, ignore provided ids
-		if len(opts.ids) != 0 {
-			return nil, fmt.Errorf("process identifiers were provided along with a processClass and would be ignored, please only provide one or the other")
-		}
-		processGroupIDs = getProcessGroupIdsWithClass(cluster, opts.processClass)
-		if len(processGroupIDs) == 0 {
-			return nil, fmt.Errorf("found no processGroups of processClass '%s' in cluster %s", opts.processClass, opts.clusterName)
-		}
-	} else if !opts.useProcessGroupID { // match by pod name
-		processGroupIDs, err = getProcessGroupIDsFromPodName(cluster, opts.ids)
-		if err != nil {
-			return nil, err
-		}
-	} else { // match by process group ID
-		for _, id := range opts.ids {
-			processGroupIDs = append(processGroupIDs, fdbv1beta2.ProcessGroupID(id))
-		}
-	}
-
-	return map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID{
-		cluster: processGroupIDs,
-	}, nil
-}
+// TODO add common set of flags which accompany processGroupSelectionOptions https://github.com/FoundationDB/fdb-kubernetes-operator/issues/615


### PR DESCRIPTION
# Description

work towards https://github.com/FoundationDB/fdb-kubernetes-operator/issues/615 by creating a function which returns a map of processGroupIDs by FDB cluster based on process selection options.  
This PR only refactors removeProcessGroup's logic, but subsequent PRs will unify `buggify no-schedule`, `buggify crash-loop` and `restart` commands with the same selection function as well.  In order to meet feature-parity with `restart`, the selection function must have the ability to select by processGroup Condition, and thus will address https://github.com/FoundationDB/fdb-kubernetes-operator/issues/614 in a separate followup PR.

## Type of change

*Please select one of the options below.*

- Cleanup / Tech debt / New Feature

## Discussion

*Are there any design details that you would like to discuss further?*
No

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*
Minor unit test changes, but this is mostly refactoring and is passively covered by existing tests

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*
No

## Documentation

Not needed beyond docstring updates

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*
This does not solve https://github.com/FoundationDB/fdb-kubernetes-operator/issues/615 quite yet, but more PRs will follow.

*Does this introduce new defaults that we should re-evaluate in the future?*
No
