### PR TITLE
Add a test case for a multi-region cluster where the majority of coordinators fail

### DIFF
--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -856,12 +856,11 @@ func (fdbCluster *FdbCluster) SetProcessGroupPrefix(prefix string) error {
 
 // SetSkipReconciliation will set the skip setting for the current FoundationDBCluster. This setting will make sure that
 // the operator is not taking any actions on this cluster.
-func (fdbCluster *FdbCluster) SetSkipReconciliation(skip bool) error {
+func (fdbCluster *FdbCluster) SetSkipReconciliation(skip bool) {
 	fdbCluster.cluster.Spec.Skip = skip
 	// Skip wait for reconciliation since this spec update is in the operator itself and by setting it, the operator
 	// skips reconciliation.
 	fdbCluster.UpdateClusterSpec()
-	return nil
 }
 
 // WaitForPodRemoval will wait until the specified Pod is deleted.

--- a/e2e/fixtures/kubernetes_fixtures.go
+++ b/e2e/fixtures/kubernetes_fixtures.go
@@ -49,7 +49,8 @@ func (factory *Factory) MultipleNamespaces(config *ClusterConfig, dcIDs []string
 	// If a namespace is provided in the config we will use this name as prefix.
 	if config.Namespace != "" {
 		factory.options.namespace = config.Namespace
-	} else {
+	} else if factory.options.namespace == "" {
+		// If not namespace is provided in the config or per command line, we will generate a random name.
 		factory.options.namespace = factory.getRandomizedNamespaceName()
 	}
 

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -589,7 +589,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var initialGeneration int64
 
 		BeforeEach(func() {
-			Expect(fdbCluster.SetSkipReconciliation(true)).ShouldNot(HaveOccurred())
+			fdbCluster.SetSkipReconciliation(true)
 			initialGeneration = fdbCluster.GetCluster().Status.Generations.Reconciled
 		})
 
@@ -608,7 +608,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		AfterEach(func() {
-			Expect(fdbCluster.SetSkipReconciliation(false)).ShouldNot(HaveOccurred())
+			fdbCluster.SetSkipReconciliation(false)
 		})
 	})
 
@@ -1820,13 +1820,13 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			spec.ProcessCounts.Test = 0
 			fdbCluster.UpdateClusterSpecWithSpec(spec)
 			// Let the operator fix the issue.
-			Expect(fdbCluster.SetSkipReconciliation(false)).NotTo(HaveOccurred())
+			fdbCluster.SetSkipReconciliation(false)
 		})
 
 		When("the tester process fails", func() {
 			BeforeEach(func() {
 				// Make sure the operator is not taking any action as long as we are preparing the setup
-				Expect(fdbCluster.SetSkipReconciliation(true)).NotTo(HaveOccurred())
+				fdbCluster.SetSkipReconciliation(true)
 				// We don't need the tester process anymore
 				spec := fdbCluster.GetCluster().Spec.DeepCopy()
 				spec.ProcessCounts.Test = 0
@@ -1860,7 +1860,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				}
 
 				// Let the operator fix the issue.
-				Expect(fdbCluster.SetSkipReconciliation(false)).NotTo(HaveOccurred())
+				fdbCluster.SetSkipReconciliation(false)
 			})
 
 			It("should show the status without any messages", func() {
@@ -1885,7 +1885,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			BeforeEach(func() {
 				// Make sure the operator is not taking any action as long as we are preparing the setup
-				Expect(fdbCluster.SetSkipReconciliation(true)).NotTo(HaveOccurred())
+				fdbCluster.SetSkipReconciliation(true)
 
 				var partitionedPod corev1.Pod
 
@@ -1927,7 +1927,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				}
 
 				// Let the operator fix the issue.
-				Expect(fdbCluster.SetSkipReconciliation(false)).NotTo(HaveOccurred())
+				fdbCluster.SetSkipReconciliation(false)
 			})
 
 			AfterEach(func() {
@@ -1997,7 +1997,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				)) * time.Second
 				Expect(fdbCluster.SetAutoReplacements(false, 30*time.Hour)).ShouldNot(HaveOccurred())
 				// Make sure the operator is not taking any action to prevent any race condition.
-				Expect(fdbCluster.SetSkipReconciliation(true)).NotTo(HaveOccurred())
+				fdbCluster.SetSkipReconciliation(true)
 
 				// Delete all Pods
 				pods := fdbCluster.GetPods()
@@ -2013,7 +2013,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				}).WithTimeout(5 * time.Minute).WithPolling(2 * time.Second).Should(BeEmpty())
 
 				// Enable the operator again
-				Expect(fdbCluster.SetSkipReconciliation(false)).NotTo(HaveOccurred())
+				fdbCluster.SetSkipReconciliation(false)
 			})
 
 			It("should recreate all Pods and bring the cluster into a healthy state again", func() {
@@ -2029,7 +2029,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			})
 
 			AfterEach(func() {
-				Expect(fdbCluster.SetSkipReconciliation(false)).NotTo(HaveOccurred())
+				fdbCluster.SetSkipReconciliation(false)
 				Expect(fdbCluster.SetAutoReplacements(true, initialReplaceTime)).ShouldNot(HaveOccurred())
 			})
 		})

--- a/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
@@ -258,8 +258,8 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 
 			// Update the cluster version.
 			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
-			// Skip the reonciliation here to have time to stage everything.
-			Expect(fdbCluster.SetSkipReconciliation(true)).NotTo(HaveOccurred())
+			// Skip the reconciliation here to have time to stage everything.
+			fdbCluster.SetSkipReconciliation(true)
 
 			// Select one Pod, this Pod will mount the fdbmonitor config file as read-only.
 			// This should block the upgrade.
@@ -317,7 +317,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(HaveOccurred())
 
 			// Now we have the faulty Pod prepared with I/O chaos injected, so we can continue with the upgrade.
-			Expect(fdbCluster.SetSkipReconciliation(false)).NotTo(HaveOccurred())
+			fdbCluster.SetSkipReconciliation(false)
 
 			// The cluster will be stuck in this state until the I/O chaos is resolved.
 			expectedConditions := map[fdbv1beta2.ProcessGroupConditionType]bool{
@@ -373,7 +373,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			// Update the cluster version.
 			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
 			// Skip the reconciliation here to have time to stage everything.
-			Expect(fdbCluster.SetSkipReconciliation(true)).NotTo(HaveOccurred())
+			fdbCluster.SetSkipReconciliation(true)
 
 			// Select one Pod, this Pod will miss the new fdbserver binary.
 			// This should block the upgrade.
@@ -427,7 +427,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).ShouldNot(HaveOccurred())
 
 			// Now we have the faulty Pod prepared, so we can continue with the upgrade.
-			Expect(fdbCluster.SetSkipReconciliation(false)).NotTo(HaveOccurred())
+			fdbCluster.SetSkipReconciliation(false)
 
 			// The cluster will be stuck in this state until the Pod is restarted and the new binary is present.
 			expectedConditions := map[fdbv1beta2.ProcessGroupConditionType]bool{


### PR DESCRIPTION
# Description

The test is in pending mode as there is no way right now to recover the loss of the majority of coordinators. The idea for this test case is to have a repeatable way to test different recovery strategies.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

Ran manually.

## Documentation

-

## Follow-up

-
