### PR TITLE
Make sure that the provided namespace will be used for HA tests

### DIFF
--- a/e2e/fixtures/fdb_operator_fixtures.go
+++ b/e2e/fixtures/fdb_operator_fixtures.go
@@ -168,7 +168,7 @@ func (factory *Factory) ensureHAFdbClusterExists(
 		},
 	}
 
-	namespaces := factory.MultipleNamespaces(dcIDs)
+	namespaces := factory.MultipleNamespaces(config, dcIDs)
 	log.Printf("ensureHAFDBClusterExists namespaces=%s", namespaces)
 
 	newConfig := config.Copy()

--- a/e2e/fixtures/kubernetes_fixtures.go
+++ b/e2e/fixtures/kubernetes_fixtures.go
@@ -47,8 +47,13 @@ func (factory *Factory) getRandomizedNamespaceName() string {
 }
 
 // MultipleNamespaces creates multiple namespaces for HA testing.
-func (factory *Factory) MultipleNamespaces(dcIDs []string) []string {
-	factory.options.namespace = factory.getRandomizedNamespaceName()
+func (factory *Factory) MultipleNamespaces(config *ClusterConfig, dcIDs []string) []string {
+	// If a namespace is provided in the config we will use this name as prefix.
+	if config.Namespace != "" {
+		factory.options.namespace = config.Namespace
+	} else {
+		factory.options.namespace = factory.getRandomizedNamespaceName()
+	}
 
 	res := make([]string, len(dcIDs))
 	for idx, dcID := range dcIDs {


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2006

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran a manual test:

```bash
$ kubectl get ns
NAME                             STATUS   AGE
jscheuermann-primary             Active   39s
jscheuermann-primary-satellite   Active   27s
jscheuermann-remote              Active   15s
jscheuermann-remote-satellite    Active   3s
```

## Documentation

-

## Follow-up

-