### PR TITLE
use extendEnv instead of append to container.Env

### DIFF
--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -184,12 +184,13 @@ func configureContainersForUnifiedImages(cluster *fdbv1beta2.FoundationDBCluster
 		"--input-dir", "/var/dynamic-conf",
 		"--log-path", "/var/log/fdb-trace-logs/monitor.log",
 	}
+	var mainContainerEnv []corev1.EnvVar
 
 	serversPerPod := cluster.GetDesiredServersPerPod(processGroup.ProcessClass)
 	if serversPerPod > 1 {
 		desiredServersPerPod := strconv.Itoa(serversPerPod)
 		mainContainer.Args = append(mainContainer.Args, "--process-count", desiredServersPerPod)
-		mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: processGroup.ProcessClass.GetServersPerPodEnvName(), Value: desiredServersPerPod})
+		mainContainerEnv = append(mainContainerEnv, corev1.EnvVar{Name: processGroup.ProcessClass.GetServersPerPodEnvName(), Value: desiredServersPerPod})
 	}
 
 	mainContainer.VolumeMounts = append(mainContainer.VolumeMounts,
@@ -199,27 +200,28 @@ func configureContainersForUnifiedImages(cluster *fdbv1beta2.FoundationDBCluster
 		corev1.VolumeMount{Name: "fdb-trace-logs", MountPath: "/var/log/fdb-trace-logs"},
 	)
 
-	mainContainer.Env = append(mainContainer.Env, getEnvForMonitorConfigSubstitution(cluster, processGroup.ProcessGroupID)...)
-	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: "FDB_POD_NAME", ValueFrom: &corev1.EnvVarSource{
-		FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-	}})
-	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: "FDB_POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
-		FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
-	}})
-	extendEnv(mainContainer, corev1.EnvVar{Name: "FDB_NETWORK_OPTION_TRACE_LOG_GROUP", Value: cluster.GetLogGroup()},
-		corev1.EnvVar{Name: "FDB_NETWORK_OPTION_TRACE_ENABLE", Value: "/var/log/fdb-trace-logs"})
-
+	mainContainerEnv = append(mainContainerEnv,
+		corev1.EnvVar{Name: "FDB_POD_NAME", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+		}},
+		corev1.EnvVar{Name: "FDB_POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+		}},
+		corev1.EnvVar{Name: "FDB_NETWORK_OPTION_TRACE_LOG_GROUP", Value: cluster.GetLogGroup()},
+		corev1.EnvVar{Name: "FDB_NETWORK_OPTION_TRACE_ENABLE", Value: "/var/log/fdb-trace-logs"},
+	)
+	mainContainerEnv = append(mainContainerEnv, getEnvForMonitorConfigSubstitution(cluster, processGroup.ProcessGroupID)...)
+	if cluster.DefineDNSLocalityFields() {
+		mainContainerEnv = append(mainContainerEnv, corev1.EnvVar{Name: "FDB_DNS_NAME", Value: GetPodDNSName(cluster, processGroup.GetPodName(cluster))})
+	}
 	// Allow the fdb-kubernetes-monitor to read the node labels and provide them as custom variables.
 	if cluster.EnableNodeWatch() {
 		mainContainer.Args = append(mainContainer.Args, "--enable-node-watch")
-		extendEnv(mainContainer, corev1.EnvVar{Name: "FDB_NODE_NAME", ValueFrom: &corev1.EnvVarSource{
+		mainContainerEnv = append(mainContainerEnv, corev1.EnvVar{Name: "FDB_NODE_NAME", ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 		}})
 	}
-
-	if cluster.DefineDNSLocalityFields() {
-		mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: "FDB_DNS_NAME", Value: GetPodDNSName(cluster, processGroup.GetPodName(cluster))})
-	}
+	extendEnv(mainContainer, mainContainerEnv...)
 
 	sidecarImage, err := GetImage(sidecarContainer.Image, cluster.Spec.MainContainer.ImageConfigs, desiredVersion, false)
 	if err != nil {
@@ -473,7 +475,7 @@ func GetPodSpec(cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta
 
 		serversPerPod := cluster.GetDesiredServersPerPod(processGroup.ProcessClass)
 		if serversPerPod > 1 {
-			sidecarContainer.Env = append(sidecarContainer.Env, corev1.EnvVar{Name: processGroup.ProcessClass.GetServersPerPodEnvName(), Value: strconv.Itoa(serversPerPod)})
+			extendEnv(sidecarContainer, corev1.EnvVar{Name: processGroup.ProcessClass.GetServersPerPodEnvName(), Value: strconv.Itoa(serversPerPod)})
 		}
 	}
 

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -809,6 +809,7 @@ func extendEnv(container *corev1.Container, env ...corev1.EnvVar) {
 	for _, envVar := range env {
 		if !existingVars[envVar.Name] {
 			container.Env = append(container.Env, envVar)
+			existingVars[envVar.Name] = true
 		}
 	}
 }

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -514,7 +514,7 @@ var _ = Describe("pod_models", func() {
 						"--log-path", "/var/log/fdb-trace-logs/monitor.log",
 					}))
 
