### PR TITLE
Fix warning of deprecated setting in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,9 +68,10 @@ linters:
 
 linters-settings:
   errcheck:
-    # path to a file containing a list of functions to exclude from checking
-    # see https://github.com/kisielk/errcheck#excluding-functions for details
-    exclude: errcheck_excludes.txt
+    exclude-functions:
+      - (io.Closer).Close
+      - (*os.File).Close
+      - (github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient.AdminClient).Close
   govet:
     enable:
       - shadow

--- a/errcheck_excludes.txt
+++ b/errcheck_excludes.txt
@@ -1,3 +1,0 @@
-(io.Closer).Close
-(*os.File).Close
-(github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient.AdminClient).Close


### PR DESCRIPTION
# Description

Fix warning of deprecated setting in golangci-lint

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran  `make lint` locally:

```bash
$ make fmt lint
make: Nothing to be done for `fmt'.
/Users/jscheuermann/go/bin/golangci-lint run ./...
```

## Documentation

-

## Follow-up

-
