### PR TITLE
Don't skip the exclusion for process groups without an address when using localities

### DIFF
--- a/internal/replacements/replace_failed_process_groups.go
+++ b/internal/replacements/replace_failed_process_groups.go
@@ -93,8 +93,10 @@ func ReplaceFailedProcessGroups(log logr.Logger, cluster *fdbv1beta2.FoundationD
 		}
 
 		skipExclusion := false
-		// Only if localities are not used for exclusions we want to skip the exclusion. Skipping the exclusion could
-		// lead to a race condition, see: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1890
+		// Only if localities are not used for exclusions we should be skipping the exclusion.
+		// Skipping the exclusion could lead to a race condition, which can be prevented if
+		// we are able to exclude by locality.
+		// see: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1890
 		if len(processGroupStatus.Addresses) == 0 && !localitiesUsedForExclusion {
 			if !hasDesiredFaultTolerance {
 				log.Info(


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1890

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Added an additional test and CI will run e2e tests.

## Documentation

-

## Follow-up

-
