### PR TITLE
Add future defaults for operator 2.0 release

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2394,7 +2394,7 @@ func (cluster *FoundationDBCluster) NeedsHeadlessService() bool {
 // UseDNSInClusterFile determines whether we need to use DNS entries in the
 // cluster file for this cluster.
 func (cluster *FoundationDBCluster) UseDNSInClusterFile() bool {
-	runningVersion, err := ParseFdbVersion(cluster.Status.RunningVersion)
+	runningVersion, err := ParseFdbVersion(cluster.GetRunningVersion())
 	// If the version cannot be parsed fall back to false.
 	if err != nil {
 		return false

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -46,13 +46,14 @@ import (
 var _ = Describe("replace_misconfigured_pods", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
 	var log logr.Logger
+	var deprecationOptions internal.DeprecationOptions
 	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
 
 	BeforeEach(func() {
 		log = logf.Log.WithName("replacements")
 		cluster = internal.CreateDefaultCluster()
-		Expect(internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{UseFutureDefaults: true})).NotTo(HaveOccurred())
-
+		deprecationOptions = internal.DeprecationOptions{UseFutureDefaults: false}
+		Expect(internal.NormalizeClusterSpec(cluster, deprecationOptions)).NotTo(HaveOccurred())
 		cluster.Spec.LabelConfig.FilterOnOwnerReferences = pointer.Bool(false)
 	})
 
@@ -92,7 +93,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				pod.Spec = *spec
-				Expect(internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})).NotTo(HaveOccurred())
+				Expect(internal.NormalizeClusterSpec(cluster, deprecationOptions)).NotTo(HaveOccurred())
 			})
 
 			When("process group has no Pod", func() {
@@ -231,7 +232,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 						Expect(err).NotTo(HaveOccurred())
 
 						pod.Spec = *spec
-						Expect(internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})).NotTo(HaveOccurred())
+						Expect(internal.NormalizeClusterSpec(cluster, deprecationOptions)).NotTo(HaveOccurred())
 					})
 
 					It("should not need a removal", func() {
@@ -559,7 +560,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				pod.Spec = *spec
-				Expect(internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})).NotTo(HaveOccurred())
+				Expect(internal.NormalizeClusterSpec(cluster, deprecationOptions)).NotTo(HaveOccurred())
 			})
 
 			When("the storageServersPerPod is changed for a non storage class process group", func() {


### PR DESCRIPTION
# Description

The defaults will be changed in the operator 2.0 release: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1035

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Updated the unit tests.

## Documentation

-

## Follow-up

-
