### PR TITLE
Make sure that only the container is build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ ${GENERATED_GO}: ${GO_SRC} hack/boilerplate.go.txt ${CONTROLLER_GEN}
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the container image
-container-build: test_if_changed
+container-build:
 	$(BUILDER) build --build-arg=TAG=${TAG} ${img_build_args} $(BUILDER_ARGS) -t ${IMG} .
 
 # Push the container image


### PR DESCRIPTION
# Description

If the `container-build` target is used, we don't want to build everything, as the build container will take care of that.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

This is a relict from the past when we didn't use the multi-stage build.

## Testing

CI pipeline is running.

## Documentation

-

## Follow-up

-
