### PR TITLE
Disable flaky test in nightly runs

### DIFF
--- a/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
+++ b/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
@@ -83,7 +83,7 @@ func clusterSetup(beforeVersion string, enableOperatorPodChaos bool) {
 	clusterSetupWithHealthCheckOption(beforeVersion, enableOperatorPodChaos, true)
 }
 
-var _ = Describe("Operator HA Upgrades", Label("e2e", "nightly"), func() {
+var _ = Describe("Operator HA Upgrades", Label("e2e"), func() {
 	BeforeEach(func() {
 		factory = fixtures.CreateFactory(testOptions)
 	})


### PR DESCRIPTION
# Description

Once those tests are not flaky anymore we can more them to the right test suite and enable them again.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

-

## Documentation

-

## Follow-up

-