### PR TITLE
use common process selection function in buggify crash-loop, buggify no-schedule, and restart commands

### DIFF
--- a/kubectl-fdb/cmd/buggify_crash_loop.go
+++ b/kubectl-fdb/cmd/buggify_crash_loop.go
@@ -72,7 +72,7 @@ func newBuggifyCrashLoop(streams genericclioptions.IOStreams) *cobra.Command {
 					clear:         clear,
 					clean:         clean,
 				},
-				*processGroupSelectionOpts,
+				processGroupSelectionOpts,
 			)
 		},
 		Example: `
@@ -83,8 +83,13 @@ kubectl fdb buggify crash-loop -c cluster --container-name container-name pod-1 
 # Remove process groups from crash loop state from a cluster in the current namespace with container name
 kubectl fdb buggify crash-loop --clear -c cluster --container-name container-name pod-1 pod-2
 
+# Remove process groups from crash loop state from a cluster in the current namespace with container name across clusters
+kubectl fdb buggify crash-loop --clear --container-name container-name pod-1-cluster-A pod-2-cluster-B -l your-cluster-label
+
 # Clean crash loop list of a cluster in the current namespace with container name
 kubectl fdb buggify crash-loop --clean -c cluster --container-name container-name
+
+See help for even more process group selection options, such as by processClass, conditions, and processGroupID!
 `,
 	}
 	addProcessSelectionFlags(cmd)
@@ -116,7 +121,7 @@ func updateCrashLoopContainerList(cmd *cobra.Command, kubeClient client.Client, 
 		}
 		return cleanCrashLoopContainerList(kubeClient, opts.containerName, processGroupOpts.clusterName, processGroupOpts.namespace, opts)
 	}
-	
+
 	processGroupsByCluster, err := getProcessGroupsByCluster(cmd, kubeClient, processGroupOpts)
 	if err != nil {
 		return err

--- a/kubectl-fdb/cmd/buggify_crash_loop_test.go
+++ b/kubectl-fdb/cmd/buggify_crash_loop_test.go
@@ -22,6 +22,8 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
@@ -37,35 +39,117 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 				ExpectedProcessGroupsInCrashLoop []fdbv1beta2.ProcessGroupID
 			}
 
