### PR TITLE
Add e2e migration test from split to unified image

### DIFF
--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -22,7 +22,7 @@ package controllers
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -122,7 +122,7 @@ func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReco
 				delayedRequeue = false
 			}
 
-			pod.ObjectMeta.Annotations[fdbv1beta2.OutdatedConfigMapKey] = fmt.Sprintf("%d", time.Now().Unix())
+			pod.ObjectMeta.Annotations[fdbv1beta2.OutdatedConfigMapKey] = strconv.FormatInt(time.Now().Unix(), 10)
 			err = r.PodLifecycleManager.UpdateMetadata(ctx, r, cluster, pod)
 			if err != nil {
 				allSynced = false

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -15,6 +15,7 @@ FDB_VERSION?=7.1.57
 NEXT_FDB_VERSION?=7.3.33
 ## Expectation is that you are running standard build image which generates both regular and debug (Symbols) images.
 FDB_IMAGE?=foundationdb/foundationdb:$(FDB_VERSION)
+UNIFIED_FDB_IMAGE?=foundationdb/fdb-kubernetes-monitor:$(FDB_VERSION)
 SIDECAR_IMAGE?=foundationdb/foundationdb-kubernetes-sidecar:$(FDB_VERSION)-1
 OPERATOR_IMAGE?=foundationdb/fdb-kubernetes-operator:latest
 REGISTRY?=docker.io
@@ -134,4 +135,5 @@ nightly-tests: run
 	  --cluster-name=$(CLUSTER_NAME) \
 	  --storage-engine=$(STORAGE_ENGINE) \
 	  --fdb-version-tag-mapping=$(FDB_VERSION_TAG_MAPPING) \
+	  --unified-fdb-image=$(UNIFIED_FDB_IMAGE) \
 	  | grep -v 'constructing many client instances from the same exec auth config can cause performance problems during cert rotation' &> $(BASE_DIR)/../logs/$<.log

--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -76,6 +76,8 @@ type ClusterConfig struct {
 	UseLocalityBasedExclusions bool
 	// UseDNS if enabled the FoundationDBCluster resource will enable the DNS feature.
 	UseDNS bool
+	// If enabled the cluster will be setup with the unified image.
+	UseUnifiedImage *bool
 	// CreationTracker if specified will be used to log the time between the creations steps.
 	CreationTracker CreationTrackerLogger
 	// Number of machines, this is used for calculating the number of Pods and is not correlated to the actual number
@@ -519,5 +521,6 @@ func (config *ClusterConfig) Copy() *ClusterConfig {
 		CreationCallback:           config.CreationCallback,
 		UseDNS:                     config.UseDNS,
 		UseLocalityBasedExclusions: config.UseLocalityBasedExclusions,
+		UseUnifiedImage:            config.UseUnifiedImage,
 	}
 }

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -406,6 +406,15 @@ func (factory *Factory) startFDBFromClusterSpec(
 		fdbCluster.cluster.Namespace,
 	)
 
+	// Make sure the cluster will be removed once the tests are done.
+	factory.AddShutdownHook(func() error {
+		if fdbCluster == nil {
+			return nil
+		}
+
+		return fdbCluster.Destroy()
+	})
+
 	gomega.Expect(fdbCluster.WaitUntilAvailable()).ToNot(gomega.HaveOccurred())
 	return fdbCluster
 }

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -203,15 +203,19 @@ func (factory *Factory) CreateFdbHaCluster(
 	return cluster
 }
 
