### PR TITLE
Add support for isolating a process group in the operator

### DIFF
--- a/api/v1beta2/foundationdb_labels.go
+++ b/api/v1beta2/foundationdb_labels.go
@@ -48,6 +48,11 @@ const (
 	// IP for a pod.
 	PublicIPAnnotation = "foundationdb.org/public-ip"
 
+	// IsolateProcessGroupAnnotation is the annotation that defines if the current Pod should be isolated. Isolated
+	// process groups will shutdown the fdbserver instance but keep the Pod and other Kubernetes resources running
+	// for debugging purpose.
+	IsolateProcessGroupAnnotation = "foundationdb.org/isolate-process-group"
+
 	// NodeAnnotation is an annotation key that specifies where a Pod is currently running on.
 	// The information is fetched from Pod.Spec.NodeName of the Pod resource.
 	NodeAnnotation = "foundationdb.org/current-node"

--- a/docs/manual/debugging.md
+++ b/docs/manual/debugging.md
@@ -181,6 +181,7 @@ For an HA cluster you have to update all clusters that are managed by the operat
 
 _NOTE_: This feature requires the [unified image](./customization.md#unified-vs-split-images).
 _WARNING_: By design this feature can be disruptive as the `fdbserver` process will be directly shutdown by the `fdb-kubernetes-monitor` to keep the state of the Pod.
+_WARNING_: Since this mechanism is not set by the operator itself but with an annotation, that annotation will not be present if the Pod gets deleted. In the case that the Pod is not marked to be removed and not yet fully excluded, the operator will recreate the Pod. Otherwise all resources will be removed.
 
 There might be cases where it is useful to isolate a specific Pod or a set of Pods from the cluster, e.g. in cases where a user wants to debug data corruption or networking issues without affecting the actual cluster.
 In those cases a user can set the Pod annotation `foundationdb.org/isolate-process-group` to `true`.

--- a/docs/manual/debugging.md
+++ b/docs/manual/debugging.md
@@ -177,6 +177,18 @@ You can also update the config directly by providing the `--update` flag to the 
 Per default a diff of the new changes will be shown before updating the cluster spec.
 For an HA cluster you have to update all clusters that are managed by the operator with the same command to ensure that all operator instance want to converge to the same configuration. 
 
+## Isolate a faulty Pod
+
+_NOTE_: This feature requires the [unified image](./customization.md#unified-vs-split-images).
+_WARNING_: By design this feature can be disruptive as the `fdbserver` process will be directly shutdown by the `fdb-kubernetes-monitor` to keep the state of the Pod.
+
+There might be cases where it is useful to isolate a specific Pod or a set of Pods from the cluster, e.g. in cases where a user wants to debug data corruption or networking issues without affecting the actual cluster.
+In those cases a user can set the Pod annotation `foundationdb.org/isolate-process-group` to `true`.
+The `fdbkubernetesmonitor` will shutdown all instances of the `fdbserver`, but the operator will not delete the resources to allow debugging.
+Once the annotations are updated the user should trigger a replacement of those Pods.
+The replacement will make sure that the operator is starting new Pods for the isolated Pods.
+When the debugging is finished just remove the `foundationdb.org/isolate-process-group` annotation or set it to `false` and the operator will remove the associated resources.
+
 ## Next
 
 You can continue on to the [next section](more.md) or go back to the [table of contents](index.md).

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2507,9 +2507,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		AfterEach(func() {
 			pod := &corev1.Pod{}
-			Expect(factory.GetControllerRuntimeClient().Get(ctx.Background(), ctrlClient.ObjectKey{Name: isolatedPod.Name, Namespace: isolatedPod.Namespace}, pod)).NotTo(HaveOccurred())
+			Expect(factory.GetControllerRuntimeClient().Get(context.Background(), ctrlClient.ObjectKey{Name: isolatedPod.Name, Namespace: isolatedPod.Namespace}, pod)).NotTo(HaveOccurred())
 			pod.Annotations[fdbv1beta2.IsolateProcessGroupAnnotation] = "false"
-			Expect(factory.GetControllerRuntimeClient().Update(ctx.Background(), pod)).NotTo(HaveOccurred())
+			Expect(factory.GetControllerRuntimeClient().Update(context.Background(), pod)).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -31,14 +31,13 @@ This cluster will be used for all tests.
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"log"
 	"math"
 	"strings"
 	"time"
-
-	"k8s.io/apimachinery/pkg/types"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"
@@ -49,7 +48,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -2462,6 +2463,53 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			fdbCluster.UpdateClusterSpecWithSpec(spec)
 			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
 
+		})
+	})
+
+	When("the Pod is set into isolate mode", func() {
+		var isolatedPod corev1.Pod
+
+		BeforeEach(func() {
+			// If we are not using the unified image, we can skip this test.
+			if !fdbCluster.GetCluster().UseUnifiedImage() {
+				Skip("The sidecar image doesn't support reading node labels")
+			}
+
+			isolatedPod = factory.RandomPickOnePod(fdbCluster.GetStatelessPods().Items)
+			isolatedPod.Annotations[fdbv1beta2.IsolateProcessGroupAnnotation] = "true"
+			Expect(factory.GetControllerRuntimeClient().Update(context.Background(), &isolatedPod)).NotTo(HaveOccurred())
+			fdbCluster.ReplacePod(isolatedPod, false)
+		})
+
+		It("should shutdown the fdbserver processes of this Pod", func() {
+			processGroupID := string(fixtures.GetProcessGroupID(isolatedPod))
+			// Make sure the process is not reporting to the cluster.
+			Eventually(func(g Gomega) bool {
+				status := fdbCluster.GetStatus()
+				for _, process := range status.Cluster.Processes {
+					if process.ProcessClass != fdbv1beta2.ProcessClassStateless {
+						continue
+					}
+
+					g.Expect(process.Locality).NotTo(HaveKeyWithValue(fdbv1beta2.FDBLocalityInstanceIDKey, processGroupID))
+				}
+
+				return true
+			}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(BeTrue())
+
+			Consistently(func(g Gomega) *metav1.Time {
+				pod, err := factory.GetPod(isolatedPod.Namespace, isolatedPod.Name)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				return pod.DeletionTimestamp
+			}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(BeNil())
+		})
+
+		AfterEach(func() {
+			pod := &corev1.Pod{}
+			Expect(factory.GetControllerRuntimeClient().Get(ctx.Background(), ctrlClient.ObjectKey{Name: isolatedPod.Name, Namespace: isolatedPod.Namespace}, pod)).NotTo(HaveOccurred())
+			pod.Annotations[fdbv1beta2.IsolateProcessGroupAnnotation] = "false"
+			Expect(factory.GetControllerRuntimeClient().Update(ctx.Background(), pod)).NotTo(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1906

Operator support for https://github.com/apple/foundationdb/pull/11464.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Added a new e2e test for that and ran it manually:

```text
ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.003 seconds]
------------------------------

Ran 1 of 54 Specs in 424.461 seconds
SUCCESS! -- 1 Passed | 0 Failed | 10 Pending | 43 Skipped
PASS | FOCUSED
FAIL    github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator       424.992s
FAIL
```

## Documentation

Added the documentation for this new feature.

## Follow-up

-