-			When("the crash-loop container list is empty", func() {
-				DescribeTable("should add all targeted process groups to crash-loop container list",
-					func(tc testCase) {
-						Expect(cluster.Spec.Buggify.CrashLoopContainers).To(HaveLen(0))
-						Expect(updateCrashLoopContainerList(k8sClient, clusterName, fdbv1beta2.MainContainerName, tc.ProcessGroups, namespace, false, false, false)).NotTo(HaveOccurred())
+			type processGroupOptionsTestCase struct {
+				ProcessGroupOpts                 processGroupSelectionOptions
+				ExpectedProcessGroupsInCrashLoop map[string][]fdbv1beta2.ProcessGroupID // keyed by cluster-name
+			}
 
-						var resCluster fdbv1beta2.FoundationDBCluster
-						Expect(k8sClient.Get(context.Background(), client.ObjectKey{
-							Namespace: namespace,
-							Name:      clusterName,
-						}, &resCluster)).NotTo(HaveOccurred())
-						Expect(resCluster.Spec.Buggify.CrashLoopContainers).To(HaveLen(1))
-						for _, crashLoopContainerObj := range resCluster.Spec.Buggify.CrashLoopContainers {
-							if crashLoopContainerObj.ContainerName != fdbv1beta2.MainContainerName {
-								continue
+			When("the crash-loop container list is empty", func() {
+				BeforeEach(func() {
+					cluster = generateClusterStruct(clusterName, namespace) // the status is overwritten by prior tests
+					Expect(createPods(clusterName, namespace)).NotTo(HaveOccurred())
+
+					secondCluster = generateClusterStruct(secondClusterName, namespace)
+					Expect(k8sClient.Create(context.TODO(), secondCluster)).NotTo(HaveOccurred())
+					Expect(createPods(secondClusterName, namespace)).NotTo(HaveOccurred())
+				})
+				DescribeTable("should add all targeted process groups to crash-loop container list",
+					func(tc processGroupOptionsTestCase) {
+						Expect(cluster.Spec.Buggify.CrashLoopContainers).To(HaveLen(0))
+						cmd := newBuggifyCrashLoop(genericclioptions.IOStreams{})
+						opts := buggifyProcessGroupOptions{
+							containerName: fdbv1beta2.MainContainerName,
+							wait:          false,
+							clear:         false,
+							clean:         false,
+						}
+						tc.ProcessGroupOpts.namespace = namespace
+						Expect(updateCrashLoopContainerList(cmd, k8sClient, opts, tc.ProcessGroupOpts)).NotTo(HaveOccurred())
+
+						for cluster, processGroupsInCrashLoop := range tc.ExpectedProcessGroupsInCrashLoop {
+							var resCluster fdbv1beta2.FoundationDBCluster
+							Expect(k8sClient.Get(context.Background(), client.ObjectKey{
+								Namespace: namespace,
+								Name:      cluster,
+							}, &resCluster)).NotTo(HaveOccurred())
+							Expect(resCluster.Spec.Buggify.CrashLoopContainers).To(HaveLen(1))
+							for _, crashLoopContainerObj := range resCluster.Spec.Buggify.CrashLoopContainers {
+								if crashLoopContainerObj.ContainerName != fdbv1beta2.MainContainerName {
+									continue
+								}
+								Expect(processGroupsInCrashLoop).To(ContainElements(crashLoopContainerObj.Targets))
+								Expect(crashLoopContainerObj.Targets).To(ContainElements(processGroupsInCrashLoop))
+								Expect(processGroupsInCrashLoop).To(HaveLen(len(crashLoopContainerObj.Targets)))
 							}
-							Expect(tc.ExpectedProcessGroupsInCrashLoop).To(ContainElements(crashLoopContainerObj.Targets))
-							Expect(tc.ExpectedProcessGroupsInCrashLoop).To(HaveLen(len(crashLoopContainerObj.Targets)))
 						}
 					},
 					Entry("Adding single process group.",
-						testCase{
-							ProcessGroups:                    []string{"test-storage-1"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
+						processGroupOptionsTestCase{
+							ProcessGroupOpts: processGroupSelectionOptions{
+								ids:         []string{"test-storage-1"},
+								clusterName: clusterName,
+							},
+							ExpectedProcessGroupsInCrashLoop: map[string][]fdbv1beta2.ProcessGroupID{
+								clusterName: {"test-storage-1"},
+							},
 						}),
 					Entry("Adding multiple process groups.",
-						testCase{
-							ProcessGroups:                    []string{"test-storage-1", "test-storage-2"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2"},
+						processGroupOptionsTestCase{
+							ProcessGroupOpts: processGroupSelectionOptions{
+								ids:         []string{"test-storage-1", "test-storage-2"},
+								clusterName: clusterName,
+							},
+							ExpectedProcessGroupsInCrashLoop: map[string][]fdbv1beta2.ProcessGroupID{
+								clusterName: {"test-storage-1", "test-storage-2"},
+							},
+						}),
+					Entry("Adding multiple process groups across clusters.",
+						processGroupOptionsTestCase{
+							ProcessGroupOpts: processGroupSelectionOptions{
+								ids: []string{
+									// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
+									fmt.Sprintf("%s-instance-1", clusterName),
+									fmt.Sprintf("%s-instance-2", clusterName),
+									fmt.Sprintf("%s-instance-2", secondClusterName),
+								},
+								clusterLabel: fdbv1beta2.FDBClusterLabel,
+							},
+							ExpectedProcessGroupsInCrashLoop: map[string][]fdbv1beta2.ProcessGroupID{
+								clusterName: {
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+								},
+								secondClusterName: {
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", secondClusterName)),
+								},
+							},
+						}),
+					Entry("Adding process groups with ProcessClassStorage.",
+						processGroupOptionsTestCase{
+							ProcessGroupOpts: processGroupSelectionOptions{
+								processClass: string(fdbv1beta2.ProcessClassStorage),
+								clusterName:  clusterName,
+							},
+							ExpectedProcessGroupsInCrashLoop: map[string][]fdbv1beta2.ProcessGroupID{
+								clusterName: {
+									// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+								},
+							},
+						}),
+					Entry("Adding process groups with condition MissingProcesses.",
+						processGroupOptionsTestCase{
+							ProcessGroupOpts: processGroupSelectionOptions{
+								clusterName: clusterName,
+								conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses},
+							},
+							ExpectedProcessGroupsInCrashLoop: map[string][]fdbv1beta2.ProcessGroupID{
+								clusterName: {
+									// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+								},
+							},
 						}),
 				)
 
@@ -83,7 +167,19 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 				DescribeTable("should add all targeted process groups to crash-loop container list",
 					func(tc testCase) {
 						Expect(cluster.Spec.Buggify.CrashLoopContainers).To(HaveLen(1))
-						Expect(updateCrashLoopContainerList(k8sClient, clusterName, fdbv1beta2.MainContainerName, tc.ProcessGroups, namespace, false, false, false)).NotTo(HaveOccurred())
+						cmd := newBuggifyCrashLoop(genericclioptions.IOStreams{})
+						opts := buggifyProcessGroupOptions{
+							containerName: fdbv1beta2.MainContainerName,
+							wait:          false,
+							clear:         false,
+							clean:         false,
+						}
+						processGroupOpts := processGroupSelectionOptions{
+							ids:         tc.ProcessGroups,
+							clusterName: clusterName,
+							namespace:   namespace,
+						}
+						Expect(updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts)).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster
 						Expect(k8sClient.Get(context.Background(), client.ObjectKey{
@@ -124,12 +220,25 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 						Targets:       []fdbv1beta2.ProcessGroupID{"should-be-ignored-storage-1"},
 					}
 					cluster.Spec.Buggify.CrashLoopContainers = append(cluster.Spec.Buggify.CrashLoopContainers, crashLoopContainerObj)
+					secondCluster.Spec.Buggify.CrashLoopContainers = append(cluster.Spec.Buggify.CrashLoopContainers, crashLoopContainerObj)
 				})
 
 				DescribeTable("should add all targeted processes to crash-loop container list",
 					func(tc testCase) {
 						Expect(cluster.Spec.Buggify.CrashLoopContainers).To(HaveLen(1))
-						Expect(updateCrashLoopContainerList(k8sClient, clusterName, fdbv1beta2.MainContainerName, tc.ProcessGroups, namespace, false, false, false)).NotTo(HaveOccurred())
+						cmd := newBuggifyCrashLoop(genericclioptions.IOStreams{})
+						opts := buggifyProcessGroupOptions{
+							containerName: fdbv1beta2.MainContainerName,
+							wait:          false,
+							clear:         false,
+							clean:         false,
+						}
+						processGroupOpts := processGroupSelectionOptions{
+							ids:         tc.ProcessGroups,
+							clusterName: clusterName,
+							namespace:   namespace,
+						}
+						Expect(updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts)).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster
 						Expect(k8sClient.Get(context.Background(), client.ObjectKey{
@@ -177,7 +286,19 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 			DescribeTable("should remove all targeted process groups from crash-loop container list",
 				func(tc testCase) {
 					Expect(cluster.Spec.Buggify.CrashLoopContainers).To(HaveLen(1))
-					Expect(updateCrashLoopContainerList(k8sClient, clusterName, fdbv1beta2.MainContainerName, tc.ProcessGroups, namespace, false, true, false)).NotTo(HaveOccurred())
+					cmd := newBuggifyCrashLoop(genericclioptions.IOStreams{})
+					opts := buggifyProcessGroupOptions{
+						containerName: fdbv1beta2.MainContainerName,
+						wait:          false,
+						clear:         true,
+						clean:         false,
+					}
+					processGroupOpts := processGroupSelectionOptions{
+						ids:         tc.ProcessGroups,
+						clusterName: clusterName,
+						namespace:   namespace,
+					}
+					Expect(updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts)).NotTo(HaveOccurred())
 
 					var resCluster fdbv1beta2.FoundationDBCluster
 					Expect(k8sClient.Get(context.Background(), client.ObjectKey{
@@ -222,7 +343,18 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 
 			It("should clear everything from the crash-loop container-list", func() {
 				Expect(cluster.Spec.Buggify.CrashLoopContainers).To(HaveLen(1))
-				Expect(updateCrashLoopContainerList(k8sClient, clusterName, fdbv1beta2.MainContainerName, []string{}, namespace, false, false, true)).NotTo(HaveOccurred())
+				cmd := newBuggifyCrashLoop(genericclioptions.IOStreams{})
+				opts := buggifyProcessGroupOptions{
+					containerName: fdbv1beta2.MainContainerName,
+					wait:          false,
+					clear:         false,
+					clean:         true,
+				}
+				processGroupOpts := processGroupSelectionOptions{
+					clusterName: clusterName,
+					namespace:   namespace,
+				}
+				Expect(updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts)).NotTo(HaveOccurred())
 
 				var resCluster fdbv1beta2.FoundationDBCluster
 				Expect(k8sClient.Get(context.Background(), client.ObjectKey{
@@ -236,6 +368,24 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 					}
 					Expect(crashLoopContainerObj.Targets).To(HaveLen(0))
 				}
+			})
+			It("should error if no cluster name is provided", func() {
+				Expect(cluster.Spec.Buggify.CrashLoopContainers).To(HaveLen(1))
+				cmd := newBuggifyCrashLoop(genericclioptions.IOStreams{})
+				opts := buggifyProcessGroupOptions{
+					containerName: fdbv1beta2.MainContainerName,
+					wait:          false,
+					clear:         false,
+					clean:         true,
+				}
+				processGroupOpts := processGroupSelectionOptions{
+					clusterName:  "",
+					clusterLabel: "attempt-cross-cluster-clean",
+					namespace:    namespace,
+				}
+				err := updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("clean option requires cluster-name argument"))
 			})
 		})
 	})

--- a/kubectl-fdb/cmd/buggify_crash_loop_test.go
+++ b/kubectl-fdb/cmd/buggify_crash_loop_test.go
@@ -46,7 +46,7 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 
 			When("the crash-loop container list is empty", func() {
 				BeforeEach(func() {
-					cluster = generateClusterStruct(clusterName, namespace) // the status is overwritten by prior tests
+					cluster = generateClusterStruct(clusterName, namespace)
 					Expect(createPods(clusterName, namespace)).NotTo(HaveOccurred())
 
 					secondCluster = generateClusterStruct(secondClusterName, namespace)

--- a/kubectl-fdb/cmd/buggify_no_schedule.go
+++ b/kubectl-fdb/cmd/buggify_no_schedule.go
@@ -51,7 +51,8 @@ func newBuggifyNoSchedule(streams genericclioptions.IOStreams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cluster, err := cmd.Flags().GetString("fdb-cluster")
+
+			processGroupSelectionOpts, err := getProcessSelectionOptsFromFlags(cmd, o, args)
 			if err != nil {
 				return err
 			}
@@ -61,12 +62,12 @@ func newBuggifyNoSchedule(streams genericclioptions.IOStreams) *cobra.Command {
 				return err
 			}
 
-			namespace, err := getNamespace(*o.configFlags.Namespace)
-			if err != nil {
-				return err
-			}
-
-			return updateNoScheduleList(kubeClient, cluster, args, namespace, wait, clear, clean)
+			return updateNoScheduleList(cmd, kubeClient,
+				buggifyProcessGroupOptions{
+					wait:  wait,
+					clear: clear,
+					clean: clean,
+				}, *processGroupSelectionOpts)
 		},
 		Example: `
 # Add process groups into no-schedule state for a cluster in the current namespace
@@ -100,24 +101,21 @@ kubectl fdb -n default buggify no-schedule  -c cluster pod-1 pod-2
 }
 
 // updateNoScheduleList updates the removal list of the cluster
-func updateNoScheduleList(kubeClient client.Client, clusterName string, pods []string, namespace string, wait bool, clear bool, clean bool) error {
-	cluster, err := loadCluster(kubeClient, namespace, clusterName)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return fmt.Errorf("could not get cluster: %s/%s", namespace, clusterName)
+func updateNoScheduleList(cmd *cobra.Command, kubeClient client.Client, opts buggifyProcessGroupOptions, processGroupOpts processGroupSelectionOptions) error {
+	if opts.clean {
+		if processGroupOpts.clusterName == "" {
+			return fmt.Errorf("clean option requires cluster-name argument")
 		}
-		return err
-	}
-
-	processGroupIDs, err := getProcessGroupIDsFromPodName(cluster, pods)
-	if err != nil {
-		return err
-	}
-
-	patch := client.MergeFrom(cluster.DeepCopy())
-	if clean {
-		if wait {
-			if !confirmAction(fmt.Sprintf("Clearing no-schedule list from cluster %s/%s", namespace, clusterName)) {
+		cluster, err := loadCluster(kubeClient, processGroupOpts.namespace, processGroupOpts.clusterName)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return fmt.Errorf("could not get cluster: %s/%s", processGroupOpts.namespace, processGroupOpts.clusterName)
+			}
+			return err
+		}
+		patch := client.MergeFrom(cluster.DeepCopy())
+		if opts.wait {
+			if !confirmAction(fmt.Sprintf("Clearing no-schedule list from cluster %s/%s", processGroupOpts.namespace, processGroupOpts.clusterName)) {
 				return fmt.Errorf("user aborted the removal")
 			}
 		}
@@ -125,27 +123,32 @@ func updateNoScheduleList(kubeClient client.Client, clusterName string, pods []s
 		return kubeClient.Patch(ctx.TODO(), cluster, patch)
 	}
 
-	if len(processGroupIDs) == 0 {
-		return fmt.Errorf("please provide at least one pod")
+	processGroupsByCluster, err := getProcessGroupsByCluster(cmd, kubeClient, processGroupOpts)
+	if err != nil {
+		return err
 	}
 
-	if wait {
-		if clear {
-			if !confirmAction(fmt.Sprintf("Removing %v from no-schedule from cluster %s/%s", processGroupIDs, namespace, clusterName)) {
+	for cluster, processGroupIDs := range processGroupsByCluster {
+		patch := client.MergeFrom(cluster.DeepCopy())
+		if len(processGroupIDs) == 0 {
+			return fmt.Errorf("please provide at least one pod")
+		}
+
+		if opts.clear {
+			if opts.wait && !confirmAction(fmt.Sprintf("Removing %v from no-schedule from cluster %s/%s", processGroupIDs, processGroupOpts.namespace, processGroupOpts.clusterName)) {
 				return fmt.Errorf("user aborted the removal")
 			}
+			cluster.RemoveProcessGroupsFromNoScheduleList(processGroupIDs)
 		} else {
-			if !confirmAction(fmt.Sprintf("Adding %v from no-schedule from cluster %s/%s", processGroupIDs, namespace, clusterName)) {
+			if opts.wait && !confirmAction(fmt.Sprintf("Adding %v from no-schedule from cluster %s/%s", processGroupIDs, processGroupOpts.namespace, processGroupOpts.clusterName)) {
 				return fmt.Errorf("user aborted the removal")
 			}
+			cluster.AddProcessGroupsToNoScheduleList(processGroupIDs)
+		}
+		err = kubeClient.Patch(ctx.TODO(), cluster, patch)
+		if err != nil {
+			return err
 		}
 	}
-
-	if clear {
-		cluster.RemoveProcessGroupsFromNoScheduleList(processGroupIDs)
-	} else {
-		cluster.AddProcessGroupsToNoScheduleList(processGroupIDs)
-	}
-
-	return kubeClient.Patch(ctx.TODO(), cluster, patch)
+	return nil
 }

--- a/kubectl-fdb/cmd/buggify_no_schedule.go
+++ b/kubectl-fdb/cmd/buggify_no_schedule.go
@@ -23,8 +23,6 @@ package cmd
 import (
 	ctx "context"
 	"fmt"
-	"log"
-
 	"github.com/spf13/cobra"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -67,7 +65,7 @@ func newBuggifyNoSchedule(streams genericclioptions.IOStreams) *cobra.Command {
 					wait:  wait,
 					clear: clear,
 					clean: clean,
-				}, *processGroupSelectionOpts)
+				}, processGroupSelectionOpts)
 		},
 		Example: `
 # Add process groups into no-schedule state for a cluster in the current namespace
@@ -76,21 +74,21 @@ kubectl fdb buggify no-schedule -c cluster pod-1 pod-2
 # Remove process groups from no-schedule state from a cluster in the current namespace
 kubectl fdb buggify no-schedule --clear -c cluster pod-1 pod-2
 
+# Remove process groups from no-schedule state from a cluster in the current namespace across clusters
+kubectl fdb buggify no-schedule --clear pod-1-cluster-A pod-2-cluster-B -l your-cluster-label
+
 # Clean no-schedule list of a cluster in the current namespace
 kubectl fdb buggify no-schedule  --clean -c cluster
 
 # Add process groups into no-schedule state for a cluster in the namespace default
 kubectl fdb -n default buggify no-schedule  -c cluster pod-1 pod-2
+
+See help for even more process group selection options, such as by processClass, conditions, and processGroupID!
 `,
 	}
-
-	cmd.Flags().StringP("fdb-cluster", "c", "", "updates the no-schedule list in the provided cluster.")
+	addProcessSelectionFlags(cmd)
 	cmd.Flags().Bool("clear", false, "removes the process groups from the no-schedule list.")
 	cmd.Flags().Bool("clean", false, "removes all process groups from the no-schedule list.")
-	err := cmd.MarkFlagRequired("fdb-cluster")
-	if err != nil {
-		log.Fatal(err)
-	}
 	cmd.SetOut(o.Out)
 	cmd.SetErr(o.ErrOut)
 	cmd.SetIn(o.In)

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -43,31 +43,7 @@ func newRemoveProcessGroupCmd(streams genericclioptions.IOStreams) *cobra.Comman
 			if err != nil {
 				return err
 			}
-			cluster, err := cmd.Flags().GetString("fdb-cluster")
-			if err != nil {
-				return err
-			}
-			clusterLabel, err := cmd.Flags().GetString("cluster-label")
-			if err != nil {
-				return err
-			}
-			processClass, err := cmd.Flags().GetString("process-class")
-			if err != nil {
-				return err
-			}
-			processConditions, err := cmd.Flags().GetStringArray("process-condition")
-			if err != nil {
-				return err
-			}
-			conditions, err := convertConditions(processConditions)
-			if err != nil {
-				return err
-			}
 			withExclusion, err := cmd.Flags().GetBool("exclusion")
-			if err != nil {
-				return err
-			}
-			useProcessGroupID, err := cmd.Flags().GetBool("use-process-group-id")
 			if err != nil {
 				return err
 			}
@@ -76,26 +52,17 @@ func newRemoveProcessGroupCmd(streams genericclioptions.IOStreams) *cobra.Comman
 				return err
 			}
 
+			processGroupSelectionOpts, err := getProcessSelectionOptsFromFlags(cmd, o, args)
+			if err != nil {
+				return err
+			}
 			kubeClient, err := getKubeClient(cmd.Context(), o)
 			if err != nil {
 				return err
 			}
 
-			namespace, err := getNamespace(*o.configFlags.Namespace)
-			if err != nil {
-				return err
-			}
-
 			totalRemoved, err := replaceProcessGroups(cmd, kubeClient,
-				processGroupSelectionOptions{
-					ids:               args,
-					namespace:         namespace,
-					clusterName:       cluster,
-					clusterLabel:      clusterLabel,
-					processClass:      processClass,
-					useProcessGroupID: useProcessGroupID,
-					conditions:        conditions,
-				},
+				*processGroupSelectionOpts,
 				replaceProcessGroupsOptions{
 					withExclusion:   withExclusion,
 					wait:            wait,

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -62,7 +62,7 @@ func newRemoveProcessGroupCmd(streams genericclioptions.IOStreams) *cobra.Comman
 			}
 
 			totalRemoved, err := replaceProcessGroups(cmd, kubeClient,
-				*processGroupSelectionOpts,
+				processGroupSelectionOpts,
 				replaceProcessGroupsOptions{
 					withExclusion:   withExclusion,
 					wait:            wait,

--- a/kubectl-fdb/cmd/restart.go
+++ b/kubectl-fdb/cmd/restart.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
@@ -48,24 +47,16 @@ func newRestartCmd(streams genericclioptions.IOStreams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			clusterName, err := cmd.Flags().GetString("fdb-cluster")
-			if err != nil {
-				return err
-			}
 			allProcesses, err := cmd.Flags().GetBool("all-processes")
 			if err != nil {
 				return err
 			}
-			processConditions, err := cmd.Flags().GetStringArray("process-condition")
-			if err != nil {
-				return err
-			}
-			conditions, err := convertConditions(processConditions)
+			processGroupSelectionOpts, err := getProcessSelectionOptsFromFlags(cmd, o, args)
 			if err != nil {
 				return err
 			}
 
-			if len(args) == 0 && !allProcesses && len(conditions) == 0 {
+			if len(args) == 0 && !allProcesses && len(processGroupSelectionOpts.conditions) == 0 {
 				return cmd.Help()
 			}
 
@@ -84,36 +75,18 @@ func newRestartCmd(streams genericclioptions.IOStreams) *cobra.Command {
 				return err
 			}
 
-			namespace, err := getNamespace(*o.configFlags.Namespace)
+			processGroupsByCluster, err := getProcessGroupsByCluster(cmd, kubeClient, processGroupSelectionOpts)
 			if err != nil {
 				return err
 			}
-
-			cluster, err := loadCluster(kubeClient, namespace, clusterName)
-			if err != nil {
-				return err
-			}
-
-			var processes []string
-			if allProcesses {
-				pods, err := getPodsForCluster(kubeClient, cluster)
+			for cluster, processGroupIDs := range processGroupsByCluster {
+				err := restartProcesses(cmd, config, clientSet, processGroupIDs, processGroupSelectionOpts.namespace, cluster.Name, wait, sleep)
 				if err != nil {
 					return err
 				}
-
-				for _, pod := range pods.Items {
-					processes = append(processes, pod.Name)
-				}
-			} else if len(conditions) > 0 {
-				processes, err = getAllPodsFromClusterWithCondition(cmd.ErrOrStderr(), kubeClient, clusterName, namespace, conditions)
-				if err != nil {
-					return err
-				}
-			} else {
-				processes = args
 			}
 
-			return restartProcesses(cmd, config, clientSet, processes, namespace, clusterName, wait, sleep)
+			return nil
 		},
 		Example: `
 # Restart processes for a cluster in the current namespace
@@ -122,19 +95,20 @@ kubectl fdb restart -c cluster pod-1 -i pod-2
 # Restart processes for a cluster in the namespace default
 kubectl fdb -n default restart -c cluster pod-1 pod-2
 
+# Restart processes for a cluster in the namespace default
+kubectl fdb -n default restart pod-1-cluster-A pod-2-cluster-B -l your-cluster-label
+
 # Restart all processes for a cluster
 kubectl fdb restart -c cluster --all-processes
 
 # Restart all processes for a cluster that have the given condition
 kubectl fdb restart -c cluster --process-condition=MissingProcesses
+
+See help for even more process group selection options, such as by processClass, and processGroupID!
 `,
 	}
 	addProcessSelectionFlags(cmd)
 	cmd.Flags().Bool("all-processes", false, "restart all processes of this cluster.")
-	err := cmd.MarkFlagRequired("fdb-cluster")
-	if err != nil {
-		log.Fatal(err)
-	}
 	cmd.SetOut(o.Out)
 	cmd.SetErr(o.ErrOut)
 	cmd.SetIn(o.In)
@@ -160,7 +134,7 @@ func convertConditions(inputConditions []string) ([]fdbv1beta2.ProcessGroupCondi
 }
 
 //nolint:interfacer // golint has a false-positive here -> `cmd` can be `github.com/hashicorp/go-retryablehttp.Logger`
-func restartProcesses(cmd *cobra.Command, restConfig *rest.Config, kubeClient *kubernetes.Clientset, processes []string, namespace string, clusterName string, wait bool, sleep uint16) error {
+func restartProcesses(cmd *cobra.Command, restConfig *rest.Config, kubeClient *kubernetes.Clientset, processes []fdbv1beta2.ProcessGroupID, namespace, clusterName string, wait bool, sleep uint16) error {
 	if wait {
 		confirmed := confirmAction(fmt.Sprintf("Restart %v in cluster %s/%s", processes, namespace, clusterName))
 		if !confirmed {
@@ -170,7 +144,7 @@ func restartProcesses(cmd *cobra.Command, restConfig *rest.Config, kubeClient *k
 
 	for _, process := range processes {
 		cmd.Printf("Restart process: %s\n", process)
-		_, _, err := executeCmd(restConfig, kubeClient, process, namespace, "pkill fdbserver")
+		_, _, err := executeCmd(restConfig, kubeClient, string(process), namespace, "pkill fdbserver")
 		if err != nil {
 			return err
 		}

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -194,36 +194,37 @@ func addProcessSelectionFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArray("process-condition", []string{}, "Selects process groups that are in any of the given FDB process group conditions.")
 }
 
-func getProcessSelectionOptsFromFlags(cmd *cobra.Command, o *fdbBOptions, ids []string) (*processGroupSelectionOptions, error) {
+func getProcessSelectionOptsFromFlags(cmd *cobra.Command, o *fdbBOptions, ids []string) (processGroupSelectionOptions, error) {
+	opts := processGroupSelectionOptions{}
 	cluster, err := cmd.Flags().GetString("fdb-cluster")
 	if err != nil {
-		return nil, err
+		return opts, err
 	}
 	clusterLabel, err := cmd.Flags().GetString("cluster-label")
 	if err != nil {
-		return nil, err
+		return opts, err
 	}
 	processClass, err := cmd.Flags().GetString("process-class")
 	if err != nil {
-		return nil, err
+		return opts, err
 	}
 	processConditions, err := cmd.Flags().GetStringArray("process-condition")
 	if err != nil {
-		return nil, err
+		return opts, err
 	}
 	conditions, err := convertConditions(processConditions)
 	if err != nil {
-		return nil, err
+		return opts, err
 	}
 	useProcessGroupID, err := cmd.Flags().GetBool("use-process-group-id")
 	if err != nil {
-		return nil, err
+		return opts, err
 	}
 	namespace, err := getNamespace(*o.configFlags.Namespace)
 	if err != nil {
-		return nil, err
+		return opts, err
 	}
-	return &processGroupSelectionOptions{
+	return processGroupSelectionOptions{
 		ids:               ids,
 		namespace:         namespace,
 		clusterName:       cluster,

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -193,3 +193,43 @@ func addProcessSelectionFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("use-process-group-id", false, "Selects process groups by process-group ID instead of the Pod name.")
 	cmd.Flags().StringArray("process-condition", []string{}, "Selects process groups that are in any of the given FDB process group conditions.")
 }
+
+func getProcessSelectionOptsFromFlags(cmd *cobra.Command, o *fdbBOptions, ids []string) (*processGroupSelectionOptions, error) {
+	cluster, err := cmd.Flags().GetString("fdb-cluster")
+	if err != nil {
+		return nil, err
+	}
+	clusterLabel, err := cmd.Flags().GetString("cluster-label")
+	if err != nil {
+		return nil, err
+	}
+	processClass, err := cmd.Flags().GetString("process-class")
+	if err != nil {
+		return nil, err
+	}
+	processConditions, err := cmd.Flags().GetStringArray("process-condition")
+	if err != nil {
+		return nil, err
+	}
+	conditions, err := convertConditions(processConditions)
+	if err != nil {
+		return nil, err
+	}
+	useProcessGroupID, err := cmd.Flags().GetBool("use-process-group-id")
+	if err != nil {
+		return nil, err
+	}
+	namespace, err := getNamespace(*o.configFlags.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	return &processGroupSelectionOptions{
+		ids:               ids,
+		namespace:         namespace,
+		clusterName:       cluster,
+		clusterLabel:      clusterLabel,
+		processClass:      processClass,
+		useProcessGroupID: useProcessGroupID,
+		conditions:        conditions,
+	}, nil
+}


### PR DESCRIPTION
# Description

This PR should end up resolving https://github.com/FoundationDB/fdb-kubernetes-operator/issues/615 by having all the process-group selection commands (buggify no-schedule, buggify crash-loop, and restart) use the common function that remove-process-groups has come to use in previous PRs https://github.com/FoundationDB/fdb-kubernetes-operator/pull/1937 and https://github.com/FoundationDB/fdb-kubernetes-operator/pull/1940 

## Type of change

- Tech Debt / New feature (non-breaking change which adds functionality)

## Discussion

*Are there any design details that you would like to discuss further?*
Not particularly

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*
Unit tests, manually (but mostly spotchecked as there are so many possible combinations)

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*
No

## Documentation

docstrings, help strings, and comments have been updated accordingly

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*
None related to this change

*Does this introduce new defaults that we should re-evaluate in the future?*
No
