### PR TITLE
Disable availability check for upgrade test

### DIFF
--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -100,7 +100,10 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 	DescribeTable(
 		"upgrading a cluster with a random Pod deleted during rolling bounce phase",
 		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion, true)
+			// We disable the availability check here as there could be some race conditions between the operator and
+			// the test suite where two pods are taken down at the same time which would affect the availability of the
+			// cluster.
+			clusterSetup(beforeVersion, false)
 			prevImage := fdbCluster.GetFDBImage()
 
 			// 1. Start upgrade.


### PR DESCRIPTION
# Description

The test is disruptive by design, so doing an availability check is providing false signals.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

As the test case is deleting pods outside of the operators scope, it's expected that this can cause disruptions, especially for those small clusters.

## Testing

CI will run e2e tests.

## Documentation

-

## Follow-up

-