### PR TITLE
Change the image type from an env variable to an annotation

### DIFF
--- a/api/v1beta2/foundationdb_env_variables.go
+++ b/api/v1beta2/foundationdb_env_variables.go
@@ -23,7 +23,4 @@ package v1beta2
 const (
 	// EnvNamePublicIP defines the FDB_PUBLIC_IP environment variable name.
 	EnvNamePublicIP = "FDB_PUBLIC_IP"
-
-	// EnvNameImageType defines the FDB_IMAGE_TYPE environment variable name.
-	EnvNameImageType = "FDB_IMAGE_TYPE"
 )

--- a/api/v1beta2/foundationdb_labels.go
+++ b/api/v1beta2/foundationdb_labels.go
@@ -52,6 +52,9 @@ const (
 	// The information is fetched from Pod.Spec.NodeName of the Pod resource.
 	NodeAnnotation = "foundationdb.org/current-node"
 
+	// ImageTypeAnnotation is an annotation key that specifies the image type of the Pod.
+	ImageTypeAnnotation = "foundationdb.org/image-type"
+
 	// FDBProcessGroupIDLabel represents the label that is used to represent a instance ID
 	FDBProcessGroupIDLabel = "foundationdb.org/fdb-process-group-id"
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1304,6 +1304,7 @@ var _ = Describe("cluster_controller", func() {
 							"foundationdb.org/existing-annotation": "test-value",
 							"fdb-annotation":                       "value1",
 							fdbv1beta2.NodeAnnotation:              item.Spec.NodeName,
+							fdbv1beta2.ImageTypeAnnotation:         string(fdbv1beta2.ImageTypeSplit),
 						}))
 					} else {
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
@@ -1312,6 +1313,7 @@ var _ = Describe("cluster_controller", func() {
 							fdbv1beta2.PublicIPSourceAnnotation: "pod",
 							"fdb-annotation":                    "value1",
 							fdbv1beta2.NodeAnnotation:           item.Spec.NodeName,
+							fdbv1beta2.ImageTypeAnnotation:      string(fdbv1beta2.ImageTypeSplit),
 						}))
 					}
 				}
@@ -1442,6 +1444,7 @@ var _ = Describe("cluster_controller", func() {
 							fdbv1beta2.LastSpecKey:              hash,
 							fdbv1beta2.PublicIPSourceAnnotation: "pod",
 							fdbv1beta2.NodeAnnotation:           item.Spec.NodeName,
+							fdbv1beta2.ImageTypeAnnotation:      string(fdbv1beta2.ImageTypeSplit),
 						}))
 					}
 
@@ -1551,6 +1554,7 @@ var _ = Describe("cluster_controller", func() {
 						fdbv1beta2.LastSpecKey:              hash,
 						fdbv1beta2.PublicIPSourceAnnotation: "pod",
 						fdbv1beta2.NodeAnnotation:           item.Spec.NodeName,
+						fdbv1beta2.ImageTypeAnnotation:      string(fdbv1beta2.ImageTypeSplit),
 					}))
 				}
 

