### PR TITLE
Label selection for pods/processGroups

### DIFF
--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -136,6 +136,9 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 		if err != nil {
 			return fmt.Errorf("issue fetching Pods running on node %s. Error: %w", node, err)
 		}
+		if len(pods.Items) == 0 {
+			return fmt.Errorf("no pods were found that were running on node %s", node)
+		}
 		var podNames []string
 		for _, pod := range pods.Items {
 			podNames = append(podNames, pod.Name)

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -109,7 +109,7 @@ var _ = Describe("[plugin] cordon command", func() {
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:       clusterName,
 					clusterLabel:      "",
-					wantErrorContains: "no processGroups could be selected with the provided options",
+					wantErrorContains: "no pods were found that were running on node",
 				}),
 			Entry("Cordon no node nodes without exclusion",
 				testCase{
@@ -119,7 +119,7 @@ var _ = Describe("[plugin] cordon command", func() {
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:       clusterName,
 					clusterLabel:      "",
-					wantErrorContains: "no processGroups could be selected with the provided options",
+					wantErrorContains: "no pods were found that were running on node",
 				}),
 			Entry("Cordon all nodes with exclusion",
 				testCase{
@@ -197,7 +197,7 @@ var _ = Describe("[plugin] cordon command", func() {
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:       "",
 					clusterLabel:      fdbv1beta2.FDBClusterLabel,
-					wantErrorContains: "no processGroups could be selected with the provided options",
+					wantErrorContains: "no pods were found that were running on node",
 				}),
 		)
 	})

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -321,7 +321,7 @@ func getPodListMatchingLabels(kubeClient client.Client, namespace string, matchL
 	for key, value := range matchLabels {
 		requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
 		if err != nil {
-			return pods, err
+			return nil, err
 		}
 		selector = selector.Add(*requirement)
 	}
@@ -331,7 +331,7 @@ func getPodListMatchingLabels(kubeClient client.Client, namespace string, matchL
 		client.MatchingLabelsSelector{Selector: selector},
 	)
 	if err != nil {
-		return pods, err
+		return nil, err
 	}
 
 	return pods, nil
@@ -351,7 +351,7 @@ func getPodsMatchingLabels(kubeClient client.Client, cluster *fdbv1beta2.Foundat
 	}
 	pods, err := getPodListMatchingLabels(kubeClient, namespace, matchLabels)
 	if err != nil {
-		return matchingPodNames, err
+		return nil, err
 	}
 
 	for _, pod := range pods.Items {

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -489,9 +489,11 @@ func getPodNamesByCluster(cmd *cobra.Command, kubeClient client.Client, opts pro
 	if opts.clusterName == "" { // cli has a default for clusterLabel
 		if opts.useProcessGroupID || opts.processClass != "" || len(opts.conditions) > 0 || len(opts.matchLabels) > 0 {
 			return nil, errors.New("selection of pods / process groups by cluster-label (cross-cluster selection) is " +
-				"incompatible with use-process-group-id, process-class, process-condition, and match-labels options")
+				"incompatible with use-process-group-id, process-class, process-condition, and match-labels options.  " +
+				"Please specify a cluster")
 		}
 	}
+
 	if len(opts.conditions) > 0 && opts.processClass != "" {
 		return nil, errors.New("selection of pods / processGroups by both processClass and conditions is not supported at this time")
 	}
@@ -549,7 +551,8 @@ func getProcessGroupsByCluster(cmd *cobra.Command, kubeClient client.Client, opt
 	if opts.clusterName == "" { // cli has a default for clusterLabel
 		if opts.useProcessGroupID || opts.processClass != "" || len(opts.conditions) > 0 {
 			return nil, errors.New("selection of process groups by cluster-label (cross-cluster selection) is " +
-				"incompatible with use-process-group-id, process-class, and process-condition options")
+				"incompatible with use-process-group-id, process-class, process-condition, and match-labels options.  " +
+				"Please specify a cluster")
 		}
 	}
 	if len(opts.conditions) > 0 && opts.processClass != "" {

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -39,7 +39,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -298,19 +300,7 @@ func getProcessGroupIDsFromPodName(cluster *fdbv1beta2.FoundationDBCluster, podN
 	return processGroupIDs, nil
 }
 
-// getProcessGroupIdsWithClass returns a list of ProcessGroupIDs in the given cluster which are of the given processClass
-func getProcessGroupIdsWithClass(cluster *fdbv1beta2.FoundationDBCluster, processClass string) []fdbv1beta2.ProcessGroupID {
-	matchingProcessGroupIDs := []fdbv1beta2.ProcessGroupID{}
-	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.ProcessClass != fdbv1beta2.ProcessClass(processClass) {
-			continue
-		}
-		matchingProcessGroupIDs = append(matchingProcessGroupIDs, processGroup.ProcessGroupID)
-	}
-	return matchingProcessGroupIDs
-}
-
-// getPodsWithProcessClass returns a list of ProcessGroupIDs in the given cluster which are of the given processClass
+// getPodsWithProcessClass returns a list of pod names in the given cluster which are of the given processClass
 func getPodsWithProcessClass(cluster *fdbv1beta2.FoundationDBCluster, processClass string) []string {
 	matchingPodNames := []string{}
 	for _, processGroupStatus := range cluster.Status.ProcessGroups {
@@ -321,6 +311,54 @@ func getPodsWithProcessClass(cluster *fdbv1beta2.FoundationDBCluster, processCla
 		matchingPodNames = append(matchingPodNames, processGroupStatus.GetPodName(cluster))
 	}
 	return matchingPodNames
+}
+
+// getPodListMatchingLabels returns a *corev1.PodList matching the given label selector map
+func getPodListMatchingLabels(kubeClient client.Client, namespace string, matchLabels map[string]string) (*corev1.PodList, error) {
+	pods := &corev1.PodList{}
+	selector := labels.NewSelector()
+
+	for key, value := range matchLabels {
+		requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
+		if err != nil {
+			return pods, err
+		}
+		selector = selector.Add(*requirement)
+	}
+
+	err := kubeClient.List(context.Background(), pods,
+		client.InNamespace(namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	)
+	if err != nil {
+		return pods, err
+	}
+
+	return pods, nil
+}
+
+// getPodsMatchingLabels returns a list of pods in the given cluster which have the matching labels and are in the
+// provided cluster
+func getPodsMatchingLabels(kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluster, namespace string, matchLabels map[string]string) ([]string, error) {
+	matchingPodNames := []string{}
+
+	// add the labels to match the specified cluster
+	for label, clusterValue := range cluster.GetMatchLabels() {
+		if specifiedValue, ok := matchLabels[label]; ok && specifiedValue != clusterValue {
+			return nil, fmt.Errorf("value for label %s is incompatible with labels for the specified cluster %s", label, cluster.Name)
+		}
+		matchLabels[label] = clusterValue
+	}
+	pods, err := getPodListMatchingLabels(kubeClient, namespace, matchLabels)
+	if err != nil {
+		return matchingPodNames, err
+	}
+
+	for _, pod := range pods.Items {
+		matchingPodNames = append(matchingPodNames, pod.Name)
+	}
+
+	return matchingPodNames, nil
 }
 
 // fetchProcessGroupsCrossCluster fetches the list of process groups matching the given podNames and returns the
@@ -449,9 +487,9 @@ func getPodNamesByCluster(cmd *cobra.Command, kubeClient client.Client, opts pro
 		return nil, errors.New("podNames will not be selected without cluster specification")
 	}
 	if opts.clusterName == "" { // cli has a default for clusterLabel
-		if opts.useProcessGroupID || opts.processClass != "" || len(opts.conditions) > 0 {
+		if opts.useProcessGroupID || opts.processClass != "" || len(opts.conditions) > 0 || len(opts.matchLabels) > 0 {
 			return nil, errors.New("selection of pods / process groups by cluster-label (cross-cluster selection) is " +
-				"incompatible with use-process-group-id, process-class, and process-condition options")
+				"incompatible with use-process-group-id, process-class, process-condition, and match-labels options")
 		}
 	}
 	if len(opts.conditions) > 0 && opts.processClass != "" {
@@ -478,6 +516,11 @@ func getPodNamesByCluster(cmd *cobra.Command, kubeClient client.Client, opts pro
 	var podNames []string
 	if opts.processClass != "" { // match against a whole process class, ignore provided ids
 		podNames = getPodsWithProcessClass(cluster, opts.processClass)
+	} else if len(opts.matchLabels) > 0 {
+		podNames, err = getPodsMatchingLabels(kubeClient, cluster, opts.namespace, opts.matchLabels)
+		if err != nil {
+			return nil, err
+		}
 	} else if len(opts.conditions) > 0 {
 		podNames, err = getAllPodsFromClusterWithCondition(cmd.ErrOrStderr(), kubeClient, opts.clusterName, opts.namespace, opts.conditions)
 		if err != nil {
@@ -500,7 +543,7 @@ func getPodNamesByCluster(cmd *cobra.Command, kubeClient client.Client, opts pro
 // processSelectionOptions.
 func getProcessGroupsByCluster(cmd *cobra.Command, kubeClient client.Client, opts processGroupSelectionOptions) (map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID, error) {
 	// option compatibility checks
-	if opts.clusterName == "" && opts.clusterLabel == "" {
+	if opts.clusterName == "" && opts.clusterLabel == "" && len(opts.matchLabels) == 0 {
 		return nil, errors.New("processGroups will not be selected without cluster specification")
 	}
 	if opts.clusterName == "" { // cli has a default for clusterLabel
@@ -530,26 +573,30 @@ func getProcessGroupsByCluster(cmd *cobra.Command, kubeClient client.Client, opt
 		return nil, err
 	}
 	// find the desired process groups in the single cluster
-	var processGroupIDs []fdbv1beta2.ProcessGroupID
+	var (
+		processGroupIDs []fdbv1beta2.ProcessGroupID
+		podNames        []string
+	)
 	if opts.processClass != "" { // match against a whole process class, ignore provided ids
-		processGroupIDs = getProcessGroupIdsWithClass(cluster, opts.processClass)
+		podNames = getPodsWithProcessClass(cluster, opts.processClass)
+	} else if len(opts.matchLabels) > 0 {
+		podNames, err = getPodsMatchingLabels(kubeClient, cluster, opts.namespace, opts.matchLabels)
 	} else if len(opts.conditions) > 0 {
-		podNames, err := getAllPodsFromClusterWithCondition(cmd.ErrOrStderr(), kubeClient, opts.clusterName, opts.namespace, opts.conditions)
-		if err != nil {
-			return nil, err
-		}
-		processGroupIDs, err = getProcessGroupIDsFromPodName(cluster, podNames)
-		if err != nil {
-			return nil, err
-		}
+		podNames, err = getAllPodsFromClusterWithCondition(cmd.ErrOrStderr(), kubeClient, opts.clusterName, opts.namespace, opts.conditions)
 	} else if !opts.useProcessGroupID { // match by pod name
-		processGroupIDs, err = getProcessGroupIDsFromPodName(cluster, opts.ids)
-		if err != nil {
-			return nil, err
-		}
+		podNames = opts.ids
 	} else { // match by process group ID
 		for _, id := range opts.ids {
 			processGroupIDs = append(processGroupIDs, fdbv1beta2.ProcessGroupID(id))
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(podNames) > 0 {
+		processGroupIDs, err = getProcessGroupIDsFromPodName(cluster, podNames)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/kubectl-fdb/cmd/k8s_client_test.go
+++ b/kubectl-fdb/cmd/k8s_client_test.go
@@ -357,7 +357,7 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 						useProcessGroupID: true,
 					},
 					wantResult:      nil,
-					wantErrContains: "selection of process groups by cluster-label (cross-cluster selection) is incompatible with use-process-group-id, process-class, and process-condition options",
+					wantErrContains: "selection of process groups by cluster-label (cross-cluster selection) is incompatible with use-process-group-id, process-class",
 				},
 			),
 			Entry("gets processGroups from podNames and clusterLabel",

--- a/kubectl-fdb/cmd/k8s_client_test.go
+++ b/kubectl-fdb/cmd/k8s_client_test.go
@@ -488,6 +488,75 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 					wantErrContains: "found no processGroups meeting the selection criteria",
 				},
 			),
+			Entry("gets all processGroups with given label",
+				testCase{
+					opts: processGroupSelectionOptions{
+						clusterName: clusterName,
+						matchLabels: map[string]string{fdbv1beta2.FDBClusterLabel: clusterName},
+					},
+					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
+						clusterName: {
+							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)),
+						},
+					},
+				},
+			),
+			Entry("gets 1 processGroup matching given label",
+				testCase{
+					opts: processGroupSelectionOptions{
+						clusterName: clusterName,
+						matchLabels: map[string]string{
+							fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStateless),
+						},
+					},
+					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
+						clusterName: {
+							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)),
+						},
+					},
+				},
+			),
+			Entry("gets 1 processGroup matching given labels",
+				testCase{
+					opts: processGroupSelectionOptions{
+						clusterName: clusterName,
+						matchLabels: map[string]string{
+							fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStateless),
+							fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
+						},
+					},
+					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
+						clusterName: {
+							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)),
+						},
+					},
+				},
+			),
+			Entry("gets 2 processGroups with given label",
+				testCase{
+					opts: processGroupSelectionOptions{
+						clusterName: secondClusterName,
+						matchLabels: map[string]string{fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage)},
+					},
+					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
+						secondClusterName: {
+							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+						},
+					},
+				},
+			),
+			Entry("gets 0 processGroups with given label",
+				testCase{
+					opts: processGroupSelectionOptions{
+						clusterName: clusterName,
+						matchLabels: map[string]string{fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassProxy)},
+					},
+					wantErrContains: "found no processGroups meeting the selection criteria",
+				},
+			),
 		)
 	})
 	When("calling getPodNamesByCluster", func() {
@@ -698,6 +767,75 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 						conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.IncorrectPodSpec},
 					},
 					wantResult:      nil,
