### PR TITLE
add podName selection functions

### DIFF
--- a/kubectl-fdb/cmd/analyze_test.go
+++ b/kubectl-fdb/cmd/analyze_test.go
@@ -66,12 +66,12 @@ func getPodList(clusterName string, namespace string, status corev1.PodStatus, d
 		Items: []corev1.Pod{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "instance-1",
+					Name:      "storage-1",
 					Namespace: namespace,
 					Labels: map[string]string{
 						fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStorage),
 						fdbv1beta2.FDBClusterLabel:        clusterName,
-						fdbv1beta2.FDBProcessGroupIDLabel: "instance-1",
+						fdbv1beta2.FDBProcessGroupIDLabel: "storage-1",
 					},
 					DeletionTimestamp: deletionTimestamp,
 				},
@@ -119,7 +119,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			Entry("Cluster is fine",
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
-						{ProcessGroupID: "instance-1"},
+						{ProcessGroupID: "storage-1"},
 					}),
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
@@ -138,7 +138,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			Entry("Cluster is unavailable",
 				testCase{
 					cluster: getCluster(clusterName, namespace, false, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
-						{ProcessGroupID: "instance-1"},
+						{ProcessGroupID: "storage-1"},
 					}),
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
@@ -156,7 +156,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			Entry("Cluster is unhealthy",
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, false, true, 1, []*fdbv1beta2.ProcessGroupStatus{
-						{ProcessGroupID: "instance-1"},
+						{ProcessGroupID: "storage-1"},
 					}),
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
@@ -175,7 +175,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			Entry("Cluster is not fully replicated",
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, false, 1, []*fdbv1beta2.ProcessGroupStatus{
-						{ProcessGroupID: "instance-1"},
+						{ProcessGroupID: "storage-1"},
 					}),
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
@@ -193,7 +193,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			Entry("Cluster is not reconciled",
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 0, []*fdbv1beta2.ProcessGroupStatus{
-						{ProcessGroupID: "instance-1"},
+						{ProcessGroupID: "storage-1"},
 					}),
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
@@ -212,7 +212,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
 						{
-							ProcessGroupID: "instance-1",
+							ProcessGroupID: "storage-1",
 							ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
 								fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.MissingProcesses),
 							},
@@ -221,7 +221,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
 					}, nil),
-					ExpectedErrMsg: fmt.Sprintf("✖ ProcessGroup: instance-1 has the following condition: MissingProcesses since %s", time.Unix(time.Now().Unix(), 0).String()),
+					ExpectedErrMsg: fmt.Sprintf("✖ ProcessGroup: storage-1 has the following condition: MissingProcesses since %s", time.Unix(time.Now().Unix(), 0).String()),
 					ExpectedStdoutMsg: `Checking cluster: test/test
 ✔ Cluster is available
 ✔ Cluster is fully replicated
@@ -235,7 +235,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
 						{
-							ProcessGroupID: "instance-1",
+							ProcessGroupID: "storage-1",
 							ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
 								fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.MissingProcesses),
 							},
@@ -245,7 +245,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
 					}, nil),
-					ExpectedErrMsg: "⚠ ProcessGroup: instance-1 is marked for removal, excluded state: false",
+					ExpectedErrMsg: "⚠ ProcessGroup: storage-1 is marked for removal, excluded state: false",
 					ExpectedStdoutMsg: `Checking cluster: test/test
 ✔ Cluster is available
 ✔ Cluster is fully replicated
@@ -259,12 +259,12 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			Entry("Pod is in Pending phase",
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
-						{ProcessGroupID: "instance-1"},
+						{ProcessGroupID: "storage-1"},
 					}),
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodPending,
 					}, nil),
