### PR TITLE
Document the delay shutdown feature and check in update Pods if pod is missing

### DIFF
--- a/controllers/update_pods_test.go
+++ b/controllers/update_pods_test.go
@@ -318,7 +318,6 @@ var _ = Describe("update_pods", func() {
 		var cluster *fdbv1beta2.FoundationDBCluster
 		var updates map[string][]*corev1.Pod
 		var pvcMap map[fdbv1beta2.ProcessGroupID]corev1.PersistentVolumeClaim
-		var expectedError bool
 		var err error
 
 		BeforeEach(func() {
@@ -338,16 +337,30 @@ var _ = Describe("update_pods", func() {
 
 		JustBeforeEach(func() {
 			updates, err = getPodsToUpdate(context.Background(), globalControllerLogger, clusterReconciler, cluster, pvcMap)
-			if !expectedError {
-				Expect(err).NotTo(HaveOccurred())
-			} else {
-				Expect(err).To(HaveOccurred())
-			}
 		})
 
 		When("the cluster has no changes", func() {
 			It("should return no errors and an empty map", func() {
 				Expect(updates).To(HaveLen(0))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			When("a Pod is missing", func() {
+				BeforeEach(func() {
+					picked := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
+					pod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      picked.GetPodName(cluster),
+							Namespace: cluster.Namespace,
+						},
+					}
+					Expect(k8sClient.Delete(context.Background(), pod)).NotTo(HaveOccurred())
+				})
+
+				It("should return no errors and an empty map", func() {
+					Expect(updates).To(HaveLen(0))
+					Expect(err).NotTo(HaveOccurred())
+				})
 			})
 		})
 
@@ -362,8 +375,28 @@ var _ = Describe("update_pods", func() {
 			It("should return no errors and a map with one zone", func() {
 				// We only have one zone in this case, the simulation zone
 				Expect(updates).To(HaveLen(1))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			When("a Pod is missing", func() {
+				BeforeEach(func() {
+					picked := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
+					pod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      picked.GetPodName(cluster),
+							Namespace: cluster.Namespace,
+						},
+					}
+					Expect(k8sClient.Delete(context.Background(), pod)).NotTo(HaveOccurred())
+				})
+
+				It("should return an error and an empty map", func() {
+					Expect(updates).To(HaveLen(0))
+					Expect(err).To(HaveOccurred())
+				})
 			})
 		})
+
 		When("there is a spec change requiring a removal", func() {
 			BeforeEach(func() {
 				storageSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
@@ -375,6 +408,7 @@ var _ = Describe("update_pods", func() {
 
 			It("should return no updates", func() {
 				Expect(updates).To(HaveLen(0))
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 
@@ -387,7 +421,6 @@ var _ = Describe("update_pods", func() {
 
 			When("max zones with unavailable pods is set to 3", func() {
 				BeforeEach(func() {
-					expectedError = false
 					cluster.Spec.MaxZonesWithUnavailablePods = pointer.Int(3)
 					// Update all processes
 					storageSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
@@ -399,12 +432,12 @@ var _ = Describe("update_pods", func() {
 				It("should return no errors and a map with the zone and all pods to update", func() {
 					Expect(updates).To(HaveLen(1))
 					Expect(updates["simulation"]).To(HaveLen(4))
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 
 			When("max zones with unavailable pods is set to 2", func() {
 				BeforeEach(func() {
-					expectedError = false
 					cluster.Spec.MaxZonesWithUnavailablePods = pointer.Int(2)
 					// Update all processes
 					storageSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
@@ -416,12 +449,12 @@ var _ = Describe("update_pods", func() {
 				It("should return no errors and a map with the zone and two pods to update", func() {
 					Expect(updates).To(HaveLen(1))
 					Expect(updates["simulation"]).To(HaveLen(2))
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 
 			When("max zones with unavailable pods is set to 1", func() {
 				BeforeEach(func() {
-					expectedError = false
 					cluster.Spec.MaxZonesWithUnavailablePods = pointer.Int(1)
 					// Update all processes
 					storageSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
@@ -432,6 +465,7 @@ var _ = Describe("update_pods", func() {
 
 				It("should return no errors and a an empty update map", func() {
 					Expect(updates).To(HaveLen(0))
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 		})

--- a/docs/manual/operations.md
+++ b/docs/manual/operations.md
@@ -189,6 +189,15 @@ This will make sure that the processes are proactively excluded, instead of wait
 
 _NOTE_: You should always set the processes under maintenance before setting the maintenance mode. See [Internals](#internals) for more details.
 
+## Delaying the shutdown of the Pod
+
+When using the [unified image](./customization.md#unified-vs-split-images) the `fdb-kubernetes-monitor` supports to delay the shutdown of itself.
+The idea is to shutdown the fdbserver processes immediately, but keep the `fdb-kubernetes-monitor` process running for the specified `foundationdb.org/delay-shutdown`.
+The value of the `foundationdb.org/delay-shutdown` annotation must be a valid [golang duration](https://pkg.go.dev/time#ParseDuration).
+Per default the failure detection mechanism of FDB takes 60 seconds to detect a failed storage server.
+Setting the `foundationdb.org/delay-shutdown` annotation to a value greater than 60 seconds will give the FDB cluster additional time to detect the failure before shutting down the actual Pod.
+The value for `foundationdb.org/delay-shutdown` and `terminationGracePeriodSeconds` in the [Pod spec](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination) should either match or the `terminationGracePeriodSeconds` should be slightly higher than the delay shutdown.
+
 ### Risks and limitations
 
 There are a few risks and limitations to the current implementation:


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1876

## Type of change

- Documentation

## Discussion

-

## Testing

-

## Documentation

Updated.

## Follow-up

-