### PR TITLE
Allow to override the image tag for specific versions

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -35,6 +35,8 @@ UPGRADE_VERSIONS?="$(FDB_VERSION):$(NEXT_FDB_VERSION)"
 FEATURE_UNIFIED_IMAGE?=false
 FEATURE_DNS?=false
 FEATURE_LOCALITIES?=false
+# Allows to specify the tag for a specific FDB version. Format is 7.1.57:7.1.57-testing,7.3.35:7.3.35-debugging
+FDB_VERSION_TAG_MAPPING?=
 
 # Make bash pickier about errors.
 SHELL=/bin/bash -euo pipefail
@@ -131,4 +133,5 @@ nightly-tests: run
 	  --dump-operator-state=$(DUMP_OPERATOR_STATE) \
 	  --cluster-name=$(CLUSTER_NAME) \
 	  --storage-engine=$(STORAGE_ENGINE) \
+	  --fdb-version-tag-mapping=$(FDB_VERSION_TAG_MAPPING) \
 	  | grep -v 'constructing many client instances from the same exec auth config can cause performance problems during cert rotation' &> $(BASE_DIR)/../logs/$<.log

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -210,11 +210,12 @@ func (factory *Factory) getContainerOverrides(
 		GetDebugImage(debugSymbols, factory.GetFoundationDBImage()),
 	)
 
-	mainOverrides := fdbv1beta2.ContainerOverrides{
-		EnableTLS: false,
+	// If the version tag mapping is define make use of that.
+	imageConfigs := factory.options.getImageVersionConfig(mainImage)
+	if len(imageConfigs) == 0 {
 		// The first entry is version specific e.g. this image + tag (if specified) will be used for the provided version
 		// the second entry ensures we set the base image for e.g. upgrades independent of the version.
-		ImageConfigs: []fdbv1beta2.ImageConfig{
+		imageConfigs = []fdbv1beta2.ImageConfig{
 			{
 				BaseImage: mainImage,
 				Tag:       mainTag,
@@ -223,7 +224,12 @@ func (factory *Factory) getContainerOverrides(
 			{
 				BaseImage: mainImage,
 			},
-		},
+		}
+	}
+
+	mainOverrides := fdbv1beta2.ContainerOverrides{
+		EnableTLS:    false,
+		ImageConfigs: imageConfigs,
 	}
 
 	sidecarImage, sidecarTag := GetBaseImageAndTag(

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -519,6 +519,9 @@ func (factory *Factory) getSidecarConfigsSplitImage() []SidecarConfig {
 	additionalSidecarVersions := factory.GetAdditionalSidecarVersions()
 	sidecarConfigs := make([]SidecarConfig, 0, len(additionalSidecarVersions)+1)
 	baseImage, tag := GetBaseImageAndTag(factory.GetSidecarImage())
+	if tag == "" {
+		tag = fmt.Sprintf("%s-1", factory.GetFDBVersion())
+	}
 
 	defaultConfig := getDefaultSidecarConfig(
 		baseImage,


### PR DESCRIPTION
# Description

Adding support to override the image tag for specific FDB versions. This can be useful if someone want to run the e2e test suite with a custom set of images.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Ran manually an upgrade test for the unified image.

## Documentation

Added in the makefile.

## Follow-up

-