+					wantErrContains: "found no pods meeting the selection criteria",
+				},
+			),
+			Entry("gets all processGroups with given label",
+				testCase{
+					opts: processGroupSelectionOptions{
+						clusterName: clusterName,
+						matchLabels: map[string]string{fdbv1beta2.FDBClusterLabel: clusterName},
+					},
+					wantResult: map[string][]string{
+						clusterName: {
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+							fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
+						},
+					},
+				},
+			),
+			Entry("gets 1 processGroup matching given label",
+				testCase{
+					opts: processGroupSelectionOptions{
+						clusterName: clusterName,
+						matchLabels: map[string]string{
+							fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStateless),
+						},
+					},
+					wantResult: map[string][]string{
+						clusterName: {
+							fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
+						},
+					},
+				},
+			),
+			Entry("gets 1 processGroup matching given labels",
+				testCase{
+					opts: processGroupSelectionOptions{
+						clusterName: clusterName,
+						matchLabels: map[string]string{
+							fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStateless),
+							fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
+						},
+					},
+					wantResult: map[string][]string{
+						clusterName: {
+							fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
+						},
+					},
+				},
+			),
+			Entry("gets 2 processGroups with given label",
+				testCase{
+					opts: processGroupSelectionOptions{
+						clusterName: secondClusterName,
+						matchLabels: map[string]string{fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage)},
+					},
+					wantResult: map[string][]string{
+						secondClusterName: {
+							fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage),
+							fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage),
+						},
+					},
+				},
+			),
+			Entry("gets 0 processGroups with given label",
+				testCase{
+					opts: processGroupSelectionOptions{
+						clusterName: clusterName,
+						matchLabels: map[string]string{fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassProxy)},
+					},
 					wantErrContains: "found no pods meeting the selection criteria",
 				},
 			),

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -90,6 +90,9 @@ kubectl fdb -n default remove process-groups -c cluster --remove-all-failed
 
 # Remove all processes in the cluster that have the given process-class (incompatible with passing pod names or process group IDs)
 kubectl fdb -n default remove process-groups -c cluster --process-class="stateless"