-					ExpectedErrMsg: "✖ Pod test/instance-1 has unexpected Phase Pending with Reason:",
+					ExpectedErrMsg: "✖ Pod test/storage-1 has unexpected Phase Pending with Reason:",
 					ExpectedStdoutMsg: `Checking cluster: test/test
 ✔ Cluster is available
 ✔ Cluster is fully replicated
@@ -277,7 +277,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			Entry("Container is in terminated state",
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
-						{ProcessGroupID: "instance-1"},
+						{ProcessGroupID: "storage-1"},
 					}),
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
@@ -294,7 +294,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 							},
 						},
 					}, nil),
-					ExpectedErrMsg: "✖ Pod test/instance-1 has an unready container: foundationdb",
+					ExpectedErrMsg: "✖ Pod test/storage-1 has an unready container: foundationdb",
 					ExpectedStdoutMsg: `Checking cluster: test/test
 ✔ Cluster is available
 ✔ Cluster is fully replicated
@@ -307,7 +307,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			Entry("Container is in ready state",
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
-						{ProcessGroupID: "instance-1"},
+						{ProcessGroupID: "storage-1"},
 					}),
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
@@ -332,13 +332,13 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			Entry("Pod is stuck in terminating",
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
-						{ProcessGroupID: "instance-1"},
+						{ProcessGroupID: "storage-1"},
 					}),
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase:             corev1.PodRunning,
 						ContainerStatuses: []corev1.ContainerStatus{},
 					}, &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}),
-					ExpectedErrMsg: fmt.Sprintf("✖ Pod test/instance-1 has been stuck in terminating since %s", time.Unix(time.Now().Add(-1*time.Hour).Unix(), 0).String()),
+					ExpectedErrMsg: fmt.Sprintf("✖ Pod test/storage-1 has been stuck in terminating since %s", time.Unix(time.Now().Add(-1*time.Hour).Unix(), 0).String()),
 					ExpectedStdoutMsg: `Checking cluster: test/test
 ✔ Cluster is available
 ✔ Cluster is fully replicated
@@ -352,7 +352,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
 						{
-							ProcessGroupID:     "instance-1",
+							ProcessGroupID:     "storage-1",
 							RemovalTimestamp:   &metav1.Time{Time: time.Now()},
 							ExclusionTimestamp: &metav1.Time{Time: time.Now()},
 						},
@@ -372,7 +372,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 							},
 						},
 					}, &metav1.Time{Time: time.Now().Add(-1 * time.Hour)}),
-					ExpectedErrMsg: "⚠ ProcessGroup: instance-1 is marked for removal, excluded state: true",
+					ExpectedErrMsg: "⚠ ProcessGroup: storage-1 is marked for removal, excluded state: true",
 					ExpectedStdoutMsg: `Checking cluster: test/test
 ✔ Cluster is available
 ✔ Cluster is fully replicated
@@ -387,7 +387,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
 						{
-							ProcessGroupID:     "instance-1",
+							ProcessGroupID:     "storage-1",
 							RemovalTimestamp:   &metav1.Time{Time: time.Now()},
 							ExclusionTimestamp: &metav1.Time{Time: time.Now()},
 						},
@@ -421,7 +421,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			Entry("Missing Pods",
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
-						{ProcessGroupID: "instance-1"},
+						{ProcessGroupID: "storage-1"},
 					}),
 					podList:        &corev1.PodList{},
 					ExpectedErrMsg: "✖ Found no Pods for this cluster",
@@ -441,7 +441,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
 					}, nil),
-					ExpectedErrMsg: "✖ Pod test/instance-1 with the ID instance-1 is not part of the cluster spec status",
+					ExpectedErrMsg: "✖ Pod test/storage-1 with the ID storage-1 is not part of the cluster spec status",
 					ExpectedStdoutMsg: `Checking cluster: test/test
 ✔ Cluster is available
 ✔ Cluster is fully replicated
@@ -455,7 +455,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 				testCase{
 					cluster: getCluster(clusterName, namespace, true, true, true, 1, []*fdbv1beta2.ProcessGroupStatus{
 						{
-							ProcessGroupID: "instance-1",
+							ProcessGroupID: "storage-1",
 							ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
 								fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.MissingProcesses),
 								fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.IncorrectPodSpec),
@@ -465,7 +465,7 @@ var _ = Describe("[plugin] analyze cluster", func() {
 					podList: getPodList(clusterName, namespace, corev1.PodStatus{
 						Phase: corev1.PodRunning,
 					}, nil),
-					ExpectedErrMsg: fmt.Sprintf("✖ ProcessGroup: instance-1 has the following condition: MissingProcesses since %s\n⚠ Ignored 1 conditions", time.Unix(time.Now().Unix(), 0).String()),
+					ExpectedErrMsg: fmt.Sprintf("✖ ProcessGroup: storage-1 has the following condition: MissingProcesses since %s\n⚠ Ignored 1 conditions", time.Unix(time.Now().Unix(), 0).String()),
 					ExpectedStdoutMsg: `Checking cluster: test/test
 ✔ Cluster is available
 ✔ Cluster is fully replicated

