### PR TITLE
Set log dir and log group through environment variables for unified image

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2468,6 +2468,15 @@ func (cluster *FoundationDBCluster) NeedsReplacement(processGroup *ProcessGroupS
 	return processGroup.ProcessClass.IsTransaction()
 }
 
+// GetLogGroup returns the cluster's logGroup for use in trace logs
+func (cluster *FoundationDBCluster) GetLogGroup() string {
+	logGroup := cluster.Spec.LogGroup
+	if logGroup == "" {
+		logGroup = cluster.Name
+	}
+	return logGroup
+}
+
 // GetResourceLabels returns the resource labels for all created resources
 func (cluster *FoundationDBCluster) GetResourceLabels() map[string]string {
 	if cluster.Spec.LabelConfig.ResourceLabels != nil {

--- a/internal/monitor_conf.go
+++ b/internal/monitor_conf.go
@@ -166,10 +166,7 @@ func GetMonitorProcessConfiguration(cluster *fdbv1beta2.FoundationDBCluster, pro
 		configuration.RunServers = pointer.Bool(false)
 	}
 
-	logGroup := cluster.Spec.LogGroup
-	if logGroup == "" {
-		logGroup = cluster.Name
-	}
+	logGroup := cluster.GetLogGroup()
 
 	var zoneVariable string
 	if strings.HasPrefix(cluster.Spec.FaultDomain.ValueFrom, "$") {

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -207,8 +207,8 @@ func configureContainersForUnifiedImages(cluster *fdbv1beta2.FoundationDBCluster
 	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: "FDB_POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
 		FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 	}})
-	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: "FDB_NETWORK_OPTION_TRACE_LOG_GROUP", Value: cluster.GetLogGroup()})
-	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: "FDB_NETWORK_OPTION_TRACE_ENABLE", Value: "/var/log/fdb-trace-logs"})
+	extendEnv(mainContainer, corev1.EnvVar{Name: "FDB_NETWORK_OPTION_TRACE_LOG_GROUP", Value: cluster.GetLogGroup()},
+		corev1.EnvVar{Name: "FDB_NETWORK_OPTION_TRACE_ENABLE", Value: "/var/log/fdb-trace-logs"})
 	if cluster.DefineDNSLocalityFields() {
 		mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: "FDB_DNS_NAME", Value: GetPodDNSName(cluster, processGroup.GetPodName(cluster))})
 	}

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -569,10 +569,7 @@ var _ = Describe("pod_models", func() {
 						{Name: "shared-binaries", MountPath: "/var/fdb/shared-binaries"},
 						{Name: "fdb-trace-logs", MountPath: "/var/log/fdb-trace-logs"},
 					}))
-					Expect(sidecarContainer.Env).To(Equal([]corev1.EnvVar{
-						{Name: "FDB_NETWORK_OPTION_TRACE_LOG_GROUP", Value: cluster.Name},
-						{Name: "FDB_NETWORK_OPTION_TRACE_ENABLE", Value: "/var/log/fdb-trace-logs"},
-					}))
+					Expect(sidecarContainer.Env).To(BeNil())
 					Expect(sidecarContainer.ReadinessProbe).To(BeNil())
 					Expect(*sidecarContainer.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
 				})

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -534,6 +534,8 @@ var _ = Describe("pod_models", func() {
 						{Name: "FDB_POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 						}},
+						{Name: "FDB_NETWORK_OPTION_TRACE_LOG_GROUP", Value: cluster.Name},
+						{Name: "FDB_NETWORK_OPTION_TRACE_ENABLE", Value: "/var/log/fdb-trace-logs"},
 					}))
 
 					Expect(*mainContainer.Resources.Limits.Cpu()).To(Equal(resource.MustParse("1")))
@@ -567,7 +569,10 @@ var _ = Describe("pod_models", func() {
 						{Name: "shared-binaries", MountPath: "/var/fdb/shared-binaries"},
 						{Name: "fdb-trace-logs", MountPath: "/var/log/fdb-trace-logs"},
 					}))
-					Expect(sidecarContainer.Env).To(BeNil())
+					Expect(sidecarContainer.Env).To(Equal([]corev1.EnvVar{
+						{Name: "FDB_NETWORK_OPTION_TRACE_LOG_GROUP", Value: cluster.Name},
+						{Name: "FDB_NETWORK_OPTION_TRACE_ENABLE", Value: "/var/log/fdb-trace-logs"},
+					}))
 					Expect(sidecarContainer.ReadinessProbe).To(BeNil())
 					Expect(*sidecarContainer.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
 				})
@@ -644,6 +649,8 @@ var _ = Describe("pod_models", func() {
 						{Name: "FDB_POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 						}},
+						{Name: "FDB_NETWORK_OPTION_TRACE_LOG_GROUP", Value: cluster.Name},
+						{Name: "FDB_NETWORK_OPTION_TRACE_ENABLE", Value: "/var/log/fdb-trace-logs"},
 					}))
 				})
 
@@ -698,6 +705,8 @@ var _ = Describe("pod_models", func() {
 						{Name: "FDB_POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 						}},
+						{Name: "FDB_NETWORK_OPTION_TRACE_LOG_GROUP", Value: cluster.Name},
+						{Name: "FDB_NETWORK_OPTION_TRACE_ENABLE", Value: "/var/log/fdb-trace-logs"},
 					}))
 				})
 
@@ -754,6 +763,8 @@ var _ = Describe("pod_models", func() {
 						{Name: "FDB_POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 						}},
+						{Name: "FDB_NETWORK_OPTION_TRACE_LOG_GROUP", Value: cluster.Name},
+						{Name: "FDB_NETWORK_OPTION_TRACE_ENABLE", Value: "/var/log/fdb-trace-logs"},
 					}))
 				})
 


### PR DESCRIPTION
# Description

fixes https://github.com/FoundationDB/fdb-kubernetes-operator/issues/245

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

N/A

## Testing

Unit tests, 
spun up e2e tests and checked that the logs are sent to the directory specified by the env variable, and that they all included the expected log group (cluster.spec.logGroup) incl. the logs from fdbcli

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*
Don't think so, no

## Documentation

I don't think documentation change is needed, I think the issue is that there is nothing passively allowing logging to work and that this shouldn't be intrusive.  Do let me know if that sounds wrong!

## Follow-up

N/A
