### PR TITLE
Update the go version to 1.22.4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.3
+          go-version: 1.22.4
       - name: Get dependencies
         run: curl -L --fail "https://github.com/apple/foundationdb/releases/download/${FDB_VER}/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.22.3
+        go-version: 1.22.4
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Get dependencies
@@ -103,7 +103,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.22.3
+        go-version: 1.22.4
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Get dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.3
+          go-version: 1.22.4
       #  https://github.com/goreleaser/goreleaser/issues/1311
       - name: Get current semver tag
         run: echo "::set-output name=CURRENT_TAG::$(git describe --tags --match "v*" --abbrev=0)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG FDB_VERSION=6.2.29
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM docker.io/library/golang:1.22.3 as builder
+FROM docker.io/library/golang:1.22.4 as builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE
@@ -45,7 +45,7 @@ RUN groupadd --gid 4059 fdb && \
 	mkdir -p /var/log/fdb && \
 	touch /var/log/fdb/.keep
 
-FROM docker.io/rockylinux:9.2-minimal
+FROM docker.io/rockylinux:9.3-minimal
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE

--- a/e2e/fixtures/fdb_data_loader.go
+++ b/e2e/fixtures/fdb_data_loader.go
@@ -221,7 +221,7 @@ spec:
       initContainers:
         {{ range $index, $version := .SidecarVersions }}
         - name: foundationdb-kubernetes-init-{{ $index }}
-          image: {{ .BaseImage }}:{{ .SidecarTag}}
+          image: {{ .Image }}
           imagePullPolicy: {{ .ImagePullPolicy }}
           args:
             - --mode


### PR DESCRIPTION
# Description

Update go version to 1.22.4 to include the latest security fixes: https://groups.google.com/g/golang-announce/c/XbxouI9gY7k

## Type of change

*Please select one of the options below.*

- Other

## Discussion

I also updated the RockyLinux version to the more recent 9.3.

## Testing

CI will run e2e tests.

## Documentation

-

## Follow-up

-
