### PR TITLE
Allow to specify the storage engine when running e2e tests

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -23,6 +23,7 @@ TEST_USERNAME?=$(USER)
 ENABLE_CHAOS_TESTS?=true
 CHAOS_NAMESPACE?=chaos-testing
 STORAGE_CLASS?=
+STORAGE_ENGINE?=
 DUMP_OPERATOR_STATE?=true
 # Defines the cloud provider used for the underlying Kubernetes cluster. Currently only kind is support, other cloud providers
 # should still work but this test framework has no special cases for those.
@@ -129,4 +130,5 @@ nightly-tests: run
 	  --cloud-provider=$(CLOUD_PROVIDER) \
 	  --dump-operator-state=$(DUMP_OPERATOR_STATE) \
 	  --cluster-name=$(CLUSTER_NAME) \
+	  --storage-engine=$(STORAGE_ENGINE) \
 	  | grep -v 'constructing many client instances from the same exec auth config can cause performance problems during cert rotation' &> $(BASE_DIR)/../logs/$<.log

--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -134,7 +134,7 @@ func (config *ClusterConfig) SetDefaults(factory *Factory) {
 	}
 
 	if config.StorageEngine == "" {
-		config.StorageEngine = fdbv1beta2.StorageEngineSSD
+		config.StorageEngine = factory.getStorageEngine()
 	}
 
 	if config.StorageServerPerPod == 0 {

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -881,3 +881,12 @@ func (fdbCluster *FdbCluster) GetNode(name string) *corev1.Node {
 
 	return node
 }
+
+// getStorageEngine returns the storage engine that should be used by the test cluster. Defaults to ssd.
+func (factory *Factory) getStorageEngine() fdbv1beta2.StorageEngine {
+	if factory.options.storageEngine == "" {
+		return fdbv1beta2.StorageEngineSSD
+	}
+
+	return fdbv1beta2.StorageEngine(factory.options.storageEngine)
+}

--- a/e2e/fixtures/options.go
+++ b/e2e/fixtures/options.go
@@ -45,6 +45,7 @@ type FactoryOptions struct {
 	upgradeString               string
 	cloudProvider               string
 	clusterName                 string
+	storageEngine               string
 	enableChaosTests            bool
 	enableDataLoading           bool
 	cleanup                     bool
@@ -134,6 +135,12 @@ func (options *FactoryOptions) BindFlags(fs *flag.FlagSet) {
 		"data-loader-image",
 		"foundationdb/fdb-data-loader:latest",
 		"defines the data loader image that should be used for testing",
+	)
+	fs.StringVar(
+		&options.storageEngine,
+		"storage-engine",
+		"",
+		"defines the storage-engine that should be used by the created FDB cluster.",
 	)
 	fs.BoolVar(
 		&options.enableChaosTests,


### PR DESCRIPTION
# Description

This change makes it easier to run e2e tests with different storage engines.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

Most of the work was already done and I just had to extend the options to take the storage engine as a command line argument.

## Testing

Ran a manual test:

```text
$ kubectl -n jscheuermann-9bn2uqhy    exec -ti fdb-cluster-8qrv6e98-stateless-1   -- bash
[root@fdb-cluster-8qrv6e98-stateless-1 /]# fdbcli
Using cluster file `/var/dynamic-conf/fdb.cluster'.

The database is available.

Welcome to the fdbcli. For help, type `help'.
fdb> status

Using cluster file `/var/dynamic-conf/fdb.cluster'.

Configuration:
  Redundancy mode        - triple
  Storage engine         - ssd-rocksdb-v1
  Coordinators           - 5
  Desired Commit Proxies - 1
  Desired GRV Proxies    - 1
  Desired Resolvers      - 1
  Desired Logs           - 3
  Desired Remote Logs    - -1
  Desired Log Routers    - -1
  Usable Regions         - 1

...
```

## Documentation

-

## Follow-up

-