-					Expect(mainContainer.Env).To(Equal([]corev1.EnvVar{
+					Expect(mainContainer.Env).To(ContainElements([]corev1.EnvVar{
 						{Name: "FDB_CLUSTER_FILE", Value: "/var/dynamic-conf/fdb.cluster"},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
@@ -624,7 +624,7 @@ var _ = Describe("pod_models", func() {
 						"--process-count", "2",
 					}))
 
-					Expect(mainContainer.Env).To(Equal([]corev1.EnvVar{
+					Expect(mainContainer.Env).To(ContainElements([]corev1.EnvVar{
 						{Name: "FDB_CLUSTER_FILE", Value: "/var/dynamic-conf/fdb.cluster"},
 						{Name: "STORAGE_SERVERS_PER_POD", Value: "2"},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
@@ -680,7 +680,7 @@ var _ = Describe("pod_models", func() {
 						"--log-path", "/var/log/fdb-trace-logs/monitor.log",
 					}))
 
-					Expect(mainContainer.Env).To(Equal([]corev1.EnvVar{
+					Expect(mainContainer.Env).To(ContainElements([]corev1.EnvVar{
 						{Name: "FDB_CLUSTER_FILE", Value: "/var/dynamic-conf/fdb.cluster"},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
@@ -736,7 +736,7 @@ var _ = Describe("pod_models", func() {
 						"--process-count", "2",
 					}))
 
-					Expect(mainContainer.Env).To(Equal([]corev1.EnvVar{
+					Expect(mainContainer.Env).To(ContainElements([]corev1.EnvVar{
 						{Name: "FDB_CLUSTER_FILE", Value: "/var/dynamic-conf/fdb.cluster"},
 						{Name: "LOG_SERVERS_PER_POD", Value: "2"},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -514,7 +514,7 @@ var _ = Describe("pod_models", func() {
 						"--log-path", "/var/log/fdb-trace-logs/monitor.log",
 					}))
 
-					Expect(mainContainer.Env).To(ContainElements([]corev1.EnvVar{
+					Expect(mainContainer.Env).To(ConsistOf([]corev1.EnvVar{
 						{Name: "FDB_CLUSTER_FILE", Value: "/var/dynamic-conf/fdb.cluster"},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
@@ -624,7 +624,7 @@ var _ = Describe("pod_models", func() {
 						"--process-count", "2",
 					}))
 
-					Expect(mainContainer.Env).To(ContainElements([]corev1.EnvVar{
+					Expect(mainContainer.Env).To(ConsistOf([]corev1.EnvVar{
 						{Name: "FDB_CLUSTER_FILE", Value: "/var/dynamic-conf/fdb.cluster"},
 						{Name: "STORAGE_SERVERS_PER_POD", Value: "2"},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
@@ -680,7 +680,7 @@ var _ = Describe("pod_models", func() {
 						"--log-path", "/var/log/fdb-trace-logs/monitor.log",
 					}))
 
-					Expect(mainContainer.Env).To(ContainElements([]corev1.EnvVar{
+					Expect(mainContainer.Env).To(ConsistOf([]corev1.EnvVar{
 						{Name: "FDB_CLUSTER_FILE", Value: "/var/dynamic-conf/fdb.cluster"},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
@@ -736,7 +736,7 @@ var _ = Describe("pod_models", func() {
 						"--process-count", "2",
 					}))
 
-					Expect(mainContainer.Env).To(ContainElements([]corev1.EnvVar{
+					Expect(mainContainer.Env).To(ConsistOf([]corev1.EnvVar{
 						{Name: "FDB_CLUSTER_FILE", Value: "/var/dynamic-conf/fdb.cluster"},
 						{Name: "LOG_SERVERS_PER_POD", Value: "2"},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
# Description

this helps avoid collisions in the case that a variable is declared in the cluster spec already (collisions will prevent Patch()s and prevent Operator from functioning normally)

## Type of change

- minor improvement

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

## Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
