### PR TITLE
Report correct current uptime in log line for safe bounce check

### DIFF
--- a/pkg/fdbstatus/status_checks.go
+++ b/pkg/fdbstatus/status_checks.go
@@ -22,11 +22,12 @@ package fdbstatus
 
 import (
 	"fmt"
+	"math"
+	"strings"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
 	"github.com/go-logr/logr"
-	"math"
-	"strings"
 )
 
 // forbiddenStatusMessages represents messages that could be part of the machine-readable status. Those messages can represent
@@ -489,7 +490,7 @@ func CanSafelyBounceProcesses(currentUptime float64, minimumUptime float64, stat
 	// If the current uptime of the cluster is below the minimum uptime we should not allow to bounce processes. This is
 	// a safeguard to reduce the risk of repeated bounces in a short timeframe.
 	if currentUptime < minimumUptime {
-		return fmt.Errorf("cluster has only been up for %.2f seconds, but must be up for %.2f seconds to safely bounce", minimumUptime, minimumUptime)
+		return fmt.Errorf("cluster has only been up for %.2f seconds, but must be up for %.2f seconds to safely bounce", currentUptime, minimumUptime)
 	}
 
 	// If the machine-readable status reports that a clean bounce is not possible, we shouldn't perform a bounce. This

--- a/pkg/fdbstatus/status_checks_test.go
+++ b/pkg/fdbstatus/status_checks_test.go
@@ -22,9 +22,10 @@ package fdbstatus
 
 import (
 	"fmt"
+	"net"
+
 	"github.com/go-logr/logr"
 	"k8s.io/utils/pointer"
-	"net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
@@ -2207,7 +2208,7 @@ var _ = Describe("status_checks", func() {
 				},
 				42.0,
 				60.0,
-				fmt.Errorf("cluster has only been up for 60.00 seconds, but must be up for 60.00 seconds to safely bounce"),
+				fmt.Errorf("cluster has only been up for 42.00 seconds, but must be up for 60.00 seconds to safely bounce"),
 			),
 			Entry("cluster cannot clean bounce",
 				&fdbv1beta2.FoundationDBStatus{


### PR DESCRIPTION
# Description

The log line for the bounce check does not report the current uptime.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

Is it okay to leave the imports change, or do you prefer me to undo that?

## Testing

Pre-existing test has been updated.

## Documentation

No changes needed.

## Follow-up

No follow-up needed.
