### PR TITLE
Fix the calculation of expected processes during upgrades for multiple servers per pod

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -443,8 +443,6 @@ func checkIfEnoughProcessesAreRunning(logger logr.Logger, cluster *fdbv1beta2.Fo
 		}
 
 		expectedProcesses += (count - missingProcesses[processClass] + markedForRemoval[processClass]) * multiplier
-		delete(missingProcesses, processClass)
-		delete(markedForRemoval, processClass)
 	}
 
 	// If not all processes are ready to restart we will block the upgrade and delay it.


### PR DESCRIPTION
# Description

The previous calculation didn't account  properly for missing processes and processes that were marked for removal in the case of multiple servers per pod.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Updated the unit tests and ran a manual test.

## Documentation

-

## Follow-up

-