### PR TITLE
Allow the operator to trigger a reconciliation if a node changes

### DIFF
--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -264,6 +264,8 @@ spec:
         # increase the time our e2e test take.
         - --minimum-recovery-time-for-inclusion=1.0
         - --minimum-recovery-time-for-exclusion=1.0
+        - --cluster-label-key-for-node-trigger="foundationdb.org/fdb-cluster-name"
+        - --enable-node-index
         image: {{ .OperatorImage }}
         name: manager
         imagePullPolicy: Always

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -264,7 +264,7 @@ spec:
         # increase the time our e2e test take.
         - --minimum-recovery-time-for-inclusion=1.0
         - --minimum-recovery-time-for-exclusion=1.0
-        - --cluster-label-key-for-node-trigger="foundationdb.org/fdb-cluster-name"
+        - --cluster-label-key-for-node-trigger=foundationdb.org/fdb-cluster-name
         - --enable-node-index
         image: {{ .OperatorImage }}
         name: manager

--- a/internal/node_predicate.go
+++ b/internal/node_predicate.go
@@ -1,0 +1,84 @@
+/*
+ * node_predicate.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import (
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var _ predicate.Predicate = (*NodeTaintChangedPredicate)(nil)
+
+// NodeTaintChangedPredicate filters events before enqueuing the keys. Only if the node taints have changed
+// a reconciliation will be triggered.
+type NodeTaintChangedPredicate struct {
+	Logger logr.Logger
+}
+
+// Create implements Predicate.
+func (n NodeTaintChangedPredicate) Create(_ event.CreateEvent) bool {
+	n.Logger.V(1).Info("Got an CreateEvent")
+	// TODO change to false again
+	return true
+}
+
+// Delete implements Predicate.
+func (n NodeTaintChangedPredicate) Delete(_ event.DeleteEvent) bool {
+	n.Logger.V(1).Info("Got an DeleteEvent")
+	return false
+}
+
+// Update returns true if the Update event should be processed. This is the case if the taints for the provided
+// node has been changed.
+func (n NodeTaintChangedPredicate) Update(event event.UpdateEvent) bool {
+	n.Logger.V(1).Info("Got an UpdateEvent")
+	if event.ObjectOld == nil {
+		return false
+	}
+
+	if event.ObjectNew == nil {
+		return false
+	}
+
+	oldNode, ok := event.ObjectOld.(*corev1.Node)
+	if !ok {
+		return false
+	}
+
+	newNode, ok := event.ObjectNew.(*corev1.Node)
+	if !ok {
+		return false
+	}
+
+	taintsChanged := !equality.Semantic.DeepEqual(oldNode.Spec.Taints, newNode.Spec.Taints)
+	n.Logger.V(1).Info("Got an update", "taintsChanged", taintsChanged, "oldTaints", oldNode.Spec.Taints, "newTaints", newNode.Spec.Taints)
+
+	return taintsChanged
+}
+
+// Generic implements Predicate.
+func (n NodeTaintChangedPredicate) Generic(_ event.GenericEvent) bool {
+	n.Logger.V(1).Info("Got an GenericEvent")
+	return false
+}

--- a/internal/node_predicate.go
+++ b/internal/node_predicate.go
@@ -38,26 +38,18 @@ type NodeTaintChangedPredicate struct {
 
 // Create implements Predicate.
 func (n NodeTaintChangedPredicate) Create(_ event.CreateEvent) bool {
-	n.Logger.V(1).Info("Got an CreateEvent")
-	// TODO change to false again
-	return true
+	return false
 }
 
 // Delete implements Predicate.
 func (n NodeTaintChangedPredicate) Delete(_ event.DeleteEvent) bool {
-	n.Logger.V(1).Info("Got an DeleteEvent")
 	return false
 }
 
 // Update returns true if the Update event should be processed. This is the case if the taints for the provided
 // node has been changed.
 func (n NodeTaintChangedPredicate) Update(event event.UpdateEvent) bool {
-	n.Logger.V(1).Info("Got an UpdateEvent")
-	if event.ObjectOld == nil {
-		return false
-	}
-
-	if event.ObjectNew == nil {
+	if event.ObjectOld == nil || event.ObjectNew == nil {
 		return false
 	}
 
@@ -72,13 +64,12 @@ func (n NodeTaintChangedPredicate) Update(event event.UpdateEvent) bool {
 	}
 
 	taintsChanged := !equality.Semantic.DeepEqual(oldNode.Spec.Taints, newNode.Spec.Taints)
-	n.Logger.V(1).Info("Got an update", "taintsChanged", taintsChanged, "oldTaints", oldNode.Spec.Taints, "newTaints", newNode.Spec.Taints)
+	n.Logger.V(1).Info("Got an UpdateEvent", "node", oldNode.Name, "taintsChanged", taintsChanged, "oldTaints", oldNode.Spec.Taints, "newTaints", newNode.Spec.Taints)
 
 	return taintsChanged
 }
 
 // Generic implements Predicate.
 func (n NodeTaintChangedPredicate) Generic(_ event.GenericEvent) bool {
-	n.Logger.V(1).Info("Got an GenericEvent")
 	return false
 }

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -267,7 +267,7 @@ func StartManager(
 		clusterReconciler.MaintenanceListWaitDuration = operatorOpts.MaintenanceListWaitDuration
 		clusterReconciler.MinimumRecoveryTimeForInclusion = operatorOpts.MinimumRecoveryTimeForInclusion
 		clusterReconciler.MinimumRecoveryTimeForExclusion = operatorOpts.MinimumRecoveryTimeForExclusion
-		clusterReconciler.ClusterLabelKeyForNodeTrigger = operatorOpts.ClusterLabelKeyForNodeTrigger
+		clusterReconciler.ClusterLabelKeyForNodeTrigger = strings.Trim(operatorOpts.ClusterLabelKeyForNodeTrigger, "\"")
 		clusterReconciler.Namespace = operatorOpts.WatchNamespace
 
 		if err := clusterReconciler.SetupWithManager(mgr, operatorOpts.MaxConcurrentReconciles, operatorOpts.EnableNodeIndex, *labelSelector, watchedObjects...); err != nil {

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -70,6 +70,7 @@ type Options struct {
 	LogFile                            string
 	LogFilePermission                  string
 	LabelSelector                      string
+	ClusterLabelKeyForNodeTrigger      string
 	WatchNamespace                     string
 	CliTimeout                         int
 	MaxCliTimeout                      int
@@ -118,6 +119,8 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 	fs.IntVar(&o.LogFileMaxSize, "log-file-max-size", 250, "Defines the maximum size in megabytes of the operator log file before it gets rotated.")
 	fs.StringVar(&o.LogFilePermission, "log-file-permission", "0644",
 		"The file permission for the log file. Only used if log-file is set. Only the octal representation is supported.")
+	fs.StringVar(&o.ClusterLabelKeyForNodeTrigger, "cluster-label-key-for-node-trigger", "",
+		"The label key to use to trigger a reconciliation if a node resources changes. Requires that --enable-node-index is set to true.")
 	fs.IntVar(&o.MaxNumberOfOldLogFiles, "max-old-log-files", 3, "Defines the maximum number of old operator log files to retain.")
 	fs.BoolVar(&o.CompressOldFiles, "compress", false, "Defines whether the rotated log files should be compressed using gzip or not.")
 	fs.BoolVar(&o.PrintVersion, "version", false, "Prints the version of the operator and exits.")
@@ -264,6 +267,8 @@ func StartManager(
 		clusterReconciler.MaintenanceListWaitDuration = operatorOpts.MaintenanceListWaitDuration
 		clusterReconciler.MinimumRecoveryTimeForInclusion = operatorOpts.MinimumRecoveryTimeForInclusion
 		clusterReconciler.MinimumRecoveryTimeForExclusion = operatorOpts.MinimumRecoveryTimeForExclusion
+		clusterReconciler.ClusterLabelKeyForNodeTrigger = operatorOpts.ClusterLabelKeyForNodeTrigger
+		clusterReconciler.Namespace = operatorOpts.WatchNamespace
 
 		if err := clusterReconciler.SetupWithManager(mgr, operatorOpts.MaxConcurrentReconciles, operatorOpts.EnableNodeIndex, *labelSelector, watchedObjects...); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "FoundationDBCluster")


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1629

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Ran some manual tests, I have to check how to test this in an e2e test or unit test.

## Documentation

Will be updated before marking this PR ready.

## Follow-up

-
