### PR TITLE
Add wait time for CI runs to reduce congestion

### DIFF
--- a/e2e/fixtures/test_runner.go
+++ b/e2e/fixtures/test_runner.go
@@ -23,7 +23,10 @@ package fixtures
 import (
 	"flag"
 	"log"
+	"math/rand"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/onsi/ginkgo/v2/types"
 
@@ -39,6 +42,15 @@ func RunGinkgoTests(t *testing.T, name string) {
 	log.SetFlags(log.LstdFlags)
 	log.SetOutput(ginkgo.GinkgoWriter)
 	gomega.RegisterFailHandler(ginkgo.Fail)
+	_, inCI := os.LookupEnv("CODEBUILD_SRC_DIR")
+	if inCI {
+		// We wait up to 300 seconds before executing the code. In CI all tests will run in parallel and adding some
+		// random wait time should help in making those tests more stable.
+		waitDuration := time.Duration(rand.Intn(300)) * time.Second
+		ginkgo.GinkgoLogr.Info("waiting for", waitDuration.String(), "before executing test suite")
+		time.Sleep(waitDuration)
+	}
+
 	ginkgo.RunSpecs(t, name)
 }
 


### PR DESCRIPTION
# Description

This should help a bit when running all test suites at the "same time".

## Type of change

- Other

## Discussion

-

## Testing

CI will be running the tests. I run a test locally by setting the environment variable manually:

```text
=== RUN   TestOperator
  "level"=0 "msg"="waiting for" "1m51s"="before executing test suite"
Running Suite: Operator test suite - /Users/jscheuermann/go/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator
=================================================================================================================================
Random Seed: 1717434974

```

## Documentation

N/A

## Follow-up

-
