### PR TITLE
Prefer upgraded processes for coordinators when the operator chooses the coordinators

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2248,7 +2248,8 @@ func (cluster *FoundationDBCluster) GetEligibleCandidateClasses() []ProcessClass
 	return candidateClasses
 }
 
-// GetClassCandidatePriority returns the priority for a class. This will be used to sort the processes for coordinator selection
+// GetClassCandidatePriority returns the priority for a class. This will be used to sort the processes for coordinator selection.
+// If not setting is configured, the default will be 0.
 func (cluster *FoundationDBCluster) GetClassCandidatePriority(pClass ProcessClass) int {
 	for _, setting := range cluster.Spec.CoordinatorSelection {
 		if pClass == setting.ProcessClass {
@@ -2256,7 +2257,12 @@ func (cluster *FoundationDBCluster) GetClassCandidatePriority(pClass ProcessClas
 		}
 	}
 
-	return math.MinInt64
+	// For coordinators prefer log processes over storage processes, as those get migrated anyway during an upgrade.
+	if pClass.IsLogProcess() {
+		return 1
+	}
+
+	return 0
 }
 
 // ShouldFilterOnOwnerReferences determines if we should check owner references

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -19,7 +19,6 @@ package v1beta2
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"math/rand"
 	"net"
 	"os"
@@ -3909,65 +3908,65 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			func(tc testCase) {
 				Expect(tc.cluster.GetClassCandidatePriority(tc.pClass)).To(Equal(tc.expected))
 			},
-			Entry("storage class without any configuration returns highest priority",
+			Entry("storage class without any configuration returns lowest priority",
 				testCase{
 					cluster:  &FoundationDBCluster{},
 					pClass:   ProcessClassStorage,
-					expected: math.MinInt64,
+					expected: 0,
 				}),
-			Entry("log class without any configuration highest prioritye",
+			Entry("log class without any configuration default priority",
 				testCase{
 					cluster:  &FoundationDBCluster{},
 					pClass:   ProcessClassLog,
-					expected: math.MinInt64,
+					expected: 1,
 				}),
-			Entry("transaction class without any configuration highest priority",
+			Entry("transaction class without any configuration default priority",
 				testCase{
 					cluster:  &FoundationDBCluster{},
 					pClass:   ProcessClassTransaction,
-					expected: math.MinInt64,
+					expected: 1,
 				}),
-			Entry("stateless class without any configuration highest priority",
+			Entry("stateless class without any configuration default priority",
 				testCase{
 					cluster:  &FoundationDBCluster{},
 					pClass:   ProcessClassStateless,
-					expected: math.MinInt64,
+					expected: 0,
 				}),
-			Entry("cluster controller class without any configuration highest priority",
+			Entry("cluster controller class without any configuration default priority",
 				testCase{
 					cluster:  &FoundationDBCluster{},
 					pClass:   ProcessClassClusterController,
-					expected: math.MinInt64,
+					expected: 0,
 				}),
-			Entry("storage class with only storage classes returns 1 as priority",
+			Entry("storage class with only storage classes returns 10 as priority",
 				testCase{
 					cluster: &FoundationDBCluster{
 						Spec: FoundationDBClusterSpec{
 							CoordinatorSelection: []CoordinatorSelectionSetting{
 								{
 									ProcessClass: ProcessClassStorage,
-									Priority:     1,
+									Priority:     10,
 								},
 							},
 						},
 					},
 					pClass:   ProcessClassStorage,
-					expected: 1,
+					expected: 10,
 				}),
-			Entry("log class with only storage classes returns highest priority",
+			Entry("log class with only storage classes returns default priority",
 				testCase{
 					cluster: &FoundationDBCluster{
 						Spec: FoundationDBClusterSpec{
 							CoordinatorSelection: []CoordinatorSelectionSetting{
 								{
 									ProcessClass: ProcessClassStorage,
-									Priority:     1,
+									Priority:     0,
 								},
 							},
 						},
 					},
 					pClass:   ProcessClassLog,
-					expected: math.MinInt64,
+					expected: 1,
 				}),
 		)
 	})

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -153,7 +153,7 @@ func selectCandidates(cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta
 
 		priority := cluster.GetClassCandidatePriority(process.ProcessClass)
 		// If the process is not running in the desired version or the binary is running from the shared volumes
-		// that means this process is pending a Pod recreation and will therefore down for some time.
+		// that means this process is pending a Pod recreation and will therefore be down for some time.
 		// We reduce the priority in this case to reduce the risk of successive coordinator changes. Reducing the
 		// priority should help in reducing the overall coordinator changes.
 		// See: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2015

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -84,6 +84,8 @@ func (c chooseRemovals) reconcile(ctx context.Context, r *FoundationDBClusterRec
 		excessCount := currentCounts[processClass] - desiredCount
 		processClassLocality := make([]locality.Info, 0, currentCounts[processClass])
 
+		// TODO (johscheuer): We could add a higher priority to the process groups that have a condition that requires
+		// an automatic replacement.
 		for _, processGroup := range cluster.Status.ProcessGroupsByProcessClass(processClass) {
 			if processGroup.IsMarkedForRemoval() {
 				excessCount--

--- a/internal/locality/locality_test.go
+++ b/internal/locality/locality_test.go
@@ -159,22 +159,32 @@ var _ = Describe("Localities", func() {
 			}
 		})
 
+		JustBeforeEach(func() {
+			for idx, cur := range localities {
+				localities[idx] = Info{
+					ID:       cur.ID,
+					Class:    cur.Class,
+					Priority: cluster.GetClassCandidatePriority(cur.Class),
+				}
+			}
+		})
+
 		When("no other preferences are defined", func() {
 			BeforeEach(func() {
 				cluster.Spec.CoordinatorSelection = []fdbv1beta2.CoordinatorSelectionSetting{}
 			})
 
-			It("should sort the localities based on the IDs", func() {
-				sortLocalities(cluster, localities)
+			It("should sort the localities based on the IDs but prefer transaction system Pods", func() {
+				sortLocalities(localities)
 
 				Expect(localities[0].Class).To(Equal(fdbv1beta2.ProcessClassLog))
 				Expect(localities[0].ID).To(Equal("log-1"))
-				Expect(localities[1].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
-				Expect(localities[1].ID).To(Equal("storage-1"))
+				Expect(localities[1].Class).To(Equal(fdbv1beta2.ProcessClassTransaction))
+				Expect(localities[1].ID).To(Equal("tlog-1"))
 				Expect(localities[2].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
-				Expect(localities[2].ID).To(Equal("storage-51"))
-				Expect(localities[3].Class).To(Equal(fdbv1beta2.ProcessClassTransaction))
-				Expect(localities[3].ID).To(Equal("tlog-1"))
+				Expect(localities[2].ID).To(Equal("storage-1"))
+				Expect(localities[3].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
+				Expect(localities[3].ID).To(Equal("storage-51"))
 			})
 		})
 
@@ -183,13 +193,13 @@ var _ = Describe("Localities", func() {
 				cluster.Spec.CoordinatorSelection = []fdbv1beta2.CoordinatorSelectionSetting{
 					{
 						ProcessClass: fdbv1beta2.ProcessClassStorage,
-						Priority:     0,
+						Priority:     10,
 					},
 				}
 			})
 
 			It("should sort the localities based on the provided config", func() {
-				sortLocalities(cluster, localities)
+				sortLocalities(localities)
 
 				Expect(localities[0].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
 				Expect(localities[0].ID).To(Equal("storage-1"))
@@ -207,26 +217,26 @@ var _ = Describe("Localities", func() {
 				cluster.Spec.CoordinatorSelection = []fdbv1beta2.CoordinatorSelectionSetting{
 					{
 						ProcessClass: fdbv1beta2.ProcessClassStorage,
-						Priority:     1,
+						Priority:     10,
 					},
 					{
 						ProcessClass: fdbv1beta2.ProcessClassTransaction,
-						Priority:     0,
+						Priority:     1,
 					},
 				}
 			})
 
 			It("should sort the localities based on the provided config", func() {
-				sortLocalities(cluster, localities)
+				sortLocalities(localities)
 
 				Expect(localities[0].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
 				Expect(localities[0].ID).To(Equal("storage-1"))
 				Expect(localities[1].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
 				Expect(localities[1].ID).To(Equal("storage-51"))
-				Expect(localities[2].Class).To(Equal(fdbv1beta2.ProcessClassTransaction))
-				Expect(localities[2].ID).To(Equal("tlog-1"))
-				Expect(localities[3].Class).To(Equal(fdbv1beta2.ProcessClassLog))
-				Expect(localities[3].ID).To(Equal("log-1"))
+				Expect(localities[2].Class).To(Equal(fdbv1beta2.ProcessClassLog))
+				Expect(localities[2].ID).To(Equal("log-1"))
+				Expect(localities[3].Class).To(Equal(fdbv1beta2.ProcessClassTransaction))
+				Expect(localities[3].ID).To(Equal("tlog-1"))
 			})
 		})
 	})


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2015

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

As mentioned in the referenced issue, during an upgrade it can happen that the operator chooses new coordinators for the Pod that is currently "updated" (deleted and created). In the previous setup the operator didn't differentiate between upgraded processes and processes to be upgraded. Choosing preferable upgraded processes as coordinators should reduce the overall recoveries caused by coordinator changes.

In addition we opted to prefer log/transaction processes as coordinators as those are not going though the rolling recreation phase but instead all are replaced. 

## Testing

Updated unit tests and current e2e test should cover all important cases.

## Documentation

I can update the docs in another PR. I have to revisit them anyways.

## Follow-up

-
