### PR TITLE
make GetProcessSettings not return volumeClaimTemplate for stateless …

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1255,7 +1255,7 @@ type ProcessSettings struct {
 	PodTemplate *corev1.PodTemplateSpec `json:"podTemplate,omitempty"`
 
 	// VolumeClaimTemplate allows customizing the persistent volume claim for the
-	// pod.
+	// pod.  This will be ignored by the operator for stateless processes.
 	VolumeClaimTemplate *corev1.PersistentVolumeClaim `json:"volumeClaimTemplate,omitempty"`
 
 	// CustomParameters defines additional parameters to pass to the fdbserver
@@ -1278,7 +1278,7 @@ func (cluster *FoundationDBCluster) GetProcessSettings(processClass ProcessClass
 		if merged.PodTemplate == nil {
 			merged.PodTemplate = entry.PodTemplate
 		}
-		if merged.VolumeClaimTemplate == nil {
+		if merged.VolumeClaimTemplate == nil && processClass.IsStateful() { // stateless pods will not use a PVC
 			merged.VolumeClaimTemplate = entry.VolumeClaimTemplate
 		}
 		if merged.CustomParameters == nil {

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -436,7 +436,7 @@ ProcessSettings defines process-level settings.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | podTemplate | PodTemplate allows customizing the pod. If a container image with a tag is specified the operator will throw an error and stop processing the cluster. | *[corev1.PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podtemplatespec-v1-core) | false |
-| volumeClaimTemplate | VolumeClaimTemplate allows customizing the persistent volume claim for the pod. | *[corev1.PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#persistentvolumeclaim-v1-core) | false |
+| volumeClaimTemplate | VolumeClaimTemplate allows customizing the persistent volume claim for the pod.  This will be ignored by the operator for stateless processes. | *[corev1.PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#persistentvolumeclaim-v1-core) | false |
 | customParameters | CustomParameters defines additional parameters to pass to the fdbserver process. | FoundationDBCustomParameters | false |
 
 [Back to TOC](#table-of-contents)

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -733,8 +733,7 @@ func usePvc(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.Pro
 			storage = &storageCopy
 		}
 	}
-	// TODO can a stateful process ever have this be true? maybe with testing?
-	return storage == nil || !storage.IsZero()
+	return storage != nil || !storage.IsZero()
 }
 
 // GetPvc builds a persistent volume claim for a FoundationDB process group.

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -722,6 +722,7 @@ func getEnvForMonitorConfigSubstitution(cluster *fdbv1beta2.FoundationDBCluster,
 }
 
 // usePvc determines whether we should attach a PVC to a pod.
+// TODO this could be simplified or cut out by solving https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1966
 func usePvc(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass) bool {
 	var storage *resource.Quantity
 	processSettings := cluster.GetProcessSettings(processClass)

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -733,7 +733,8 @@ func usePvc(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.Pro
 			storage = &storageCopy
 		}
 	}
-	return processClass.IsStateful() && (storage == nil || !storage.IsZero())
+	// TODO can a stateful process ever have this be true? maybe with testing?
+	return storage == nil || !storage.IsZero()
 }
 
 // GetPvc builds a persistent volume claim for a FoundationDB process group.

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -734,7 +734,8 @@ func usePvc(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.Pro
 			storage = &storageCopy
 		}
 	}
-	return storage != nil || !storage.IsZero()
+	// TODO should be storage != nil, which would make the IsStateful redundant, but this breaks tests so next commit
+	return processClass.IsStateful() && (storage == nil || !storage.IsZero())
 }
 
 // GetPvc builds a persistent volume claim for a FoundationDB process group.


### PR DESCRIPTION
…processes

# Description

This addresses https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1310.  
Some odd logic was discovered in the `usePvc()` function, which roughly resulted in its logic being "use PVC if a processGroup is stateful and does not have a volumeClaimTemplate (nil), or if a processGroup is stateful and has a non-zero request for storage resources".  This seemed a bit counter-intuitive, and could result in the case where someone accidentally creates storage pods with no PVC, which is dangerous for a non-test FDB cluster.
As a result, I removed the `usePvc()` function and replaced it with a `processClass.isStateful()` check.  I think this more closely matches the original intent.  (As of writing, it is valid for a stateful process to have a nil volumeClaimTemplate, see https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1966, so, as far as I can tell the only meaningful check is `isStateful()`)

## Type of change

*Please select one of the options below.*

- "Bug" fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

- Other

## Discussion

TODO link forum post regarding the breaking change after build number is created

## Testing

unit tests

## Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
