### PR TITLE
Document the limitation that only custom parameters for fdbserver can be defined

### DIFF
--- a/api/v1beta2/foundationdb_custom_parameter_test.go
+++ b/api/v1beta2/foundationdb_custom_parameter_test.go
@@ -71,20 +71,29 @@ var _ = Describe("FoundationDBCustomParameters", func() {
 				FoundationDBCustomParameters{
 					"datadir=test",
 				},
-				errors.New("found the following customParameters violations:\nfound protected customParameter: datadir, please remove this parameter from the customParameters list")),
+				errors.New("found the following customParameters violations:\nfound protected customParameter: datadir, please remove this parameter from the customParameters list"),
+			),
 			Entry("duplicate custom parameters",
 				FoundationDBCustomParameters{
 					"test=test",
 					"test=test",
 				},
-				errors.New("found the following customParameters violations:\nfound duplicated customParameter: test")),
+				errors.New("found the following customParameters violations:\nfound duplicated customParameter: test"),
+			),
 			Entry("duplicate custom parameters",
 				FoundationDBCustomParameters{
 					"test=test",
 					"datadir=test",
 					"test=test",
 				},
-				errors.New("found the following customParameters violations:\nfound protected customParameter: datadir, please remove this parameter from the customParameters list\nfound duplicated customParameter: test")),
+				errors.New("found the following customParameters violations:\nfound protected customParameter: datadir, please remove this parameter from the customParameters list\nfound duplicated customParameter: test"),
+			),
+			Entry("custom parameters that sets general knob",
+				FoundationDBCustomParameters{
+					"restart-delay",
+				},
+				errors.New("found the following customParameters violations:\nfound general or fdbmonitor customParameter: restart-delay, please remove this parameter from the customParameters list as they are not supported"),
+			),
 		)
 	})
 })

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1270,7 +1270,9 @@ type ProcessSettings struct {
 	VolumeClaimTemplate *corev1.PersistentVolumeClaim `json:"volumeClaimTemplate,omitempty"`
 
 	// CustomParameters defines additional parameters to pass to the fdbserver
-	// process.
+	// process. Only parameters for the [fdbserver] section are supported. Parameters
+	// from the [general] and [fdbmonitor] section are not supported. For more Information
+	// see: https://apple.github.io/foundationdb/configuration.html#general-section
 	CustomParameters FoundationDBCustomParameters `json:"customParameters,omitempty"`
 }
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -438,7 +438,7 @@ ProcessSettings defines process-level settings.
 | ----- | ----------- | ------ | -------- |
 | podTemplate | PodTemplate allows customizing the pod. If a container image with a tag is specified the operator will throw an error and stop processing the cluster. | *[corev1.PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podtemplatespec-v1-core) | false |
 | volumeClaimTemplate | VolumeClaimTemplate allows customizing the persistent volume claim for the pod.  This will be ignored by the operator for stateless processes. | *[corev1.PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#persistentvolumeclaim-v1-core) | false |
-| customParameters | CustomParameters defines additional parameters to pass to the fdbserver process. | FoundationDBCustomParameters | false |
+| customParameters | CustomParameters defines additional parameters to pass to the fdbserver process. Only parameters for the [fdbserver] section are supported. Parameters from the [general] and [fdbmonitor] section are not supported. For more Information see: https://apple.github.io/foundationdb/configuration.html#general-section | FoundationDBCustomParameters | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/manual/operations.md
+++ b/docs/manual/operations.md
@@ -65,6 +65,7 @@ _NOTE_:
 
 - The custom parameters must be unique and duplicate entries for the same process class will lead to a failure.
 - The custom parameters will not be merged together. You have to define the full list of all custom parameters for all process classes.
+- Only custom parameters from the `[fdbserver]` section are support. The operator doesn't support changes to the [[fdbmonitor] and [general] section](https://apple.github.io/foundationdb/configuration.html#general-section).
 
 ## Upgrading a Cluster
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1976 

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

As long as we are not supporting to set those general parameters we should make sure that the operator rejects those.

## Testing

Added unit tests.

## Documentation

Updated.

## Follow-up

We have to clarify if there is a need to set those parameters.