### PR TITLE
Make sure to wait until the namespace is completely deleted

### DIFF
--- a/e2e/fixtures/chaos_common.go
+++ b/e2e/fixtures/chaos_common.go
@@ -23,10 +23,11 @@ package fixtures
 import (
 	ctx "context"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"log"
 	"strconv"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/onsi/gomega"
 

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -335,6 +335,7 @@ func (factory *Factory) Shutdown() {
 
 	factory.invariantShutdownHooks.InvokeShutdownHandlers()
 	factory.shutdownHooks.InvokeShutdownHandlers()
+	factory.shutdownInProgress = false
 }
 
 // Get returns the (eventually consistent) status of this cluster.  This is used when bootstrapping an

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -23,14 +23,15 @@ package fixtures
 import (
 	ctx "context"
 	"fmt"
-	"golang.org/x/sync/errgroup"
-	"k8s.io/apimachinery/pkg/types"
 	"log"
 	"math"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/client-go/util/retry"
 

--- a/e2e/fixtures/fdb_data_loader.go
+++ b/e2e/fixtures/fdb_data_loader.go
@@ -24,8 +24,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/onsi/gomega"
 	"io"
+	"text/template"
+	"time"
+
+	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,8 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"text/template"
-	"time"
 )
 
 const (

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -26,10 +26,11 @@ import (
 	"errors"
 	"html/template"
 	"io"
-	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"time"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 

--- a/e2e/fixtures/fdb_operator_fixtures.go
+++ b/e2e/fixtures/fdb_operator_fixtures.go
@@ -22,8 +22,9 @@ package fixtures
 
 import (
 	"fmt"
-	"github.com/onsi/gomega"
 	"log"
+
+	"github.com/onsi/gomega"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/e2e/fixtures/ha_fdb_cluster.go
+++ b/e2e/fixtures/ha_fdb_cluster.go
@@ -22,12 +22,13 @@ package fixtures
 
 import (
 	"fmt"
+	"strings"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/onsi/gomega"
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 // This file contains fixtures to set up HA configurations.

--- a/e2e/fixtures/pods.go
+++ b/e2e/fixtures/pods.go
@@ -23,11 +23,12 @@ package fixtures
 import (
 	"context"
 	"fmt"
-	"github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"log"
 	"math/rand"
 	"time"
+
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/equality"
 
 	"github.com/onsi/ginkgo/v2"
 

--- a/e2e/fixtures/singleton.go
+++ b/e2e/fixtures/singleton.go
@@ -21,9 +21,7 @@
 package fixtures
 
 import (
-	"math/rand"
 	"os/user"
-	"time"
 
 	chaosmesh "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -68,7 +66,6 @@ func getSingleton(options *FactoryOptions) (*singleton, error) {
 		userName = options.username
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	certificate, _ := GenerateCertificate()
 	if err != nil {
 		return nil, err

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -33,12 +33,13 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"log"
 	"math"
 	"math/rand"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -28,15 +28,16 @@ Each test will create a new HA FoundationDB cluster which will be upgraded.
 
 import (
 	"fmt"
-	"golang.org/x/sync/errgroup"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"

--- a/e2e/test_operator_maintenance_mode/operator_maintenance_mode_test.go
+++ b/e2e/test_operator_maintenance_mode/operator_maintenance_mode_test.go
@@ -26,10 +26,11 @@ This test suite includes tests around the interaction of the maintenance mode an
 
 import (
 	"fmt"
-	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
-	corev1 "k8s.io/api/core/v1"
 	"log"
 	"time"
+
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"
 	. "github.com/onsi/ginkgo/v2"

--- a/e2e/test_operator_migrate_image_type/operator_migate_image_type_test.go
+++ b/e2e/test_operator_migrate_image_type/operator_migate_image_type_test.go
@@ -26,12 +26,13 @@ This test suite includes tests for migrating between the different image types.
 */
 
 import (
+	"log"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
-	"log"
 )
 
 var (

--- a/e2e/test_operator_migrations/operator_migration_test.go
+++ b/e2e/test_operator_migrations/operator_migration_test.go
@@ -26,12 +26,13 @@ expected under different scenarios.
 */
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"strconv"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"
 	. "github.com/onsi/ginkgo/v2"


### PR DESCRIPTION
# Description

We have seen a few cases where the same namespace name is used when the e2e tests are running, so we should be waiting in the test setup until the namespace is deleted before using it. Waiting for it to be deleted will recreate the namespace and all required resources.

Some test  set a custom finalizer, this change checks for pods with a finalizer and resets them if one is set.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

CI will be running.

## Documentation

-

## Follow-up

-