--- a/controllers/update_metadata.go
+++ b/controllers/update_metadata.go
@@ -56,6 +56,7 @@ func (updateMetadata) reconcile(ctx context.Context, r *FoundationDBClusterRecon
 		if err != nil {
 			logger.Error(err, "Could not update Pod metadata",
 				"processGroupID", processGroup.ProcessGroupID)
+			shouldRequeue = true
 		}
 
 		// We can skip all stateless processes because they won't have a PVC attached.

--- a/controllers/update_metadata.go
+++ b/controllers/update_metadata.go
@@ -104,6 +104,8 @@ func (updateMetadata) reconcile(ctx context.Context, r *FoundationDBClusterRecon
 
 func metadataCorrect(desiredMetadata metav1.ObjectMeta, currentMetadata *metav1.ObjectMeta) bool {
 	desiredMetadata.Annotations[fdbv1beta2.LastSpecKey] = currentMetadata.Annotations[fdbv1beta2.LastSpecKey]
+	// Don't change the annotation for the image type, this will require a pod update.
+	desiredMetadata.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(internal.GetImageTypeFromAnnotation(currentMetadata.Annotations))
 	// If the annotations or labels have changed the metadata has to be updated.
 	return !mergeLabelsInMetadata(currentMetadata, desiredMetadata) && !mergeAnnotations(currentMetadata, desiredMetadata)
 }

--- a/controllers/update_metadata_test.go
+++ b/controllers/update_metadata_test.go
@@ -36,9 +36,9 @@ var _ = Describe("Update metadata", func() {
 		expectedMeta metav1.ObjectMeta
 	}
 
-	DescribeTable("Test metadata correctness",
+	DescribeTable("test pod metadata correctness",
 		func(tc testCase) {
-			result := metadataCorrect(tc.metadata, &tc.pod.ObjectMeta)
+			result := podMetadataCorrect(tc.metadata, tc.pod)
 			Expect(result).To(Equal(tc.expected))
 			Expect(tc.pod.ObjectMeta.Labels).To(Equal(tc.expectedMeta.Labels))
 			Expect(tc.pod.ObjectMeta.Annotations).To(Equal(tc.expectedMeta.Annotations))
@@ -48,19 +48,22 @@ var _ = Describe("Update metadata", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbv1beta2.LastSpecKey: "1",
+							fdbv1beta2.LastSpecKey:         "1",
+							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 				expected: true,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 			},
@@ -70,19 +73,22 @@ var _ = Describe("Update metadata", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbv1beta2.LastSpecKey: "1",
+							fdbv1beta2.LastSpecKey:         "1",
+							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "2",
+						fdbv1beta2.LastSpecKey:         "2",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 				expected: true,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 			},
@@ -92,22 +98,25 @@ var _ = Describe("Update metadata", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbv1beta2.LastSpecKey: "1",
-							"special":              "43",
+							fdbv1beta2.LastSpecKey:         "1",
+							"special":                      "43",
+							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
-						"special":              "42",
+						fdbv1beta2.LastSpecKey:         "1",
+						"special":                      "42",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 				expected: false,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
-						"special":              "42",
+						fdbv1beta2.LastSpecKey:         "1",
+						"special":                      "42",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 			},
@@ -117,21 +126,24 @@ var _ = Describe("Update metadata", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbv1beta2.LastSpecKey: "1",
+							fdbv1beta2.LastSpecKey:         "1",
+							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
-						"controller/X":         "wrong",
+						fdbv1beta2.LastSpecKey:         "1",
+						"controller/X":                 "wrong",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 				expected: false,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
-						"controller/X":         "wrong",
+						fdbv1beta2.LastSpecKey:         "1",
+						"controller/X":                 "wrong",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 			},
@@ -141,21 +153,24 @@ var _ = Describe("Update metadata", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbv1beta2.LastSpecKey: "1",
-							"controller/X":         "wrong",
+							fdbv1beta2.LastSpecKey:         "1",
+							"controller/X":                 "wrong",
+							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 				expected: true,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
-						"controller/X":         "wrong",
+						fdbv1beta2.LastSpecKey:         "1",
+						"controller/X":                 "wrong",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 			},
@@ -165,22 +180,25 @@ var _ = Describe("Update metadata", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbv1beta2.LastSpecKey: "1",
-							"controller/X":         "true",
+							fdbv1beta2.LastSpecKey:         "1",
+							"controller/X":                 "true",
+							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 						},
 					},
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
-						"controller/X":         "wrong",
+						fdbv1beta2.LastSpecKey:         "1",
+						"controller/X":                 "wrong",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 				expected: false,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
-						"controller/X":         "wrong",
+						fdbv1beta2.LastSpecKey:         "1",
+						"controller/X":                 "wrong",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 			},
@@ -190,7 +208,8 @@ var _ = Describe("Update metadata", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbv1beta2.LastSpecKey: "1",
+							fdbv1beta2.LastSpecKey:         "1",
+							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 						},
 						Labels: map[string]string{
 							"test": "test",
@@ -199,13 +218,15 @@ var _ = Describe("Update metadata", func() {
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 				expected: true,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 					Labels: map[string]string{
 						"test": "test",
@@ -218,7 +239,8 @@ var _ = Describe("Update metadata", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbv1beta2.LastSpecKey: "1",
+							fdbv1beta2.LastSpecKey:         "1",
+							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 						},
 						Labels: map[string]string{
 							fdbv1beta2.FDBProcessClassLabel: "storage",
@@ -227,7 +249,8 @@ var _ = Describe("Update metadata", func() {
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 					Labels: map[string]string{
 						fdbv1beta2.FDBProcessClassLabel: "globalControllerLogger",
@@ -236,7 +259,8 @@ var _ = Describe("Update metadata", func() {
 				expected: false,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey: "1",
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 
 					Labels: map[string]string{
@@ -250,7 +274,8 @@ var _ = Describe("Update metadata", func() {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							fdbv1beta2.LastSpecKey: "1",
+							fdbv1beta2.LastSpecKey:         "1",
+							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 						},
 					},
 					Spec: corev1.PodSpec{
@@ -259,15 +284,47 @@ var _ = Describe("Update metadata", func() {
 				},
 				metadata: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey:    "1",
-						fdbv1beta2.NodeAnnotation: "testing-node",
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.NodeAnnotation:      "testing-node",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 				expected: false,
 				expectedMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.LastSpecKey:    "1",
-						fdbv1beta2.NodeAnnotation: "testing-node",
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.NodeAnnotation:      "testing-node",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
+					},
+				},
+			},
+		),
+		Entry("Metadata for image type is not matching",
+			testCase{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							fdbv1beta2.LastSpecKey:         "1",
+							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "testing-node",
+					},
+				},
+				metadata: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.NodeAnnotation:      "testing-node",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeUnified),
+					},
+				},
+				expected: false,
+				expectedMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.LastSpecKey:         "1",
+						fdbv1beta2.NodeAnnotation:      "testing-node",
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
 					},
 				},
 			},

--- a/e2e/test_operator_migrate_image_type/operator_migate_image_type_test.go
+++ b/e2e/test_operator_migrate_image_type/operator_migate_image_type_test.go
@@ -55,7 +55,7 @@ var _ = AfterSuite(func() {
 	factory.Shutdown()
 })
 
-var _ = Describe("Operator Migrate Image Type", Label("e2e"), func() {
+var _ = PDescribe("Operator Migrate Image Type", Label("e2e"), func() {
 	When("migrating from split to unified", func() {
 		BeforeEach(func() {
 			config := fixtures.DefaultClusterConfig(false)

--- a/e2e/test_operator_migrate_image_type/operator_migate_image_type_test.go
+++ b/e2e/test_operator_migrate_image_type/operator_migate_image_type_test.go
@@ -55,7 +55,7 @@ var _ = AfterSuite(func() {
 	factory.Shutdown()
 })
 
-var _ = PDescribe("Operator Migrate Image Type", Label("e2e"), func() {
+var _ = Describe("Operator Migrate Image Type", Label("e2e"), func() {
 	When("migrating from split to unified", func() {
 		BeforeEach(func() {
 			config := fixtures.DefaultClusterConfig(false)
@@ -65,7 +65,7 @@ var _ = PDescribe("Operator Migrate Image Type", Label("e2e"), func() {
 				factory.GetClusterOptions()...,
 			)
 
-			//Load some data async into the cluster. We will only block as long as the Job is created.
+			// Load some data async into the cluster. We will only block as long as the Job is created.
 			factory.CreateDataLoaderIfAbsent(fdbCluster)
 
 			// Update the cluster spec to run with the unified image.
@@ -114,7 +114,7 @@ var _ = PDescribe("Operator Migrate Image Type", Label("e2e"), func() {
 				factory.GetClusterOptions()...,
 			)
 
-			//Load some data async into the cluster. We will only block as long as the Job is created.
+			// Load some data async into the cluster. We will only block as long as the Job is created.
 			factory.CreateDataLoaderIfAbsent(fdbCluster)
 
 			// Update the cluster spec to run with the split image.

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -399,20 +399,16 @@ func podHasSidecarTLS(pod *corev1.Pod) bool {
 	return false
 }
 
-// GetImageType determines whether a pod is using the unified or the split
-// image.
+// GetImageType determines whether a pod is using the unified or the split image.
 func GetImageType(pod *corev1.Pod) fdbv1beta2.ImageType {
-	for _, container := range pod.Spec.Containers {
-		if container.Name != fdbv1beta2.MainContainerName {
-			continue
-		}
-		for _, envVar := range container.Env {
-			if envVar.Name == fdbv1beta2.EnvNameImageType {
-				return fdbv1beta2.ImageType(envVar.Value)
-			}
-		}
+	if pod.Annotations == nil {
+		return fdbv1beta2.ImageTypeSplit
 	}
 
+	imageType, ok := pod.Annotations[fdbv1beta2.ImageTypeAnnotation]
+	if ok {
+		return fdbv1beta2.ImageType(imageType)
+	}
 	return fdbv1beta2.ImageTypeSplit
 }
 

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -401,14 +401,20 @@ func podHasSidecarTLS(pod *corev1.Pod) bool {
 
 // GetImageType determines whether a pod is using the unified or the split image.
 func GetImageType(pod *corev1.Pod) fdbv1beta2.ImageType {
-	if pod.Annotations == nil {
+	return GetImageTypeFromAnnotation(pod.Annotations)
+}
+
+// GetImageTypeFromAnnotation determines whether a pod is using the unified or the split image based on the annotations.
+func GetImageTypeFromAnnotation(annotations map[string]string) fdbv1beta2.ImageType {
+	if annotations == nil {
 		return fdbv1beta2.ImageTypeSplit
 	}
 
-	imageType, ok := pod.Annotations[fdbv1beta2.ImageTypeAnnotation]
+	imageType, ok := annotations[fdbv1beta2.ImageTypeAnnotation]
 	if ok {
 		return fdbv1beta2.ImageType(imageType)
 	}
+
 	return fdbv1beta2.ImageTypeSplit
 }
 

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -200,7 +200,6 @@ func configureContainersForUnifiedImages(cluster *fdbv1beta2.FoundationDBCluster
 	)
 
 	mainContainer.Env = append(mainContainer.Env, getEnvForMonitorConfigSubstitution(cluster, processGroup.ProcessGroupID)...)
-	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: fdbv1beta2.EnvNameImageType, Value: string(fdbv1beta2.ImageTypeUnified)})
 	mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: "FDB_POD_NAME", ValueFrom: &corev1.EnvVarSource{
 		FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 	}})
@@ -1031,6 +1030,7 @@ func GetPodMetadata(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1b
 	}
 	metadata.Annotations[fdbv1beta2.LastSpecKey] = specHash
 	metadata.Annotations[fdbv1beta2.PublicIPSourceAnnotation] = string(cluster.GetPublicIPSource())
+	metadata.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(cluster.DesiredImageType())
 
 	return metadata
 }

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -531,7 +531,6 @@ var _ = Describe("replace_misconfigured_pods", func() {
 						})
 					})
 				})
-
 			})
 		})
 


### PR DESCRIPTION
# Description

It's probably better and more flexible to use an annotation instead of an env variable on the Pod.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

I'm running the migration test suite manually (will update the result here).

## Documentation

-

## Follow-up

-
