### PR TITLE
Make use of unstructured when using SSA to prevent default values causing issues

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -38,6 +38,13 @@ FEATURE_DNS?=false
 FEATURE_LOCALITIES?=false
 # Allows to specify the tag for a specific FDB version. Format is 7.1.57:7.1.57-testing,7.3.35:7.3.35-debugging
 FDB_VERSION_TAG_MAPPING?=
+# If the FEATURE_SERVER_SIDE_APPLY environment variable is not defined the test suite will be randomly enable (1) or disable (0)
+# the server side apply feature.
+ifndef FEATURE_SERVER_SIDE_APPLY
+  FEATURE_SERVER_SIDE_APPLY=$(shell shuf -i 0-1 -n 1)
+else
+  FEATURE_SERVER_SIDE_APPLY=false
+endif
 
 # Make bash pickier about errors.
 SHELL=/bin/bash -euo pipefail
@@ -136,4 +143,5 @@ nightly-tests: run
 	  --storage-engine=$(STORAGE_ENGINE) \
 	  --fdb-version-tag-mapping=$(FDB_VERSION_TAG_MAPPING) \
 	  --unified-fdb-image=$(UNIFIED_FDB_IMAGE) \
+	  --feature-server-side-apply=$(FEATURE_SERVER_SIDE_APPLY) \
 	  | grep -v 'constructing many client instances from the same exec auth config can cause performance problems during cert rotation' &> $(BASE_DIR)/../logs/$<.log

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -485,7 +485,7 @@ spec:
           - --max-concurrent-reconciles=5
           - --zap-log-level=debug
           - --minimum-required-uptime-for-cc-bounce=60s
-          #- --server-side-apply
+          - --server-side-apply
           # We are setting low values here as the e2e test are taking down processes multiple times
           # and having a high wait time between recoveries will increase the reliability of the cluster but also
           # increase the time our e2e test take.

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -485,7 +485,9 @@ spec:
           - --max-concurrent-reconciles=5
           - --zap-log-level=debug
           - --minimum-required-uptime-for-cc-bounce=60s
+{{ if .EnableServerSideApply }}
           - --server-side-apply
+{{ end }}
           # We are setting low values here as the e2e test are taking down processes multiple times
           # and having a high wait time between recoveries will increase the reliability of the cluster but also
           # increase the time our e2e test take.
@@ -518,6 +520,8 @@ type operatorConfig struct {
 	MemoryRequests string
 	// Defines the user that runs the current e2e tests.
 	User string
+	// EnableServerSideApply if true, the operator will make use of server side apply.
+	EnableServerSideApply bool
 }
 
 // SidecarConfig represents the configuration for a sidecar. This can be used for templating.
@@ -603,15 +607,16 @@ func (factory *Factory) getOperatorConfig(namespace string) *operatorConfig {
 	}
 
 	return &operatorConfig{
-		OperatorImage:    factory.GetOperatorImage(),
-		SecretName:       factory.GetSecretName(),
-		BackupSecretName: factory.GetBackupSecretName(),
-		Namespace:        namespace,
-		SidecarVersions:  factory.GetSidecarConfigs(),
-		ImagePullPolicy:  factory.getImagePullPolicy(),
-		CPURequests:      cpuRequests,
-		MemoryRequests:   MemoryRequests,
-		User:             factory.options.username,
+		OperatorImage:         factory.GetOperatorImage(),
+		SecretName:            factory.GetSecretName(),
+		BackupSecretName:      factory.GetBackupSecretName(),
+		Namespace:             namespace,
+		SidecarVersions:       factory.GetSidecarConfigs(),
+		ImagePullPolicy:       factory.getImagePullPolicy(),
+		CPURequests:           cpuRequests,
+		MemoryRequests:        MemoryRequests,
+		User:                  factory.options.username,
+		EnableServerSideApply: factory.options.featureOperatorServerSideApply,
 	}
 }
 

--- a/e2e/fixtures/options.go
+++ b/e2e/fixtures/options.go
@@ -31,30 +31,31 @@ import (
 
 // FactoryOptions defines the (command line) options that are support for the e2e test cases.
 type FactoryOptions struct {
-	namespace                   string
-	chaosNamespace              string
-	context                     string
-	fdbImage                    string
-	unifiedFDBImage             string
-	sidecarImage                string
-	operatorImage               string
-	dataLoaderImage             string
-	registry                    string
-	fdbVersion                  string
-	username                    string
-	storageClass                string
-	upgradeString               string
-	cloudProvider               string
-	clusterName                 string
-	storageEngine               string
-	fdbVersionTagMapping        string
-	enableChaosTests            bool
-	enableDataLoading           bool
-	cleanup                     bool
-	featureOperatorDNS          bool
-	featureOperatorLocalities   bool
-	featureOperatorUnifiedImage bool
-	dumpOperatorState           bool
+	namespace                      string
+	chaosNamespace                 string
+	context                        string
+	fdbImage                       string
+	unifiedFDBImage                string
+	sidecarImage                   string
+	operatorImage                  string
+	dataLoaderImage                string
+	registry                       string
+	fdbVersion                     string
+	username                       string
+	storageClass                   string
+	upgradeString                  string
+	cloudProvider                  string
+	clusterName                    string
+	storageEngine                  string
+	fdbVersionTagMapping           string
+	enableChaosTests               bool
+	enableDataLoading              bool
+	cleanup                        bool
+	featureOperatorDNS             bool
+	featureOperatorLocalities      bool
+	featureOperatorUnifiedImage    bool
+	featureOperatorServerSideApply bool
+	dumpOperatorState              bool
 }
 
 // BindFlags binds the FactoryOptions flags to the provided FlagSet. This can be used to extend the current test setup
@@ -191,6 +192,12 @@ func (options *FactoryOptions) BindFlags(fs *flag.FlagSet) {
 		"dump-operator-state",
 		true,
 		"defines if the operator tests should print the state of the cluster and the according Pods for better debugging.",
+	)
+	fs.BoolVar(
+		&options.featureOperatorServerSideApply,
+		"feature-server-side-apply",
+		true, // TODO change to false.
+		"defines if the operator should make use of server side apply.",
 	)
 	fs.StringVar(&options.clusterName,
 		"cluster-name",

--- a/e2e/fixtures/options.go
+++ b/e2e/fixtures/options.go
@@ -196,7 +196,7 @@ func (options *FactoryOptions) BindFlags(fs *flag.FlagSet) {
 	fs.BoolVar(
 		&options.featureOperatorServerSideApply,
 		"feature-server-side-apply",
-		true, // TODO change to false.
+		false,
 		"defines if the operator should make use of server side apply.",
 	)
 	fs.StringVar(&options.clusterName,


### PR DESCRIPTION
# Description

There have been some issues in the past when we tested SSA in the current implementation with default values and it's also a known issue with the controller-runtime, e.g.: https://github.com/kubernetes-sigs/controller-runtime/issues/1669 (only to link one issue).

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

This will add some more cpu cycles to the operator when pushing the patch but I think this is the simplest way to approach this issue right now. Once the controller-runtime has a better approach we can remove this workaround.

## Testing

Ran a manual e2e test.

CI will run all e2e tests with the SSA feature as I enabled it in the operator deployment.

## Documentation

-

## Follow-up

-