### PR TITLE
Add condition selection option to common processGroup selection function

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -964,10 +964,14 @@ func GetProcessGroupConditionType(processGroupConditionType string) (ProcessGrou
 		return MissingService, nil
 	case "MissingProcesses":
 		return MissingProcesses, nil
+	case "ResourcesTerminating":
+		return ResourcesTerminating, nil
 	case "SidecarUnreachable":
 		return SidecarUnreachable, nil
 	case "PodPending":
 		return PodPending, nil
+	case "Ready":
+		return ReadyCondition, nil
 	case "NodeTaintDetected":
 		return NodeTaintDetected, nil
 	case "NodeTaintReplacing":

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -400,7 +400,7 @@ func getProcessGroupsByCluster(cmd *cobra.Command, kubeClient client.Client, opt
 	if opts.clusterName == "" && opts.clusterLabel == "" {
 		return nil, errors.New("processGroups will not be selected without cluster specification")
 	}
-	if opts.clusterName == "" { // cli has a valid default for clusterLabel
+	if opts.clusterName == "" { // cli has a default for clusterLabel
 		if opts.useProcessGroupID || opts.processClass != "" || len(opts.conditions) > 0 {
 			return nil, errors.New("selection of process groups by cluster-label (cross-cluster selection) is " +
 				"incompatible with use-process-group-id, process-class, and process-condition options")

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -400,7 +400,7 @@ func getProcessGroupsByCluster(cmd *cobra.Command, kubeClient client.Client, opt
 	if opts.clusterName == "" && opts.clusterLabel == "" {
 		return nil, errors.New("processGroups will not be selected without cluster specification")
 	}
-	if opts.clusterLabel != "" {
+	if opts.clusterName == "" { // cli has a valid default for clusterLabel
 		if opts.useProcessGroupID || opts.processClass != "" || len(opts.conditions) > 0 {
 			return nil, errors.New("selection of process groups by cluster-label (cross-cluster selection) is " +
 				"incompatible with use-process-group-id, process-class, and process-condition options")

--- a/kubectl-fdb/cmd/restart.go
+++ b/kubectl-fdb/cmd/restart.go
@@ -129,10 +129,8 @@ kubectl fdb restart -c cluster --all-processes
 kubectl fdb restart -c cluster --process-condition=MissingProcesses
 `,
 	}
-
-	cmd.Flags().StringP("fdb-cluster", "c", "", "restart processes(s) from the provided cluster.")
+	addProcessSelectionFlags(cmd)
 	cmd.Flags().Bool("all-processes", false, "restart all processes of this cluster.")
-	cmd.Flags().StringArray("process-condition", []string{}, "restart all processes with the given process conditions.")
 	err := cmd.MarkFlagRequired("fdb-cluster")
 	if err != nil {
 		log.Fatal(err)

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -180,6 +181,15 @@ type processGroupSelectionOptions struct {
 	clusterLabel      string
 	processClass      string
 	useProcessGroupID bool
+	conditions        []fdbv1beta2.ProcessGroupConditionType
 }
 
-// TODO add common set of flags which accompany processGroupSelectionOptions https://github.com/FoundationDB/fdb-kubernetes-operator/issues/615
+func addProcessSelectionFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP("fdb-cluster", "c", "", "Selects process groups from the provided cluster. "+
+		"Required if not passing cluster-label.")
+	cmd.Flags().String("process-class", "", "Selects process groups matching the provided value in the provided cluster.  Using this option ignores provided ids.")
+	cmd.Flags().StringP("cluster-label", "l", fdbv1beta2.FDBClusterLabel, "cluster label used to identify the cluster for a requested pod. "+
+		"It is incompatible with use-process-group-id, process-class, and process-condition.")
+	cmd.Flags().Bool("use-process-group-id", false, "Selects process groups by process-group ID instead of the Pod name.")
+	cmd.Flags().StringArray("process-condition", []string{}, "Selects process groups that are in any of the given FDB process group conditions.")
+}

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -77,10 +77,17 @@ func generateClusterStruct(name string, namespace string) *fdbv1beta2.Foundation
 				{
 					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-instance-1"),
 					ProcessClass:   fdbv1beta2.ProcessClassStorage,
+					ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
+						fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.PodFailing),
+					},
 				},
 				{
 					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-instance-2"),
 					ProcessClass:   fdbv1beta2.ProcessClassStorage,
+					ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
+						fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.PodFailing),
+						fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.MissingProcesses),
+					},
 				},
 				{
 					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-instance-3"),


### PR DESCRIPTION
The common function is currently only used by remove-process-group.  This solves https://github.com/FoundationDB/fdb-kubernetes-operator/issues/614.
It also includes some refactoring of the error logic in the unified function -- I tried to make it as clear as possible for end users and it definitely assumes that this is on CLI use.  Definitely open to complaints!
This is work towards https://github.com/FoundationDB/fdb-kubernetes-operator/issues/615; the next PR will involve having all the process-group selection commands (`buggify no-schedule`, `buggify crash-loop`, and `restart`) use the common function now that it supports all the selection options with this PR.

# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

## Type of change

*Please select one of the options below.*

- Cleanup / Tech debt / New Feature

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*
Added unit tests, manually (via `buggify crash-loop`)

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*
No

## Documentation

I updated the docstrings, error, and help messages to the best of my ability

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*
No

*Does this introduce new defaults that we should re-evaluate in the future?*
No
