### PR TITLE
Add another ha e2e test for pod failures

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1236,7 +1236,7 @@ type TaintReplacementOption struct {
 // failed processes.
 type AutomaticReplacementOptions struct {
 	// Enabled controls whether automatic replacements are enabled.
-	// The default is false.
+	// The default is true.
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// FaultDomainBasedReplacements controls whether automatic replacements are targeting all failed process groups

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -46,7 +46,7 @@ AutomaticReplacementOptions controls options for automatically replacing failed 
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| enabled | Enabled controls whether automatic replacements are enabled. The default is false. | *bool | false |
+| enabled | Enabled controls whether automatic replacements are enabled. The default is true. | *bool | false |
 | faultDomainBasedReplacements | FaultDomainBasedReplacements controls whether automatic replacements are targeting all failed process groups in a fault domain or only specific Process Groups. If this setting is enabled, the number of different fault domains that can have all their failed process groups replaced at the same time will be equal to MaxConcurrentReplacements. e.g. MaxConcurrentReplacements = 2 would mean that at most 2 different fault domains can have their failed process groups replaced at the same time. The default is false. | *bool | false |
 | failureDetectionTimeSeconds | FailureDetectionTimeSeconds controls how long a process must be failed or missing before it is automatically replaced. The default is 7200 seconds, or 2 hours. | *int | false |
 | taintReplacementTimeSeconds | TaintReplacementTimeSeconds controls how long a pod stays in NodeTaintReplacing condition before it is automatically replaced. The default is 1800 seconds, i.e., 30min | *int | false |


### PR DESCRIPTION
# Description

Add another test case to cover: https://forums.foundationdb.org/t/multi-dc-coordinators/4503/6

I have to add some additional steps, but all of them should already be covered in other (e2e) tests.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

Tested manually:

```text
ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.001 seconds]
------------------------------

Ran 1 of 3 Specs in 924.803 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 2 Skipped
PASS | FOCUSED
FAIL    github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_ha    925.298s
FAIL
```

## Documentation

-

## Follow-up

-