### PR TITLE
Initial changes for new maintenance mode integration

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1186,7 +1186,6 @@ type MaintenanceModeOptions struct {
 	// ResetMaintenanceMode defines whether the operator should reset the maintenance mode if all storage processes
 	// under the maintenance zone have been restarted. The default is false. If UseMaintenanceModeChecker is set to true
 	// the operator will be allowed to reset the maintenance mode.
-	// TODO (johscheuer): Link to documentation!
 	ResetMaintenanceMode *bool `json:"resetMaintenanceMode,omitempty"`
 
 	// MaintenanceModeTimeSeconds provides the duration for the zone to be in maintenance. It will automatically be switched off after the time elapses.

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -306,7 +306,7 @@ type FoundationDBClusterStatus struct {
 	Locks LockSystemStatus `json:"locks,omitempty"`
 
 	// MaintenenanceModeInfo contains information regarding process groups in maintenance mode
-	// Deprecated: This setting it not used anymore.
+	// Deprecated: This setting is not used anymore.
 	MaintenanceModeInfo MaintenanceModeInfo `json:"maintenanceModeInfo,omitempty"`
 
 	// DesiredProcessGroups reflects the number of expected running process groups.
@@ -320,14 +320,14 @@ type FoundationDBClusterStatus struct {
 // into maintenance mode by the operator
 type MaintenanceModeInfo struct {
 	// StartTimestamp provides the timestamp when this zone is put into maintenance mode
-	// Deprecated: This setting it not used anymore.
+	// Deprecated: This setting is not used anymore.
 	StartTimestamp *metav1.Time `json:"startTimestamp,omitempty"`
 	// ZoneID that is placed in maintenance mode
-	// Deprecated: This setting it not used anymore.
+	// Deprecated: This setting is not used anymore.
 	ZoneID FaultDomain `json:"zoneID,omitempty"`
 	// ProcessGroups that are placed in maintenance mode
 	// +kubebuilder:validation:MaxItems=200
-	// Deprecated: This setting it not used anymore.
+	// Deprecated: This setting is not used anymore.
 	ProcessGroups []string `json:"processGroups,omitempty"`
 }
 

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1179,13 +1179,16 @@ type LogGroup string
 // MaintenanceModeOptions controls options for placing zones in maintenance mode.
 type MaintenanceModeOptions struct {
 	// UseMaintenanceModeChecker defines whether the operator is allowed to use maintenance mode before updating pods.
-	// If this setting is set to true the operator will set and reset the maintenance mode when updating pods.
+	// If this setting is set to true the operator will set and reset the maintenance mode when updating pods. If this
+	// setting is set to true, then ResetMaintenanceMode will also be enabled to make sure the operator is able to
+	// reset the maintenance mode again.
 	// Default is false.
 	UseMaintenanceModeChecker *bool `json:"UseMaintenanceModeChecker,omitempty"`
 
 	// ResetMaintenanceMode defines whether the operator should reset the maintenance mode if all storage processes
-	// under the maintenance zone have been restarted. The default is false. If UseMaintenanceModeChecker is set to true
-	// the operator will be allowed to reset the maintenance mode.
+	// under the maintenance zone have been restarted. The default is false. For more details see:
+	// https://github.com/FoundationDB/fdb-kubernetes-operator/blob/improve-maintenance-mode-integration/docs/manual/operations.md#maintenance
+	// Default is false.
 	ResetMaintenanceMode *bool `json:"resetMaintenanceMode,omitempty"`
 
 	// MaintenanceModeTimeSeconds provides the duration for the zone to be in maintenance. It will automatically be switched off after the time elapses.

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -1584,6 +1584,11 @@ func (in *MaintenanceModeOptions) DeepCopyInto(out *MaintenanceModeOptions) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ResetMaintenanceMode != nil {
+		in, out := &in.ResetMaintenanceMode, &out.ResetMaintenanceMode
+		*out = new(bool)
+		**out = **in
+	}
 	if in.MaintenanceModeTimeSeconds != nil {
 		in, out := &in.MaintenanceModeTimeSeconds, &out.MaintenanceModeTimeSeconds
 		*out = new(int)

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -10169,6 +10169,8 @@ spec:
                         type: boolean
                       maintenanceModeTimeSeconds:
                         type: integer
+                      resetMaintenanceMode:
+                        type: boolean
                     type: object
                   maxConcurrentReplacements:
                     minimum: 0

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -81,6 +81,13 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 		return &requeue{curError: err, delayedRequeue: true}
 	}
 
+	defer func() {
+		lockErr := r.releaseLock(logger, cluster)
+		if lockErr != nil {
+			logger.Error(lockErr, "could not release lock")
+		}
+	}()
+
 	logger.Info("Changing coordinators")
 	r.Recorder.Event(cluster, corev1.EventTypeNormal, "ChangingCoordinators", "Choosing new coordinators")
 

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -63,6 +63,8 @@ type FoundationDBClusterReconciler struct {
 	GetTimeout                                  time.Duration
 	PostTimeout                                 time.Duration
 	MinimumRequiredUptimeCCBounce               time.Duration
+	MaintenanceListStaleDuration                time.Duration
+	MaintenanceListWaitDuration                 time.Duration
 }
 
 // NewFoundationDBClusterReconciler creates a new FoundationDBClusterReconciler with defaults.

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -26,6 +26,7 @@ import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal/maintenance"
 	"github.com/go-logr/logr"
+	"time"
 )
 
 // maintenanceModeChecker provides a reconciliation step for clearing the maintenance mode if all the processes in the current maintenance zone have been restarted.
@@ -83,7 +84,7 @@ func (maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBCluste
 
 	// Some of the processes are not yet restarted.
 	if len(processesToUpdate) > 0 {
-		return &requeue{message: fmt.Sprintf("Waiting for %d processes in zone %s to be updated", len(processesToUpdate), status.Cluster.MaintenanceZone), delayedRequeue: true}
+		return &requeue{message: fmt.Sprintf("Waiting for %d processes in zone %s to be updated", len(processesToUpdate), status.Cluster.MaintenanceZone), delayedRequeue: true, delay: 5 * time.Second}
 	}
 
 	// Make sure we take a lock before we continue.

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -53,7 +53,7 @@ func (maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBCluste
 
 	// If the cluster is not available we skip any further checks.
 	if !status.Client.DatabaseStatus.Available {
-		return nil
+		return &requeue{message: "cluster is not available", delayedRequeue: true}
 	}
 
 	// Get all the processes that are currently under maintenance based on the information stored in FDB.

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -23,57 +23,19 @@ package controllers
 import (
 	"context"
 	"fmt"
-
-	"github.com/go-logr/logr"
-
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal/maintenance"
+	"github.com/go-logr/logr"
+	"time"
 )
 
 // maintenanceModeChecker provides a reconciliation step for clearing the maintenance mode if all the pods in the current maintenance zone are up.
 type maintenanceModeChecker struct{}
 
 // reconcile runs the reconciler's work.
-func (maintenanceModeChecker) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
-	if !cluster.UseMaintenaceMode() {
+func (maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+	if !cluster.ResetMaintenanceMode() {
 		return nil
-	}
-
-	if cluster.Status.MaintenanceModeInfo.ZoneID == "" {
-		return nil
-	}
-
-	logger.Info("Cluster in maintenance mode", "zone", cluster.Status.MaintenanceModeInfo.ZoneID)
-
-	var processGroupsToUpdate int
-	var hasProcessGroupsInZone bool
-	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.FaultDomain != cluster.Status.MaintenanceModeInfo.ZoneID {
-			continue
-		}
-
-		hasProcessGroupsInZone = true
-
-		// If a process group has any conditions like IncorrectPodSpec or MissingProcess, that means the update is not
-		// yet done and we have to wait until this process group is in the desired state.
-		if len(processGroup.ProcessGroupConditions) > 0 {
-			processGroupsToUpdate++
-		}
-	}
-
-	// If none of the process groups are in the specified zone, that means a different operator or a human operator has set the maintenance mode.
-	if !hasProcessGroupsInZone {
-		return nil
-	}
-
-	// Some of the pods are not yet up
-	if processGroupsToUpdate > 0 {
-		return &requeue{message: fmt.Sprintf("Waiting for %d process groups in zone %s to be updated", processGroupsToUpdate, cluster.Status.MaintenanceModeInfo.ZoneID), delayedRequeue: true}
-	}
-
-	// All the Pods for this zone under maintenance are up
-	hasLock, err := r.takeLock(logger, cluster, "maintenance mode check")
-	if !hasLock {
-		return &requeue{curError: err}
 	}
 
 	adminClient, err := r.DatabaseClientProvider.GetAdminClient(cluster, r)
@@ -81,13 +43,70 @@ func (maintenanceModeChecker) reconcile(ctx context.Context, r *FoundationDBClus
 		return &requeue{curError: err, delayedRequeue: true}
 	}
 
-	logger.Info("Switching off maintenance mode", "zone", cluster.Status.MaintenanceModeInfo.ZoneID)
-	err = adminClient.ResetMaintenanceMode()
+	// If the status is not cached, we have to fetch it.
+	if status == nil {
+		status, err = adminClient.GetStatus()
+		if err != nil {
+			return &requeue{curError: err}
+		}
+	}
+
+	// If the cluster is not available we skip any further checks.
+	if !status.Client.DatabaseStatus.Available {
+		return nil
+	}
+
+	// Get all the processes that are currently under maintenance based on the information stored in FDB.
+	processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}
-	cluster.Status.MaintenanceModeInfo = fdbv1beta2.MaintenanceModeInfo{}
-	err = r.updateOrApply(ctx, cluster)
+
+	logger.Info("Cluster in maintenance mode", "zone", status.Cluster.MaintenanceZone, "processesUnderMaintenance", processesUnderMaintenance)
+
+	// If none of the process groups are in the specified zone, that means a different operator or a human operator has set the maintenance mode.
+	if len(processesUnderMaintenance) == 0 {
+		return nil
+	}
+
+	// Get all the maintenance information from the FDB cluster.
+	finishedMaintenance, staleMaintenanceInformation, processesToUpdate := maintenance.GetMaintenanceInformation(logger, status, processesUnderMaintenance, 4*time.Hour)
+	logger.Info("maintenance information", "finishedMaintenance", finishedMaintenance, "staleMaintenanceInformation", staleMaintenanceInformation, "processesToUpdate", processesToUpdate)
+
+	// We can remove the information for all the finished maintenance and the stale entries.
+	if len(finishedMaintenance) > 0 || len(staleMaintenanceInformation) > 0 {
+		// Remove all the processes that finished maintenance and all the stale information.
+		err = adminClient.RemoveProcessesUnderMaintenance(append(finishedMaintenance, staleMaintenanceInformation...))
+		if err != nil {
+			return &requeue{curError: err, delayedRequeue: true}
+		}
+	}
+
+	// If no maintenance zone is active, we can ignore all further steps to reset the maintenance zone.
+	if status.Cluster.MaintenanceZone == "" {
+		return nil
+	}
+
+	// Some of the processes are not yet restarted.
+	if len(processesToUpdate) > 0 {
+		return &requeue{message: fmt.Sprintf("Waiting for %d processes in zone %s to be updated", len(processesToUpdate), status.Cluster.MaintenanceZone), delayedRequeue: true}
+	}
+
+	// Make sure we take a lock before we continue.
+	hasLock, err := r.takeLock(logger, cluster, "maintenance mode check")
+	if !hasLock {
+		return &requeue{curError: err}
+	}
+
+	defer func() {
+		lockErr := r.releaseLock(logger, cluster)
+		if lockErr != nil {
+			logger.Error(lockErr, "could not release lock")
+		}
+	}()
+
+	logger.Info("Switching off maintenance mode", "zone", status.Cluster.MaintenanceZone)
+	err = adminClient.ResetMaintenanceMode()
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}

--- a/controllers/maintenance_mode_checker_test.go
+++ b/controllers/maintenance_mode_checker_test.go
@@ -22,7 +22,9 @@ package controllers
 
 import (
 	"context"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
 	"k8s.io/utils/pointer"
+	"time"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 
@@ -32,16 +34,15 @@ import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 )
 
-// TODO (johscheuer): Modify tests to represent different scenarios with the new maintenance integration.
 var _ = Describe("maintenance_mode_checker", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
 	var err error
-	//var requeue *requeue
-	//targetProcessGroup := "operator-test-1-storage-1"
+	var requeue *requeue
+	var adminClient *mock.AdminClient
+	targetProcessGroup := fdbv1beta2.ProcessGroupID("storage-1")
 
 	BeforeEach(func() {
 		cluster = internal.CreateDefaultCluster()
-		// TODO: Also test the Reset option
 		cluster.Spec.AutomationOptions.MaintenanceModeOptions.UseMaintenanceModeChecker = pointer.Bool(true)
 		Expect(k8sClient.Create(context.TODO(), cluster)).NotTo(HaveOccurred())
 
@@ -52,12 +53,303 @@ var _ = Describe("maintenance_mode_checker", func() {
 		generation, err := reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(generation).To(Equal(int64(1)))
+
+		adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	JustBeforeEach(func() {
-		//requeue = maintenanceModeChecker{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
-		//Expect(err).NotTo(HaveOccurred())
+		requeue = maintenanceModeChecker{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	When("no maintenance is ongoing", func() {
+		When("no processes are in the maintenance list", func() {
+			It("shouldn't requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+		})
+
+		When("one processes is in the maintenance list with a recent timestamp", func() {
+			BeforeEach(func() {
+				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{targetProcessGroup}, time.Now().Unix())).NotTo(HaveOccurred())
+			})
+
+			It("shouldn't requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			It("shouldn't clear the entry", func() {
+				processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(processesUnderMaintenance).To(HaveLen(1))
+				Expect(processesUnderMaintenance).To(HaveKey(targetProcessGroup))
+			})
+		})
+
+		When("one stale processes is in the maintenance list", func() {
+			BeforeEach(func() {
+				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{targetProcessGroup}, time.Now().Add(-12*time.Hour).Unix())).NotTo(HaveOccurred())
+			})
+
+			It("shouldn't requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			It("should clear the entry", func() {
+				processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(processesUnderMaintenance).To(BeEmpty())
+			})
+		})
+	})
+
+	When("the maintenance mode is active", func() {
+		var currentMaintenanceZone fdbv1beta2.FaultDomain
+		var secondStorageProcess fdbv1beta2.ProcessGroupID
+
+		BeforeEach(func() {
+			for _, pg := range cluster.Status.ProcessGroups {
+				if pg.ProcessClass != fdbv1beta2.ProcessClassStorage {
+					continue
+				}
+
+				if pg.ProcessGroupID == targetProcessGroup {
+					currentMaintenanceZone = pg.FaultDomain
+					continue
+				}
+
+				if secondStorageProcess != "" {
+					continue
+				}
+
+				secondStorageProcess = pg.ProcessGroupID
+			}
+
+			Expect(currentMaintenanceZone).NotTo(BeEmpty())
+			Expect(adminClient.SetMaintenanceZone(string(currentMaintenanceZone), 3600)).NotTo(HaveOccurred())
+		})
+
+		When("no processes are in the maintenance list", func() {
+			It("shouldn't requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			// We expect that the maintenance zone will be reset in this case as no processes are reported to be under maintenance.
+			// We could hit such a case when the operator was able to remove the finished processes from the maintenance list
+			// then for some reason the operator crashes/stops. In this case we want to make sure that the operator resets
+			// the maintenance mode.
+			It("should reset the maintenance", func() {
+				maintenanceZone, err := adminClient.GetMaintenanceZone()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(maintenanceZone).To(BeEmpty())
+			})
+
+			It("shouldn remove the entry from the maintenance list", func() {
+				processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(processesUnderMaintenance).To(BeEmpty())
+			})
+		})
+
+		When("one processes is in the maintenance list but the process was not yet restarted", func() {
+			BeforeEach(func() {
+				// The maintenance is targeted for the future.
+				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{targetProcessGroup}, time.Now().Add(1*time.Minute).Unix())).NotTo(HaveOccurred())
+			})
+
+			It("should requeue", func() {
+				Expect(requeue).NotTo(BeNil())
+				Expect(requeue.delayedRequeue).To(BeTrue())
+				Expect(requeue.message).To(Equal("Waiting for 1 processes in zone operator-test-1-storage-1 to be updated"))
+			})
+
+			It("shouldn't reset the maintenance", func() {
+				maintenanceZone, err := adminClient.GetMaintenanceZone()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(maintenanceZone).To(Equal(string(currentMaintenanceZone)))
+			})
+
+			It("shouldn't remove the entry from the maintenance list", func() {
+				processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(processesUnderMaintenance).To(HaveLen(1))
+				Expect(processesUnderMaintenance).To(HaveKey(targetProcessGroup))
+			})
+		})
+
+		When("one processes is in the maintenance list and the process is missing in the machine-readable status", func() {
+			BeforeEach(func() {
+				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{targetProcessGroup}, time.Now().Add(-1*time.Minute).Unix())).NotTo(HaveOccurred())
+				adminClient.MockMissingProcessGroup(targetProcessGroup, true)
+			})
+
+			It("should requeue", func() {
+				Expect(requeue).NotTo(BeNil())
+				Expect(requeue.delayedRequeue).To(BeTrue())
+				Expect(requeue.message).To(Equal("Waiting for 1 processes in zone operator-test-1-storage-1 to be updated"))
+			})
+
+			It("shouldn't reset the maintenance", func() {
+				maintenanceZone, err := adminClient.GetMaintenanceZone()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(maintenanceZone).To(Equal(string(currentMaintenanceZone)))
+			})
+
+			It("shouldn't remove the entry from the maintenance list", func() {
+				processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(processesUnderMaintenance).To(HaveLen(1))
+				Expect(processesUnderMaintenance).To(HaveKey(targetProcessGroup))
+			})
+		})
+
+		When("one processes is in the maintenance list and the process was restarted", func() {
+			BeforeEach(func() {
+				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{targetProcessGroup}, time.Now().Add(-1*time.Minute).Unix())).NotTo(HaveOccurred())
+			})
+
+			It("shouldn't requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			It("should reset the maintenance", func() {
+				maintenanceZone, err := adminClient.GetMaintenanceZone()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(maintenanceZone).To(BeEmpty())
+			})
+
+			It("should remove the entry from the maintenance list", func() {
+				processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(processesUnderMaintenance).To(BeEmpty())
+			})
+		})
+
+		When("one processes for a different zone is in the maintenance list and was recently added", func() {
+			BeforeEach(func() {
+				// The maintenance is targeted for the future.
+				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{secondStorageProcess}, time.Now().Add(1*time.Minute).Unix())).NotTo(HaveOccurred())
+			})
+
+			It("should requeue", func() {
+				Expect(requeue).NotTo(BeNil())
+				Expect(requeue.delayedRequeue).To(BeTrue())
+				Expect(requeue.message).To(Equal("Waiting for 1 processes in zone operator-test-1-storage-1 to be updated"))
+			})
+
+			It("shouldn't reset the maintenance", func() {
+				maintenanceZone, err := adminClient.GetMaintenanceZone()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(maintenanceZone).To(Equal(string(currentMaintenanceZone)))
+			})
+
+			It("shouldn't remove the entry from the maintenance list", func() {
+				processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(processesUnderMaintenance).To(HaveLen(1))
+				Expect(processesUnderMaintenance).To(HaveKey(secondStorageProcess))
+			})
+		})
+
+		When("one processes is in the maintenance list and the process was restarted and another one is missing", func() {
+			BeforeEach(func() {
+				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{targetProcessGroup}, time.Now().Add(-1*time.Minute).Unix())).NotTo(HaveOccurred())
+				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{secondStorageProcess}, time.Now().Add(-1*time.Minute).Unix())).NotTo(HaveOccurred())
+			})
+
+			It("should requeue", func() {
+				Expect(requeue).NotTo(BeNil())
+				Expect(requeue.delayedRequeue).To(BeTrue())
+				Expect(requeue.message).To(Equal("Waiting for 1 processes in zone operator-test-1-storage-1 to be updated"))
+			})
+
+			It("shouldn't reset the maintenance", func() {
+				maintenanceZone, err := adminClient.GetMaintenanceZone()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(maintenanceZone).To(Equal(string(currentMaintenanceZone)))
+			})
+
+			It("shouldn't remove the entry from the maintenance list for the second entry", func() {
+				processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(processesUnderMaintenance).To(HaveLen(1))
+				Expect(processesUnderMaintenance).To(HaveKey(secondStorageProcess))
+			})
+		})
+
+		When("one processes for a different zone is in the maintenance list and was recently added and the process is missing", func() {
+			BeforeEach(func() {
+				// The maintenance is targeted for the future.
+				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{secondStorageProcess}, time.Now().Add(1*time.Minute).Unix())).NotTo(HaveOccurred())
+				adminClient.MockMissingProcessGroup(secondStorageProcess, true)
+			})
+
+			It("should requeue", func() {
+				Expect(requeue).NotTo(BeNil())
+				Expect(requeue.delayedRequeue).To(BeTrue())
+				Expect(requeue.message).To(Equal("Waiting for 1 processes in zone operator-test-1-storage-1 to be updated"))
+			})
+
+			It("shouldn't reset the maintenance", func() {
+				maintenanceZone, err := adminClient.GetMaintenanceZone()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(maintenanceZone).To(Equal(string(currentMaintenanceZone)))
+			})
+
+			It("shouldn't remove the entry from the maintenance list", func() {
+				processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(processesUnderMaintenance).To(HaveLen(1))
+				Expect(processesUnderMaintenance).To(HaveKey(secondStorageProcess))
+			})
+		})
+
+		When("one processes for a different zone is in the maintenance list and was added multiple minutes ago", func() {
+			BeforeEach(func() {
+				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{secondStorageProcess}, time.Now().Add(-10*time.Minute).Unix())).NotTo(HaveOccurred())
+			})
+
+			It("shouldn't requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			It("should reset the maintenance", func() {
+				maintenanceZone, err := adminClient.GetMaintenanceZone()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(maintenanceZone).To(BeEmpty())
+			})
+
+			It("shouldn't remove the entry from the maintenance list", func() {
+				processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(processesUnderMaintenance).To(HaveLen(1))
+				Expect(processesUnderMaintenance).To(HaveKey(secondStorageProcess))
+			})
+		})
+
+		When("one processes for a different zone is in the maintenance list and was added multiple hours ago", func() {
+			BeforeEach(func() {
+				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{secondStorageProcess}, time.Now().Add(-10*time.Hour).Unix())).NotTo(HaveOccurred())
+			})
+
+			It("shouldn't requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			It("should reset the maintenance", func() {
+				maintenanceZone, err := adminClient.GetMaintenanceZone()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(maintenanceZone).To(BeEmpty())
+			})
+
+			It("should remove the entry from the maintenance list", func() {
+				processesUnderMaintenance, err := adminClient.GetProcessesUnderMaintenance()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(processesUnderMaintenance).To(BeEmpty())
+			})
+		})
 	})
 })

