### PR TITLE
Automatically add port for backup and restore

### DIFF
--- a/api/v1beta2/foundationdbbackup_types.go
+++ b/api/v1beta2/foundationdbbackup_types.go
@@ -183,6 +183,8 @@ type BlobStoreConfiguration struct {
 	BackupName string `json:"backupName,omitempty"`
 
 	// The account name to use with the backup destination.
+	// If no port is included, it will default to 443,
+	// or 80 if secure_connection URL Parameter is set to 0.
 	// +kubebuilder:validation:MaxLength=100
 	// +kubebuilder:validation:Required
 	AccountName string `json:"accountName"`
@@ -194,6 +196,7 @@ type BlobStoreConfiguration struct {
 	Bucket string `json:"bucket,omitempty"`
 
 	// Additional URL parameters passed to the blobstore URL.
+	// See: https://apple.github.io/foundationdb/backups.html#backup-urls
 	// +kubebuilder:validation:MaxItems=100
 	URLParameters []URLParameter `json:"urlParameters,omitempty"`
 }
@@ -320,14 +323,32 @@ func (configuration *BlobStoreConfiguration) getURL(backup string, bucket string
 	if configuration.AccountName == "" {
 		return ""
 	}
-
-	var sb strings.Builder
+	var (
+		defaultPort string
+		sb          strings.Builder
+	)
+	if !strings.Contains(configuration.AccountName, ":") { // add default http port
+		defaultPort = ":443"
+	}
 	for _, param := range configuration.URLParameters {
 		sb.WriteString("&")
 		sb.WriteString(string(param))
+		// check if default port should be 80 instead of 443; see https://apple.github.io/foundationdb/backups.html#backup-urls
+		suffix, exists := strings.CutPrefix(string(param), "sc")
+		if !exists {
+			suffix, exists = strings.CutPrefix(string(param), "secure_connection")
+			if !exists { // then it's not setting secure connection
+				continue
+			}
+		}
+		if suffix == "=0" {
+			if defaultPort != "" { // i.e. if a port was not provided
+				defaultPort = ":80"
+			}
+		}
 	}
 
-	return fmt.Sprintf("blobstore://%s/%s?bucket=%s%s", configuration.AccountName, backup, bucket, sb.String())
+	return fmt.Sprintf("blobstore://%s%s/%s?bucket=%s%s", configuration.AccountName, defaultPort, backup, bucket, sb.String())
 }
 
 // BucketName gets the bucket this backup will use.

--- a/api/v1beta2/foundationdbbackup_types_test.go
+++ b/api/v1beta2/foundationdbbackup_types_test.go
@@ -241,7 +241,7 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@account/test?bucket=fdb-backups"),
+				"blobstore://account@account:443/test?bucket=fdb-backups"),
 			Entry("A Backup with a blobstore config with a bucket name",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
@@ -254,7 +254,7 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@account/mybackup?bucket=my-bucket"),
+				"blobstore://account@account:443/mybackup?bucket=my-bucket"),
 			Entry("A Backup with a blobstore config with a bucket and backup name",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
@@ -268,7 +268,55 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@account/test?bucket=my-bucket"),
+				"blobstore://account@account:443/test?bucket=my-bucket"),
+			Entry("A Backup with a blobstore config with a bucket and backup name and a defined port",
+				FoundationDBBackup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mybackup",
+					},
+					Spec: FoundationDBBackupSpec{
+						BlobStoreConfiguration: &BlobStoreConfiguration{
+							AccountName: "account@account:931",
+							BackupName:  "test",
+							Bucket:      "my-bucket",
+						},
+					},
+				},
+				"blobstore://account@account:931/test?bucket=my-bucket"),
+			Entry("A Backup with a blobstore config with a bucket and backup name and HTTPS parameters",
+				FoundationDBBackup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mybackup",
+					},
+					Spec: FoundationDBBackupSpec{
+						BlobStoreConfiguration: &BlobStoreConfiguration{
+							AccountName: "account@account",
+							BackupName:  "test",
+							Bucket:      "my-bucket",
+							URLParameters: []URLParameter{
+								"secure_connection=1",
+							},
+						},
+					},
+				},
+				"blobstore://account@account:443/test?bucket=my-bucket&secure_connection=1"),
+			Entry("A Backup with a blobstore config with a bucket and backup name and HTTPS parameters (shorthand)",
+				FoundationDBBackup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mybackup",
+					},
+					Spec: FoundationDBBackupSpec{
+						BlobStoreConfiguration: &BlobStoreConfiguration{
+							AccountName: "account@account",
+							BackupName:  "test",
+							Bucket:      "my-bucket",
+							URLParameters: []URLParameter{
+								"sc=1",
+							},
+						},
+					},
+				},
+				"blobstore://account@account:443/test?bucket=my-bucket&sc=1"),
 			Entry("A Backup with a blobstore config with HTTP parameters and backup and bucket name",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
@@ -285,7 +333,7 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@account/test?bucket=my-bucket&secure_connection=0"),
+				"blobstore://account@account:80/test?bucket=my-bucket&secure_connection=0"),
 			Entry("A Backup with a blobstore config with HTTP parameters",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
@@ -300,7 +348,67 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@account/mybackup?bucket=fdb-backups&secure_connection=0"),
+				"blobstore://account@account:80/mybackup?bucket=fdb-backups&secure_connection=0"),
+			Entry("A Backup with a blobstore config with HTTP parameters and a defined port",
+				FoundationDBBackup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mybackup",
+					},
+					Spec: FoundationDBBackupSpec{
+						BlobStoreConfiguration: &BlobStoreConfiguration{
+							AccountName: "account@account:8453",
+							URLParameters: []URLParameter{
+								"secure_connection=0",
+							},
+						},
+					},
+				},
+				"blobstore://account@account:8453/mybackup?bucket=fdb-backups&secure_connection=0"),
+			Entry("A Backup with a blobstore config with HTTP parameters (shorthand) and a defined port",
+				FoundationDBBackup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mybackup",
+					},
+					Spec: FoundationDBBackupSpec{
+						BlobStoreConfiguration: &BlobStoreConfiguration{
+							AccountName: "account@account:8453",
+							URLParameters: []URLParameter{
+								"sc=0",
+							},
+						},
+					},
+				},
+				"blobstore://account@account:8453/mybackup?bucket=fdb-backups&sc=0"),
+			Entry("A Backup with a blobstore config with invalid HTTP parameters",
+				FoundationDBBackup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mybackup",
+					},
+					Spec: FoundationDBBackupSpec{
+						BlobStoreConfiguration: &BlobStoreConfiguration{
+							AccountName: "account@account",
+							URLParameters: []URLParameter{
+								"secure_con=0",
+							},
+						},
+					},
+				},
+				"blobstore://account@account:443/mybackup?bucket=fdb-backups&secure_con=0"),
+			Entry("A Backup with a blobstore config with invalid HTTP parameters and a defined port",
+				FoundationDBBackup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mybackup",
+					},
+					Spec: FoundationDBBackupSpec{
+						BlobStoreConfiguration: &BlobStoreConfiguration{
+							AccountName: "account@account:633",
+							URLParameters: []URLParameter{
+								"secure_con=0",
+							},
+						},
+					},
+				},
+				"blobstore://account@account:633/mybackup?bucket=fdb-backups&secure_con=0"),
 		)
 	})
 })

