### PR TITLE
Document issue with older fdb bindings and DNS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ dist/
 
 # Ignore any temporary created kube config files
 *.kubeconfig
+
+# Used for testing locally build FDB library
+libfdb_c.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,14 +54,6 @@ VOLUME /usr/lib/fdb
 
 WORKDIR /
 
-# Add tini to the operator image to allow to take coredumps.
-ENV TINI_VERSION v0.19.0
-RUN curl --fail -L "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" -o /tini && \
-    curl --fail -L "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc" -o /tini.asc && \
-    gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
-    gpg --batch --verify /tini.asc /tini
-RUN chmod +x /tini
-
 RUN set -eux && \
     curl --fail -L "${FDB_WEBSITE}/${FDB_VERSION}/foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm" -o foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm && \
     curl --fail -L "${FDB_WEBSITE}/${FDB_VERSION}/foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm.sha256" -o foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm.sha256 && \
@@ -85,4 +77,4 @@ ENV FDB_NETWORK_OPTION_TRACE_ENABLE=/var/log/fdb
 ENV FDB_BINARY_DIR=/usr/bin/fdb
 ENV FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY=/usr/bin/fdb
 
-ENTRYPOINT ["/tini", "--", "/manager"]
+ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,14 @@ VOLUME /usr/lib/fdb
 
 WORKDIR /
 
+# Add tini to the operator image to allow to take coredumps.
+ENV TINI_VERSION v0.19.0
+RUN curl --fail -L "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" -o /tini && \
+    curl --fail -L "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc" -o /tini.asc && \
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+    gpg --batch --verify /tini.asc /tini
+RUN chmod +x /tini
+
 RUN set -eux && \
     curl --fail -L "${FDB_WEBSITE}/${FDB_VERSION}/foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm" -o foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm && \
     curl --fail -L "${FDB_WEBSITE}/${FDB_VERSION}/foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm.sha256" -o foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm.sha256 && \
@@ -77,4 +85,4 @@ ENV FDB_NETWORK_OPTION_TRACE_ENABLE=/var/log/fdb
 ENV FDB_BINARY_DIR=/usr/bin/fdb
 ENV FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY=/usr/bin/fdb
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/tini", "--", "/manager"]

--- a/docs/manual/operator_customization.md
+++ b/docs/manual/operator_customization.md
@@ -19,7 +19,10 @@ At start time, the operator scans this directory for version-specific binaries, 
 
 ## Customizing the Primary Client Library
 
-By default, the primary client library used by the operator is the oldest supported version, as discussed above. If you want to use a newer version of the client library as your primary client, you can control that through additonal init containers. 
+By default, the primary client library used by the operator is the oldest supported version, as discussed above.
+If you want to use a newer version of the client library as your primary client, you can control that through additional init containers.
+**NOTE**: When using this approach it can happen that the operator keeps crashing when all coordinators are deleted, see https://github.com/apple/foundationdb/issues/11222.
+A better solution is to build the operator with the `7.1` version to prevent those crashes.
 
 ```yaml
 # This provides partial configuration for the deployment to show what needs to change in order to


### PR DESCRIPTION
# Description

Documents the limitations of the copy approach for the primary FDB lib, see: https://github.com/apple/foundationdb/issues/11222

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1950

## Type of change

*Please select one of the options below.*

- Documentation

## Discussion

I also added `tini` to the operator image to allow the manager to generate coredumps, if the process is PID 1 it doesn't work.

## Testing

-

## Documentation

Updated.

## Follow-up

-
