### PR TITLE
Make sure we ignore clients that share the same machine address as a process from the FoundationDB cluster

### DIFF
--- a/api/v1beta2/foundationdb_status.go
+++ b/api/v1beta2/foundationdb_status.go
@@ -325,9 +325,10 @@ type FoundationDBStatusConnectedClient struct {
 
 // Description returns a string description of the a connected client.
 func (client FoundationDBStatusConnectedClient) Description() string {
-	if client.LogGroup == "default" || client.LogGroup == "" {
+	if client.LogGroup == "" {
 		return client.Address
 	}
+
 	return fmt.Sprintf("%s (%s)", client.Address, client.LogGroup)
 }
 

--- a/controllers/check_client_compatibility_test.go
+++ b/controllers/check_client_compatibility_test.go
@@ -24,204 +24,289 @@ import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"net"
 )
 
-var supportedVersion = []fdbv1beta2.FoundationDBStatusSupportedVersion{
-	{
-		ClientVersion: "Unknown",
-		ConnectedClients: []fdbv1beta2.FoundationDBStatusConnectedClient{
-			{
-				Address:  "10.1.38.92:52762",
-				LogGroup: "default",
-			},
-			{
-				Address:  "10.1.38.92:56406",
-				LogGroup: "default",
-			},
-			{
-				Address:  "10.1.38.103:43346",
-				LogGroup: "default",
-			},
-			{
-				Address:  "10.1.38.103:43354",
-				LogGroup: "default",
-			},
-			{
-				Address:  "10.1.38.103:51458",
-				LogGroup: "default",
-			},
-			{
-				Address:  "10.1.38.103:51472",
-				LogGroup: "default",
-			},
-			{
-				Address:  "10.1.38.103:59442",
-				LogGroup: "default",
-			},
-			{
-				Address:  "10.1.38.103:59942",
-				LogGroup: "default",
-			},
-			{
-				Address:  "10.1.38.103:60222",
-				LogGroup: "default",
-			},
-			{
-				Address:  "10.1.38.103:60230",
-				LogGroup: "default",
+var status = &fdbv1beta2.FoundationDBStatus{
+	Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+		Clients: fdbv1beta2.FoundationDBStatusClusterClientInfo{
+			SupportedVersions: []fdbv1beta2.FoundationDBStatusSupportedVersion{
+				{
+					ClientVersion: "Unknown",
+					ConnectedClients: []fdbv1beta2.FoundationDBStatusConnectedClient{
+						{
+							Address:  "10.1.38.92:52762",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.92:56406",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.103:43346",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.103:43354",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.103:51458",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.103:51472",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.103:59442",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.103:59942",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.103:60222",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.103:60230",
+							LogGroup: "default",
+						},
+					},
+					MaxProtocolClients: nil,
+					ProtocolVersion:    "Unknown",
+					SourceVersion:      "Unknown",
+				},
+				{
+					ClientVersion: "6.1.8",
+					ConnectedClients: []fdbv1beta2.FoundationDBStatusConnectedClient{
+						{
+							Address:  "10.1.38.106:35640",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.106:36128",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.106:36802",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.107:42234",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.107:49684",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.108:47320",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.108:47388",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.108:58734",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.103:60222",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.103:60230",
+							LogGroup: "default",
+						},
+					},
+					MaxProtocolClients: nil,
+					ProtocolVersion:    "fdb00b061060001",
+					SourceVersion:      "bd6b10cbcee08910667194e6388733acd3b80549",
+				},
+				{
+					ClientVersion: "6.2.15",
+					ConnectedClients: []fdbv1beta2.FoundationDBStatusConnectedClient{
+						{
+							Address:  "10.1.38.106:35640",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.106:36128",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.106:36802",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.107:42234",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.107:49684",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.108:47320",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.108:47388",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.108:58734",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.18.249:34874",
+							LogGroup: "fdb-kubernetes-operator",
+						},
+						{
+							Address:  "10.1.18.249:35022",
+							LogGroup: "fdb-kubernetes-operator",
+						},
+						{
+							Address:  "10.1.38.103:60222",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.103:60230",
+							LogGroup: "default",
+						},
+					},
+					MaxProtocolClients: []fdbv1beta2.FoundationDBStatusConnectedClient{
+						{
+							Address:  "10.1.38.106:35640",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.106:36128",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.106:36802",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.107:42234",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.107:49684",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.108:47320",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.108:47388",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.38.108:58734",
+							LogGroup: "sample-cluster-client",
+						},
+						{
+							Address:  "10.1.18.249:34874",
+							LogGroup: "fdb-kubernetes-operator",
+						},
+						{
+							Address:  "10.1.18.249:35022",
+							LogGroup: "fdb-kubernetes-operator",
+						},
+						{
+							Address:  "10.1.38.103:60222",
+							LogGroup: "default",
+						},
+						{
+							Address:  "10.1.38.103:60230",
+							LogGroup: "default",
+						},
+					},
+					ProtocolVersion: "fdb00b062010002",
+					SourceVersion:   "20566f2ff06a7e822b30e8cfd91090fbd863a393",
+				},
 			},
 		},
-		MaxProtocolClients: nil,
-		ProtocolVersion:    "Unknown",
-		SourceVersion:      "Unknown",
-	},
-	{
-		ClientVersion: "6.1.8",
-		ConnectedClients: []fdbv1beta2.FoundationDBStatusConnectedClient{
-			{
-				Address:  "10.1.38.106:35640",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.106:36128",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.106:36802",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.107:42234",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.107:49684",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.108:47320",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.108:47388",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.108:58734",
-				LogGroup: "sample-cluster-client",
-			},
-		},
-		MaxProtocolClients: nil,
-		ProtocolVersion:    "fdb00b061060001",
-		SourceVersion:      "bd6b10cbcee08910667194e6388733acd3b80549",
-	},
-	{
-		ClientVersion: "6.2.15",
-		ConnectedClients: []fdbv1beta2.FoundationDBStatusConnectedClient{
-			{
-				Address:  "10.1.38.106:35640",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.106:36128",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.106:36802",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.107:42234",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.107:49684",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.108:47320",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.108:47388",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.108:58734",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.18.249:34874",
-				LogGroup: "fdb-kubernetes-operator",
-			},
-			{
-				Address:  "10.1.18.249:35022",
-				LogGroup: "fdb-kubernetes-operator",
-			},
-		},
-		MaxProtocolClients: []fdbv1beta2.FoundationDBStatusConnectedClient{
-			{
-				Address:  "10.1.38.106:35640",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.106:36128",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.106:36802",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.107:42234",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.107:49684",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.108:47320",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.108:47388",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.38.108:58734",
-				LogGroup: "sample-cluster-client",
-			},
-			{
-				Address:  "10.1.18.249:34874",
-				LogGroup: "fdb-kubernetes-operator",
-			},
-			{
-				Address:  "10.1.18.249:35022",
-				LogGroup: "fdb-kubernetes-operator",
-			},
-		},
-		ProtocolVersion: "fdb00b062010002",
-		SourceVersion:   "20566f2ff06a7e822b30e8cfd91090fbd863a393",
 	},
 }
 
 var _ = Describe("check client compatibility", func() {
 	When("getting the list of unsupported clients from the cluster status json", func() {
-		type testCase struct {
-			ignoredLogGroups           map[fdbv1beta2.LogGroup]fdbv1beta2.None
-			expectedUnsupportedClients []string
-		}
+		var unsupportedClients []string
+		var ignoredLogGroups map[fdbv1beta2.LogGroup]fdbv1beta2.None
 
-		DescribeTable("should return all the unsupported clients",
-			func(tc testCase) {
-				unsupportedClients := getUnsupportedClients(supportedVersion, "fdb00b063010001", tc.ignoredLogGroups)
-				Expect(unsupportedClients).To(ConsistOf(tc.expectedUnsupportedClients))
-			},
-			Entry("with an empty ignoreProcessGroups map.",
-				testCase{
-					ignoredLogGroups: nil,
-					expectedUnsupportedClients: []string{
+		JustBeforeEach(func() {
+			unsupportedClients = getUnsupportedClients(status, "fdb00b063010001", ignoredLogGroups)
+		})
+
+		AfterEach(func() {
+			unsupportedClients = nil
+			ignoredLogGroups = nil
+		})
+
+		When("no log groups should be ignored", func() {
+			It("should show all clients as unsupported", func() {
+				Expect(unsupportedClients).To(ConsistOf([]string{
+					"10.1.38.106:35640 (sample-cluster-client)",
+					"10.1.38.106:36128 (sample-cluster-client)",
+					"10.1.38.106:36802 (sample-cluster-client)",
+					"10.1.38.107:42234 (sample-cluster-client)",
+					"10.1.38.107:49684 (sample-cluster-client)",
+					"10.1.38.108:47320 (sample-cluster-client)",
+					"10.1.38.108:47388 (sample-cluster-client)",
+					"10.1.38.108:58734 (sample-cluster-client)",
+					"10.1.18.249:34874 (fdb-kubernetes-operator)",
+					"10.1.18.249:35022 (fdb-kubernetes-operator)",
+					"10.1.38.103:60222 (default)",
+					"10.1.38.103:60230 (default)",
+				}))
+			})
+		})
+
+		When("the fdb-kubernetes-operator log group should be ignored", func() {
+			BeforeEach(func() {
+				ignoredLogGroups = map[fdbv1beta2.LogGroup]fdbv1beta2.None{"fdb-kubernetes-operator": {}}
+			})
+
+			It("should show all clients as unsupported", func() {
+				Expect(unsupportedClients).To(ConsistOf([]string{
+					"10.1.38.106:35640 (sample-cluster-client)",
+					"10.1.38.106:36128 (sample-cluster-client)",
+					"10.1.38.106:36802 (sample-cluster-client)",
+					"10.1.38.107:42234 (sample-cluster-client)",
+					"10.1.38.107:49684 (sample-cluster-client)",
+					"10.1.38.108:47320 (sample-cluster-client)",
+					"10.1.38.108:47388 (sample-cluster-client)",
+					"10.1.38.108:58734 (sample-cluster-client)",
+					"10.1.38.103:60222 (default)",
+					"10.1.38.103:60230 (default)",
+				}))
+			})
+		})
+
+		When("clients are matching the address of running processes", func() {
+			BeforeEach(func() {
+				status.Cluster.Processes = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+					"1": {
+						Address: fdbv1beta2.ProcessAddress{
+							IPAddress: net.ParseIP("10.1.38.103"),
+							Port:      4500,
+							Flags: map[string]bool{
+								"tls": true,
+							},
+						},
+					},
+				}
+
+				It("should ignore clients running on the FoundationDB Pod", func() {
+					Expect(unsupportedClients).To(ConsistOf([]string{
 						"10.1.38.106:35640 (sample-cluster-client)",
 						"10.1.38.106:36128 (sample-cluster-client)",
 						"10.1.38.106:36802 (sample-cluster-client)",
@@ -232,16 +317,28 @@ var _ = Describe("check client compatibility", func() {
 						"10.1.38.108:58734 (sample-cluster-client)",
 						"10.1.18.249:34874 (fdb-kubernetes-operator)",
 						"10.1.18.249:35022 (fdb-kubernetes-operator)",
-					},
-				}),
-			Entry("with non empty ignoreProcessGroups map.",
-				testCase{
-					ignoredLogGroups: map[fdbv1beta2.LogGroup]fdbv1beta2.None{"sample-cluster-client": {}},
-					expectedUnsupportedClients: []string{
-						"10.1.18.249:34874 (fdb-kubernetes-operator)",
-						"10.1.18.249:35022 (fdb-kubernetes-operator)",
-					},
-				}),
-		)
+					}))
+				})
+
+				When("the fdb-kubernetes-operator log group should be ignored", func() {
+					BeforeEach(func() {
+						ignoredLogGroups = map[fdbv1beta2.LogGroup]fdbv1beta2.None{"fdb-kubernetes-operator": {}}
+					})
+
+					It("should show all clients as unsupported", func() {
+						Expect(unsupportedClients).To(ConsistOf([]string{
+							"10.1.38.106:35640 (sample-cluster-client)",
+							"10.1.38.106:36128 (sample-cluster-client)",
+							"10.1.38.106:36802 (sample-cluster-client)",
+							"10.1.38.107:42234 (sample-cluster-client)",
+							"10.1.38.107:49684 (sample-cluster-client)",
+							"10.1.38.108:47320 (sample-cluster-client)",
+							"10.1.38.108:47388 (sample-cluster-client)",
+							"10.1.38.108:58734 (sample-cluster-client)",
+						}))
+					})
+				})
+			})
+		})
 	})
 })


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1991

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

We can ignore clients that share the same machine address as the FoundationDB processes. In most (if not all) cases that will be an `fdbcli` command that was manually ran to e.g. get the cluster status.

## Testing

Updated the unit tests and CI will run e2e tests.

## Documentation

-

## Follow-up

-
