### PR TITLE
Unified image code clean up and make use of the same constant

### DIFF
--- a/api/v1beta2/foundationdb_env_variables.go
+++ b/api/v1beta2/foundationdb_env_variables.go
@@ -23,4 +23,7 @@ package v1beta2
 const (
 	// EnvNamePublicIP defines the FDB_PUBLIC_IP environment variable name.
 	EnvNamePublicIP = "FDB_PUBLIC_IP"
+
+	// EnvNameImageType defines the FDB_IMAGE_TYPE environment variable name.
+	EnvNameImageType = "FDB_IMAGE_TYPE"
 )

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2557,6 +2557,15 @@ func (cluster *FoundationDBCluster) UseUnifiedImage() bool {
 	return imageType == ImageTypeUnified
 }
 
+// DesiredImageType returns the desired image type that should be used.
+func (cluster *FoundationDBCluster) DesiredImageType() ImageType {
+	if cluster.UseUnifiedImage() {
+		return ImageTypeUnified
+	}
+
+	return ImageTypeSplit
+}
+
 // GetIgnoreTerminatingPodsSeconds returns the value of IgnoreTerminatingPodsSeconds or defaults to 10 minutes.
 func (cluster *FoundationDBCluster) GetIgnoreTerminatingPodsSeconds() int {
 	return pointer.IntDeref(cluster.Spec.AutomationOptions.IgnoreTerminatingPodsSeconds, int((10 * time.Minute).Seconds()))

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -386,7 +386,7 @@ func (r *FoundationDBClusterReconciler) updatePodDynamicConf(logger logr.Logger,
 	var expectedConf string
 
 	imageType := internal.GetImageType(pod)
-	if imageType == internal.FDBImageTypeUnified {
+	if imageType == fdbv1beta2.ImageTypeUnified {
 		config := internal.GetMonitorProcessConfiguration(cluster, processClass, serversPerPod, imageType)
 		configData, err := json.Marshal(config)
 		if err != nil {

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -62,7 +62,7 @@ func (updateSidecarVersions) reconcile(ctx context.Context, r *FoundationDBClust
 			continue
 		}
 
-		if internal.GetImageType(pod) != internal.GetDesiredImageType(cluster) {
+		if internal.GetImageType(pod) != cluster.DesiredImageType() {
 			logger.V(1).Info("Ignore process group with the wrong image type",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue

--- a/internal/configmap_helper_test.go
+++ b/internal/configmap_helper_test.go
@@ -92,7 +92,7 @@ var _ = Describe("configmap_helper", func() {
 				config := monitorapi.ProcessConfiguration{}
 				err = json.Unmarshal([]byte(jsonData), &config)
 				Expect(err).NotTo(HaveOccurred())
-				expectedConfig := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				expectedConfig := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config).To(Equal(expectedConfig))
 			})
 
@@ -165,7 +165,7 @@ var _ = Describe("configmap_helper", func() {
 					config := monitorapi.ProcessConfiguration{}
 					err = json.Unmarshal([]byte(jsonData), &config)
 					Expect(err).NotTo(HaveOccurred())
-					expectedConfig := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+					expectedConfig := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 					Expect(config).To(Equal(expectedConfig))
 
 					jsonData, present = configMap.Data["fdbmonitor-conf-storage-json"]
@@ -173,7 +173,7 @@ var _ = Describe("configmap_helper", func() {
 					config = monitorapi.ProcessConfiguration{}
 					err = json.Unmarshal([]byte(jsonData), &config)
 					Expect(err).NotTo(HaveOccurred())
-					expectedConfig = GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 2, FDBImageTypeUnified)
+					expectedConfig = GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 2, fdbv1beta2.ImageTypeUnified)
 					Expect(config).To(Equal(expectedConfig))
 				})
 			})
@@ -212,7 +212,7 @@ var _ = Describe("configmap_helper", func() {
 					config := monitorapi.ProcessConfiguration{}
 					err = json.Unmarshal([]byte(jsonData), &config)
 					Expect(err).NotTo(HaveOccurred())
-					expectedConfig := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassLog, 1, FDBImageTypeUnified)
+					expectedConfig := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassLog, 1, fdbv1beta2.ImageTypeUnified)
 					Expect(config).To(Equal(expectedConfig))
 
 					jsonData, present = configMap.Data["fdbmonitor-conf-log-json"]
@@ -220,7 +220,7 @@ var _ = Describe("configmap_helper", func() {
 					config = monitorapi.ProcessConfiguration{}
 					err = json.Unmarshal([]byte(jsonData), &config)
 					Expect(err).NotTo(HaveOccurred())
-					expectedConfig = GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassLog, 2, FDBImageTypeUnified)
+					expectedConfig = GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassLog, 2, fdbv1beta2.ImageTypeUnified)
 					Expect(config).To(Equal(expectedConfig))
 				})
 

--- a/internal/monitor_conf.go
+++ b/internal/monitor_conf.go
@@ -47,7 +47,7 @@ func GetStartCommandWithSubstitutions(cluster *fdbv1beta2.FoundationDBCluster, p
 		return "", nil
 	}
 
-	imageType := GetDesiredImageType(cluster)
+	imageType := cluster.DesiredImageType()
 	config := GetMonitorProcessConfiguration(cluster, processClass, processCount, imageType)
 
 	extractPlaceholderEnvVars(substitutions, config.Arguments)
@@ -59,7 +59,7 @@ func GetStartCommandWithSubstitutions(cluster *fdbv1beta2.FoundationDBCluster, p
 		return "", err
 	}
 
-	if imageType == FDBImageTypeUnified {
+	if imageType == fdbv1beta2.ImageTypeUnified {
 		return strings.Join(arguments, " "), nil
 	}
 
@@ -126,7 +126,7 @@ func GetMonitorConf(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1b
 func getMonitorConfStartCommandLines(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, substitutions map[string]string, processNumber int, processCount int) ([]string, error) {
 	confLines := make([]string, 0, 20)
 
-	config := GetMonitorProcessConfiguration(cluster, processClass, processCount, FDBImageTypeSplit)
+	config := GetMonitorProcessConfiguration(cluster, processClass, processCount, fdbv1beta2.ImageTypeSplit)
 
 	if substitutions == nil {
 		substitutions = make(map[string]string)
@@ -155,7 +155,7 @@ func getMonitorConfStartCommandLines(cluster *fdbv1beta2.FoundationDBCluster, pr
 }
 
 // GetMonitorProcessConfiguration builds the monitor conf template for the unified image.
-func GetMonitorProcessConfiguration(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, processCount int, imageType FDBImageType) monitorapi.ProcessConfiguration {
+func GetMonitorProcessConfiguration(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, processCount int, imageType fdbv1beta2.ImageType) monitorapi.ProcessConfiguration {
 	configuration := monitorapi.ProcessConfiguration{
 		Version: cluster.Spec.Version,
 	}
@@ -304,10 +304,10 @@ func getKnobParameterWithValue(key string, value string, isLocality bool) string
 }
 
 // buildIPArgument builds an argument that takes an IP address from an environment variable
-func buildIPArgument(parameter string, environmentVariable string, imageType FDBImageType, sampleAddresses []fdbv1beta2.ProcessAddress, podIPFamily *int) []monitorapi.Argument {
+func buildIPArgument(parameter string, environmentVariable string, imageType fdbv1beta2.ImageType, sampleAddresses []fdbv1beta2.ProcessAddress, podIPFamily *int) []monitorapi.Argument {
 	var leftIPWrap string
 	var rightIPWrap string
-	if imageType == FDBImageTypeUnified {
+	if imageType == fdbv1beta2.ImageTypeUnified {
 		leftIPWrap = "["
 		rightIPWrap = "]"
 	} else {
@@ -324,7 +324,7 @@ func buildIPArgument(parameter string, environmentVariable string, imageType FDB
 		ipArgument := monitorapi.Argument{
 			Source: environmentVariable,
 		}
-		if podIPFamily != nil && imageType == FDBImageTypeUnified {
+		if podIPFamily != nil && imageType == fdbv1beta2.ImageTypeUnified {
 			ipArgument.ArgumentType = monitorapi.IPListArgumentType
 			ipArgument.IPFamily = *podIPFamily
 		} else {

--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -56,7 +56,7 @@ var _ = Describe("monitor_conf", func() {
 			It("generates conf with an no processes", func() {
 				Expect(cluster).NotTo(BeNil())
 				cluster.Status.ConnectionString = ""
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.RunServers).NotTo(BeNil())
 				Expect(*config.RunServers).To(BeFalse())
 				Expect(config.Version).To(Equal(fdbv1beta2.Versions.Default.String()))
@@ -65,7 +65,7 @@ var _ = Describe("monitor_conf", func() {
 
 		When("running a storage instance", func() {
 			It("generates the conf", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Version).To(Equal(fdbv1beta2.Versions.Default.String()))
 				Expect(config.BinaryPath).To(BeEmpty())
 				Expect(config.RunServers).To(BeNil())
@@ -100,7 +100,7 @@ var _ = Describe("monitor_conf", func() {
 
 		When("running a log instance", func() {
 			It("generates the conf", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassLog, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassLog, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Version).To(Equal(fdbv1beta2.Versions.Default.String()))
 				Expect(config.BinaryPath).To(BeEmpty())
 				Expect(config.RunServers).To(BeNil())
@@ -112,7 +112,7 @@ var _ = Describe("monitor_conf", func() {
 
 		When("using the split image type", func() {
 			It("generates the conf", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeSplit)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeSplit)
 				Expect(config.Version).To(Equal(fdbv1beta2.Versions.Default.String()))
 				Expect(config.BinaryPath).To(BeEmpty())
 				Expect(config.RunServers).To(BeNil())
@@ -147,7 +147,7 @@ var _ = Describe("monitor_conf", func() {
 
 		When("running multiple processes", func() {
 			It("adds a process ID argument", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 2, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 2, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(config.Arguments[7]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--locality_process_id="},
@@ -162,7 +162,7 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("includes the process number in the data directory", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 2, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 2, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments[6]).To(Equal(monitorapi.Argument{
 					ArgumentType: monitorapi.ConcatenateArgumentType,
 					Values: []monitorapi.Argument{
@@ -180,7 +180,7 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("does not have a listen address", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address=["},
@@ -199,7 +199,7 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("adds a separate listen address", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address=["},
@@ -221,7 +221,7 @@ var _ = Describe("monitor_conf", func() {
 				})
 
 				It("does not have a listen address", func() {
-					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 					Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 						{Value: "--public_address=["},
@@ -241,7 +241,7 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("includes the TLS flag in the address", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address=["},
@@ -261,7 +261,7 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("includes both addresses", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address=["},
@@ -285,7 +285,7 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("includes both addresses", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address=["},
@@ -310,7 +310,7 @@ var _ = Describe("monitor_conf", func() {
 				})
 
 				It("includes the custom parameters", func() {
-					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 					Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
 						ArgumentType: monitorapi.ConcatenateArgumentType,
@@ -343,7 +343,7 @@ var _ = Describe("monitor_conf", func() {
 				})
 
 				It("includes the custom parameters for that class", func() {
-					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 					Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
 						ArgumentType: monitorapi.ConcatenateArgumentType,
@@ -366,7 +366,7 @@ var _ = Describe("monitor_conf", func() {
 				})
 
 				It("specifies the IP family for the public address", func() {
-					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 					Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 						{Value: "--public_address=["},
@@ -383,7 +383,7 @@ var _ = Describe("monitor_conf", func() {
 				})
 
 				It("specifies the IP family for the public address", func() {
-					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 					Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 						{Value: "--public_address=["},
@@ -404,7 +404,7 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("uses the variable as the zone ID", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 
 				Expect(config.Arguments[9]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
@@ -420,7 +420,7 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("includes the verification rules", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{Value: "--tls_verify_peers=S.CN=foundationdb.org"}))
 			})
@@ -432,7 +432,7 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("includes the log group", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(config.Arguments[5]).To(Equal(monitorapi.Argument{Value: "--loggroup=test-fdb-cluster"}))
 			})
@@ -444,7 +444,7 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("adds an argument for the data center", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{Value: "--locality_dcid=dc01"}))
 			})
@@ -456,7 +456,7 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("adds an argument for the data hall", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, FDBImageTypeUnified)
+				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{Value: "--locality_data_hall=dh01"}))
 			})

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -200,7 +200,7 @@ func configureContainersForUnifiedImages(cluster *fdbv1beta2.FoundationDBCluster
 	)
 
 	mainContainer.Env = append(mainContainer.Env, getEnvForMonitorConfigSubstitution(cluster, processGroup.ProcessGroupID)...)
-	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: "FDB_IMAGE_TYPE", Value: string(FDBImageTypeUnified)})
+	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: fdbv1beta2.EnvNameImageType, Value: string(fdbv1beta2.ImageTypeUnified)})
 	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: "FDB_POD_NAME", ValueFrom: &corev1.EnvVarSource{
 		FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 	}})
@@ -296,7 +296,7 @@ func setAffinityForFaultDomain(cluster *fdbv1beta2.FoundationDBCluster, podSpec 
 
 func configureVolumesForContainers(cluster *fdbv1beta2.FoundationDBCluster, podSpec *corev1.PodSpec, volumeClaimTemplate *corev1.PersistentVolumeClaim, podName string, processClass fdbv1beta2.ProcessClass) {
 	useUnifiedImage := cluster.UseUnifiedImage()
-	monitorConfKey := GetConfigMapMonitorConfEntry(processClass, GetDesiredImageType(cluster), cluster.GetDesiredServersPerPod(processClass))
+	monitorConfKey := GetConfigMapMonitorConfEntry(processClass, cluster.DesiredImageType(), cluster.GetDesiredServersPerPod(processClass))
 
 	var monitorConfFile string
 	if useUnifiedImage {

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -527,7 +527,7 @@ var _ = Describe("pod_models", func() {
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 						}},
 						{Name: "FDB_INSTANCE_ID", Value: "storage-1"},
-						{Name: "FDB_IMAGE_TYPE", Value: "unified"},
+						{Name: fdbv1beta2.EnvNameImageType, Value: "unified"},
 						{Name: "FDB_POD_NAME", ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 						}},
@@ -637,7 +637,7 @@ var _ = Describe("pod_models", func() {
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 						}},
 						{Name: "FDB_INSTANCE_ID", Value: "storage-1"},
-						{Name: "FDB_IMAGE_TYPE", Value: "unified"},
+						{Name: fdbv1beta2.EnvNameImageType, Value: "unified"},
 						{Name: "FDB_POD_NAME", ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 						}},
@@ -691,7 +691,7 @@ var _ = Describe("pod_models", func() {
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 						}},
 						{Name: "FDB_INSTANCE_ID", Value: "log-1"},
-						{Name: "FDB_IMAGE_TYPE", Value: "unified"},
+						{Name: fdbv1beta2.EnvNameImageType, Value: "unified"},
 						{Name: "FDB_POD_NAME", ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 						}},
@@ -747,7 +747,7 @@ var _ = Describe("pod_models", func() {
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 						}},
 						{Name: "FDB_INSTANCE_ID", Value: "log-1"},
-						{Name: "FDB_IMAGE_TYPE", Value: "unified"},
+						{Name: fdbv1beta2.EnvNameImageType, Value: "unified"},
 						{Name: "FDB_POD_NAME", ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 						}},


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2043

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

We changed the disk layout with the unified image, if only a single storage server per pod is used, then the data directory is still suffixed with `/1`. This would break the transition to the unified image for cluster with a single storage server per pod.

I also made sure we remove some internal method duplications.

## Testing

Updated the unit tests and CI will run e2e tests.

## Documentation

-

## Follow-up

-