-func (factory *Factory) getContainerOverrides(
-	debugSymbols bool,
-) (fdbv1beta2.ContainerOverrides, fdbv1beta2.ContainerOverrides) {
+// GetMainContainerOverrides will return the main container overrides.
+func (factory *Factory) GetMainContainerOverrides(debugSymbols bool, unifiedImage bool) fdbv1beta2.ContainerOverrides {
+	image := factory.GetFoundationDBImage()
+	if unifiedImage {
+		image = factory.GetUnifiedFoundationDBImage()
+	}
+
 	mainImage, mainTag := GetBaseImageAndTag(
-		GetDebugImage(debugSymbols, factory.GetFoundationDBImage()),
+		GetDebugImage(debugSymbols, image),
 	)
 
 	// If the version tag mapping is define make use of that.
-	imageConfigs := factory.options.getImageVersionConfig(mainImage)
+	imageConfigs := factory.options.getImageVersionConfig(mainImage, false)
 	if len(imageConfigs) == 0 {
 		// The first entry is version specific e.g. this image + tag (if specified) will be used for the provided version
 		// the second entry ensures we set the base image for e.g. upgrades independent of the version.
@@ -227,17 +231,22 @@ func (factory *Factory) getContainerOverrides(
 		}
 	}
 
-	mainOverrides := fdbv1beta2.ContainerOverrides{
+	return fdbv1beta2.ContainerOverrides{
 		EnableTLS:    false,
 		ImageConfigs: imageConfigs,
 	}
+}
 
+// GetSidecarContainerOverrides will return the sidecar container overrides. If the unified image should be used an empty
+// container override will be returned.
+func (factory *Factory) GetSidecarContainerOverrides(debugSymbols bool) fdbv1beta2.ContainerOverrides {
 	sidecarImage, sidecarTag := GetBaseImageAndTag(
 		GetDebugImage(debugSymbols, factory.GetSidecarImage()),
 	)
-	sidecarOverrides := fdbv1beta2.ContainerOverrides{
-		EnableTLS: false,
-		ImageConfigs: []fdbv1beta2.ImageConfig{
+
+	imageConfigs := factory.options.getImageVersionConfig(sidecarImage, true)
+	if len(imageConfigs) == 0 {
+		imageConfigs = []fdbv1beta2.ImageConfig{
 			{
 				BaseImage: sidecarImage,
 				Tag:       sidecarTag,
@@ -247,15 +256,15 @@ func (factory *Factory) getContainerOverrides(
 				BaseImage: sidecarImage,
 				TagSuffix: "-1",
 			},
-		},
+		}
 	}
 
-	// If no tag is specified ensure we add the required tag suffix.
-	if sidecarTag == "" {
-		sidecarOverrides.ImageConfigs[0].TagSuffix = "-1"
+	sidecarOverrides := fdbv1beta2.ContainerOverrides{
+		EnableTLS:    false,
+		ImageConfigs: imageConfigs,
 	}
 
-	return mainOverrides, sidecarOverrides
+	return sidecarOverrides
 }
 
 func (factory *Factory) getClusterName() string {
@@ -776,10 +785,6 @@ func (factory *Factory) OperatorIsAtLeast(version string) bool {
 func (factory *Factory) GetClusterOptions(options ...ClusterOption) []ClusterOption {
 	options = append(options, WithTLSEnabled)
 
-	if factory.options.featureOperatorUnifiedImage {
-		options = append(options, WithUnifiedImage)
-	}
-
 	if factory.options.featureOperatorLocalities {
 		options = append(options, WithLocalitiesForExclusion)
 	}
@@ -854,6 +859,12 @@ func (factory *Factory) GetSidecarImage() string {
 // prepended.
 func (factory *Factory) GetFoundationDBImage() string {
 	return prependRegistry(factory.options.registry, factory.options.fdbImage)
+}
+
+// GetUnifiedFoundationDBImage returns the unified FoundationDB image provided via command line. If a registry was defined the registry will be
+// prepended.
+func (factory *Factory) GetUnifiedFoundationDBImage() string {
+	return prependRegistry(factory.options.registry, factory.options.unifiedFDBImage)
 }
 
 // getImagePullPolicy returns the image pull policy based on the provided cloud provider. For Kind this will be Never, otherwise

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -214,7 +214,7 @@ func (factory *Factory) GetMainContainerOverrides(debugSymbols bool, unifiedImag
 		GetDebugImage(debugSymbols, image),
 	)
 
-	// If the version tag mapping is define make use of that.
+	// If the version tag mapping is defined make use of that.
 	imageConfigs := factory.options.getImageVersionConfig(mainImage, false)
 	if len(imageConfigs) == 0 {
 		// The first entry is version specific e.g. this image + tag (if specified) will be used for the provided version
@@ -244,13 +244,17 @@ func (factory *Factory) GetSidecarContainerOverrides(debugSymbols bool) fdbv1bet
 		GetDebugImage(debugSymbols, factory.GetSidecarImage()),
 	)
 
+	// If the version tag mapping is defined make use of that.
 	imageConfigs := factory.options.getImageVersionConfig(sidecarImage, true)
 	if len(imageConfigs) == 0 {
+		// The first entry is version specific e.g. this image + tag (if specified) will be used for the provided version
+		// the second entry ensures we set the base image for e.g. upgrades independent of the version.
 		imageConfigs = []fdbv1beta2.ImageConfig{
 			{
 				BaseImage: sidecarImage,
 				Tag:       sidecarTag,
 				Version:   factory.GetFDBVersionAsString(),
+				TagSuffix: "-1",
 			},
 			{
 				BaseImage: sidecarImage,
@@ -259,12 +263,10 @@ func (factory *Factory) GetSidecarContainerOverrides(debugSymbols bool) fdbv1bet
 		}
 	}
 
-	sidecarOverrides := fdbv1beta2.ContainerOverrides{
+	return fdbv1beta2.ContainerOverrides{
 		EnableTLS:    false,
 		ImageConfigs: imageConfigs,
 	}
-
-	return sidecarOverrides
 }
 
 func (factory *Factory) getClusterName() string {

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -406,15 +406,6 @@ func (factory *Factory) startFDBFromClusterSpec(
 		fdbCluster.cluster.Namespace,
 	)
 
-	// Make sure the cluster will be removed once the tests are done.
-	factory.AddShutdownHook(func() error {
-		if fdbCluster == nil {
-			return nil
-		}
-
-		return fdbCluster.Destroy()
-	})
-
 	gomega.Expect(fdbCluster.WaitUntilAvailable()).ToNot(gomega.HaveOccurred())
 	return fdbCluster
 }

--- a/e2e/fixtures/fdb_data_loader.go
+++ b/e2e/fixtures/fdb_data_loader.go
@@ -101,7 +101,7 @@ spec:
       initContainers:
         {{ range $index, $version := .SidecarVersions }}
         - name: foundationdb-kubernetes-init-{{ $index }}
-          image: {{ .BaseImage }}:{{ .SidecarTag}}
+          image: {{ .Image }}
           imagePullPolicy: Always
           command:
             - /bin/bash
@@ -118,7 +118,7 @@ spec:
         # Install this library in a special location to force the operator to use it as the primary library.
         {{ if eq .FDBVersion.Compact "7.1" }}
         - name: foundationdb-kubernetes-init-7-1-primary
-          image: {{ .BaseImage }}:{{ .SidecarTag}}
+          image: {{ .Image }}
           imagePullPolicy: {{ .ImagePullPolicy }}
           args:
             # Note that we are only copying a library, rather than copying any binaries. 
@@ -242,7 +242,7 @@ spec:
             runAsGroup: 0
 {{ if .CopyAsPrimary }}
         - name: foundationdb-kubernetes-init-cluster-file
-          image: {{ .BaseImage }}:{{ .SidecarTag}}
+          image: {{ .Image }}
           imagePullPolicy: {{ .ImagePullPolicy }}
           args:
             - --mode

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -511,7 +511,7 @@ type SidecarConfig struct {
 	CopyAsPrimary bool
 }
 
-// getSidecarConfigsSplitImage returns the sidecar config for the split image configuration.
+// getSidecarConfigs returns the sidecar config based on the provided imageConfigs.
 func (factory *Factory) getSidecarConfigs(imageConfigs []fdbv1beta2.ImageConfig) []SidecarConfig {
 	var hasCopyPrimarySet bool
 	additionalSidecarVersions := factory.GetAdditionalSidecarVersions()
@@ -536,14 +536,14 @@ func (factory *Factory) getSidecarConfigs(imageConfigs []fdbv1beta2.ImageConfig)
 
 	// Add all other versions that are required e.g. for major or minor upgrades.
 	for _, version := range additionalSidecarVersions {
-		// Don't add the sidecar another time if we already added it
-		if version.Equal(factory.GetFDBVersion()) {
+		// Don't add the sidecar another time if we already added a protocol compatible version.
+		if version.IsProtocolCompatible(factory.GetFDBVersion()) {
 			continue
 		}
 
 		sidecarConfig := SidecarConfig{
 			Image:           fdbv1beta2.SelectImageConfig(imageConfigs, version.String()).Image(),
-			FDBVersion:      factory.GetFDBVersion(),
+			FDBVersion:      version,
 			ImagePullPolicy: pullPolicy,
 		}
 

--- a/e2e/fixtures/fdb_operator_fixtures.go
+++ b/e2e/fixtures/fdb_operator_fixtures.go
@@ -264,9 +264,3 @@ func WithOneMinuteMinimumUptimeSecondsForBounce(
 func WithLocalitiesForExclusion(_ *Factory, cluster *fdbv1beta2.FoundationDBCluster) {
 	cluster.Spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(true)
 }
-
-// WithUnifiedImage is an option that enables the unified image for a cluster.
-func WithUnifiedImage(_ *Factory, cluster *fdbv1beta2.FoundationDBCluster) {
-	imageType := fdbv1beta2.ImageTypeUnified
-	cluster.Spec.ImageType = &imageType
-}

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -82,7 +82,7 @@ var _ = BeforeSuite(func() {
 	)
 
 	//Load some data async into the cluster. We will only block as long as the Job is created.
-	// factory.CreateDataLoaderIfAbsent(fdbCluster)
+	factory.CreateDataLoaderIfAbsent(fdbCluster)
 
 	// In order to test the robustness of the operator we try to kill the operator Pods every minute.
 	if factory.ChaosTestsEnabled() {

--- a/e2e/test_operator_migrate_image_type/operator_migate_image_type_test.go
+++ b/e2e/test_operator_migrate_image_type/operator_migate_image_type_test.go
@@ -1,0 +1,161 @@
+/*
+ * operator_migrate_image_type_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package operator
+
+/*
+
+This test suite includes tests for migrating between the different image types.
+*/
+
+import (
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+	"log"
+)
+
+var (
+	factory     *fixtures.Factory
+	fdbCluster  *fixtures.FdbCluster
+	testOptions *fixtures.FactoryOptions
+)
+
+func init() {
+	testOptions = fixtures.InitFlags()
+}
+
+var _ = BeforeSuite(func() {
+	factory = fixtures.CreateFactory(testOptions)
+})
+
+var _ = AfterSuite(func() {
+	if CurrentSpecReport().Failed() {
+		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
+	}
+	factory.Shutdown()
+})
+
+var _ = PDescribe("Operator Migrate Image Type", Label("e2e"), func() {
+	When("migrating from split to unified", func() {
+		BeforeEach(func() {
+			config := fixtures.DefaultClusterConfig(false)
+			config.UseUnifiedImage = pointer.Bool(false)
+			fdbCluster = factory.CreateFdbCluster(
+				config,
+				factory.GetClusterOptions()...,
+			)
+
+			//Load some data async into the cluster. We will only block as long as the Job is created.
+			factory.CreateDataLoaderIfAbsent(fdbCluster)
+
+			// Update the cluster spec to run with the unified image.
+			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			imageType := fdbv1beta2.ImageTypeUnified
+			spec.ImageType = &imageType
+			// Generate the new config to make use of the unified images.
+			overrides := factory.GetMainContainerOverrides(false, true)
+			overrides.EnableTLS = spec.MainContainer.EnableTLS
+			spec.MainContainer = overrides
+			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			Expect(fdbCluster.Destroy()).NotTo(HaveOccurred())
+		})
+
+		It("should convert the cluster", func() {
+			// Make sure we didn't lose data.
+			fdbCluster.EnsureTeamTrackersAreHealthy()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+
+			unifiedImage := factory.GetUnifiedFoundationDBImage()
+			pods := fdbCluster.GetPods()
+			for _, pod := range pods.Items {
+				// Ignore Pods that are pending the deletion.
+				if !pod.DeletionTimestamp.IsZero() {
+					continue
+				}
+
+				// With the unified image no init containers are used.
+				Expect(pod.Spec.InitContainers).To(HaveLen(0))
+				// Make sure they run the unified image.
+				Expect(pod.Spec.Containers[0].Image).To(ContainSubstring(unifiedImage))
+			}
+		})
+	})
+
+	When("migrating from unified to split", func() {
+		BeforeEach(func() {
+			config := fixtures.DefaultClusterConfig(false)
+			config.UseUnifiedImage = pointer.Bool(true)
+			fdbCluster = factory.CreateFdbCluster(
+				config,
+				factory.GetClusterOptions()...,
+			)
+
+			//Load some data async into the cluster. We will only block as long as the Job is created.
+			factory.CreateDataLoaderIfAbsent(fdbCluster)
+
+			// Update the cluster spec to run with the split image.
+			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			imageType := fdbv1beta2.ImageTypeSplit
+			spec.ImageType = &imageType
+			// Generate the new config to make use of the split images.
+			overrides := factory.GetMainContainerOverrides(false, false)
+			overrides.EnableTLS = spec.MainContainer.EnableTLS
+			spec.MainContainer = overrides
+			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			Expect(fdbCluster.Destroy()).NotTo(HaveOccurred())
+		})
+
+		It("should convert the cluster", func() {
+			// Make sure we didn't lose data.
+			fdbCluster.EnsureTeamTrackersAreHealthy()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+
+			fdbImage := factory.GetFoundationDBImage()
+			sidecarImage := factory.GetSidecarImage()
+			pods := fdbCluster.GetPods()
+			for _, pod := range pods.Items {
+				// Ignore Pods that are pending the deletion.
+				if !pod.DeletionTimestamp.IsZero() {
+					continue
+				}
+				Expect(pod.Spec.InitContainers).NotTo(HaveLen(0))
+				// Make sure they run the split image.
+				for _, container := range pod.Spec.Containers {
+					if container.Name == fdbv1beta2.MainContainerName {
+						Expect(container.Image).To(ContainSubstring(fdbImage))
+					} else {
+						Expect(container.Image).To(ContainSubstring(sidecarImage))
+					}
+				}
+			}
+		})
+	})
+})

--- a/e2e/test_operator_migrate_image_type/suite_test.go
+++ b/e2e/test_operator_migrate_image_type/suite_test.go
@@ -1,0 +1,34 @@
+/*
+ * suite_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package operator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"
+	"github.com/onsi/gomega"
+)
+
+func TestOperator(t *testing.T) {
+	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
+	fixtures.RunGinkgoTests(t, "Operator Migrate Image Type test suite")
+}


### PR DESCRIPTION
# Description

Adding e2e test cases for converting a cluster from split image to unified and from the unified to the split image.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

I adjusted the e2e testing code to make sure we can test those migrations.

## Testing

Manually tested:

```text
tail -f /Users/jscheuermann/go/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/../logs/test_operator_migrate_image_type.log

[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.003 seconds]
------------------------------

Ran 2 of 2 Specs in 1011.427 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestOperator (1011.43s)
PASS
ok      github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_migrate_image_type    1011.843s
```

## Documentation

-

## Follow-up

Run those tests regularly.
