### PR TITLE
Fix e2e upgrade tests with chaos for unified image

### DIFF
--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -879,6 +879,11 @@ func (factory *Factory) getImagePullPolicy() corev1.PullPolicy {
 	return corev1.PullAlways
 }
 
+// UseUnifiedImage returns true if the e2e tests should use the unified image.
+func (factory *Factory) UseUnifiedImage() bool {
+	return factory.options.featureOperatorUnifiedImage
+}
+
 // UpdateNode update node definition
 func (fdbCluster *FdbCluster) UpdateNode(node *corev1.Node) {
 	gomega.Eventually(func() bool {

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -61,6 +61,12 @@ func (fdbCluster *FdbCluster) GetFDBImage() string {
 
 // GetSidecarImageForVersion return the sidecar image used for the specified version.
 func (fdbCluster *FdbCluster) GetSidecarImageForVersion(version string) string {
+	// In the case of the unified image the sidecar will also be the main container image.
+	if fdbCluster.cluster.UseUnifiedImage() {
+		return fdbv1beta2.SelectImageConfig(fdbCluster.GetClusterSpec().MainContainer.ImageConfigs, version).
+			Image()
+	}
+
 	return fdbv1beta2.SelectImageConfig(fdbCluster.GetClusterSpec().SidecarContainer.ImageConfigs, version).
 		Image()
 }
@@ -1194,12 +1200,11 @@ func (fdbCluster *FdbCluster) Destroy() error {
 }
 
 // SetIgnoreMissingProcessesSeconds sets the IgnoreMissingProcessesSeconds setting.
-func (fdbCluster *FdbCluster) SetIgnoreMissingProcessesSeconds(duration time.Duration) error {
+func (fdbCluster *FdbCluster) SetIgnoreMissingProcessesSeconds(duration time.Duration) {
 	fdbCluster.cluster.Spec.AutomationOptions.IgnoreMissingProcessesSeconds = pointer.Int(
 		int(duration.Seconds()),
 	)
 	fdbCluster.UpdateClusterSpec()
-	return fdbCluster.WaitForReconciliation()
 }
 
 // SetKillProcesses sets the automation option to allow the operator to restart processes or not.

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -42,7 +42,7 @@ func (factory *Factory) createFDBClusterSpec(
 	config *ClusterConfig,
 	databaseConfiguration fdbv1beta2.DatabaseConfiguration,
 ) *fdbv1beta2.FoundationDBCluster {
-	useUnifiedImage := pointer.BoolDeref(config.UseUnifiedImage, factory.options.featureOperatorUnifiedImage)
+	useUnifiedImage := pointer.BoolDeref(config.UseUnifiedImage, factory.UseUnifiedImage())
 	imageType := fdbv1beta2.ImageTypeSplit
 	if useUnifiedImage {
 		imageType = fdbv1beta2.ImageTypeUnified
@@ -121,7 +121,7 @@ func (factory *Factory) createPodTemplate(
 	var initContainers []corev1.Container
 	var annotations map[string]string
 	// In the case of the unified image we don't need to use an init container.
-	if !factory.options.featureOperatorUnifiedImage {
+	if !factory.UseUnifiedImage() {
 		initContainers = []corev1.Container{
 			{
 				Name:            fdbv1beta2.InitContainerName,

--- a/e2e/fixtures/fdb_data_loader.go
+++ b/e2e/fixtures/fdb_data_loader.go
@@ -315,7 +315,7 @@ func (factory *Factory) CreateDataLoaderIfAbsent(cluster *FdbCluster) {
 	}
 
 	dataLoaderJobTemplate := dataLoaderJob
-	if factory.options.featureOperatorUnifiedImage {
+	if factory.UseUnifiedImage() {
 		dataLoaderJobTemplate = dataLoaderJobUnifiedImage
 	}
 	t, err := template.New("dataLoaderJob").Parse(dataLoaderJobTemplate)

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -564,7 +564,7 @@ func (factory *Factory) getSidecarConfigs(imageConfigs []fdbv1beta2.ImageConfig)
 // GetSidecarConfigs returns the sidecar configs. The sidecar configs can be used to template applications that will use
 // all provided sidecar versions to inject FDB client libraries.
 func (factory *Factory) GetSidecarConfigs() []SidecarConfig {
-	if factory.options.featureOperatorUnifiedImage {
+	if factory.UseUnifiedImage() {
 		return factory.getSidecarConfigs(factory.GetMainContainerOverrides(false, true).ImageConfigs)
 	}
 
@@ -629,7 +629,7 @@ func (factory *Factory) CreateFDBOperatorIfAbsent(namespace string) error {
 	}
 
 	deploymentTemplate := operatorDeployment
-	if factory.options.featureOperatorUnifiedImage {
+	if factory.UseUnifiedImage() {
 		deploymentTemplate = operatorDeploymentUnifiedImage
 	}
 

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -315,6 +315,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
 
+	// TODO double check failure!!
 	DescribeTable(
 		"upgrading a cluster and one coordinator is not restarted",
 		func(beforeVersion string, targetVersion string) {
@@ -459,7 +460,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
 
-	DescribeTable(
+	FDescribeTable(
 		"one process is marked for removal",
 		func(beforeVersion string, targetVersion string) {
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
@@ -507,6 +508,8 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 					if !ok || fdbv1beta2.ProcessGroupID(processGroupID) != processGroupMarkedForRemoval {
 						continue
 					}
+
+					log.Println("processGroupMarkedForRemoval:", processGroupMarkedForRemoval, "processGroupID:", processGroupID, "version", process.Version)
 
 					return process.Version
 				}

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -460,7 +460,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
 
-	FDescribeTable(
+	DescribeTable(
 		"one process is marked for removal",
 		func(beforeVersion string, targetVersion string) {
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -315,7 +315,6 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
 
-	// TODO double check failure!!
 	DescribeTable(
 		"upgrading a cluster and one coordinator is not restarted",
 		func(beforeVersion string, targetVersion string) {


### PR DESCRIPTION
# Description

Some of the e2e upgrade tests with chaos had some assumption that were only true for the split image approach.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

I ran those tests manually with the fix from https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2056.

## Documentation

-

## Follow-up

-