+
+# Remove all processes in the cluster that match the given label set
+kubectl fdb remove process-groups --match-labels="label-key=label-value,other-key=other-value" -c cluster
 `,
 	}
 
@@ -118,7 +121,8 @@ type replaceProcessGroupsOptions struct {
 // If processClass is specified, it will ignore the given ids and remove all processes in the given cluster whose pods
 // have a processClassLabel matching the processClass.
 func replaceProcessGroups(cmd *cobra.Command, kubeClient client.Client, processGroupOpts processGroupSelectionOptions, opts replaceProcessGroupsOptions) (int, error) {
-	if len(processGroupOpts.ids) == 0 && !opts.removeAllFailed && processGroupOpts.processClass == "" && len(processGroupOpts.conditions) == 0 {
+	// TODO(nic): consider putting "allProcesses" into the process selection functions to avoid having these checks outside for more sensitive commands
+	if len(processGroupOpts.ids) == 0 && !opts.removeAllFailed && processGroupOpts.processClass == "" && len(processGroupOpts.conditions) == 0 && len(processGroupOpts.matchLabels) == 0 {
 		return 0, errors.New("no processGroups could be selected with the provided options")
 	}
 

--- a/kubectl-fdb/cmd/restart.go
+++ b/kubectl-fdb/cmd/restart.go
@@ -55,8 +55,8 @@ func newRestartCmd(streams genericclioptions.IOStreams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			if len(args) == 0 && !allProcesses && len(processGroupSelectionOpts.conditions) == 0 {
+			// TODO(nic): consider putting "allProcesses" into the process selection functions to avoid having these checks outside for more sensitive commands
+			if len(args) == 0 && !allProcesses && len(processGroupSelectionOpts.conditions) == 0 && len(processGroupSelectionOpts.matchLabels) == 0 && processGroupSelectionOpts.processClass == "" {
 				return cmd.Help()
 			}
 

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -193,7 +193,7 @@ func addProcessSelectionFlags(cmd *cobra.Command) {
 		"It is incompatible with use-process-group-id, process-class, and process-condition.")
 	cmd.Flags().Bool("use-process-group-id", false, "Selects process groups by process-group ID instead of the Pod name.")
 	cmd.Flags().StringArray("process-condition", []string{}, "Selects process groups that are in any of the given FDB process group conditions.")
-	cmd.Flags().StringToString("match-labels", map[string]string{}, "Selects process groups running on pods matching the given labels and are in the provided cluster.")
+	cmd.Flags().StringToString("match-labels", map[string]string{}, "Selects process groups running on pods matching the given labels and are in the provided cluster.  Using this option ignores provided ids.")
 }
 
 func getProcessSelectionOptsFromFlags(cmd *cobra.Command, o *fdbBOptions, ids []string) (processGroupSelectionOptions, error) {

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -179,6 +179,7 @@ type processGroupSelectionOptions struct {
 	namespace         string
 	clusterName       string
 	clusterLabel      string
+	matchLabels       map[string]string
 	processClass      string
 	useProcessGroupID bool
 	conditions        []fdbv1beta2.ProcessGroupConditionType
@@ -192,6 +193,7 @@ func addProcessSelectionFlags(cmd *cobra.Command) {
 		"It is incompatible with use-process-group-id, process-class, and process-condition.")
 	cmd.Flags().Bool("use-process-group-id", false, "Selects process groups by process-group ID instead of the Pod name.")
 	cmd.Flags().StringArray("process-condition", []string{}, "Selects process groups that are in any of the given FDB process group conditions.")
+	cmd.Flags().StringToString("match-labels", map[string]string{}, "Selects process groups running on pods matching the given labels and are in the provided cluster.")
 }
 
 func getProcessSelectionOptsFromFlags(cmd *cobra.Command, o *fdbBOptions, ids []string) (processGroupSelectionOptions, error) {
@@ -201,6 +203,10 @@ func getProcessSelectionOptsFromFlags(cmd *cobra.Command, o *fdbBOptions, ids []
 		return opts, err
 	}
 	clusterLabel, err := cmd.Flags().GetString("cluster-label")
+	if err != nil {
+		return opts, err
+	}
+	matchLabels, err := cmd.Flags().GetStringToString("match-labels")
 	if err != nil {
 		return opts, err
 	}
@@ -228,6 +234,7 @@ func getProcessSelectionOptsFromFlags(cmd *cobra.Command, o *fdbBOptions, ids []
 		ids:               ids,
 		namespace:         namespace,
 		clusterName:       cluster,
+		matchLabels:       matchLabels,
 		clusterLabel:      clusterLabel,
 		processClass:      processClass,
 		useProcessGroupID: useProcessGroupID,


### PR DESCRIPTION
# Description

This PR adds the ability to select pods/processGroups by label selection.  This still requires a cluster name to be provided as I felt that would reduce the risk of accidental selection.
It also improves the error message of the `cordon` command for when no pods are found to be running on a node.

This solves https://github.com/FoundationDB/fdb-kubernetes-operator/issues/597

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)


## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

t

## Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
