### PR TITLE
Allow to specify a cluster name in test suite

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -7,8 +7,8 @@ compile:
 # INPUT ENVIRONMENT VARIABLES
 TIMEOUT?=168h
 
+CLUSTER_NAME?=
 NAMESPACE?=
-PREFIX?=
 CONTEXT?=
 FDB_VERSION?=7.1.53
 # This will be the version used for upgrade tests.
@@ -111,7 +111,6 @@ nightly-tests: run
 	  --ginkgo.timeout=$(TIMEOUT) \
 	  --timeout=$(TIMEOUT) \
 	  --namespace="$(NAMESPACE)" \
-	  --prefix="$(PREFIX)" \
 	  --context="$(CONTEXT)" \
 	  --fdb-image="$(FDB_IMAGE)" \
 	  --sidecar-image="$(SIDECAR_IMAGE)" \
@@ -129,4 +128,5 @@ nightly-tests: run
 	  --feature-dns=$(FEATURE_DNS) \
 	  --cloud-provider=$(CLOUD_PROVIDER) \
 	  --dump-operator-state=$(DUMP_OPERATOR_STATE) \
+	  --cluster-name=$(CLUSTER_NAME) \
 	  | grep -v 'constructing many client instances from the same exec auth config can cause performance problems during cert rotation' &> $(BASE_DIR)/../logs/$<.log

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -19,6 +19,17 @@ make -C e2e test_operator.run
 
 Every test suite will create at least one namespace, HA cluster tests will create all the required namespaces.
 
+### Reusing an existing test cluster
+
+A test cluster can be reused if wanted, e.g. for test cases that load a large amount of data into the cluster.
+This requires to specify the `CLUSTER_NAME` and the `NAMESPACE`, if those values are not specified the test suite will use randomized values.
+** NOTE ** The limitation of this approach is that the test suite will not update the existing `FoundationDBCluster` in the creation step.
+So if you're modifying the `FoundationDBCluster` spec, you have to recreate the cluster.
+
+```bash
+CLEANUP=false CLUSTER_NAME=dev-cluster-1 NAMESPACE=dev make -kj -C e2e run
+```
+
 ### StorageClass selection
 
 The e2e tests assume that at least one `StorageClass` is present in the target Kubernetes cluster.

