### PR TITLE
Update pods check needs removal

### DIFF
--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbstatus"
 
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal/replacements"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 	"github.com/go-logr/logr"
@@ -39,7 +41,14 @@ type updatePods struct{}
 
 // reconcile runs the reconciler's work.
 func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
-	updates, err := getPodsToUpdate(ctx, logger, r, cluster)
+	// TODO(johscheuer): Remove the pvc map an make direct calls.
+	pvcs := &corev1.PersistentVolumeClaimList{}
+	err := r.List(ctx, pvcs, internal.GetPodListOptions(cluster, "", "")...)
+	if err != nil {
+		return &requeue{curError: err}
+	}
+
+	updates, err := getPodsToUpdate(ctx, logger, r, cluster, internal.CreatePVCMap(cluster, pvcs))
 	if err != nil {
 		return &requeue{curError: err, delay: podSchedulingDelayDuration, delayedRequeue: true}
 	}
@@ -117,7 +126,7 @@ func getFaultDomainsWithUnavailablePods(ctx context.Context, logger logr.Logger,
 }
 
 // getPodsToUpdate returns a map of Zone to Pods mapping. The map has the fault domain as key and all Pods in that fault domain will be present as a slice of *corev1.Pod.
-func getPodsToUpdate(ctx context.Context, logger logr.Logger, reconciler *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster) (map[string][]*corev1.Pod, error) {
+func getPodsToUpdate(ctx context.Context, logger logr.Logger, reconciler *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, pvcMap map[fdbv1beta2.ProcessGroupID]corev1.PersistentVolumeClaim) (map[string][]*corev1.Pod, error) {
 	updates := make(map[string][]*corev1.Pod)
 
 	faultDomainsWithUnavailablePods := getFaultDomainsWithUnavailablePods(ctx, logger, reconciler, cluster)
@@ -160,6 +169,15 @@ func getPodsToUpdate(ctx context.Context, logger logr.Logger, reconciler *Founda
 		if cluster.NeedsReplacement(processGroup) {
 			logger.V(1).Info("Skip process group for deletion, requires a replacement",
 				"processGroupID", processGroup.ProcessGroupID)
+			continue
+		}
+
+		needsRemoval, err := replacements.ProcessGroupNeedsRemoval(ctx, reconciler.PodLifecycleManager, reconciler, logger, cluster, processGroup, pvcMap)
+		// Do not update the Pod if unable to determine if it needs to be removed.
+		if err != nil {
+			continue
+		}
+		if needsRemoval {
 			continue
 		}
 

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -175,9 +175,13 @@ func getPodsToUpdate(ctx context.Context, logger logr.Logger, reconciler *Founda
 		needsRemoval, err := replacements.ProcessGroupNeedsRemoval(ctx, reconciler.PodLifecycleManager, reconciler, logger, cluster, processGroup, pvcMap)
 		// Do not update the Pod if unable to determine if it needs to be removed.
 		if err != nil {
+			logger.V(1).Info("Failed checking if process group needs removal",
+				"processGroupID", processGroup.ProcessGroupID)
 			continue
 		}
 		if needsRemoval {
+			logger.V(1).Info("Skip process group for deletion, requires a removal",
+				"processGroupID", processGroup.ProcessGroupID)
 			continue
 		}
 

--- a/controllers/update_pods_test.go
+++ b/controllers/update_pods_test.go
@@ -309,7 +309,8 @@ var _ = Describe("update_pods", func() {
 		})
 
 		JustBeforeEach(func() {
-			updates, err = getPodsToUpdate(context.Background(), globalControllerLogger, clusterReconciler, cluster)
+			// TODO update tests with pvcMap
+			updates, err = getPodsToUpdate(context.Background(), globalControllerLogger, clusterReconciler, cluster, nil)
 			if !expectedError {
 				Expect(err).NotTo(HaveOccurred())
 			} else {

--- a/controllers/update_pods_test.go
+++ b/controllers/update_pods_test.go
@@ -296,6 +296,7 @@ var _ = Describe("update_pods", func() {
 	When("fetching all Pods that needs an update", func() {
 		var cluster *fdbv1beta2.FoundationDBCluster
 		var updates map[string][]*corev1.Pod
+		var pvcMap map[fdbv1beta2.ProcessGroupID]corev1.PersistentVolumeClaim
 		var expectedError bool
 		var err error
 
@@ -306,11 +307,16 @@ var _ = Describe("update_pods", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
 			Expect(k8sClient.Get(context.TODO(), ctrlClient.ObjectKeyFromObject(cluster), cluster)).NotTo(HaveOccurred())
+
+			allPvcs := &corev1.PersistentVolumeClaimList{}
+			err = clusterReconciler.List(context.TODO(), allPvcs, internal.GetPodListOptions(cluster, "", "")...)
+			Expect(err).NotTo(HaveOccurred())
+
+			pvcMap = internal.CreatePVCMap(cluster, allPvcs)
 		})
 
 		JustBeforeEach(func() {
-			// TODO update tests with pvcMap
-			updates, err = getPodsToUpdate(context.Background(), globalControllerLogger, clusterReconciler, cluster, nil)
+			updates, err = getPodsToUpdate(context.Background(), globalControllerLogger, clusterReconciler, cluster, pvcMap)
 			if !expectedError {
 				Expect(err).NotTo(HaveOccurred())
 			} else {
@@ -327,7 +333,7 @@ var _ = Describe("update_pods", func() {
 		When("there is a spec change for all processes", func() {
 			BeforeEach(func() {
 				storageSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
-				storageSettings.PodTemplate.Spec.NodeSelector = map[string]string{"test": "test"}
+				storageSettings.PodTemplate.Spec.Tolerations = []corev1.Toleration{{Key: "test", Operator: "Exists", Effect: "NoSchedule"}}
 				cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = storageSettings
 				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 			})
@@ -337,6 +343,19 @@ var _ = Describe("update_pods", func() {
 				Expect(updates).To(HaveLen(1))
 			})
 		})
+		When("there is a spec change requiring a removal", func() {
+			BeforeEach(func() {
+				storageSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
+				// Updates to NodeSelector requires a removal
+				storageSettings.PodTemplate.Spec.NodeSelector = map[string]string{"test": "test"}
+				cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = storageSettings
+				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+			})
+
+			It("should return no updates", func() {
+				Expect(updates).To(HaveLen(0))
+			})
+		})
 
 		When("max zones with unavailable pods is set to 3 and there are two process groups with pods in pending status", func() {
 			BeforeEach(func() {
@@ -344,7 +363,7 @@ var _ = Describe("update_pods", func() {
 				cluster.Spec.MaxZonesWithUnavailablePods = pointer.Int(3)
 				// Update all processes
 				storageSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
-				storageSettings.PodTemplate.Spec.NodeSelector = map[string]string{"test": "test"}
+				storageSettings.PodTemplate.Spec.Tolerations = []corev1.Toleration{{Key: "test", Operator: "Exists", Effect: "NoSchedule"}}
 				cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = storageSettings
 				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 
@@ -367,7 +386,7 @@ var _ = Describe("update_pods", func() {
 				cluster.Spec.MaxZonesWithUnavailablePods = pointer.Int(2)
 				// Update all processes
 				storageSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
-				storageSettings.PodTemplate.Spec.NodeSelector = map[string]string{"test": "test"}
+				storageSettings.PodTemplate.Spec.Tolerations = []corev1.Toleration{{Key: "test", Operator: "Exists", Effect: "NoSchedule"}}
 				cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = storageSettings
 				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 
@@ -390,7 +409,7 @@ var _ = Describe("update_pods", func() {
 				cluster.Spec.MaxZonesWithUnavailablePods = pointer.Int(1)
 				// Update all processes
 				storageSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
-				storageSettings.PodTemplate.Spec.NodeSelector = map[string]string{"test": "test"}
+				storageSettings.PodTemplate.Spec.Tolerations = []corev1.Toleration{{Key: "test", Operator: "Exists", Effect: "NoSchedule"}}
 				cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = storageSettings
 				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2006,17 +2006,17 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		When("a change that requires a replacement of all storage pods", func() {
 			var initialVolumeClaims *corev1.PersistentVolumeClaimList
-			var newCpuRequest, initialCpuRequest resource.Quantity
+			var newCPURequest, initialCPURequest resource.Quantity
 			BeforeEach(func() {
 
 				initialVolumeClaims = fdbCluster.GetVolumeClaimsForProcesses(fdbv1beta2.ProcessClassStorage)
 				spec := fdbCluster.GetCluster().Spec.DeepCopy()
-				initialCpuRequest = spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests["cpu"]
-				newCpuRequest = initialCpuRequest.DeepCopy()
+				initialCPURequest = spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests["cpu"]
+				newCPURequest = initialCPURequest.DeepCopy()
 
 				// An increase in request requires a replacement when ReplaceInstancesWhenResourcesChange is set to true
-				newCpuRequest.Add(resource.MustParse("1m"))
-				spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests["cpu"] = newCpuRequest
+				newCPURequest.Add(resource.MustParse("1m"))
+				spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests["cpu"] = newCPURequest
 
 				fdbCluster.UpdateClusterSpecWithSpec(spec)
 
@@ -2027,7 +2027,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			AfterEach(func() {
 				// Undo the change to cpu requests
 				spec := fdbCluster.GetCluster().Spec.DeepCopy()
-				spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests["cpu"] = initialCpuRequest
+				spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests["cpu"] = initialCPURequest
 				fdbCluster.UpdateClusterSpecWithSpec(spec)
 
 				// Wait for the reconciliation to finish

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -70,6 +70,7 @@ func ReplaceMisconfiguredProcessGroups(ctx context.Context, podManager podmanage
 	return hasReplacements, nil
 }
 
+// ProcessGroupNeedsRemoval checks if a process group needs to be removed.
 func ProcessGroupNeedsRemoval(ctx context.Context, podManager podmanager.PodLifecycleManager, client client.Client, log logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus, pvcMap map[fdbv1beta2.ProcessGroupID]corev1.PersistentVolumeClaim) (bool, error) {
 	// TODO(johscheuer): Fix how we fetch the pvc to make better use of the controller runtime cache.
 	pvc, hasPVC := pvcMap[processGroup.ProcessGroupID]

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -95,13 +95,7 @@ func ProcessGroupNeedsRemoval(ctx context.Context, podManager podmanager.PodLife
 		return false, podErr
 	}
 
-	needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
-
-	if err != nil {
-		return false, err
-	}
-
-	return needsRemoval, nil
+	return  processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 }
 
 func processGroupNeedsRemovalForPVC(cluster *fdbv1beta2.FoundationDBCluster, pvc corev1.PersistentVolumeClaim, log logr.Logger, processGroup *fdbv1beta2.ProcessGroupStatus) (bool, error) {

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -53,7 +53,7 @@ func ReplaceMisconfiguredProcessGroups(ctx context.Context, podManager podmanage
 			continue
 		}
 
-		needsRemoval, err := processGroupNeedsRemoval(ctx, podManager, client, log, cluster, processGroup, pvcMap)
+		needsRemoval, err := ProcessGroupNeedsRemoval(ctx, podManager, client, log, cluster, processGroup, pvcMap)
 
 		// Do not mark for removal if there is an error
 		if err != nil {
@@ -70,7 +70,7 @@ func ReplaceMisconfiguredProcessGroups(ctx context.Context, podManager podmanage
 	return hasReplacements, nil
 }
 
-func processGroupNeedsRemoval(ctx context.Context, podManager podmanager.PodLifecycleManager, client client.Client, log logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus, pvcMap map[fdbv1beta2.ProcessGroupID]corev1.PersistentVolumeClaim) (bool, error) {
+func ProcessGroupNeedsRemoval(ctx context.Context, podManager podmanager.PodLifecycleManager, client client.Client, log logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus, pvcMap map[fdbv1beta2.ProcessGroupID]corev1.PersistentVolumeClaim) (bool, error) {
 	// TODO(johscheuer): Fix how we fetch the pvc to make better use of the controller runtime cache.
 	pvc, hasPVC := pvcMap[processGroup.ProcessGroupID]
 	pod, podErr := podManager.GetPod(ctx, client, cluster, processGroup.GetPodName(cluster))

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -95,7 +95,7 @@ func ProcessGroupNeedsRemoval(ctx context.Context, podManager podmanager.PodLife
 		return false, podErr
 	}
 
-	return  processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
+	return processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 }
 
 func processGroupNeedsRemovalForPVC(cluster *fdbv1beta2.FoundationDBCluster, pvc corev1.PersistentVolumeClaim, log logr.Logger, processGroup *fdbv1beta2.ProcessGroupStatus) (bool, error) {
@@ -126,12 +126,12 @@ func processGroupNeedsRemovalForPVC(cluster *fdbv1beta2.FoundationDBCluster, pvc
 	}
 
 	if pvc.Annotations[fdbv1beta2.LastSpecKey] != pvcHash {
-		logger.Info("Process group requires removal",
+		logger.Info("Replace process group",
 			"reason", fmt.Sprintf("PVC spec has changed from %s to %s", pvcHash, pvc.Annotations[fdbv1beta2.LastSpecKey]))
 		return true, nil
 	}
 	if pvc.Name != desiredPVC.Name {
-		logger.Info("Process group requires removal",
+		logger.Info("Replace process group",
 			"reason", fmt.Sprintf("PVC name has changed from %s to %s", desiredPVC.Name, pvc.Name))
 		return true, nil
 	}
@@ -157,7 +157,7 @@ func processGroupNeedsRemovalForPod(cluster *fdbv1beta2.FoundationDBCluster, pod
 
 	_, desiredProcessGroupID := cluster.GetProcessGroupID(processGroupStatus.ProcessClass, idNum)
 	if processGroupStatus.ProcessGroupID != desiredProcessGroupID {
-		logger.Info("Process group requires removal",
+		logger.Info("Replace process group",
 			"reason", fmt.Sprintf("expect process group ID: %s", desiredProcessGroupID))
 		return true, nil
 	}
@@ -167,7 +167,7 @@ func processGroupNeedsRemovalForPod(cluster *fdbv1beta2.FoundationDBCluster, pod
 		return false, err
 	}
 	if ipSource != cluster.GetPublicIPSource() {
-		logger.Info("Process group requires removal",
+		logger.Info("Replace process group",
 			"reason", fmt.Sprintf("publicIP source has changed from %s to %s", ipSource, cluster.GetPublicIPSource()))
 		return true, nil
 	}
@@ -179,7 +179,7 @@ func processGroupNeedsRemovalForPod(cluster *fdbv1beta2.FoundationDBCluster, pod
 	desiredServersPerPod := cluster.GetDesiredServersPerPod(processGroupStatus.ProcessClass)
 	// Replace the process group if the expected servers differ from the desired servers
 	if serversPerPod != desiredServersPerPod {
-		logger.Info("Process group requires removal",
+		logger.Info("Replace process group",
 			"serversPerPod", serversPerPod,
 			"desiredServersPerPod", desiredServersPerPod,
 			"reason", fmt.Sprintf("serversPerPod have changes from current: %d to desired: %d", serversPerPod, desiredServersPerPod))
@@ -194,7 +194,7 @@ func processGroupNeedsRemovalForPod(cluster *fdbv1beta2.FoundationDBCluster, pod
 		}
 
 		if pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] != specHash {
-			logger.Info("Process group requires removal",
+			logger.Info("Replace process group",
 				"reason", fmt.Sprintf("nodeSelector has changed from %s to %s", pod.Spec.NodeSelector, expectedNodeSelector))
 			return true, nil
 		}
@@ -217,7 +217,7 @@ func processGroupNeedsRemovalForPod(cluster *fdbv1beta2.FoundationDBCluster, pod
 				return false, err
 			}
 
-			logger.Info("Process group requires removal",
+			logger.Info("Replace process group",
 				"reason", "specHash has changed",
 				"desiredSpecHash", specHash,
 				"currentSpecHash", pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey],
@@ -234,13 +234,13 @@ func processGroupNeedsRemovalForPod(cluster *fdbv1beta2.FoundationDBCluster, pod
 		}
 
 		if resourcesNeedsReplacement(desiredSpec.Containers, pod.Spec.Containers) {
-			logger.Info("Process group requires removal",
+			logger.Info("Replace process group",
 				"reason", "Resource requests have changed")
 			return true, nil
 		}
 
 		if resourcesNeedsReplacement(desiredSpec.InitContainers, pod.Spec.InitContainers) {
-			logger.Info("Process group requires removal",
+			logger.Info("Replace process group",
 				"reason", "Resource requests have changed")
 			return true, nil
 		}

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -98,7 +98,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 		Describe("Check process group", func() {
 			When("process group has no Pod", func() {
 				It("should not need removal", func() {
-					needsRemoval, err := processGroupNeedsRemoval(cluster, nil, nil, log)
+					needsRemoval, err := processGroupNeedsRemovalForPod(cluster, nil, nil, log)
 					Expect(needsRemoval).To(BeFalse())
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -111,7 +111,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should not need a removal", func() {
-					needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+					needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 					Expect(needsRemoval).To(BeFalse())
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -125,13 +125,13 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					})
 
 					It("should need a removal", func() {
-						needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+						needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 						Expect(needsRemoval).To(BeFalse())
 						Expect(err).NotTo(HaveOccurred())
 
 						// Change the process group ID should trigger a removal
 						cluster.Spec.ProcessGroupIDPrefix = "test"
-						needsRemoval, err = processGroupNeedsRemoval(cluster, pod, processGroup, log)
+						needsRemoval, err = processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 						Expect(needsRemoval).To(BeTrue())
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -144,13 +144,13 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					})
 
 					It("should need a removal", func() {
-						needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+						needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 						Expect(needsRemoval).To(BeFalse())
 						Expect(err).NotTo(HaveOccurred())
 
 						// Change the process group ID should trigger a removal
 						cluster.Spec.ProcessGroupIDPrefix = "test"
-						needsRemoval, err = processGroupNeedsRemoval(cluster, pod, processGroup, log)
+						needsRemoval, err = processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 						Expect(needsRemoval).To(BeTrue())
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -164,13 +164,13 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should need a removal", func() {
-					needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+					needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 					Expect(needsRemoval).To(BeFalse())
 					Expect(err).NotTo(HaveOccurred())
 
 					ipSource := fdbv1beta2.PublicIPSourceService
 					cluster.Spec.Routing.PublicIPSource = &ipSource
-					needsRemoval, err = processGroupNeedsRemoval(cluster, pod, processGroup, log)
+					needsRemoval, err = processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 					Expect(needsRemoval).To(BeTrue())
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -191,12 +191,12 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				ipSource := fdbv1beta2.PublicIPSourceService
 				cluster.Spec.Routing.PublicIPSource = &ipSource
 
-				needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 
 				cluster.Spec.Routing.PublicIPSource = nil
-				needsRemoval, err = processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err = processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -209,13 +209,13 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			})
 
 			It("should not need a removal", func() {
-				needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 
 				ipSource := fdbv1beta2.PublicIPSourcePod
 				cluster.Spec.Routing.PublicIPSource = &ipSource
-				needsRemoval, err = processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err = processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -228,12 +228,12 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			})
 
 			It("should need a removal", func() {
-				needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 
 				cluster.Spec.StorageServersPerPod = 2
-				needsRemoval, err = processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err = processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -246,12 +246,12 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			})
 
 			It("should not need a removal", func() {
-				needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 
 				cluster.Spec.StorageServersPerPod = 2
-				needsRemoval, err = processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err = processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -264,14 +264,14 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			})
 
 			It("should need a removal", func() {
-				needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 
 				cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral].PodTemplate.Spec.NodeSelector = map[string]string{
 					"dummy": "test",
 				}
-				needsRemoval, err = processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err = processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -290,7 +290,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				pod.Spec.NodeSelector = map[string]string{
 					"dummy": "test",
 				}
-				needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -306,7 +306,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				pod.Spec = corev1.PodSpec{
 					Containers: []corev1.Container{{}},
 				}
-				needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -321,7 +321,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			It("should need a removal", func() {
 				pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = "-1"
 				cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyReplacement
-				needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -336,7 +336,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			It("should not need a removal", func() {
 				pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = "-1"
 				cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyTransactionReplacement
-				needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -351,7 +351,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			It("should need a removal", func() {
 				pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = "-1"
 				cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyTransactionReplacement
-				needsRemoval, err := processGroupNeedsRemoval(cluster, pod, processGroup, log)
+				needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, processGroup, log)
 				Expect(needsRemoval).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -403,7 +403,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					ProcessClass:   fdbv1beta2.ProcessClassStorage,
 				}
 
-				needsRemoval, err := processGroupNeedsRemoval(cluster, pod, status, log)
+				needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, status, log)
 				Expect(needsRemoval).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -425,7 +425,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					})
 
 					It("should need a removal", func() {
-						needsRemoval, err := processGroupNeedsRemoval(cluster, pod, status, log)
+						needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, status, log)
 						Expect(needsRemoval).To(BeTrue())
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -443,7 +443,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					})
 
 					It("should not need a removal", func() {
-						needsRemoval, err := processGroupNeedsRemoval(cluster, pod, status, log)
+						needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, status, log)
 						Expect(needsRemoval).To(BeFalse())
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -461,7 +461,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					})
 
 					It("should need a removal", func() {
-						needsRemoval, err := processGroupNeedsRemoval(cluster, pod, status, log)
+						needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, status, log)
 						Expect(needsRemoval).To(BeTrue())
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -479,7 +479,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					})
 
 					It("should not need a removal", func() {
-						needsRemoval, err := processGroupNeedsRemoval(cluster, pod, status, log)
+						needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, status, log)
 						Expect(needsRemoval).To(BeFalse())
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -500,7 +500,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					})
 
 					It("should need a removal", func() {
-						needsRemoval, err := processGroupNeedsRemoval(cluster, pod, status, log)
+						needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, status, log)
 						Expect(needsRemoval).To(BeTrue())
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -524,7 +524,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					})
 
 					It("should not need a removal", func() {
-						needsRemoval, err := processGroupNeedsRemoval(cluster, pod, status, log)
+						needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, status, log)
 						Expect(needsRemoval).To(BeFalse())
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -542,7 +542,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					})
 
 					It("should not need a removal", func() {
-						needsRemoval, err := processGroupNeedsRemoval(cluster, pod, status, log)
+						needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, status, log)
 						Expect(needsRemoval).To(BeFalse())
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -560,7 +560,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					})
 
 					It("should not need a removal", func() {
-						needsRemoval, err := processGroupNeedsRemoval(cluster, pod, status, log)
+						needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, status, log)
 						Expect(needsRemoval).To(BeFalse())
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -578,7 +578,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					})
 
 					It("should not need a removal", func() {
-						needsRemoval, err := processGroupNeedsRemoval(cluster, pod, status, log)
+						needsRemoval, err := processGroupNeedsRemovalForPod(cluster, pod, status, log)
 						Expect(needsRemoval).To(BeFalse())
 						Expect(err).NotTo(HaveOccurred())
 					})


### PR DESCRIPTION
# Description

Fixes bug where delete strategy is applied on pods not marked for removal in the replaceMisconfiguredProcessGroups step, https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1918, by checking if the pod needs removal in the updatePods reconciler.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing
In addition to the ginkgo tests, also tested in a kubernetes deployment, verifying that update deletion strategy will not be applied if the update requires a removal / replacement.