### PR TITLE
Allow more addresses to be present in the upgrade bounce case

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -263,7 +263,7 @@ func getProcessesReadyForRestart(logger logr.Logger, cluster *fdbv1beta2.Foundat
 		return nil, &requeue{message: "Waiting for config map to sync to all pods", delayedRequeue: true}
 	}
 
-	// Only if the cluster is upgraded with ab incompatible version we have to make sure that all processes are ready to be restarted.
+	// Only if the cluster is upgraded with an incompatible version we have to make sure that all processes are ready to be restarted.
 	// In the case of a patch upgrade we will be recreating the Pods anyway without this bounce step.
 	if cluster.IsBeingUpgradedWithVersionIncompatibleVersion() {
 		counts, err := cluster.GetProcessCountsWithDefaults()


### PR DESCRIPTION
# Description

We have seen a case in our nightly runs where one process was marked for removal but not yet fully excluded. I believe in such cases it's fine to have more addresses than the expected list, as it could take a while until a process is fully excluded,

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran unit tests and CI will run e2e tests.

## Documentation

-

## Follow-up

-