--- a/api/v1beta2/foundationdbrestore_types_test.go
+++ b/api/v1beta2/foundationdbrestore_types_test.go
@@ -43,7 +43,7 @@ var _ = Describe("[api] FoundationDBRestore", func() {
 						},
 					},
 				},
-				"blobstore://account@account/mybackup?bucket=fdb-backups"),
+				"blobstore://account@account:443/mybackup?bucket=fdb-backups"),
 			Entry("A restore with a blobstore config with backup name",
 				FoundationDBRestore{
 					ObjectMeta: metav1.ObjectMeta{
@@ -56,7 +56,7 @@ var _ = Describe("[api] FoundationDBRestore", func() {
 						},
 					},
 				},
-				"blobstore://account@account/test?bucket=fdb-backups"),
+				"blobstore://account@account:443/test?bucket=fdb-backups"),
 			Entry("A restore with a blobstore config with a bucket name",
 				FoundationDBRestore{
 					ObjectMeta: metav1.ObjectMeta{
@@ -69,7 +69,7 @@ var _ = Describe("[api] FoundationDBRestore", func() {
 						},
 					},
 				},
-				"blobstore://account@account/mybackup?bucket=my-bucket"),
+				"blobstore://account@account:443/mybackup?bucket=my-bucket"),
 			Entry("A restore with a blobstore config with a bucket and backup name",
 				FoundationDBRestore{
 					ObjectMeta: metav1.ObjectMeta{
@@ -83,7 +83,7 @@ var _ = Describe("[api] FoundationDBRestore", func() {
 						},
 					},
 				},
-				"blobstore://account@account/test?bucket=my-bucket"),
+				"blobstore://account@account:443/test?bucket=my-bucket"),
 			Entry("A restore with a blobstore config with HTTP parameters and backup and bucket name",
 				FoundationDBRestore{
 					ObjectMeta: metav1.ObjectMeta{
@@ -100,7 +100,7 @@ var _ = Describe("[api] FoundationDBRestore", func() {
 						},
 					},
 				},
-				"blobstore://account@account/test?bucket=my-bucket&secure_connection=0"),
+				"blobstore://account@account:80/test?bucket=my-bucket&secure_connection=0"),
 			Entry("A restore with a blobstore config with HTTP parameters",
 				FoundationDBRestore{
 					ObjectMeta: metav1.ObjectMeta{
@@ -115,7 +115,7 @@ var _ = Describe("[api] FoundationDBRestore", func() {
 						},
 					},
 				},
-				"blobstore://account@account/mybackup?bucket=fdb-backups&secure_connection=0"),
+				"blobstore://account@account:80/mybackup?bucket=fdb-backups&secure_connection=0"),
 		)
 	})
 })

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -134,7 +134,7 @@ var _ = Describe("backup_controller", func() {
 					AgentCount:           3,
 					DeploymentConfigured: true,
 					BackupDetails: &fdbv1beta2.FoundationDBBackupStatusBackupDetails{
-						URL:                   "blobstore://test@test-service/test-backup?bucket=fdb-backups",
+						URL:                   "blobstore://test@test-service:443/test-backup?bucket=fdb-backups",
 						Running:               true,
 						SnapshotPeriodSeconds: 864000,
 					},
@@ -147,7 +147,7 @@ var _ = Describe("backup_controller", func() {
 			It("should start a backup", func() {
 				status, err := adminClient.GetBackupStatus()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(status.DestinationURL).To(Equal("blobstore://test@test-service/test-backup?bucket=fdb-backups"))
+				Expect(status.DestinationURL).To(Equal("blobstore://test@test-service:443/test-backup?bucket=fdb-backups"))
 				Expect(status.Status.Running).To(BeTrue())
 				Expect(status.BackupAgentsPaused).To(BeFalse())
 			})

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -94,7 +94,7 @@ var _ = Describe("restore_controller", func() {
 			It("should start a restore", func() {
 				status, err := adminClient.GetRestoreStatus()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(status).To(Equal("blobstore://test@test-service/test-backup?bucket=fdb-backups\n"))
+				Expect(status).To(Equal("blobstore://test@test-service:443/test-backup?bucket=fdb-backups\n"))
 			})
 		})
 

--- a/docs/backup_spec.md
+++ b/docs/backup_spec.md
@@ -44,9 +44,9 @@ BlobStoreConfiguration describes the blob store configuration.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | backupName | The name for the backup. If empty defaults to .metadata.name. | string | false |
-| accountName | The account name to use with the backup destination. | string | true |
+| accountName | The account name to use with the backup destination. If no port is included, it will default to 443, or 80 if secure_connection URL Parameter is set to 0. | string | true |
 | bucket | The backup bucket to write to. The default is \"fdb-backups\". | string | false |
-| urlParameters | Additional URL parameters passed to the blobstore URL. | [][URLParameter](#urlparameter) | false |
+| urlParameters | Additional URL parameters passed to the blobstore URL. See: https://apple.github.io/foundationdb/backups.html#backup-urls | [][URLParameter](#urlparameter) | false |
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
# Description

This PR adds a default port, 443 unless secure_connection is set to 0 (in which case, it will default to port 80) as described here https://apple.github.io/foundationdb/backups.html#backup-urls
As described in the issue, a port is required by FDB backup/restore, so this should not be breaking.

Solves https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1240 

## Type of change
Depends who you ask
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*
Unit tests 

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*
Unsure

## Documentation

*Did you update relevant documentation within this repository?*
I believe so

*If this change is adding new functionality, do we need to describe it in our user manual?*
No

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
I do not think they are of concern
