### PR TITLE
Fix the e2e test case for the new FDB version that supports to remove old tester processes automatically

### DIFF
--- a/api/v1beta2/foundationdb_version.go
+++ b/api/v1beta2/foundationdb_version.go
@@ -232,6 +232,16 @@ func (version Version) SupportsLocalityBasedExclusions() bool {
 	return version.IsAtLeast(Versions.SupportsLocalityBasedExclusions)
 }
 
+// AutomaticallyRemovesDeadTesterProcesses returns true if the FDB version automatically removes old tester processes
+// from the list of processes.
+func (version Version) AutomaticallyRemovesDeadTesterProcesses() bool {
+	if version.IsProtocolCompatible(Version{Major: 7, Minor: 3, Patch: 0}) {
+		return version.IsAtLeast(Version{Major: 7, Minor: 1, Patch: 35})
+	}
+
+	return version.IsAtLeast(Version{Major: 7, Minor: 1, Patch: 55})
+}
+
 // Versions provides a shorthand for known versions.
 // This is only to be used in testing.
 var Versions = struct {

--- a/controllers/bounce_processes_test.go
+++ b/controllers/bounce_processes_test.go
@@ -723,6 +723,30 @@ var _ = Describe("bounceProcesses", func() {
 					Expect(adminClient.KilledAddresses).To(BeEmpty())
 				})
 			})
+
+			When("the FDB version automatically removes old tester processes", func() {
+				var previousVersion string
+
+				BeforeEach(func() {
+					previousVersion = cluster.Status.RunningVersion
+					cluster.Spec.Version = "7.1.57"
+					cluster.Status.RunningVersion = "7.1.57"
+				})
+
+				AfterEach(func() {
+					cluster.Status.RunningVersion = previousVersion
+					cluster.Spec.Version = previousVersion
+				})
+
+				It("should not requeue", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeue).To(BeNil())
+				})
+
+				It("should not kill the cluster controller", func() {
+					Expect(adminClient.KilledAddresses).To(BeEmpty())
+				})
+			})
 		})
 
 		When("the unreachable processes include no tester processes", func() {
@@ -774,7 +798,7 @@ var _ = Describe("bounceProcesses", func() {
 			})
 		})
 
-		When("the cluster message doesn not contain unreachable processes", func() {
+		When("the cluster message does not contain unreachable processes", func() {
 			BeforeEach(func() {
 				adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
 				Expect(err).NotTo(HaveOccurred())

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -10,9 +10,9 @@ TIMEOUT?=168h
 CLUSTER_NAME?=
 NAMESPACE?=
 CONTEXT?=
-FDB_VERSION?=7.1.53
+FDB_VERSION?=7.1.57
 # This will be the version used for upgrade tests.
-NEXT_FDB_VERSION?=7.3.29
+NEXT_FDB_VERSION?=7.3.33
 ## Expectation is that you are running standard build image which generates both regular and debug (Symbols) images.
 FDB_IMAGE?=foundationdb/foundationdb:$(FDB_VERSION)
 SIDECAR_IMAGE?=foundationdb/foundationdb-kubernetes-sidecar:$(FDB_VERSION)-1


### PR DESCRIPTION
# Description

Updates the operator logic and e2e test case for this change in FDB: https://github.com/apple/foundationdb/pull/11149

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran unit tests and CI will run the e2e tests.

## Documentation

-

## Follow-up

-