--- a/controllers/maintenance_mode_checker_test.go
+++ b/controllers/maintenance_mode_checker_test.go
@@ -180,7 +180,7 @@ var _ = Describe("maintenance_mode_checker", func() {
 			})
 		})
 
-		When("one processes is in the maintenance list and the process is missing in the machine-readable status", func() {
+		FWhen("one processes is in the maintenance list and the process is missing in the machine-readable status", func() {
 			BeforeEach(func() {
 				Expect(adminClient.SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID{targetProcessGroup}, time.Now().Add(-1*time.Minute).Unix())).NotTo(HaveOccurred())
 				adminClient.MockMissingProcessGroup(targetProcessGroup, true)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -185,12 +185,14 @@ func setupClusterForTest(cluster *fdbv1beta2.FoundationDBCluster) error {
 
 func createTestClusterReconciler() *FoundationDBClusterReconciler {
 	return &FoundationDBClusterReconciler{
-		Client:                 k8sClient,
-		Log:                    ctrl.Log.WithName("controllers").WithName("FoundationDBCluster"),
-		Recorder:               k8sClient,
-		InSimulation:           true,
-		PodLifecycleManager:    podmanager.StandardPodLifecycleManager{},
-		PodClientProvider:      mockpodclient.NewMockFdbPodClient,
-		DatabaseClientProvider: mock.DatabaseClientProvider{},
+		Client:                       k8sClient,
+		Log:                          ctrl.Log.WithName("controllers").WithName("FoundationDBCluster"),
+		Recorder:                     k8sClient,
+		InSimulation:                 true,
+		PodLifecycleManager:          podmanager.StandardPodLifecycleManager{},
+		PodClientProvider:            mockpodclient.NewMockFdbPodClient,
+		DatabaseClientProvider:       mock.DatabaseClientProvider{},
+		MaintenanceListStaleDuration: 4 * time.Hour,
+		MaintenanceListWaitDuration:  5 * time.Minute,
 	}
 }

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -104,6 +104,13 @@ func (u updateDatabaseConfiguration) reconcile(_ context.Context, r *FoundationD
 			if !hasLock {
 				return &requeue{curError: err, delayedRequeue: true}
 			}
+
+			defer func() {
+				lockErr := r.releaseLock(logger, cluster)
+				if lockErr != nil {
+					logger.Error(lockErr, "could not release lock")
+				}
+			}()
 		}
 
 		logger.Info("Configuring database", "current configuration", currentConfiguration, "desired configuration", desiredConfiguration)

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -23,6 +23,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
 	"time"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbstatus"
@@ -62,11 +63,6 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 		if r.PodLifecycleManager.GetDeletionMode(cluster) == fdbv1beta2.PodUpdateModeNone {
 			r.Recorder.Event(cluster, corev1.EventTypeNormal,
 				"NeedsPodsDeletion", "Spec require deleting some pods, but deleting pods is disabled")
-			cluster.Status.Generations.NeedsPodDeletion = cluster.ObjectMeta.Generation
-			err = r.updateOrApply(ctx, cluster)
-			if err != nil {
-				logger.Error(err, "Error updating cluster status")
-			}
 			return &requeue{message: "Pod deletion is disabled"}
 		}
 	}
@@ -75,7 +71,21 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 		return nil
 	}
 
-	return deletePodsForUpdates(ctx, r, cluster, updates, logger, status)
+	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r.Client)
+	if err != nil {
+		return &requeue{curError: err, delayedRequeue: true}
+	}
+	defer adminClient.Close()
+
+	// If the status is not cached, we have to fetch it.
+	if status == nil {
+		status, err = adminClient.GetStatus()
+		if err != nil {
+			return &requeue{curError: err}
+		}
+	}
+
+	return deletePodsForUpdates(ctx, r, cluster, updates, logger, status, adminClient)
 }
 
 // processGroupIsUnavailable returns true if the process group is unavailable.
@@ -256,7 +266,7 @@ func shouldRequeueDueToTerminatingPod(pod *corev1.Pod, cluster *fdbv1beta2.Found
 		!cluster.ProcessGroupIsBeingRemoved(processGroupID)
 }
 
-func getPodsToDelete(deletionMode fdbv1beta2.PodUpdateMode, updates map[string][]*corev1.Pod) (string, []*corev1.Pod, error) {
+func getPodsToDelete(deletionMode fdbv1beta2.PodUpdateMode, updates map[string][]*corev1.Pod, currentMaintenanceZone string) (string, []*corev1.Pod, error) {
 	if deletionMode == fdbv1beta2.PodUpdateModeAll {
 		var deletions []*corev1.Pod
 
@@ -278,13 +288,22 @@ func getPodsToDelete(deletionMode fdbv1beta2.PodUpdateMode, updates map[string][
 		}
 	}
 
-	// TODO(jscheuermann): If a maintenance zone is already set, we should favour Pods in this zone to be updated.
 	if deletionMode == fdbv1beta2.PodUpdateModeZone {
 		// Default case is zone
-		for zoneName, zoneProcesses := range updates {
+		for zone, zoneProcesses := range updates {
+			// If there is currently an active maintenance zone and the zones are not matching skip any further
+			// work.
+			// TODO (johscheuer): Only if the zone contains storage processes, otherwise we can ignore this check.
+			if currentMaintenanceZone != "" && zone != currentMaintenanceZone {
+				continue
+			}
+
 			// Fetch the first zone and stop
-			return zoneName, zoneProcesses, nil
+			return zone, zoneProcesses, nil
 		}
+
+		// If we are here no zone was matching.
+		return "", nil, nil
 	}
 
 	if deletionMode == fdbv1beta2.PodUpdateModeNone {
@@ -295,18 +314,21 @@ func getPodsToDelete(deletionMode fdbv1beta2.PodUpdateMode, updates map[string][
 }
 
 // deletePodsForUpdates will delete Pods with the specified deletion mode
-func deletePodsForUpdates(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, updates map[string][]*corev1.Pod, logger logr.Logger, status *fdbv1beta2.FoundationDBStatus) *requeue {
+func deletePodsForUpdates(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, updates map[string][]*corev1.Pod, logger logr.Logger, status *fdbv1beta2.FoundationDBStatus, adminClient fdbadminclient.AdminClient) *requeue {
 	deletionMode := r.PodLifecycleManager.GetDeletionMode(cluster)
-	zone, deletions, err := getPodsToDelete(deletionMode, updates)
+	currentMaintenanceZone := "unknown"
+	if status != nil {
+		currentMaintenanceZone = string(status.Cluster.MaintenanceZone)
+	}
+
+	zone, deletions, err := getPodsToDelete(deletionMode, updates, currentMaintenanceZone)
 	if err != nil {
 		return &requeue{curError: err}
 	}
 
-	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r.Client)
-	if err != nil {
-		return &requeue{curError: err, delayedRequeue: true}
+	if len(deletions) == 0 {
+		return &requeue{message: "Reconciliation requires deleting pods, but cannot delete any Pods", delay: podSchedulingDelayDuration}
 	}
-	defer adminClient.Close()
 
 	newContext := logr.NewContext(ctx, logger)
 	if status != nil {
@@ -328,15 +350,51 @@ func deletePodsForUpdates(ctx context.Context, r *FoundationDBClusterReconciler,
 		if !hasLock {
 			return &requeue{curError: err}
 		}
+
+		defer func() {
+			lockErr := r.releaseLock(logger, cluster)
+			if lockErr != nil {
+				logger.Error(lockErr, "could not release lock")
+			}
+		}()
 	}
 
-	// TODO(jscheuermann): If a maintenance zone is already set, we should allow to delete Pods in this zone.
+	// If the maintenance mode feature is enabled we have to determine if the maintenance mode must be set. This is only
+	// the case if at least one storage process is in the deletions slice.
 	if deletionMode == fdbv1beta2.PodUpdateModeZone && cluster.UseMaintenaceMode() {
-		logger.Info("Setting maintenance mode", "zone", zone)
+		storageProcessIDs := make([]fdbv1beta2.ProcessGroupID, 0, len(deletions))
+		for _, pod := range deletions {
+			if internal.GetProcessClassFromMeta(cluster, pod.ObjectMeta) != fdbv1beta2.ProcessClassStorage {
+				continue
+			}
 
-		err = adminClient.SetMaintenanceZone(zone, cluster.GetMaintenaceModeTimeoutSeconds())
-		if err != nil {
-			return &requeue{curError: err}
+			processGroupID := internal.GetProcessGroupIDFromMeta(cluster, pod.ObjectMeta)
+			if processGroupID == "" {
+				continue
+			}
+
+			storageProcessIDs = append(storageProcessIDs, processGroupID)
+		}
+
+		// Only if at least one storage process is present in the deletions we have to set the maintenance zone.
+		if len(storageProcessIDs) > 0 {
+			// If there is a maintenance zone active that doesn't match the current zone we have to skip any further work.
+			if status.Cluster.MaintenanceZone != "" && status.Cluster.MaintenanceZone != fdbv1beta2.FaultDomain(zone) {
+				return &requeue{message: "Pods need to be recreated", delayedRequeue: true}
+			}
+			logger.Info("Setting maintenance mode", "zone", zone)
+
+			// Update the process information for the maintenance.
+			err = adminClient.SetProcessesUnderMaintenance(storageProcessIDs, time.Now().Unix())
+			if err != nil {
+				return &requeue{curError: err}
+			}
+
+			// Set the maintenance mode here.
+			err = adminClient.SetMaintenanceZone(zone, cluster.GetMaintenaceModeTimeoutSeconds())
+			if err != nil {
+				return &requeue{curError: err}
+			}
 		}
 	}
 

--- a/controllers/update_pods_test.go
+++ b/controllers/update_pods_test.go
@@ -45,6 +45,7 @@ var _ = Describe("update_pods", func() {
 		type testCase struct {
 			deletionMode         fdbv1beta2.PodUpdateMode
 			expectedDeletionsCnt int
+			maintenanceZone      string
 			expectedErr          error
 		}
 
@@ -84,9 +85,10 @@ var _ = Describe("update_pods", func() {
 			}
 		})
 
+		// TODO (johscheuer): Add test case for maintenance zone!
 		DescribeTable("should delete the Pods based on the deletion mode",
 			func(input testCase) {
-				_, deletion, err := getPodsToDelete(input.deletionMode, updates)
+				_, deletion, err := getPodsToDelete(input.deletionMode, updates, input.maintenanceZone)
 				if input.expectedErr != nil {
 					Expect(err).To(Equal(input.expectedErr))
 				}
@@ -96,26 +98,31 @@ var _ = Describe("update_pods", func() {
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeZone,
 					expectedDeletionsCnt: 2,
+					maintenanceZone:      "",
 				}),
 			Entry("With the deletion mode Process Group",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeProcessGroup,
 					expectedDeletionsCnt: 1,
+					maintenanceZone:      "",
 				}),
 			Entry("With the deletion mode All",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeAll,
 					expectedDeletionsCnt: 4,
+					maintenanceZone:      "",
 				}),
 			Entry("With the deletion mode None",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeNone,
 					expectedDeletionsCnt: 0,
+					maintenanceZone:      "",
 				}),
 			Entry("With the deletion mode All",
 				testCase{
 					deletionMode:         "banana",
 					expectedDeletionsCnt: 0,
+					maintenanceZone:      "",
 					expectedErr:          fmt.Errorf("unknown deletion mode: \"banana\""),
 				}),
 		)

--- a/controllers/update_pods_test.go
+++ b/controllers/update_pods_test.go
@@ -47,7 +47,6 @@ var _ = Describe("update_pods", func() {
 			expectedDeletionsCnt int
 			maintenanceZone      string
 			expectedErr          error
-			cluster              *fdbv1beta2.FoundationDBCluster
 		}
 
 		BeforeEach(func() {
@@ -100,7 +99,7 @@ var _ = Describe("update_pods", func() {
 
 		DescribeTable("should delete the Pods based on the deletion mode",
 			func(input testCase) {
-				_, deletion, err := getPodsToDelete(input.cluster, input.deletionMode, updates, input.maintenanceZone)
+				_, deletion, err := getPodsToDelete(&fdbv1beta2.FoundationDBCluster{}, input.deletionMode, updates, input.maintenanceZone)
 				if input.expectedErr != nil {
 					Expect(err).To(Equal(input.expectedErr))
 				}
@@ -111,42 +110,36 @@ var _ = Describe("update_pods", func() {
 					deletionMode:         fdbv1beta2.PodUpdateModeZone,
 					expectedDeletionsCnt: 2,
 					maintenanceZone:      "",
-					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 			Entry("With the deletion mode Zone and an active maintenance zone",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeZone,
 					expectedDeletionsCnt: 2,
 					maintenanceZone:      "zone1",
-					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 			Entry("With the deletion mode Zone and an active maintenance zone that doesn't match",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeZone,
 					expectedDeletionsCnt: 0,
 					maintenanceZone:      "zone3",
-					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 			Entry("With the deletion mode Process Group",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeProcessGroup,
 					expectedDeletionsCnt: 1,
 					maintenanceZone:      "",
-					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 			Entry("With the deletion mode All",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeAll,
 					expectedDeletionsCnt: 4,
 					maintenanceZone:      "",
-					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 			Entry("With the deletion mode None",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeNone,
 					expectedDeletionsCnt: 0,
 					maintenanceZone:      "",
-					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 			Entry("With the deletion mode All",
 				testCase{
@@ -154,7 +147,6 @@ var _ = Describe("update_pods", func() {
 					expectedDeletionsCnt: 0,
 					maintenanceZone:      "",
 					expectedErr:          fmt.Errorf("unknown deletion mode: \"banana\""),
-					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 		)
 	})

--- a/controllers/update_pods_test.go
+++ b/controllers/update_pods_test.go
@@ -47,6 +47,7 @@ var _ = Describe("update_pods", func() {
 			expectedDeletionsCnt int
 			maintenanceZone      string
 			expectedErr          error
+			cluster              *fdbv1beta2.FoundationDBCluster
 		}
 
 		BeforeEach(func() {
@@ -62,11 +63,17 @@ var _ = Describe("update_pods", func() {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "Pod1",
+							Labels: map[string]string{
+								fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+							},
 						},
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "Pod2",
+							Labels: map[string]string{
+								fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+							},
 						},
 					},
 				},
@@ -74,49 +81,72 @@ var _ = Describe("update_pods", func() {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "Pod3",
+							Labels: map[string]string{
+								fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+							},
 						},
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "Pod4",
+							Labels: map[string]string{
+								fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+							},
 						},
 					},
 				},
 			}
 		})
 
-		// TODO (johscheuer): Add test case for maintenance zone!
 		DescribeTable("should delete the Pods based on the deletion mode",
 			func(input testCase) {
-				_, deletion, err := getPodsToDelete(input.deletionMode, updates, input.maintenanceZone)
+				_, deletion, err := getPodsToDelete(input.cluster, input.deletionMode, updates, input.maintenanceZone)
 				if input.expectedErr != nil {
 					Expect(err).To(Equal(input.expectedErr))
 				}
-				Expect(len(deletion)).To(Equal(input.expectedDeletionsCnt))
+				Expect(deletion).To(HaveLen(input.expectedDeletionsCnt))
 			},
 			Entry("With the deletion mode Zone",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeZone,
 					expectedDeletionsCnt: 2,
 					maintenanceZone:      "",
+					cluster:              &fdbv1beta2.FoundationDBCluster{},
+				}),
+			Entry("With the deletion mode Zone and an active maintenance zone",
+				testCase{
+					deletionMode:         fdbv1beta2.PodUpdateModeZone,
+					expectedDeletionsCnt: 2,
+					maintenanceZone:      "zone1",
+					cluster:              &fdbv1beta2.FoundationDBCluster{},
+				}),
+			Entry("With the deletion mode Zone and an active maintenance zone that doesn't match",
+				testCase{
+					deletionMode:         fdbv1beta2.PodUpdateModeZone,
+					expectedDeletionsCnt: 0,
+					maintenanceZone:      "zone3",
+					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 			Entry("With the deletion mode Process Group",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeProcessGroup,
 					expectedDeletionsCnt: 1,
 					maintenanceZone:      "",
+					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 			Entry("With the deletion mode All",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeAll,
 					expectedDeletionsCnt: 4,
 					maintenanceZone:      "",
+					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 			Entry("With the deletion mode None",
 				testCase{
 					deletionMode:         fdbv1beta2.PodUpdateModeNone,
 					expectedDeletionsCnt: 0,
 					maintenanceZone:      "",
+					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 			Entry("With the deletion mode All",
 				testCase{
@@ -124,6 +154,7 @@ var _ = Describe("update_pods", func() {
 					expectedDeletionsCnt: 0,
 					maintenanceZone:      "",
 					expectedErr:          fmt.Errorf("unknown deletion mode: \"banana\""),
+					cluster:              &fdbv1beta2.FoundationDBCluster{},
 				}),
 		)
 	})

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -52,8 +52,6 @@ type updateStatus struct{}
 func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, databaseStatus *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	originalStatus := cluster.Status.DeepCopy()
 	clusterStatus := fdbv1beta2.FoundationDBClusterStatus{}
-	// Pass through Maintenance Mode Info as the maintenance_mode_checker reconciler takes care of updating it
-	originalStatus.MaintenanceModeInfo.DeepCopyInto(&clusterStatus.MaintenanceModeInfo)
 	clusterStatus.Generations.Reconciled = cluster.Status.Generations.Reconciled
 
 	// Initialize with the current desired storage servers per Pod
@@ -132,7 +130,6 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 		clusterStatus.Health.Healthy = databaseStatus.Client.DatabaseStatus.Healthy
 		clusterStatus.Health.FullReplication = databaseStatus.Cluster.FullReplication
 		clusterStatus.Health.DataMovementPriority = databaseStatus.Cluster.Data.MovingData.HighestPriority
-		clusterStatus.MaintenanceModeInfo.ZoneID = databaseStatus.Cluster.MaintenanceZone
 	}
 
 	cluster.Status.RequiredAddresses = clusterStatus.RequiredAddresses

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -691,7 +691,6 @@ var _ = Describe("update_status", func() {
 		var cluster *fdbv1beta2.FoundationDBCluster
 		var err error
 		var requeue *requeue
-		var adminClient *mock.AdminClient
 
 		BeforeEach(func() {
 			cluster = internal.CreateDefaultCluster()
@@ -705,9 +704,6 @@ var _ = Describe("update_status", func() {
 			generation, err := reloadCluster(cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(generation).To(Equal(int64(1)))
-
-			adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
-			Expect(err).NotTo(HaveOccurred())
 		})
 
 		JustBeforeEach(func() {
@@ -746,18 +742,6 @@ var _ = Describe("update_status", func() {
 			})
 		})
 
-		When("testing maintenance mode functionality", func() {
-			When("maintenance mode is on", func() {
-				BeforeEach(func() {
-					Expect(adminClient.SetMaintenanceZone("operator-test-1-storage-4", 0)).NotTo(HaveOccurred())
-				})
-
-				It("status maintenance zone should match", func() {
-					Expect(cluster.Status.MaintenanceModeInfo).To(Equal(fdbv1beta2.MaintenanceModeInfo{ZoneID: "operator-test-1-storage-4"}))
-				})
-			})
-		})
-
 		When("multiple storage server per Pod are used", func() {
 			BeforeEach(func() {
 				cluster.Spec.StorageServersPerPod = 2
@@ -770,9 +754,6 @@ var _ = Describe("update_status", func() {
 				generation, err := reloadCluster(cluster)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(generation).To(Equal(int64(2)))
-
-				adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
-				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should set the fault domain for all process groups", func() {

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -288,7 +288,7 @@ FoundationDBClusterStatus defines the observed state of FoundationDBCluster
 | imageTypes | ImageTypes defines the kinds of images that are in use in the cluster. If there is more than one value in the slice the reconcile phase is not finished. | [][ImageType](#imagetype) | false |
 | processGroups | ProcessGroups contain information about a process group. This information is used in multiple places to trigger the according action. | []*[ProcessGroupStatus](#processgroupstatus) | false |
 | locks | Locks contains information about the locking system. | [LockSystemStatus](#locksystemstatus) | false |
-| maintenanceModeInfo | MaintenenanceModeInfo contains information regarding process groups in maintenance mode | [MaintenanceModeInfo](#maintenancemodeinfo) | false |
+| maintenanceModeInfo | MaintenenanceModeInfo contains information regarding process groups in maintenance mode **Deprecated: This setting it not used anymore.** | [MaintenanceModeInfo](#maintenancemodeinfo) | false |
 | desiredProcessGroups | DesiredProcessGroups reflects the number of expected running process groups. | int | false |
 | reconciledProcessGroups | ReconciledProcessGroups reflects the number of process groups that have no condition and are not marked for removal. | int | false |
 
@@ -361,7 +361,7 @@ MaintenanceModeInfo contains information regarding the zone and process groups t
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | startTimestamp | StartTimestamp provides the timestamp when this zone is put into maintenance mode **Deprecated: This setting it not used anymore.** | *metav1.Time | false |
-| zoneID | ZoneID that is placed in maintenance mode | [FaultDomain](#faultdomain) | false |
+| zoneID | ZoneID that is placed in maintenance mode **Deprecated: This setting it not used anymore.** | [FaultDomain](#faultdomain) | false |
 | processGroups | ProcessGroups that are placed in maintenance mode **Deprecated: This setting it not used anymore.** | []string | false |
 
 [Back to TOC](#table-of-contents)
@@ -372,7 +372,8 @@ MaintenanceModeOptions controls options for placing zones in maintenance mode.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| UseMaintenanceModeChecker | UseMaintenanceModeChecker defines whether the operator is allowed to use maintenance mode before updating pods. Default is false. | *bool | false |
+| UseMaintenanceModeChecker | UseMaintenanceModeChecker defines whether the operator is allowed to use maintenance mode before updating pods. If this setting is set to true the operator will set and reset the maintenance mode when updating pods. Default is false. | *bool | false |
+| resetMaintenanceMode | ResetMaintenanceMode defines whether the operator should reset the maintenance mode if all storage processes under the maintenance zone have been restarted. The default is false. If UseMaintenanceModeChecker is set to true the operator will be allowed to reset the maintenance mode. | *bool | false |
 | maintenanceModeTimeSeconds | MaintenanceModeTimeSeconds provides the duration for the zone to be in maintenance. It will automatically be switched off after the time elapses. Default is 600. | *int | false |
 
 [Back to TOC](#table-of-contents)

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -288,7 +288,7 @@ FoundationDBClusterStatus defines the observed state of FoundationDBCluster
 | imageTypes | ImageTypes defines the kinds of images that are in use in the cluster. If there is more than one value in the slice the reconcile phase is not finished. | [][ImageType](#imagetype) | false |
 | processGroups | ProcessGroups contain information about a process group. This information is used in multiple places to trigger the according action. | []*[ProcessGroupStatus](#processgroupstatus) | false |
 | locks | Locks contains information about the locking system. | [LockSystemStatus](#locksystemstatus) | false |
-| maintenanceModeInfo | MaintenenanceModeInfo contains information regarding process groups in maintenance mode **Deprecated: This setting it not used anymore.** | [MaintenanceModeInfo](#maintenancemodeinfo) | false |
+| maintenanceModeInfo | MaintenenanceModeInfo contains information regarding process groups in maintenance mode **Deprecated: This setting is not used anymore.** | [MaintenanceModeInfo](#maintenancemodeinfo) | false |
 | desiredProcessGroups | DesiredProcessGroups reflects the number of expected running process groups. | int | false |
 | reconciledProcessGroups | ReconciledProcessGroups reflects the number of process groups that have no condition and are not marked for removal. | int | false |
 
@@ -360,9 +360,9 @@ MaintenanceModeInfo contains information regarding the zone and process groups t
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| startTimestamp | StartTimestamp provides the timestamp when this zone is put into maintenance mode **Deprecated: This setting it not used anymore.** | *metav1.Time | false |
-| zoneID | ZoneID that is placed in maintenance mode **Deprecated: This setting it not used anymore.** | [FaultDomain](#faultdomain) | false |
-| processGroups | ProcessGroups that are placed in maintenance mode **Deprecated: This setting it not used anymore.** | []string | false |
+| startTimestamp | StartTimestamp provides the timestamp when this zone is put into maintenance mode **Deprecated: This setting is not used anymore.** | *metav1.Time | false |
+| zoneID | ZoneID that is placed in maintenance mode **Deprecated: This setting is not used anymore.** | [FaultDomain](#faultdomain) | false |
+| processGroups | ProcessGroups that are placed in maintenance mode **Deprecated: This setting is not used anymore.** | []string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -372,8 +372,8 @@ MaintenanceModeOptions controls options for placing zones in maintenance mode.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| UseMaintenanceModeChecker | UseMaintenanceModeChecker defines whether the operator is allowed to use maintenance mode before updating pods. If this setting is set to true the operator will set and reset the maintenance mode when updating pods. Default is false. | *bool | false |
-| resetMaintenanceMode | ResetMaintenanceMode defines whether the operator should reset the maintenance mode if all storage processes under the maintenance zone have been restarted. The default is false. If UseMaintenanceModeChecker is set to true the operator will be allowed to reset the maintenance mode. | *bool | false |
+| UseMaintenanceModeChecker | UseMaintenanceModeChecker defines whether the operator is allowed to use maintenance mode before updating pods. If this setting is set to true the operator will set and reset the maintenance mode when updating pods. If this setting is set to true, then ResetMaintenanceMode will also be enabled to make sure the operator is able to reset the maintenance mode again. Default is false. | *bool | false |
+| resetMaintenanceMode | ResetMaintenanceMode defines whether the operator should reset the maintenance mode if all storage processes under the maintenance zone have been restarted. The default is false. For more details see: https://github.com/FoundationDB/fdb-kubernetes-operator/blob/improve-maintenance-mode-integration/docs/manual/operations.md#maintenance Default is false. | *bool | false |
 | maintenanceModeTimeSeconds | MaintenanceModeTimeSeconds provides the duration for the zone to be in maintenance. It will automatically be switched off after the time elapses. Default is 600. | *int | false |
 
 [Back to TOC](#table-of-contents)

--- a/docs/manual/operations.md
+++ b/docs/manual/operations.md
@@ -176,6 +176,8 @@ For the non-storage processes, you should consider to cordon the node before tak
 You can use the [kubectl-fdb cordon](../../kubectl-fdb/Readme.md) for that.
 This will make sure that the processes are proactively excluded, instead of waiting for the FDB failure monitor to discover the failure.
 
+_NOTE_: You should always set the processes under maintenance before setting the maintenance mode.
+
 ### Risks and limitations
 
 There are a few risks and limitations to the current implementation:

--- a/docs/manual/operations.md
+++ b/docs/manual/operations.md
@@ -143,7 +143,7 @@ spec:
 
 ### Internals
 
-When the operator recreates a storage Pod it will first update the list of process groups under maintenance in the FDB cluster by adding the following values:
+Before the operator recreates a storage Pod it will first update the list of process groups under maintenance in the FDB cluster by adding the following values:
 
 ```text
 \xff\x02/org.foundationdb.kubernetes-operator/maintenance/<process-groupd-id> <unix-timestamp>
@@ -176,7 +176,7 @@ For the non-storage processes, you should consider to cordon the node before tak
 You can use the [kubectl-fdb cordon](../../kubectl-fdb/Readme.md) for that.
 This will make sure that the processes are proactively excluded, instead of waiting for the FDB failure monitor to discover the failure.
 
-_NOTE_: You should always set the processes under maintenance before setting the maintenance mode.
+_NOTE_: You should always set the processes under maintenance before setting the maintenance mode. See [Internals](#internals) for more details.
 
 ### Risks and limitations
 

--- a/docs/manual/operations.md
+++ b/docs/manual/operations.md
@@ -117,6 +117,62 @@ When using a label selector you must ensure that your FDB custom resources like 
 In addition to that you must ensure that you add the required labels in the `resourceLabels` of the `labels` section in the `FoundationDBCluster` otherwise the operator will ignore events from the created resources.
 For more information how to add additional labels to the resources managed by the operator refer to the [Resource Labeling](customization.md#resource-labeling) section.
 
+## Maintenance
+
+FDB has a feature called [maintenance mode](https://github.com/apple/foundationdb/wiki/Maintenance-mode), which allows the user to let FDB know that a set of storage servers are expected to be taken offline.
+Using the maintenance mode brings the benefit that the data movement is not triggered for the zone under maintenance.
+During upgrades or rollouts, this can reduce the unnecessary data movement.
+
+The operator supports two integration modes for the maintenance mode:
+
+1. The operator will set the maintenance mode when at least one storage Pod is taken down to be recreated and the operator will reset the maintenance mode once all processes (Pods) have been restarted.
+2. The operator will only reset the maintenance mode when all processes have been restarted.
+
+The 2. case can make sense if you have another system managing the Kubernetes node upgrades or if you have another component that takes care of the recreation of Pods.
+In most cases a user wants to make use of 1. as this offers the same integrations as 2. but also makes sure that the operator sets the maintenance mode before recreating storage Pods.
+
+When the operator recreates a storage Pod it will first update the list of process groups under maintenance in the FDB cluster by adding the following values:
+
+```text
+\xff\x02/org.foundationdb.kubernetes-operator/maintenance/<process-groupd-id> <unix-timestamp>
+```
+
+For every process group that will be taken down the operator will add an entry.
+The `unix-timestamp` will be the current time, or the time when the maintenance is expected to happen.
+A user can modify the prefix by setting a different value as [lockKeyPrefix](../cluster_spec.md#lockoptions), this value will be appended by `/maintenance/`.
+After this the operator sets the maintenance mode for the zone of the storage Pods.
+
+In the [maintenance mode checker](../../controllers/maintenance_mode_checker.go) the operator will evaluate the current list of processes under maintenance, based a range read over the maintenance key space.
+The [GetMaintenanceInformation method](../../internal/maintenance/maintenance.go) will check the status of those entries, there are the possible outcomes for an entry:
+
+1. The process has not yet restarted, either the maintenance action is still pending or is currently in progress (process has not be restarted).
+2. The maintenance on the process is done, this is discovered by a reporting process in the machine-readable status that was restarted after the maintenance timestamp.
+3. The entry is stale, all entries that are in the list for a longer time, default is 4h, will be removed to make sure old entries are removed.
+
+All processes that have finished the maintenance and the stale entries will be removed from that key space.
+Processes that have not yet finished their maintenance will stay untouched.
+If a maintenance zone is active and some processes have not yet finished the operator will requeue a reconciliation and wait until all processes are done.
+If all processes have finished their maintenance and a maintenance zone is active the operator will reset the maintenance zone.
+
+### External integration
+
+Depending on your Kubernetes setup, you might be able to use this integration during Kubernetes node upgrades.
+You can either use the [SetProcessesUnderMaintenance](../../fdbclient/admin_client.go) implementation or do the according fdbcli call.
+If you want to perform the fdbcli call programmatically you can take a look at the [the operator is allowed to reset the maintenance zone](../../e2e/test_operator/operator_test.go) test case.
+
+For the non-storage processes, you should consider to cordon the node before taking it down for maintenance.
+You can use the [kubectl-fdb cordon](../../kubectl-fdb/Readme.md) for that.
+This will make sure that the processes are proactively excluded, instead of waiting for the FDB failure monitor to discover the failure.
+
+### Risks and limitations
+
+There are a few risks and limitations to the current implementation:
+
+1. If a process is crashing/restarting during the maintenance operation it could lead to a case where the operator is releasing the maintenance mode earlier than it should be.
+
+The current risks are limited to releasing the maintenance mode earlier than it should be.
+In this case data-movement will be triggered for the down processes after 60 seconds, the data-movement shouldn't cause any operational issues.
+
 ## Next
 
 You can continue on to the [next section](scaling.md) or go back to the [table of contents](index.md).

--- a/docs/manual/operations.md
+++ b/docs/manual/operations.md
@@ -131,6 +131,18 @@ The operator supports two integration modes for the maintenance mode:
 The 2. case can make sense if you have another system managing the Kubernetes node upgrades or if you have another component that takes care of the recreation of Pods.
 In most cases a user wants to make use of 1. as this offers the same integrations as 2. but also makes sure that the operator sets the maintenance mode before recreating storage Pods.
 
+```yaml
+spec:
+  automationOptions:
+    maintenanceModeOptions:
+      # Enables option 1
+      UseMaintenanceModeChecker: true
+      # Will enable option 2, is implicitly true if UseMaintenanceModeChecker is true
+      resetMaintenanceMode: true
+```
+
+### Internals
+
 When the operator recreates a storage Pod it will first update the list of process groups under maintenance in the FDB cluster by adding the following values:
 
 ```text

--- a/docs/manual/replacements_and_deletions.md
+++ b/docs/manual/replacements_and_deletions.md
@@ -139,6 +139,10 @@ The default deletion mode is `Zone`.
 
 Depending on your requirements and the underlying Kubernetes cluster you might choose a different deletion mode than the default.
 
+## Maintenance Mode
+
+TODO ...
+
 ## Limit Zones (fault domains) with Unavailable Pods
 
 The operator allows to limit the number of zones with unavailable pods during deletions. This is configurable through `maxZonesWithUnavailablePods` in the cluster spec. Which is disabled by default. When enabled the operator will wait before deleting pods if the number of zones with unavailable pods is higher than the configured value and the pods to update do not belong to any of the zones with unavailable pods. This is useful to avoid deleting too many pods from different zones at once when recreating pods is not fast enough.

--- a/docs/manual/replacements_and_deletions.md
+++ b/docs/manual/replacements_and_deletions.md
@@ -139,10 +139,6 @@ The default deletion mode is `Zone`.
 
 Depending on your requirements and the underlying Kubernetes cluster you might choose a different deletion mode than the default.
 
-## Maintenance Mode
-
-TODO ...
-
 ## Limit Zones (fault domains) with Unavailable Pods
 
 The operator allows to limit the number of zones with unavailable pods during deletions. This is configurable through `maxZonesWithUnavailablePods` in the cluster spec. Which is disabled by default. When enabled the operator will wait before deleting pods if the number of zones with unavailable pods is higher than the configured value and the pods to update do not belong to any of the zones with unavailable pods. This is useful to avoid deleting too many pods from different zones at once when recreating pods is not fast enough.

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -24,6 +24,7 @@ import (
 	ctx "context"
 	"fmt"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/types"
 	"log"
 	"math"
 	"strconv"
@@ -1363,4 +1364,16 @@ func (fdbCluster *FdbCluster) EnsureTeamTrackersHaveMinReplicas() {
 
 		return minReplicas
 	}).WithTimeout(1 * time.Minute).WithPolling(1 * time.Second).MustPassRepeatedly(5).Should(gomega.BeNumerically(">=", desiredFaultTolerance))
+}
+
+// GetListOfUIDsFromVolumeClaims will return of list of UIDs for the current volume claims for the provided processes class.
+func (fdbCluster *FdbCluster) GetListOfUIDsFromVolumeClaims(processClass fdbv1beta2.ProcessClass) []types.UID {
+	volumesClaims := fdbCluster.GetVolumeClaimsForProcesses(processClass)
+
+	uids := make([]types.UID, 0, len(volumesClaims.Items))
+	for _, volumeClaim := range volumesClaims.Items {
+		uids = append(uids, volumeClaim.ObjectMeta.GetObjectMeta().GetUID())
+	}
+
+	return uids
 }

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -21,6 +21,7 @@
 package fixtures
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -431,4 +432,24 @@ func (fdbCluster FdbCluster) GetCommandlineForProcessesPerClass() map[fdbv1beta2
 	}
 
 	return knobs
+}
+
+// FdbPrintable copied from foundationdb bindings/go/src/fdb/fdb.go func Printable(d []byte) string
+// Printable returns a human readable version of a byte array. The bytes that correspond with
+// ASCII printable characters [32-127) are passed through. Other bytes are
+// replaced with \x followed by a two character zero-padded hex code for byte.
+func FdbPrintable(d []byte) string {
+	buf := new(bytes.Buffer)
+	for _, b := range d {
+		if b >= 32 && b < 127 && b != '\\' {
+			buf.WriteByte(b)
+			continue
+		}
+		if b == '\\' {
+			buf.WriteString("\\\\")
+			continue
+		}
+		buf.WriteString(fmt.Sprintf("\\x%02x", b))
+	}
+	return buf.String()
 }

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2064,13 +2064,14 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				return fdbCluster.GetStatus().Cluster.MaintenanceZone
 			}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Equal(faultDomain))
 
-			log.Println("Delete Pod")
-			factory.DeletePod(fdbCluster.GetPod(pickedProcessGroup.GetPodName(fdbCluster.GetCluster())))
+			podName := pickedProcessGroup.GetPodName(fdbCluster.GetCluster())
+			log.Println("Delete Pod", podName)
+			factory.DeletePod(fdbCluster.GetPod(podName))
 
 			// Make sure the maintenance mode is reset
 			Eventually(func() fdbv1beta2.FaultDomain {
 				return fdbCluster.GetStatus().Cluster.MaintenanceZone
-			}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).MustPassRepeatedly(10).Should(Equal(fdbv1beta2.FaultDomain("")))
+			}).WithTimeout(5 * time.Minute).WithPolling(2 * time.Second).MustPassRepeatedly(10).Should(Equal(fdbv1beta2.FaultDomain("")))
 		})
 
 		AfterEach(func() {

--- a/internal/maintenance/maintenance.go
+++ b/internal/maintenance/maintenance.go
@@ -87,14 +87,14 @@ func GetMaintenanceInformation(logger logr.Logger, status *fdbv1beta2.Foundation
 			// list, even if the zones are not matching. We are doing this to reduce the risk of the operator acting on
 			// a stale version of the machine-readable status, e.g. because of CPU throttling or the operator
 			// caching the machine-readable status and taking a long time to reconcile.
-			durationSineMaintenanceStarted := time.Since(maintenanceStartTime)
-			if durationSineMaintenanceStarted < differentZoneWaitDuration {
+			durationSinceMaintenanceStarted := time.Since(maintenanceStartTime)
+			if durationSinceMaintenanceStarted < differentZoneWaitDuration {
 				processesToUpdate = append(processesToUpdate, fdbv1beta2.ProcessGroupID(processGroupID))
 			}
 
-			// If the maintenance start time is longer ago than the define stale duration, we can assume that this is
+			// If the maintenance start time is longer ago than the defined stale duration, we can assume that this is
 			// an old entry that should be cleaned up.
-			if durationSineMaintenanceStarted > staleDuration {
+			if durationSinceMaintenanceStarted > staleDuration {
 				staleMaintenanceInformation = append(staleMaintenanceInformation, fdbv1beta2.ProcessGroupID(processGroupID))
 			}
 
@@ -114,7 +114,7 @@ func GetMaintenanceInformation(logger logr.Logger, status *fdbv1beta2.Foundation
 	// restarted we have to filter out all stale entries. We filter out those stale entries to make sure the entries
 	// are eventually cleaned up.
 	for processGroupID, maintenanceStart := range processesUnderMaintenance {
-		// If the maintenance start time is longer ago than the define stale duration, we can assume that this is
+		// If the maintenance start time is longer ago than the defined stale duration, we can assume that this is
 		// an old entry that should be cleaned up.
 		if time.Since(time.Unix(maintenanceStart, 0)) > staleDuration {
 			staleMaintenanceInformation = append(staleMaintenanceInformation, processGroupID)

--- a/internal/maintenance/maintenance.go
+++ b/internal/maintenance/maintenance.go
@@ -1,0 +1,114 @@
+/*
+ * maintenance.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package maintenance
+
+import (
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/go-logr/logr"
+	"time"
+)
+
+// GetMaintenanceInformation returns the information about processes that have finished, stale information in the maintenance list and processes that still must be updated.
+func GetMaintenanceInformation(logger logr.Logger, status *fdbv1beta2.FoundationDBStatus, processesUnderMaintenance map[fdbv1beta2.ProcessGroupID]int64, staleDuration time.Duration) ([]fdbv1beta2.ProcessGroupID, []fdbv1beta2.ProcessGroupID, []fdbv1beta2.ProcessGroupID) {
+	finishedMaintenance := make([]fdbv1beta2.ProcessGroupID, 0, len(processesUnderMaintenance))
+	staleMaintenanceInformation := make([]fdbv1beta2.ProcessGroupID, 0, len(processesUnderMaintenance))
+	processesToUpdate := make([]fdbv1beta2.ProcessGroupID, 0, len(processesUnderMaintenance))
+	processesInDifferentZone := map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None{}
+
+	// If the provided status is empty return all processes to be updated.
+	if status == nil {
+		for processGroupID := range processesUnderMaintenance {
+			processesToUpdate = append(processesToUpdate, processGroupID)
+		}
+
+		logger.Info("provided status is empty")
+		return nil, nil, processesToUpdate
+	}
+
+	logger.Info("start evaluation", "processesUnderMaintenance", processesUnderMaintenance)
+
+	for _, process := range status.Cluster.Processes {
+		// Only storage processes are affected by the maintenance mode.
+		if process.ProcessClass != fdbv1beta2.ProcessClassStorage {
+			continue
+		}
+
+		processGroupID, ok := process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]
+		if !ok {
+			continue
+		}
+
+		// Check if the provided process is under maintenance, if not we can skip further checks.
+		maintenanceStart, isUnderMaintenance := processesUnderMaintenance[fdbv1beta2.ProcessGroupID(processGroupID)]
+		if !isUnderMaintenance {
+			continue
+		}
+
+		// Get the start time of the processes, based on the current time and the uptime seconds reported by the process.
+		startTime := time.Now().Add(-1 * time.Duration(process.UptimeSeconds) * time.Second)
+		maintenanceStartTime := time.Unix(maintenanceStart, 0)
+
+		zoneID, ok := process.Locality[fdbv1beta2.FDBLocalityZoneIDKey]
+		if !ok {
+			continue
+		}
+
+		logger.Info("found process under maintenance", "processGroupID", processGroupID, "zoneID", zoneID, "currentMaintenance", status.Cluster.MaintenanceZone, "startTime", startTime.String(), "maintenanceStartTime", maintenanceStartTime.String(), "UptimeSeconds", process.UptimeSeconds)
+		// If the zones are not matching those are probably stale entries. Once they are long enough in the list of
+		// entries they will be removed.
+		if zoneID != string(status.Cluster.MaintenanceZone) {
+			processesInDifferentZone[fdbv1beta2.ProcessGroupID(processGroupID)] = fdbv1beta2.None{}
+			continue
+		}
+
+		// If the start time is after the maintenance start time, we can assume that maintenance for this specific process is done.
+		if startTime.After(maintenanceStartTime) {
+			finishedMaintenance = append(finishedMaintenance, fdbv1beta2.ProcessGroupID(processGroupID))
+		} else {
+			processesToUpdate = append(processesToUpdate, fdbv1beta2.ProcessGroupID(processGroupID))
+		}
+
+		delete(processesUnderMaintenance, fdbv1beta2.ProcessGroupID(processGroupID))
+	}
+
+	// After we checked above the processes that are done with their maintenance and the processes that still must be
+	// restarted we have to filter out all stale entries. We filter out those stale entries to make sure the entries
+	// are eventually cleaned up.
+	for processGroupID, maintenanceStart := range processesUnderMaintenance {
+		// If the maintenance start time is longer ago than the define stale duration, we can assume that this is
+		// an old entry that should be cleaned up.
+		if time.Since(time.Unix(maintenanceStart, 0)) > staleDuration {
+			staleMaintenanceInformation = append(staleMaintenanceInformation, processGroupID)
+			continue
+		}
+
+		// This process is in a different zone than the maintenance zone, so we can ignore it here. It will be cleaned
+		// up after some time, but it will not block the reset of the maintenance zone.
+		_, inDifferentZone := processesInDifferentZone[processGroupID]
+		if inDifferentZone {
+			continue
+		}
+
+		processesToUpdate = append(processesToUpdate, processGroupID)
+	}
+
+	return finishedMaintenance, staleMaintenanceInformation, processesToUpdate
+}

--- a/internal/maintenance/maintenance_test.go
+++ b/internal/maintenance/maintenance_test.go
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,13 +33,14 @@ var _ = Describe("maintenance", func() {
 		status                      *fdbv1beta2.FoundationDBStatus
 		processesUnderMaintenance   map[fdbv1beta2.ProcessGroupID]int64
 		staleDuration               time.Duration
+		differentZoneWaitDuration   time.Duration
 		finishedMaintenance         []fdbv1beta2.ProcessGroupID
 		staleMaintenanceInformation []fdbv1beta2.ProcessGroupID
 		processesToUpdate           []fdbv1beta2.ProcessGroupID
 	}
 
 	DescribeTable("when getting the maintenance information", func(input maintenanceTest) {
-		finishedMaintenance, staleMaintenanceInformation, processesToUpdate := GetMaintenanceInformation(logr.Discard(), input.status, input.processesUnderMaintenance, input.staleDuration)
+		finishedMaintenance, staleMaintenanceInformation, processesToUpdate := GetMaintenanceInformation(logr.Discard(), input.status, input.processesUnderMaintenance, input.staleDuration, input.differentZoneWaitDuration)
 		Expect(finishedMaintenance).To(ConsistOf(input.finishedMaintenance))
 		Expect(staleMaintenanceInformation).To(ConsistOf(input.staleMaintenanceInformation))
 		Expect(processesToUpdate).To(ConsistOf(input.processesToUpdate))
@@ -213,4 +214,6 @@ var _ = Describe("maintenance", func() {
 			},
 		),
 	)
+
+	// TODO test case for different zone -> differentZoneWaitDuration
 })

--- a/internal/maintenance/maintenance_test.go
+++ b/internal/maintenance/maintenance_test.go
@@ -1,0 +1,216 @@
+/*
+ * maintenance_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package maintenance
+
+import (
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+var _ = Describe("maintenance", func() {
+	type maintenanceTest struct {
+		status                      *fdbv1beta2.FoundationDBStatus
+		processesUnderMaintenance   map[fdbv1beta2.ProcessGroupID]int64
+		staleDuration               time.Duration
+		finishedMaintenance         []fdbv1beta2.ProcessGroupID
+		staleMaintenanceInformation []fdbv1beta2.ProcessGroupID
+		processesToUpdate           []fdbv1beta2.ProcessGroupID
+	}
+
+	DescribeTable("when getting the maintenance information", func(input maintenanceTest) {
+		finishedMaintenance, staleMaintenanceInformation, processesToUpdate := GetMaintenanceInformation(logr.Discard(), input.status, input.processesUnderMaintenance, input.staleDuration)
+		Expect(finishedMaintenance).To(ConsistOf(input.finishedMaintenance))
+		Expect(staleMaintenanceInformation).To(ConsistOf(input.staleMaintenanceInformation))
+		Expect(processesToUpdate).To(ConsistOf(input.processesToUpdate))
+	},
+		Entry("when no process are under maintenance",
+			maintenanceTest{
+				status:                      &fdbv1beta2.FoundationDBStatus{},
+				processesUnderMaintenance:   nil,
+				staleDuration:               1 * time.Hour,
+				finishedMaintenance:         nil,
+				staleMaintenanceInformation: nil,
+				processesToUpdate:           nil,
+			},
+		),
+		Entry("when one process is done with the maintenance",
+			maintenanceTest{
+				status: &fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						MaintenanceZone: "rack-1",
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"storage-1": {
+								ProcessClass: fdbv1beta2.ProcessClassStorage,
+								Locality: map[string]string{
+									fdbv1beta2.FDBLocalityInstanceIDKey: "storage-1",
+									fdbv1beta2.FDBLocalityZoneIDKey:     "rack-1",
+								},
+								UptimeSeconds: 15.0,
+							},
+						},
+					},
+				},
+				processesUnderMaintenance: map[fdbv1beta2.ProcessGroupID]int64{
+					"storage-1": time.Now().Add(-1 * time.Minute).Unix(),
+				},
+				staleDuration:               1 * time.Hour,
+				finishedMaintenance:         []fdbv1beta2.ProcessGroupID{"storage-1"},
+				staleMaintenanceInformation: nil,
+				processesToUpdate:           nil,
+			},
+		),
+		Entry("when one process is done with the maintenance but another one is pending",
+			maintenanceTest{
+				status: &fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						MaintenanceZone: "rack-1",
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"storage-1": {
+								ProcessClass: fdbv1beta2.ProcessClassStorage,
+								Locality: map[string]string{
+									fdbv1beta2.FDBLocalityInstanceIDKey: "storage-1",
+									fdbv1beta2.FDBLocalityZoneIDKey:     "rack-1",
+								},
+								UptimeSeconds: 15.0,
+							},
+							"storage-2": {
+								ProcessClass: fdbv1beta2.ProcessClassStorage,
+								Locality: map[string]string{
+									fdbv1beta2.FDBLocalityInstanceIDKey: "storage-2",
+									fdbv1beta2.FDBLocalityZoneIDKey:     "rack-1",
+								},
+								UptimeSeconds: 900000.0,
+							},
+						},
+					},
+				},
+				processesUnderMaintenance: map[fdbv1beta2.ProcessGroupID]int64{
+					"storage-1": time.Now().Add(-1 * time.Minute).Unix(),
+					"storage-2": time.Now().Add(-1 * time.Minute).Unix(),
+				},
+				staleDuration:               1 * time.Hour,
+				finishedMaintenance:         []fdbv1beta2.ProcessGroupID{"storage-1"},
+				staleMaintenanceInformation: nil,
+				processesToUpdate:           []fdbv1beta2.ProcessGroupID{"storage-2"},
+			},
+		),
+		Entry("when one process is done with the maintenance but another one is missing in the status",
+			maintenanceTest{
+				status: &fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						MaintenanceZone: "rack-1",
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"storage-1": {
+								ProcessClass: fdbv1beta2.ProcessClassStorage,
+								Locality: map[string]string{
+									fdbv1beta2.FDBLocalityInstanceIDKey: "storage-1",
+									fdbv1beta2.FDBLocalityZoneIDKey:     "rack-1",
+								},
+								UptimeSeconds: 15.0,
+							},
+						},
+					},
+				},
+				processesUnderMaintenance: map[fdbv1beta2.ProcessGroupID]int64{
+					"storage-1": time.Now().Add(-1 * time.Minute).Unix(),
+					"storage-2": time.Now().Add(-1 * time.Minute).Unix(),
+				},
+				staleDuration:               1 * time.Hour,
+				finishedMaintenance:         []fdbv1beta2.ProcessGroupID{"storage-1"},
+				staleMaintenanceInformation: nil,
+				processesToUpdate:           []fdbv1beta2.ProcessGroupID{"storage-2"},
+			},
+		),
+		Entry("when one process is done with the maintenance and another one from a different fault domain is present",
+			maintenanceTest{
+				status: &fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						MaintenanceZone: "rack-1",
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"storage-1": {
+								ProcessClass: fdbv1beta2.ProcessClassStorage,
+								Locality: map[string]string{
+									fdbv1beta2.FDBLocalityInstanceIDKey: "storage-1",
+									fdbv1beta2.FDBLocalityZoneIDKey:     "rack-1",
+								},
+								UptimeSeconds: 15.0,
+							},
+							"storage-2": {
+								ProcessClass: fdbv1beta2.ProcessClassStorage,
+								Locality: map[string]string{
+									fdbv1beta2.FDBLocalityInstanceIDKey: "storage-2",
+									fdbv1beta2.FDBLocalityZoneIDKey:     "rack-2",
+								},
+								UptimeSeconds: 900000.0,
+							},
+						},
+					},
+				},
+				processesUnderMaintenance: map[fdbv1beta2.ProcessGroupID]int64{
+					"storage-1": time.Now().Add(-1 * time.Minute).Unix(),
+					"storage-2": time.Now().Add(-1 * time.Minute).Unix(),
+				},
+				staleDuration:               1 * time.Hour,
+				finishedMaintenance:         []fdbv1beta2.ProcessGroupID{"storage-1"},
+				staleMaintenanceInformation: nil,
+				processesToUpdate:           nil,
+			},
+		),
+		Entry("when one process is done with the maintenance and another one from a different fault domain is present with an old entry",
+			maintenanceTest{
+				status: &fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						MaintenanceZone: "rack-1",
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"storage-1": {
+								ProcessClass: fdbv1beta2.ProcessClassStorage,
+								Locality: map[string]string{
+									fdbv1beta2.FDBLocalityInstanceIDKey: "storage-1",
+									fdbv1beta2.FDBLocalityZoneIDKey:     "rack-1",
+								},
+								UptimeSeconds: 15.0,
+							},
+							"storage-2": {
+								ProcessClass: fdbv1beta2.ProcessClassStorage,
+								Locality: map[string]string{
+									fdbv1beta2.FDBLocalityInstanceIDKey: "storage-2",
+									fdbv1beta2.FDBLocalityZoneIDKey:     "rack-2",
+								},
+								UptimeSeconds: 900000.0,
+							},
+						},
+					},
+				},
+				processesUnderMaintenance: map[fdbv1beta2.ProcessGroupID]int64{
+					"storage-1": time.Now().Add(-1 * time.Minute).Unix(),
+					"storage-2": time.Now().Add(-2 * time.Hour).Unix(),
+				},
+				staleDuration:               1 * time.Hour,
+				finishedMaintenance:         []fdbv1beta2.ProcessGroupID{"storage-1"},
+				staleMaintenanceInformation: []fdbv1beta2.ProcessGroupID{"storage-2"},
+				processesToUpdate:           nil,
+			},
+		),
+	)
+})

--- a/internal/maintenance/suite_test.go
+++ b/internal/maintenance/suite_test.go
@@ -1,0 +1,33 @@
+/*
+ * suite_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package maintenance
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "maintenance")
+}

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -119,4 +119,17 @@ type AdminClient interface {
 
 	// SetTimeout will overwrite the default timeout for interacting the FDB cluster.
 	SetTimeout(timeout time.Duration)
+
+	// GetProcessesUnderMaintenance will return all process groups that are currently stored to be under maintenance.
+	// The result is a map with the process group ID as key and the start of the maintenance as value.
+	GetProcessesUnderMaintenance() (map[fdbv1beta2.ProcessGroupID]int64, error)
+
+	// RemoveProcessesUnderMaintenance will remove the provided process groups from the list of processes that
+	// are planned to be taken down for maintenance. If a process group is not present in the list it will be ignored.
+	RemoveProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID) error
+
+	// SetProcessesUnderMaintenance will add the provided process groups to the list of processes that will be taken
+	// down for maintenance. The value will be the provided time stamp. If a process group is already present in the
+	// list, the timestamp will be updated.
+	SetProcessesUnderMaintenance([]fdbv1beta2.ProcessGroupID, int64) error
 }

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -69,6 +69,7 @@ type AdminClient struct {
 	Logs                                     []fdbv1beta2.FoundationDBStatusLogInfo
 	mockError                                error
 	LagInfo                                  map[string]fdbv1beta2.FoundationDBStatusLagInfo
+	processesUnderMaintenance                map[fdbv1beta2.ProcessGroupID]int64
 }
 
 // adminClientCache provides a cache of mock admin clients.
@@ -1057,3 +1058,29 @@ func (client *AdminClient) WithValues(_ ...interface{}) {}
 
 // SetTimeout will overwrite the default timeout for interacting the FDB cluster.
 func (client *AdminClient) SetTimeout(_ time.Duration) {}
+
+// GetProcessesUnderMaintenance will return all process groups that are currently stored to be under maintenance.
+// The result is a map with the process group ID as key and the start of the maintenance as value.
+func (client *AdminClient) GetProcessesUnderMaintenance() (map[fdbv1beta2.ProcessGroupID]int64, error) {
+	return client.processesUnderMaintenance, nil
+}
+
+// RemoveProcessesUnderMaintenance will remove the provided process groups from the list of processes that
+// are planned to be taken down for maintenance.
+func (client *AdminClient) RemoveProcessesUnderMaintenance(ids []fdbv1beta2.ProcessGroupID) error {
+	for _, id := range ids {
+		delete(client.processesUnderMaintenance, id)
+	}
+
+	return nil
+}
+
+// SetProcessesUnderMaintenance will add the provided process groups to the list of processes that will be taken
+// down for maintenance. The value will be the provided time stamp.
+func (client *AdminClient) SetProcessesUnderMaintenance(ids []fdbv1beta2.ProcessGroupID, timestamp int64) error {
+	for _, id := range ids {
+		client.processesUnderMaintenance[id] = timestamp
+	}
+
+	return nil
+}

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -80,6 +80,8 @@ type Options struct {
 	LogFileMinAge                      time.Duration
 	GetTimeout                         time.Duration
 	PostTimeout                        time.Duration
+	MaintenanceListStaleDuration       time.Duration
+	MaintenanceListWaitDuration        time.Duration
 	// LeaseDuration is the duration that non-leader candidates will
 	// wait to force acquire leadership. This is measured against time of
 	// last observed ack. Default is 15 seconds.
@@ -124,6 +126,8 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&o.LeaseDuration, "leader-election-lease-duration", 15*time.Second, "the duration that non-leader candidates will wait to force acquire leadership.")
 	fs.DurationVar(&o.RenewDeadline, "leader-election-renew-deadline", 10*time.Second, "the duration that the acting controlplane will retry refreshing leadership before giving up.")
 	fs.DurationVar(&o.RetryPeriod, "leader-election-retry-period", 2*time.Second, "the duration the LeaderElector clients should wait between tries of action.")
+	fs.DurationVar(&o.MaintenanceListStaleDuration, "maintenance-list-stale-duration", 4*time.Hour, "the duration after stale entries will be deleted form the maintenance list. Only has an affect if the operator is allowed to reset the maintenance zone.")
+	fs.DurationVar(&o.MaintenanceListWaitDuration, "maintenance-list-wait-duration", 5*time.Minute, "the duration where a process in the maintenance list in a different zone will be assumed to block the maintenance zone reset. Only has an affect if the operator is allowed to reset the maintenance zone.")
 	fs.DurationVar(&o.MinimumRequiredUptimeCCBounce, "minimum-required-uptime-for-cc-bounce", 1*time.Hour, "the minimum required uptime of the cluster before allowing the operator to restart the CC if there is a failed tester process.")
 	fs.BoolVar(&o.EnableRestartIncompatibleProcesses, "enable-restart-incompatible-processes", true, "This flag enables/disables in the operator to restart incompatible fdbserver processes.")
 	fs.BoolVar(&o.ServerSideApply, "server-side-apply", false, "This flag enables server side apply.")
@@ -248,6 +252,8 @@ func StartManager(
 		clusterReconciler.EnableRecoveryState = operatorOpts.EnableRecoveryState
 		clusterReconciler.CacheDatabaseStatusForReconciliationDefault = operatorOpts.CacheDatabaseStatus
 		clusterReconciler.MinimumRequiredUptimeCCBounce = operatorOpts.MinimumRequiredUptimeCCBounce
+		clusterReconciler.MaintenanceListStaleDuration = operatorOpts.MaintenanceListStaleDuration
+		clusterReconciler.MaintenanceListWaitDuration = operatorOpts.MaintenanceListWaitDuration
 
 		if err := clusterReconciler.SetupWithManager(mgr, operatorOpts.MaxConcurrentReconciles, operatorOpts.EnableNodeIndex, *labelSelector, watchedObjects...); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "FoundationDBCluster")


### PR DESCRIPTION
# Description

This PR provides changes for a better integration with the maintenance mode for the operator. I'll provide more information in the docs.

fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1656
fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1655
fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1654
fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1650

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Manual testing. I added a new e2e test for this and added a new HA test with maintenance mode enabled. 
I will also add some additional unit tests to the once I already added.

## Documentation

Will be updated before merging.

## Follow-up

-
