### PR TITLE
Add better error message when command failed and remove flaky check

### DIFF
--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -75,7 +75,11 @@ func (fdbCluster *FdbCluster) RunFdbCliCommandInOperator(
 			timeout,
 		)
 
-		return fmt.Errorf("could not run the command: \"%s\": got an error: %w", command, err)
+		if err != nil {
+			return fmt.Errorf("could not run the command: \"%s\": got an error: %w", command, err)
+		}
+
+		return nil
 	}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).ShouldNot(gomega.HaveOccurred())
 
 	return stdout, stderr

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -75,7 +75,7 @@ func (fdbCluster *FdbCluster) RunFdbCliCommandInOperator(
 			timeout,
 		)
 
-		return err
+		return fmt.Errorf("could not run the command: \"%s\": got an error: %w", command, err)
 	}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).ShouldNot(gomega.HaveOccurred())
 
 	return stdout, stderr

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -507,24 +507,6 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			// Make sure the cluster is upgraded
 			fdbCluster.VerifyVersion(targetVersion)
 
-			// Make sure the process running inside the Pod that is marked for removal is running on the new version.
-			Eventually(func() string {
-				status := fdbCluster.GetStatus()
-
-				for _, process := range status.Cluster.Processes {
-					processGroupID, ok := process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]
-					if !ok || fdbv1beta2.ProcessGroupID(processGroupID) != processGroupMarkedForRemoval {
-						continue
-					}
-
-					log.Println("processGroupMarkedForRemoval:", processGroupMarkedForRemoval, "processGroupID:", processGroupID, "version", process.Version)
-
-					return process.Version
-				}
-
-				return ""
-			}).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).MustPassRepeatedly(5).Should(Equal(targetVersion))
-
 			// Make sure the other processes are updated to the new image and the operator is able to proceed with the upgrade.
 			Eventually(func() int {
 				var processesToUpdate int

--- a/internal/buggify/buggify.go
+++ b/internal/buggify/buggify.go
@@ -29,7 +29,6 @@ func FilterBlockedRemovals(cluster *fdbv1beta2.FoundationDBCluster, processGroup
 		return processGroupsToRemove
 	}
 
-	// processGroupsToRemove
 	blockedProcessGroups := make(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None, len(cluster.Spec.Buggify.BlockRemoval))
 	for _, blockedProcessGroup := range cluster.Spec.Buggify.BlockRemoval {
 		blockedProcessGroups[blockedProcessGroup] = fdbv1beta2.None{}


### PR DESCRIPTION
# Description

Return the actual command that failed. Also remove the `Eventually` statement as that one was flaky, there was a race condition where the test detected the process and then the operator updated that Pod with the new version, which would cause the test to fail (as the process would be missing and `MustPassRepeatedly(5)` was set).

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

Ran the tests manually.

## Documentation

-

## Follow-up

-
