### PR TITLE
Change the useUnifiedImage setting to a more generic imageType

### DIFF
--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -445,9 +445,9 @@ func (in *FoundationDBBackupSpec) DeepCopyInto(out *FoundationDBBackupSpec) {
 	}
 	in.MainContainer.DeepCopyInto(&out.MainContainer)
 	in.SidecarContainer.DeepCopyInto(&out.SidecarContainer)
-	if in.UseUnifiedImage != nil {
-		in, out := &in.UseUnifiedImage, &out.UseUnifiedImage
-		*out = new(bool)
+	if in.ImageType != nil {
+		in, out := &in.ImageType, &out.ImageType
+		*out = new(ImageType)
 		**out = **in
 	}
 }
@@ -730,9 +730,9 @@ func (in *FoundationDBClusterSpec) DeepCopyInto(out *FoundationDBClusterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.UseUnifiedImage != nil {
-		in, out := &in.UseUnifiedImage, &out.UseUnifiedImage
-		*out = new(bool)
+	if in.ImageType != nil {
+		in, out := &in.ImageType, &out.ImageType
+		*out = new(ImageType)
 		**out = **in
 	}
 	if in.MaxZonesWithUnavailablePods != nil {

--- a/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml
@@ -3460,6 +3460,13 @@ spec:
                   type: string
                 maxItems: 100
                 type: array
+              imageType:
+                default: split
+                enum:
+                - split
+                - unified
+                maxLength: 1024
+                type: string
               mainContainer:
                 properties:
                   enableLivenessProbe:
@@ -6741,8 +6748,6 @@ spec:
                 type: object
               snapshotPeriodSeconds:
                 type: integer
-              useUnifiedImage:
-                type: boolean
               version:
                 type: string
             required:

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -10434,6 +10434,13 @@ spec:
                 type: object
               ignoreUpgradabilityChecks:
                 type: boolean
+              imageType:
+                default: split
+                enum:
+                - split
+                - unified
+                maxLength: 1024
+                type: string
               labels:
                 properties:
                   filterOnOwnerReference:
@@ -14055,8 +14062,6 @@ spec:
                   type: string
                 type: array
               useExplicitListenAddress:
-                type: boolean
-              useUnifiedImage:
                 type: boolean
               version:
                 pattern: (\d+)\.(\d+)\.(\d+)

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -298,7 +298,8 @@ var _ = Describe("cluster_controller", func() {
 				// There is a bug in the fake client that when updating the status the spec is updated.
 				cluster.Spec.MainContainer.ImageConfigs = nil
 				cluster.Spec.SidecarContainer.ImageConfigs = nil
-				cluster.Spec.UseUnifiedImage = pointer.Bool(true)
+				imageType := fdbv1beta2.ImageTypeUnified
+				cluster.Spec.ImageType = &imageType
 				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 			})
 

--- a/docs/backup_spec.md
+++ b/docs/backup_spec.md
@@ -91,7 +91,7 @@ FoundationDBBackupSpec describes the desired state of the backup for a cluster.
 | blobStoreConfiguration | This is the configuration of the target blobstore for this backup. | *[BlobStoreConfiguration](#blobstoreconfiguration) | false |
 | mainContainer | MainContainer defines customization for the foundationdb container. | ContainerOverrides | false |
 | sidecarContainer | SidecarContainer defines customization for the foundationdb-kubernetes-sidecar container. | ContainerOverrides | false |
-| useUnifiedImage | UseUnifiedImage determines if we should use the unified image rather than separate images for the main container and the sidecar container. | *bool | false |
+| imageType | ImageType defines the image type that should be used for the FoundationDBCluster deployment. When the type is set to \"unified\" the deployment will use the new fdb-kubernetes-monitor. Otherwise the main container and the sidecar container will use different images. Default: split | *ImageType | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -262,7 +262,7 @@ FoundationDBClusterSpec defines the desired state of a cluster.
 | coordinatorSelection | CoordinatorSelection defines which process classes are eligible for coordinator selection. If empty all stateful processes classes are equally eligible. A higher priority means that a process class is preferred over another process class. If the FoundationDB cluster is spans across multiple Kubernetes clusters or DCs the CoordinatorSelection must match in all FoundationDB cluster resources otherwise the coordinator selection process could conflict. | [][CoordinatorSelectionSetting](#coordinatorselectionsetting) | false |
 | labels | LabelConfig allows customizing labels used by the operator. | [LabelConfig](#labelconfig) | false |
 | useExplicitListenAddress | UseExplicitListenAddress determines if we should add a listen address that is separate from the public address. **Deprecated: This setting will be removed in the next major release.** | *bool | false |
-| useUnifiedImage | UseUnifiedImage determines if we should use the unified image rather than separate images for the main container and the sidecar container. | *bool | false |
+| imageType | ImageType defines the image type that should be used for the FoundationDBCluster deployment. When the type is set to \"unified\" the deployment will use the new fdb-kubernetes-monitor. Otherwise the main container and the sidecar container will use different images. Default: split | *[ImageType](#imagetype) | false |
 | maxZonesWithUnavailablePods | MaxZonesWithUnavailablePods defines the maximum number of zones that can have unavailable pods during the update process. When unset, there is no limit to the  number of zones with unavailable pods. | *int | false |
 
 [Back to TOC](#table-of-contents)

--- a/docs/manual/customization.md
+++ b/docs/manual/customization.md
@@ -503,7 +503,9 @@ kubectl label pod,pvc,configmap,service -l foundationdb.org/fdb-cluster-name=sam
 
 ## Unified vs Split Images
 
-The operator currently supports two different image types: a split image and a unified image. The split image provides two different images for the `foundationdb` container and the `foundationdb-kubernetes-sidecar` container. The unified image provides a single image which handles launching `fdbserver` processes as well as providing feedback to the operator on locality information and updates to dynamic conf.
+The operator currently supports two different image types: a split image and a unified image.
+The split image provides two different images for the `foundationdb` container and the `foundationdb-kubernetes-sidecar` container.
+The unified image provides a single image which handles launching `fdbserver` processes as well as providing feedback to the operator on locality information and updates to dynamic conf.
 
 **NOTE**: The unified image is still experimental, and is not recommended outside of development environments.
 
@@ -516,7 +518,7 @@ metadata:
   name: sample-cluster
 spec:
   version: 7.1.26
-  useUnifiedImage: true
+  imageType: "unified"
 ```
 
 For more information on how the interaction between the operator and these images works, see the [technical design](technical_design.md#interaction-between-the-operator-and-the-pods).

--- a/e2e/fixtures/fdb_operator_fixtures.go
+++ b/e2e/fixtures/fdb_operator_fixtures.go
@@ -267,5 +267,6 @@ func WithLocalitiesForExclusion(_ *Factory, cluster *fdbv1beta2.FoundationDBClus
 
 // WithUnifiedImage is an option that enables the unified image for a cluster.
 func WithUnifiedImage(_ *Factory, cluster *fdbv1beta2.FoundationDBCluster) {
-	cluster.Spec.UseUnifiedImage = pointer.Bool(true)
+	imageType := fdbv1beta2.ImageTypeUnified
+	cluster.Spec.ImageType = &imageType
 }

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2180,7 +2180,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		It("should update the Pod IP family", func() {
 			var expectedContainerWithEnv string
 			// In the case of the split image the sidecar will have that env variable.
-			if fdbCluster.GetCluster().GetUseUnifiedImage() {
+			if fdbCluster.GetCluster().UseUnifiedImage() {
 				expectedContainerWithEnv = fdbv1beta2.MainContainerName
 			} else {
 				expectedContainerWithEnv = fdbv1beta2.SidecarContainerName

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2281,7 +2281,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		BeforeEach(func() {
 			// If we are not using the unified image, we can skip this test.
-			if !fdbCluster.GetCluster().GetUseUnifiedImage() {
+			if !fdbCluster.GetCluster().UseUnifiedImage() {
 				Skip("The sidecar image doesn't require connectivity to the Kubernetes API")
 			}
 

--- a/internal/configmap_helper_test.go
+++ b/internal/configmap_helper_test.go
@@ -23,8 +23,6 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"k8s.io/utils/pointer"
-
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	monitorapi "github.com/apple/foundationdb/fdbkubernetesmonitor/api"
 	. "github.com/onsi/ginkgo/v2"
@@ -156,8 +154,9 @@ var _ = Describe("configmap_helper", func() {
 
 			When("using the unified image", func() {
 				BeforeEach(func() {
-					cluster.Spec.UseUnifiedImage = pointer.Bool(true)
-					cluster.Status.ImageTypes = []fdbv1beta2.ImageType{"unified"}
+					imageType := fdbv1beta2.ImageTypeUnified
+					cluster.Spec.ImageType = &imageType
+					cluster.Status.ImageTypes = []fdbv1beta2.ImageType{fdbv1beta2.ImageTypeUnified}
 				})
 
 				It("includes the data for both configurations", func() {
@@ -202,8 +201,9 @@ var _ = Describe("configmap_helper", func() {
 
 			When("using the unified image", func() {
 				BeforeEach(func() {
-					cluster.Spec.UseUnifiedImage = pointer.Bool(true)
-					cluster.Status.ImageTypes = []fdbv1beta2.ImageType{"unified"}
+					imageType := fdbv1beta2.ImageTypeUnified
+					cluster.Spec.ImageType = &imageType
+					cluster.Status.ImageTypes = []fdbv1beta2.ImageType{fdbv1beta2.ImageTypeUnified}
 				})
 
 				It("includes the data for both configurations", func() {

--- a/internal/deprecations.go
+++ b/internal/deprecations.go
@@ -89,13 +89,13 @@ func NormalizeClusterSpec(cluster *fdbv1beta2.FoundationDBCluster, options Depre
 				}
 			}
 
-			if !cluster.GetUseUnifiedImage() {
+			if !cluster.UseUnifiedImage() {
 				template.Spec.InitContainers = customizeContainerFromList(template.Spec.InitContainers, fdbv1beta2.InitContainerName, sidecarUpdater)
 			}
 			template.Spec.Containers = customizeContainerFromList(template.Spec.Containers, fdbv1beta2.SidecarContainerName, sidecarUpdater)
 		})
 
-		updateImageConfigs(&cluster.Spec, cluster.GetUseUnifiedImage())
+		updateImageConfigs(&cluster.Spec, cluster.UseUnifiedImage())
 	}
 
 	if len(cluster.Spec.Buggify.CrashLoop) > 0 {

--- a/internal/deprecations_test.go
+++ b/internal/deprecations_test.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("[internal] deprecations", func() {
@@ -256,12 +255,13 @@ var _ = Describe("[internal] deprecations", func() {
 				})
 
 				It("should have the unified images disabled", func() {
-					Expect(cluster.GetUseUnifiedImage()).To(BeFalse())
+					Expect(cluster.UseUnifiedImage()).To(BeFalse())
 				})
 
 				Context("with unified images enabled", func() {
 					BeforeEach(func() {
-						spec.UseUnifiedImage = pointer.Bool(true)
+						imageType := fdbv1beta2.ImageTypeUnified
+						spec.ImageType = &imageType
 					})
 
 					It("should use the default image config for the unified image", func() {

--- a/internal/monitor_conf.go
+++ b/internal/monitor_conf.go
@@ -190,7 +190,7 @@ func GetMonitorProcessConfiguration(cluster *fdbv1beta2.FoundationDBCluster, pro
 
 	// If the unified image is used we will always make use of the more specific data directory and add the process_id
 	// locality.
-	if processCount > 1 || cluster.GetUseUnifiedImage() {
+	if processCount > 1 || cluster.UseUnifiedImage() {
 		configuration.Arguments = append(configuration.Arguments, monitorapi.Argument{
 			ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 				{Value: "--datadir=/var/fdb/data/"},

--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -668,7 +668,8 @@ var _ = Describe("monitor_conf", func() {
 
 		When("using the unified image", func() {
 			BeforeEach(func() {
-				cluster.Spec.UseUnifiedImage = pointer.Bool(true)
+				imageType := fdbv1beta2.ImageTypeUnified
+				cluster.Spec.ImageType = &imageType
 			})
 
 			It("should generate the unsorted command-line", func() {

--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -481,7 +481,8 @@ var _ = Describe("monitor_conf", func() {
 
 		When("using the split image", func() {
 			BeforeEach(func() {
-				cluster.Spec.UseUnifiedImage = pointer.Bool(false)
+				imageType := fdbv1beta2.ImageTypeSplit
+				cluster.Spec.ImageType = &imageType
 			})
 
 			When("no additional custom parameters are defined", func() {

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -37,8 +37,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/utils/pointer"
-
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podclient"
 	monitorapi "github.com/apple/foundationdb/fdbkubernetesmonitor/api"
@@ -432,9 +430,10 @@ func GetImageType(pod *corev1.Pod) FDBImageType {
 // GetDesiredImageType determines whether a cluster is configured to use the
 // unified or the split image.
 func GetDesiredImageType(cluster *fdbv1beta2.FoundationDBCluster) FDBImageType {
-	if pointer.BoolDeref(cluster.Spec.UseUnifiedImage, false) {
+	if cluster.UseUnifiedImage() {
 		return FDBImageTypeUnified
 	}
+
 	return FDBImageTypeSplit
 }
 

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -215,7 +215,7 @@ func GetSidecarImage(cluster *fdbv1beta2.FoundationDBCluster, pClass fdbv1beta2.
 	}
 
 	var imageConfigs []fdbv1beta2.ImageConfig
-	if pointer.BoolDeref(cluster.Spec.UseUnifiedImage, false) {
+	if cluster.UseUnifiedImage() {
 		imageConfigs = cluster.Spec.MainContainer.ImageConfigs
 	} else {
 		imageConfigs = cluster.Spec.SidecarContainer.ImageConfigs

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -295,11 +295,11 @@ func setAffinityForFaultDomain(cluster *fdbv1beta2.FoundationDBCluster, podSpec 
 }
 
 func configureVolumesForContainers(cluster *fdbv1beta2.FoundationDBCluster, podSpec *corev1.PodSpec, volumeClaimTemplate *corev1.PersistentVolumeClaim, podName string, processClass fdbv1beta2.ProcessClass) {
-	useUnifiedImages := pointer.BoolDeref(cluster.Spec.UseUnifiedImage, false)
+	useUnifiedImage := cluster.UseUnifiedImage()
 	monitorConfKey := GetConfigMapMonitorConfEntry(processClass, GetDesiredImageType(cluster), cluster.GetDesiredServersPerPod(processClass))
 
 	var monitorConfFile string
-	if useUnifiedImages {
+	if useUnifiedImage {
 		monitorConfFile = "config.json"
 	} else {
 		monitorConfFile = "fdbmonitor.conf"
@@ -340,7 +340,7 @@ func configureVolumesForContainers(cluster *fdbv1beta2.FoundationDBCluster, podS
 		{Name: "data", VolumeSource: mainVolumeSource},
 	}
 
-	if useUnifiedImages {
+	if useUnifiedImage {
 		volumes = append(volumes, corev1.Volume{Name: "shared-binaries", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}})
 	} else {
 		volumes = append(volumes, corev1.Volume{Name: "dynamic-conf", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}})
@@ -390,7 +390,7 @@ func configureNoSchedule(podSpec *corev1.PodSpec, processGroupID fdbv1beta2.Proc
 func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus) (*corev1.PodSpec, error) {
 	processSettings := cluster.GetProcessSettings(processGroup.ProcessClass)
 	podSpec := processSettings.PodTemplate.Spec.DeepCopy()
-	useUnifiedImage := cluster.GetUseUnifiedImage()
+	useUnifiedImage := cluster.UseUnifiedImage()
 
 	mainContainer, sidecarContainer, err := getContainers(podSpec)
 	if err != nil {

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -481,7 +481,8 @@ var _ = Describe("pod_models", func() {
 		When("the unified image is enabled", func() {
 			BeforeEach(func() {
 				cluster = CreateDefaultCluster()
-				cluster.Spec.UseUnifiedImage = pointer.Bool(true)
+				imageType := fdbv1beta2.ImageTypeUnified
+				cluster.Spec.ImageType = &imageType
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -3323,7 +3324,8 @@ var _ = Describe("pod_models", func() {
 
 		When("using the unified image", func() {
 			BeforeEach(func() {
-				backup.Spec.UseUnifiedImage = pointer.Bool(true)
+				imageType := fdbv1beta2.ImageTypeUnified
+				backup.Spec.ImageType = &imageType
 				deployment, err = GetBackupDeployment(backup)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(deployment).NotTo(BeNil())


### PR DESCRIPTION
# Description

Following the best practices from: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#primitive-types

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Discussion

This is a breaking change but since the feature is currently not usable I think it's fine to change it anyways. We should make sure to announce it in the release notes but from my point of view the risk is minimal as we haven't released the unified image yet.

## Testing

Unit tests.

## Documentation

-

## Follow-up

-
