### PR TITLE
Fix nil pointer ha e2e

### DIFF
--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -193,14 +193,14 @@ func (factory *Factory) CreateFdbHaCluster(
 		options,
 	)
 
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
 	log.Println(
 		"FoundationDB HA cluster created (at version",
 		cluster.GetPrimary().cluster.Spec.Version,
 		") in minutes",
 		time.Since(startTime).Minutes(),
 	)
-
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	return cluster
 }

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -188,12 +188,10 @@ func (factory *Factory) CreateFdbHaCluster(
 	startTime := time.Now()
 	config.SetDefaults(factory)
 
-	cluster, err := factory.ensureHAFdbClusterExists(
+	cluster := factory.ensureHAFdbClusterExists(
 		config,
 		options,
 	)
-
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	log.Println(
 		"FoundationDB HA cluster created (at version",

--- a/e2e/fixtures/fdb_operator_fixtures.go
+++ b/e2e/fixtures/fdb_operator_fixtures.go
@@ -186,10 +186,11 @@ func (factory *Factory) ensureHAFdbClusterExists(
 		return nil, err
 	}
 	err = fdb.WaitForReconciliation(CreationTrackerLoggerOption(config.CreationTracker))
-	log.Printf("primary cluster is reconciled in namespaces=%s", namespaces)
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("primary cluster is reconciled in namespaces=%s", namespaces)
+
 	cluster, err := factory.getClusterStatus(fdb.GetPrimary().Name(), fdb.GetPrimary().Namespace())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

We observed the following issue in our nightly test cases:

```text
  [PANICKED] Test Panicked
  In [It] at: /usr/local/go/src/runtime/panic.go:260 @ 02/28/24 13:40:16.976

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures.(*HaFdbCluster).GetCluster(...)
    	/codebuild/output/src3955936553/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures/ha_fdb_cluster.go:95
    github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures.(*HaFdbCluster).GetPrimary(...)
    	/codebuild/output/src3955936553/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures/ha_fdb_cluster.go:54
    github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures.(*Factory).CreateFdbHaCluster(0xc000615218?, 0xf91e4ee5dfcf676b?, {0xc000455de0, 0x2, 0x2})
    	/codebuild/output/src3955936553/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures/factory.go:198 +0xb7
    github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_ha_upgrades.clusterSetupWithTestConfig({{0xc00004ce60, 0x6}, 0x1, 0x1, 0x1, 0xc0004fb3f0})
    	/codebuild/output/src3955936553/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go:83 +0x26c
    github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_ha_upgrades.glob..func2.4({0xc00004ce60?, 0x0?}, {0xc00004ce66, 0x6})
    	/codebuild/output/src3955936553/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go:180 +0x9b
    reflect.Value.call({0x17877c0?, 0x1ad9818?, 0x13?}, {0x19d9e3f, 0x4}, {0xc00057e510, 0x2, 0x2?})
    	/usr/local/go/src/reflect/value.go:586 +0xb0b
    reflect.Value.Call({0x17877c0?, 0x1ad9818?, 0x1c7d818?}, {0xc00057e510?, 0x430f8290b0bcbfd9?, 0xe7557fe55be6e393?})
    	/usr/local/go/src/reflect/value.go:370 +0xbc

  There were additional failures detected.  To view them in detail run ginkgo -vv
```

The issue was that the returned error was checked after the method was accessing the returned pointer.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

CI will be running tests.

## Documentation

-

## Follow-up

-
