### PR TITLE
Correct log line for maintenance check and remove process if restarted in different zone

### DIFF
--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -62,7 +62,9 @@ func (maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBCluste
 		return &requeue{curError: err, delayedRequeue: true}
 	}
 
-	logger.Info("Cluster in maintenance mode", "zone", status.Cluster.MaintenanceZone, "processesUnderMaintenance", processesUnderMaintenance)
+	if status.Cluster.MaintenanceZone != "" {
+		logger.Info("Cluster in maintenance mode", "zone", status.Cluster.MaintenanceZone, "processesUnderMaintenance", processesUnderMaintenance)
+	}
 
 	// Get all the maintenance information from the FDB cluster.
 	finishedMaintenance, staleMaintenanceInformation, processesToUpdate := maintenance.GetMaintenanceInformation(logger, status, processesUnderMaintenance, r.MaintenanceListStaleDuration, r.MaintenanceListWaitDuration)

--- a/internal/maintenance/maintenance.go
+++ b/internal/maintenance/maintenance.go
@@ -80,6 +80,12 @@ func GetMaintenanceInformation(logger logr.Logger, status *fdbv1beta2.Foundation
 		// Remove the process group ID from processesUnderMaintenance as we have found a processes.
 		delete(processesUnderMaintenance, fdbv1beta2.ProcessGroupID(processGroupID))
 
+		// If the start time is after the maintenance start time, we can assume that maintenance for this specific process is done.
+		if startTime.After(maintenanceStartTime) {
+			finishedMaintenance = append(finishedMaintenance, fdbv1beta2.ProcessGroupID(processGroupID))
+			continue
+		}
+
 		// If the zones are not matching those are probably stale entries. Once they are long enough in the list of
 		// entries they will be removed.
 		if zoneID != string(status.Cluster.MaintenanceZone) {
@@ -98,12 +104,6 @@ func GetMaintenanceInformation(logger logr.Logger, status *fdbv1beta2.Foundation
 				staleMaintenanceInformation = append(staleMaintenanceInformation, fdbv1beta2.ProcessGroupID(processGroupID))
 			}
 
-			continue
-		}
-
-		// If the start time is after the maintenance start time, we can assume that maintenance for this specific process is done.
-		if startTime.After(maintenanceStartTime) {
-			finishedMaintenance = append(finishedMaintenance, fdbv1beta2.ProcessGroupID(processGroupID))
 			continue
 		}
 


### PR DESCRIPTION
# Description

Only log `Cluster in maintenance mode` if the maintenance zone is actually set. Allow the operator to remove processes that are restarted from the `underMaintenance` list, even if they are running in a different zone. For clusters using disaggregated storage this could happen.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran manual e2e tests.

## Documentation

-

## Follow-up

-