--- a/kubectl-fdb/cmd/buggify_crash_loop_test.go
+++ b/kubectl-fdb/cmd/buggify_crash_loop_test.go
@@ -108,19 +108,19 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							ProcessGroupOpts: processGroupSelectionOptions{
 								ids: []string{
 									// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
-									fmt.Sprintf("%s-instance-1", clusterName),
-									fmt.Sprintf("%s-instance-2", clusterName),
-									fmt.Sprintf("%s-instance-2", secondClusterName),
+									fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+									fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+									fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage),
 								},
 								clusterLabel: fdbv1beta2.FDBClusterLabel,
 							},
 							ExpectedProcessGroupsInCrashLoop: map[string][]fdbv1beta2.ProcessGroupID{
 								clusterName: {
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 								},
 								secondClusterName: {
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", secondClusterName)),
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
 								},
 							},
 						}),
@@ -133,8 +133,8 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							ExpectedProcessGroupsInCrashLoop: map[string][]fdbv1beta2.ProcessGroupID{
 								clusterName: {
 									// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 								},
 							},
 						}),
@@ -147,7 +147,7 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							ExpectedProcessGroupsInCrashLoop: map[string][]fdbv1beta2.ProcessGroupID{
 								clusterName: {
 									// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 								},
 							},
 						}),

--- a/kubectl-fdb/cmd/buggify_no_schedule_test.go
+++ b/kubectl-fdb/cmd/buggify_no_schedule_test.go
@@ -91,19 +91,19 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 						ProcessGroupOpts: processGroupSelectionOptions{
 							ids: []string{
 								// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
-								fmt.Sprintf("%s-instance-1", clusterName),
-								fmt.Sprintf("%s-instance-2", clusterName),
-								fmt.Sprintf("%s-instance-2", secondClusterName),
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+								fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+								fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage),
 							},
 							clusterLabel: fdbv1beta2.FDBClusterLabel,
 						},
 						ExpectedProcessGroupsInNoSchedule: map[string][]fdbv1beta2.ProcessGroupID{
 							clusterName: {
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 							},
 							secondClusterName: {
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", secondClusterName)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
 							},
 						},
 					}),
@@ -116,8 +116,8 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 						ExpectedProcessGroupsInNoSchedule: map[string][]fdbv1beta2.ProcessGroupID{
 							clusterName: {
 								// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 							},
 						},
 					}),
@@ -130,7 +130,7 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 						ExpectedProcessGroupsInNoSchedule: map[string][]fdbv1beta2.ProcessGroupID{
 							clusterName: {
 								// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 							},
 						},
 					}),

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -87,7 +87,7 @@ var _ = Describe("[plugin] cordon command", func() {
 				testCase{
 					nodes:                     []string{"node-1"},
 					WithExclusion:             true,
-					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName))},
+					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage))},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:  clusterName,
 					clusterLabel: "",
@@ -97,7 +97,7 @@ var _ = Describe("[plugin] cordon command", func() {
 					nodes:                     []string{"node-1"},
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
-					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName))},
+					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage))},
 					clusterName:  clusterName,
 					clusterLabel: "",
 				}),
@@ -126,8 +126,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					nodes:         []string{"node-1", "node-2"},
 					WithExclusion: true,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 					},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:  clusterName,
@@ -139,8 +139,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 					},
 					clusterName:  clusterName,
 					clusterLabel: "",
@@ -149,7 +149,7 @@ var _ = Describe("[plugin] cordon command", func() {
 				testCase{
 					nodes:                     []string{"node-1"},
 					WithExclusion:             true,
-					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", secondClusterName))},
+					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage))},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:  secondClusterName,
 					clusterLabel: "",