--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -125,7 +125,7 @@ func DefaultClusterConfig(debugSymbols bool) *ClusterConfig {
 // SetDefaults will set all unset fields to the default values.
 func (config *ClusterConfig) SetDefaults(factory *Factory) {
 	if config.Name == "" {
-		config.Name = factory.getClusterPrefix()
+		config.Name = factory.getClusterName()
 	}
 
 	// Only create the namespace for non HA clusters, otherwise the namespaces will be created in a different way.

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -254,12 +254,12 @@ func (factory *Factory) getContainerOverrides(
 	return mainOverrides, sidecarOverrides
 }
 
-func (factory *Factory) getClusterPrefix() string {
-	prefix := factory.options.prefix
-	if prefix == "" {
+func (factory *Factory) getClusterName() string {
+	if factory.options.clusterName == "" {
 		return fmt.Sprintf("fdb-cluster-%s", RandStringRunes(8))
 	}
-	return prefix
+
+	return factory.options.clusterName
 }
 
 // GetDefaultStorageClass returns either the StorageClass provided by the command line or fetches the StorageClass passed on

--- a/e2e/fixtures/fdb_operator_fixtures.go
+++ b/e2e/fixtures/fdb_operator_fixtures.go
@@ -151,7 +151,7 @@ func (factory *Factory) ensureHAFdbClusterExists(
 	options []ClusterOption,
 ) (*HaFdbCluster, error) {
 	fdb := &HaFdbCluster{}
-	clusterPrefix := factory.getClusterPrefix()
+	clusterPrefix := factory.getClusterName()
 
 	databaseConfiguration := config.CreateDatabaseConfiguration()
 	dcIDs := GetDcIDsFromConfig(databaseConfiguration)

--- a/e2e/fixtures/options.go
+++ b/e2e/fixtures/options.go
@@ -33,7 +33,6 @@ import (
 type FactoryOptions struct {
 	namespace                   string
 	chaosNamespace              string
-	prefix                      string
 	context                     string
 	fdbImage                    string // TODO (johscheuer): Make this optional if we use the default
 	sidecarImage                string // TODO (johscheuer): Make this optional if we use the default
@@ -45,6 +44,7 @@ type FactoryOptions struct {
 	storageClass                string
 	upgradeString               string
 	cloudProvider               string
+	clusterName                 string
 	enableChaosTests            bool
 	enableDataLoading           bool
 	cleanup                     bool
@@ -68,12 +68,6 @@ func (options *FactoryOptions) BindFlags(fs *flag.FlagSet) {
 		"chaos-namespace",
 		"",
 		"defines the chaos namespace to run experiments (will be created if missing)",
-	)
-	fs.StringVar(
-		&options.prefix,
-		"prefix",
-		"",
-		"defines the prefix of fdb cluster to run the test (will be created if missing)",
 	)
 	fs.StringVar(
 		&options.context,
@@ -183,6 +177,11 @@ func (options *FactoryOptions) BindFlags(fs *flag.FlagSet) {
 		true,
 		"defines if the operator tests should print the state of the cluster and the according Pods for better debugging.",
 	)
+	fs.StringVar(&options.clusterName,
+		"cluster-name",
+		"",
+		"if defined, the test suite will create a cluster with the specified name or update the setting of an existing cluster."+
+			"For multi-region clusters, this will define the prefix for all clusters.")
 }
 
 func (options *FactoryOptions) validateFlags() error {

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -152,16 +152,19 @@ func (fdbCluster *FdbCluster) RunFdbCliCommandInOperatorWithoutRetry(
 			break
 		}
 
-		var parsedStatus *fdbv1beta2.FoundationDBStatus
-		parsedStatus, err = parseStatusOutput(stdout)
-		// If we cannot parse the status we probably have an error or timeout
-		if err != nil {
-			continue
-		}
+		// Only try to parse the content to json if the command was "status json".
+		if strings.Contains(command, "status json") {
+			var parsedStatus *fdbv1beta2.FoundationDBStatus
+			parsedStatus, err = parseStatusOutput(stdout)
+			// If we cannot parse the status we probably have an error or timeout
+			if err != nil {
+				continue
+			}
 
-		// Quorum of coordinators are available, so we probably use the correct version
-		if parsedStatus.Client.Coordinators.QuorumReachable {
-			break
+			// Quorum of coordinators are available, so we probably use the correct version
+			if parsedStatus.Client.Coordinators.QuorumReachable {
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description

Depending on the test case it would be useful to reuse a cluster, e.g. in cases where a test cluster gets loaded with some amount of data.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

Ran a manual test:
```text
NAMESPACE=jdev CLUSTER_NAME=jdev  make -C e2e test_operator.run
```

With the following cluster and Pods created (the cluster is not available as the data loader is active):

```text
$ kubectl -n jdev get fdb,po 
NAME                                             GENERATION   RECONCILED   AVAILABLE   FULLREPLICATION   VERSION   AGE
foundationdbcluster.apps.foundationdb.org/jdev   1                                                       7.1.53    4m46s

NAME                                                              READY   STATUS    RESTARTS   AGE
pod/jdev-log-1                                                    2/2     Running   0          4m45s
pod/jdev-log-2                                                    2/2     Running   0          4m45s
pod/jdev-log-3                                                    2/2     Running   0          4m45s
pod/jdev-log-4                                                    2/2     Running   0          4m45s
pod/jdev-log-5                                                    2/2     Running   0          4m45s
pod/jdev-stateless-1                                              2/2     Running   0          4m45s
pod/jdev-stateless-2                                              2/2     Running   0          4m45s
pod/jdev-stateless-3                                              2/2     Running   0          4m45s
pod/jdev-stateless-4                                              2/2     Running   0          4m45s
pod/jdev-stateless-5                                              2/2     Running   0          4m45s
pod/jdev-stateless-6                                              2/2     Running   0          4m45s
pod/jdev-stateless-7                                              2/2     Running   0          4m45s
...
```

## Documentation

Added

## Follow-up

-