### PR TITLE
Let the operator requeue another reconcile attempt if more failed process groups are detected

### DIFF
--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -61,7 +61,7 @@ func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *Foundation
 	// Only replace process groups without an address, if the cluster has the desired fault tolerance and is available.
 	hasDesiredFaultTolerance := fdbstatus.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
 	hasReplacement, hasMoreFailedProcesses := replacements.ReplaceFailedProcessGroups(logger, cluster, status, hasDesiredFaultTolerance)
-	// If the reonciler replaced at least one process group we want to update the status and requeue.
+	// If the reconciler replaced at least one process group we want to update the status and requeue.
 	if hasReplacement {
 		err := r.updateOrApply(ctx, cluster)
 		if err != nil {

--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -22,6 +22,7 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbstatus"
 	"github.com/go-logr/logr"
@@ -59,13 +60,21 @@ func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *Foundation
 
 	// Only replace process groups without an address, if the cluster has the desired fault tolerance and is available.
 	hasDesiredFaultTolerance := fdbstatus.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
-	if replacements.ReplaceFailedProcessGroups(logger, cluster, status, hasDesiredFaultTolerance) {
+	hasReplacement, hasMoreFailedProcesses := replacements.ReplaceFailedProcessGroups(logger, cluster, status, hasDesiredFaultTolerance)
+	// If the reonciler replaced at least one process group we want to update the status and requeue.
+	if hasReplacement {
 		err := r.updateOrApply(ctx, cluster)
 		if err != nil {
 			return &requeue{curError: err}
 		}
 
 		return &requeue{message: "Removals have been updated in the cluster status"}
+	}
+
+	// If there are more failed processes that are not yet automatically replaced, we want the controller to requeue this
+	// request to make sure it takes another attempt to replace the faulty process group(s).
+	if hasMoreFailedProcesses {
+		return &requeue{message: "More failed process groups are detected", delayedRequeue: true, delay: 5 * time.Minute}
 	}
 
 	return nil

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -786,8 +786,10 @@ var _ = Describe("replace_failed_process_groups", func() {
 				processGroup.MarkForRemoval()
 			})
 
-			It("should return nil", func() {
-				Expect(result).To(BeNil())
+			It("should not return nil", func() {
+				Expect(result).NotTo(BeNil())
+				Expect(result.delayedRequeue).To(BeTrue())
+				Expect(result.message).To(Equal("More failed process groups are detected"))
 			})
 
 			It("should not mark the process group for removal", func() {

--- a/internal/replacements/replace_failed_process_groups.go
+++ b/internal/replacements/replace_failed_process_groups.go
@@ -43,8 +43,9 @@ func getMaxReplacements(cluster *fdbv1beta2.FoundationDBCluster, maxReplacements
 	return maxReplacements - removalCount
 }
 
-// ReplaceFailedProcessGroups flags failed processes groups for removal and returns an indicator
-// of whether any processes were thus flagged.
+// ReplaceFailedProcessGroups flags failed processes groups for removal. The first return value will indicate if any
+// new Process Group was removed and the second return value will indicate if there are more Process Groups that
+// needs a replacement, but the operator is not allowed to replace those as the limit is reached.
 func ReplaceFailedProcessGroups(log logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, hasDesiredFaultTolerance bool) (bool, bool) {
 	// Automatic replacements are disabled or set to 0, so we don't have to check anything further
 	if !cluster.GetEnableAutomaticReplacements() || cluster.GetMaxConcurrentAutomaticReplacements() == 0 {

--- a/internal/replacements/replace_failed_process_groups.go
+++ b/internal/replacements/replace_failed_process_groups.go
@@ -45,15 +45,26 @@ func getMaxReplacements(cluster *fdbv1beta2.FoundationDBCluster, maxReplacements
 
 // ReplaceFailedProcessGroups flags failed processes groups for removal and returns an indicator
 // of whether any processes were thus flagged.
-func ReplaceFailedProcessGroups(log logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, hasDesiredFaultTolerance bool) bool {
-	// Automatic replacements are disabled, so we don't have to check anything further
-	if !cluster.GetEnableAutomaticReplacements() {
-		return false
+func ReplaceFailedProcessGroups(log logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, hasDesiredFaultTolerance bool) (bool, bool) {
+	// Automatic replacements are disabled or set to 0, so we don't have to check anything further
+	if !cluster.GetEnableAutomaticReplacements() || cluster.GetMaxConcurrentAutomaticReplacements() == 0 {
+		return false, false
+	}
+
+	ignore := map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None{}
+	crashLoopContainerProcessGroups := cluster.GetCrashLoopContainerProcessGroups()
+	for _, targets := range crashLoopContainerProcessGroups {
+		// If all Process Groups are targeted to be crash looping, we can skip any further work.
+		if _, ok := targets["*"]; ok {
+			return false, false
+		}
+
+		ignore = targets
 	}
 
 	maxReplacements := getMaxReplacements(cluster, cluster.GetMaxConcurrentAutomaticReplacements())
 	hasReplacement := false
-	crashLoopContainerProcessGroups := cluster.GetCrashLoopContainerProcessGroups()
+	hasMoreFailedProcesses := false
 	localitiesUsedForExclusion := cluster.UseLocalitiesForExclusion()
 
 	for _, processGroupStatus := range cluster.Status.ProcessGroups {
@@ -70,25 +81,13 @@ func ReplaceFailedProcessGroups(log logr.Logger, cluster *fdbv1beta2.FoundationD
 			continue
 		}
 
-		var shouldBeIgnored bool
-		for _, targets := range crashLoopContainerProcessGroups {
-			if _, ok := targets[processGroupStatus.ProcessGroupID]; ok {
-				shouldBeIgnored = true
-				break
-			}
-
-			if _, ok := targets["*"]; ok {
-				shouldBeIgnored = true
-				break
-			}
-		}
-
-		if shouldBeIgnored {
+		failureCondition, failureTime := processGroupStatus.NeedsReplacement(cluster.GetFailureDetectionTimeSeconds(), cluster.GetTaintReplacementTimeSeconds())
+		if failureTime == 0 {
 			continue
 		}
 
-		failureCondition, failureTime := processGroupStatus.NeedsReplacement(cluster.GetFailureDetectionTimeSeconds(), cluster.GetTaintReplacementTimeSeconds())
-		if failureTime == 0 {
+		// If the process is crash looping we can ignore it.
+		if _, ok := ignore[processGroupStatus.ProcessGroupID]; ok {
 			continue
 		}
 
@@ -118,6 +117,9 @@ func ReplaceFailedProcessGroups(log logr.Logger, cluster *fdbv1beta2.FoundationD
 
 		// We are not allowed to replace additional process groups.
 		if maxReplacements <= 0 {
+			// If there are more processes that should be replaced but we hit the replace limit, we want to make sure
+			// the controller queues another reconciliation to eventually replace this failed process group.
+			hasMoreFailedProcesses = true
 			log.Info("Detected replace process group but cannot replace it because we hit the replacement limit",
 				"processGroupID", processGroupStatus.ProcessGroupID,
 				"failureCondition", failureCondition,
@@ -138,5 +140,5 @@ func ReplaceFailedProcessGroups(log logr.Logger, cluster *fdbv1beta2.FoundationD
 		maxReplacements--
 	}
 
-	return hasReplacement
+	return hasReplacement, hasMoreFailedProcesses
 }


### PR DESCRIPTION
# Description

Let the operator requeue another reconcile attempt if more failed process groups are detected.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

Otherwise the operator might not requeue and has to wait for another event to trigger a new reconciliation step.

## Testing

Unit tests + CI will run e2e tests.

## Documentation

-

## Follow-up

-