@@ -158,7 +158,7 @@ var _ = Describe("[plugin] cordon command", func() {
 				testCase{
 					nodes:                     []string{"node-1"},
 					WithExclusion:             true,
-					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", secondClusterName))},
+					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage))},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:  secondClusterName,
 					clusterLabel: fdbv1beta2.FDBClusterLabel,
@@ -168,8 +168,8 @@ var _ = Describe("[plugin] cordon command", func() {
 					nodes:         []string{"node-1"},
 					WithExclusion: true,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", secondClusterName)),
+						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
 					},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:  "",
@@ -181,10 +181,10 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", secondClusterName)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", secondClusterName)),
+						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
 					},
 					clusterName:  "",
 					clusterLabel: fdbv1beta2.FDBClusterLabel,
@@ -207,12 +207,12 @@ func createPods(clusterName string, namespace string) error {
 	pods := []corev1.Pod{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-instance-1", clusterName),
+				Name:      fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
 				Namespace: namespace,
 				Labels: map[string]string{
 					fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStorage),
 					fdbv1beta2.FDBClusterLabel:        clusterName,
-					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-instance-1", clusterName),
+					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -221,12 +221,12 @@ func createPods(clusterName string, namespace string) error {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-instance-2", clusterName),
+				Name:      fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
 				Namespace: namespace,
 				Labels: map[string]string{
 					fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStorage),
 					fdbv1beta2.FDBClusterLabel:        clusterName,
-					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-instance-2", clusterName),
+					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -235,12 +235,12 @@ func createPods(clusterName string, namespace string) error {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-instance-3", clusterName),
+				Name:      fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
 				Namespace: namespace,
 				Labels: map[string]string{
 					fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStateless),
 					fdbv1beta2.FDBClusterLabel:        clusterName,
-					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-instance-3", clusterName),
+					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
 				},
 			},
 			Spec: corev1.PodSpec{

--- a/kubectl-fdb/cmd/exec_test.go
+++ b/kubectl-fdb/cmd/exec_test.go
@@ -43,7 +43,7 @@ var _ = Describe("[plugin] exec command", func() {
 		BeforeEach(func() {
 			Expect(k8sClient.Create(context.TODO(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "instance-1",
+					Name:      "storage-1",
 					Namespace: namespace,
 					Labels: map[string]string{
 						fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
@@ -70,12 +70,12 @@ var _ = Describe("[plugin] exec command", func() {
 			},
 			Entry("Exec into instance with valid pod",
 				testCase{
-					ExpectedArgs: []string{"--namespace", "test", "exec", "-it", "instance-1", "--", "bash"},
+					ExpectedArgs: []string{"--namespace", "test", "exec", "-it", "storage-1", "--", "bash"},
 				}),
 			Entry("Exec into instance with explicit context",
 				testCase{
 					Context:      "remote-kc",
-					ExpectedArgs: []string{"--context", "remote-kc", "--namespace", "test", "exec", "-it", "instance-1", "--", "bash"},
+					ExpectedArgs: []string{"--context", "remote-kc", "--namespace", "test", "exec", "-it", "storage-1", "--", "bash"},
 				}),
 		)
 	})

--- a/kubectl-fdb/cmd/fix_coordinator_ips_test.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips_test.go
@@ -41,7 +41,7 @@ var _ = Describe("[plugin] fix-coordinator-ips command", func() {
 		BeforeEach(func() {
 			Expect(k8sClient.Create(context.TODO(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "instance-1",
+					Name:      "storage-1",
 					Namespace: namespace,
 					Labels: map[string]string{
 						fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
@@ -78,7 +78,7 @@ var _ = Describe("[plugin] fix-coordinator-ips command", func() {
 							"-it",
 							"-c",
 							fdbv1beta2.MainContainerName,
-							"instance-1",
+							"storage-1",
 							"--",
 							"bash",
 							"-c",
@@ -100,7 +100,7 @@ var _ = Describe("[plugin] fix-coordinator-ips command", func() {
 							"-it",
 							"-c",
 							fdbv1beta2.MainContainerName,
-							"instance-1",
+							"storage-1",
 							"--",
 							"bash",
 							"-c",

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -386,9 +386,7 @@ func fetchPodNamesCrossCluster(kubeClient client.Client, namespace string, clust
 			}
 			return nil, err
 		}
-		for _, podName := range pods {
-			podsByCluster[cluster] = append(podsByCluster[cluster], podName)
-		}
+		podsByCluster[cluster] = append(podsByCluster[cluster], pods...)
 	}
 	return podsByCluster, nil
 }

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -264,9 +264,9 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					},
 					Entry("errors when process group IDs are provided instead of pod names",
 						testCase{
-							podNames:          []string{"instance-1"},
+							podNames:          []string{"storage-1"},
 							clusterLabel:      fdbv1beta2.FDBClusterLabel,
-							wantErrorContains: "could not get pod: test/instance-1",
+							wantErrorContains: "could not get pod: test/storage-1",
 							clusterDataMap: map[string]clusterData{
 								clusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
@@ -279,9 +279,9 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					),
 					Entry("errors when no cluster found with given label",
 						testCase{
-							podNames:          []string{fmt.Sprintf("%s-instance-1", clusterName)},
+							podNames:          []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)},
 							clusterLabel:      "invalid-cluster-label",
-							wantErrorContains: fmt.Sprintf("no cluster-label 'invalid-cluster-label' found for pod '%s-instance-1'", clusterName),
+							wantErrorContains: fmt.Sprintf("no cluster-label 'invalid-cluster-label' found for pod '%s-storage-1'", clusterName),
 							clusterDataMap: map[string]clusterData{
 								clusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
@@ -294,12 +294,12 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					),
 					Entry("removes valid 1 process group referred to by pod name and cluster-label",
 						testCase{
-							podNames:     []string{fmt.Sprintf("%s-instance-1", clusterName)},
+							podNames:     []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)},
 							clusterLabel: fdbv1beta2.FDBClusterLabel,
 							clusterDataMap: map[string]clusterData{
 								clusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -316,12 +316,12 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					),
 					Entry("removes two process groups, each on a different cluster",
 						testCase{
-							podNames:     []string{fmt.Sprintf("%s-instance-1", clusterName), fmt.Sprintf("%s-instance-1", secondClusterName)},
+							podNames:     []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)},
 							clusterLabel: fdbv1beta2.FDBClusterLabel,
 							clusterDataMap: map[string]clusterData{
 								clusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -329,7 +329,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 								},
 								secondClusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", secondClusterName)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -340,12 +340,12 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					),
 					Entry("removes 3 process groups, on 2 different clusters",
 						testCase{
-							podNames:     []string{fmt.Sprintf("%s-instance-1", clusterName), fmt.Sprintf("%s-instance-1", secondClusterName), fmt.Sprintf("%s-instance-2", secondClusterName)},
+							podNames:     []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)},
 							clusterLabel: fdbv1beta2.FDBClusterLabel,
 							clusterDataMap: map[string]clusterData{
 								clusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -353,8 +353,8 @@ var _ = Describe("[plugin] remove process groups command", func() {
 								},
 								secondClusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", secondClusterName)),
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", secondClusterName)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -365,14 +365,14 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					),
 					Entry("removes 4 process groups, on 2 different clusters",
 						testCase{
-							podNames: []string{fmt.Sprintf("%s-instance-1", clusterName), fmt.Sprintf("%s-instance-2", clusterName),
-								fmt.Sprintf("%s-instance-1", secondClusterName), fmt.Sprintf("%s-instance-2", secondClusterName)},
+							podNames: []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+								fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)},
 							clusterLabel: fdbv1beta2.FDBClusterLabel,
 							clusterDataMap: map[string]clusterData{
 								clusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -380,8 +380,8 @@ var _ = Describe("[plugin] remove process groups command", func() {
 								},
 								secondClusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", secondClusterName)),
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", secondClusterName)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -462,7 +462,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 							processClass: string(fdbv1beta2.ProcessClassStateless),
 							clusterName:  clusterName,
 							ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-3", clusterName)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)),
 							},
 						},
 					),
@@ -471,8 +471,8 @@ var _ = Describe("[plugin] remove process groups command", func() {
 							processClass: string(fdbv1beta2.ProcessClassStorage),
 							clusterName:  clusterName,
 							ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 							},
 						},
 					),
@@ -489,8 +489,8 @@ var _ = Describe("[plugin] remove process groups command", func() {
 							conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.PodFailing},
 							clusterName: clusterName,
 							ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-1", clusterName)),
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 							},
 						},
 					),
@@ -499,7 +499,7 @@ var _ = Describe("[plugin] remove process groups command", func() {
 							conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses},
 							clusterName: clusterName,
 							ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-instance-2", clusterName)),
+								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
 							},
 						},
 					),

--- a/kubectl-fdb/cmd/restart.go
+++ b/kubectl-fdb/cmd/restart.go
@@ -75,22 +75,11 @@ func newRestartCmd(streams genericclioptions.IOStreams) *cobra.Command {
 				return err
 			}
 
-			processGroupsByCluster, err := getProcessGroupsByCluster(cmd, kubeClient, processGroupSelectionOpts)
+			podsByCluster, err := getPodNamesByCluster(cmd, kubeClient, processGroupSelectionOpts)
 			if err != nil {
 				return err
 			}
-			for cluster, processGroupIDs := range processGroupsByCluster {
-				// TODO remove this once we've removed support for processGroupID (instead of pod) lookup and
-				//  can more nicely convert getProcessGroupsByCluster to return podNames (possible now, but less clean)
-				var podNames []string
-				for _, processGroupStatus := range cluster.Status.ProcessGroups {
-					for _, processGroupID := range processGroupIDs {
-						if processGroupStatus.ProcessGroupID != processGroupID {
-							continue
-						}
-						podNames = append(podNames, processGroupStatus.GetPodName(cluster))
-					}
-				}
+			for cluster, podNames := range podsByCluster {
 				err := restartProcesses(cmd, config, clientSet, podNames, processGroupSelectionOpts.namespace, cluster.Name, wait, sleep)
 				if err != nil {
 					return err

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -75,14 +75,14 @@ func generateClusterStruct(name string, namespace string) *fdbv1beta2.Foundation
 		Status: fdbv1beta2.FoundationDBClusterStatus{
 			ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
 				{
-					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-instance-1"),
+					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-" + string(fdbv1beta2.ProcessClassStorage) + "-1"),
 					ProcessClass:   fdbv1beta2.ProcessClassStorage,
 					ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
 						fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.PodFailing),
 					},
 				},
 				{
-					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-instance-2"),
+					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-" + string(fdbv1beta2.ProcessClassStorage) + "-2"),
 					ProcessClass:   fdbv1beta2.ProcessClassStorage,
 					ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
 						fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.PodFailing),
@@ -90,7 +90,7 @@ func generateClusterStruct(name string, namespace string) *fdbv1beta2.Foundation
 					},
 				},
 				{
-					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-instance-3"),
+					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-" + string(fdbv1beta2.ProcessClassStateless) + "-3"),
 					ProcessClass:   fdbv1beta2.ProcessClassStateless,
 				},
 			},


### PR DESCRIPTION
# Description

This is just a followup to https://github.com/FoundationDB/fdb-kubernetes-operator/pull/1941 which used an unsatisfying way to get podNames from processGroupIDs.  

I am not sure that this is much better, but they do seem like useful functions in the transition away from selecting by processGroupID.  

**It will be much easier to see the changes if you view by commit to avoid looking at the second commit,** which changes test pod names to include processClass in the name, which is an expectation of built-in functions (GetPodName will index-out-of-bounds).

## Type of change

- Code Cleanup

## Discussion

I wonder if there should be some explicit creation function which does not allow FDB pods to have invalid names, as I suspect that it is not only GetPodName which could have undefined behavior if expectations aren't met. 

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*
Unit tests, manual test of restart.

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

## Documentation

Docstrings have been added

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*
Arguably this could be progress towards not allowing useProcessGroupID and working more with podNames when possible, but we had trouble finding that issue before.  Perhaps we should raise one?  

*Does this introduce new defaults that we should re-evaluate in the future?*
No
