### PR TITLE
Randomize process group ids

### DIFF
--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -56,18 +56,14 @@ func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterR
 			continue
 		}
 
+		hasNewProcessGroups = true
 		logger.Info("Adding new Process Groups", "processClass", processClass, "newCount", newCount, "desiredCount", desiredCount, "currentCount", processCounts[processClass])
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "AddingProcesses", fmt.Sprintf("Adding %d %s processes", newCount, processClass))
-		idNum := 1
-
 		for i := 0; i < newCount; i++ {
-			var processGroupID fdbv1beta2.ProcessGroupID
-			processGroupID, idNum = cluster.GetNextProcessGroupID(processClass, processGroupIDs[processClass], idNum)
+			processGroupID := cluster.GetNextRandomProcessGroupID(processClass, processGroupIDs[processClass])
+			logger.Info("Adding new Process Group to cluster", "processClass", processClass, "processGroupID", processGroupID)
 			cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(processGroupID, processClass, nil))
-			// Increase the idNum here, since we just added a Process Group with this ID number.
-			idNum++
 		}
-		hasNewProcessGroups = true
 	}
 
 	if hasNewProcessGroups {

--- a/controllers/change_coordinators_test.go
+++ b/controllers/change_coordinators_test.go
@@ -133,12 +133,16 @@ var _ = Describe("Change coordinators", func() {
 			})
 
 			When("when multiple storage process are marked for removal", func() {
-				removals := []fdbv1beta2.ProcessGroupID{
-					"storage-2",
-					"storage-3",
-				}
+				var removals []fdbv1beta2.ProcessGroupID
 
 				BeforeEach(func() {
+					removals = make([]fdbv1beta2.ProcessGroupID, 0, 2)
+
+					for _, processGroup := range internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2) {
+						removals = append(removals, processGroup.ProcessGroupID)
+						processGroup.MarkForRemoval()
+					}
+
 					cluster.Spec.ProcessGroupsToRemove = removals
 					for _, removal := range removals {
 						Expect(cluster.ProcessGroupIsBeingRemoved(removal)).To(BeTrue())

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -92,7 +92,7 @@ func sortPodsByName(pods *corev1.PodList) {
 	})
 }
 
-var _ = FDescribe("cluster_controller", func() {
+var _ = Describe("cluster_controller", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
 	var fakeConnectionString string
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -92,7 +92,7 @@ func sortPodsByName(pods *corev1.PodList) {
 	})
 }
 
-var _ = Describe("cluster_controller", func() {
+var _ = FDescribe("cluster_controller", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
 	var fakeConnectionString string
 
@@ -168,23 +168,24 @@ var _ = Describe("cluster_controller", func() {
 
 				sortPodsByName(pods)
 
-				Expect(pods.Items[0].Name).To(Equal("operator-test-1-cluster-controller-1"))
-				Expect(pods.Items[0].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("cluster_controller-1"))
+				Expect(pods.Items[0].Name).To(HavePrefix("operator-test-1-cluster-controller-"))
+				Expect(pods.Items[0].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("cluster_controller-"))
+				Expect(pods.Items[0].Labels[fdbv1beta2.FDBProcessClassLabel]).To(Equal(string(fdbv1beta2.ProcessClassClusterController)))
 				Expect(pods.Items[0].Annotations[fdbv1beta2.PublicIPSourceAnnotation]).To(Equal("pod"))
 				Expect(pods.Items[0].Annotations[fdbv1beta2.PublicIPAnnotation]).To(Equal(""))
 
-				Expect(pods.Items[1].Name).To(Equal("operator-test-1-log-1"))
-				Expect(pods.Items[1].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("log-1"))
-				Expect(pods.Items[4].Name).To(Equal("operator-test-1-log-4"))
-				Expect(pods.Items[4].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("log-4"))
-				Expect(pods.Items[5].Name).To(Equal("operator-test-1-stateless-1"))
-				Expect(pods.Items[5].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("stateless-1"))
-				Expect(pods.Items[12].Name).To(Equal("operator-test-1-stateless-8"))
-				Expect(pods.Items[12].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("stateless-8"))
-				Expect(pods.Items[13].Name).To(Equal("operator-test-1-storage-1"))
-				Expect(pods.Items[13].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("storage-1"))
-				Expect(pods.Items[16].Name).To(Equal("operator-test-1-storage-4"))
-				Expect(pods.Items[16].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("storage-4"))
+				Expect(pods.Items[1].Name).To(HavePrefix("operator-test-1-log-"))
+				Expect(pods.Items[1].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("log-"))
+				Expect(pods.Items[4].Name).To(HavePrefix("operator-test-1-log-"))
+				Expect(pods.Items[4].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("log-"))
+				Expect(pods.Items[5].Name).To(HavePrefix("operator-test-1-stateless-"))
+				Expect(pods.Items[5].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("stateless-"))
+				Expect(pods.Items[12].Name).To(HavePrefix("operator-test-1-stateless-"))
+				Expect(pods.Items[12].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("stateless-"))
+				Expect(pods.Items[13].Name).To(HavePrefix("operator-test-1-storage-"))
+				Expect(pods.Items[13].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("storage-"))
+				Expect(pods.Items[16].Name).To(HavePrefix("operator-test-1-storage-"))
+				Expect(pods.Items[16].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("storage-"))
 
 				Expect(getProcessClassMap(cluster, pods.Items)).To(Equal(map[fdbv1beta2.ProcessClass]int{
 					fdbv1beta2.ProcessClassStorage:           4,
@@ -343,20 +344,22 @@ var _ = Describe("cluster_controller", func() {
 		})
 
 		Context("when buggifying a pod to make it crash loop", func() {
+			var processGroupID fdbv1beta2.ProcessGroupID
+
 			BeforeEach(func() {
-				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{"storage-1"}
-				err = k8sClient.Update(context.TODO(), cluster)
-				Expect(err).NotTo(HaveOccurred())
+				processGroupID = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0].ProcessGroupID
+				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{processGroupID}
+				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 			})
 
 			It("should add the crash loop flag", func() {
 				pods := &corev1.PodList{}
 				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-				Expect(len(pods.Items)).To(Equal(len(originalPods.Items)))
+				Expect(pods.Items).To(HaveLen(len(originalPods.Items)))
 				sortPodsByName(pods)
 
 				pod := pods.Items[firstStorageIndex]
-				Expect(pod.ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("storage-1"))
+				Expect(pod.ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal(string(processGroupID)))
 
 				mainContainer := pod.Spec.Containers[0]
 				Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
@@ -556,298 +559,229 @@ var _ = Describe("cluster_controller", func() {
 			})
 		})
 
-		Context("with a coordinator replacement", func() {
+		When("a coordinator is replaced", func() {
 			var originalConnectionString string
+			var replacedProcessGroup *fdbv1beta2.ProcessGroupStatus
 
 			BeforeEach(func() {
 				originalConnectionString = cluster.Status.ConnectionString
+
+				adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(adminClient).NotTo(BeNil())
+
+				coordinatorSet, err := adminClient.GetCoordinatorSet()
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, processGroup := range cluster.Status.ProcessGroups {
+					if _, ok := coordinatorSet[string(processGroup.ProcessGroupID)]; !ok {
+						continue
+					}
+
+					replacedProcessGroup = processGroup
+					break
+				}
+
+				Expect(replacedProcessGroup).NotTo(BeNil())
+				cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{replacedProcessGroup.ProcessGroupID}
+				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 			})
 
-			Context("with an entry in the process groups to remove list", func() {
+			It("should replace the targeted Pod and update the cluster status", func() {
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+				Expect(pods.Items).To(HaveLen(17))
+
+				Expect(getProcessClassMap(cluster, pods.Items)).To(Equal(map[fdbv1beta2.ProcessClass]int{
+					fdbv1beta2.ProcessClassStorage:           4,
+					fdbv1beta2.ProcessClassLog:               4,
+					fdbv1beta2.ProcessClassStateless:         8,
+					fdbv1beta2.ProcessClassClusterController: 1,
+				}))
+
+				processGroupIDs := make([]string, 17)
+				for idx, pod := range pods.Items {
+					processGroupIDs[idx] = pod.Labels[fdbv1beta2.FDBProcessGroupIDLabel]
+				}
+				Expect(processGroupIDs).NotTo(ContainElements(string(replacedProcessGroup.ProcessGroupID)))
+
+				// Should change the connection string
+				Expect(cluster.Status.ConnectionString).NotTo(Equal(originalConnectionString))
+
+				// Should remove the process group
+				Expect(fdbv1beta2.ContainsProcessGroupID(cluster.Status.ProcessGroups, replacedProcessGroup.ProcessGroupID)).To(BeFalse())
+
+				// Should exclude and re-include the process
+				adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(adminClient).NotTo(BeNil())
+				Expect(adminClient.ExcludedAddresses).To(BeEmpty())
+				Expect(adminClient.ReincludedAddresses).To(HaveKeyWithValue(replacedProcessGroup.Addresses[0], true))
+			})
+
+			When("a pod is stuck in terminating", func() {
 				BeforeEach(func() {
-					cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(originalPods.Items[firstStorageIndex].ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-					}
-					err := k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					replacedProcessGroup.UpdateCondition(fdbv1beta2.MissingProcesses, true)
+					Expect(k8sClient.Status().Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+
+					pod := &corev1.Pod{}
+					Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: replacedProcessGroup.GetPodName(cluster), Namespace: cluster.Namespace}, pod)).NotTo(HaveOccurred())
+					Expect(k8sClient.MockStuckTermination(pod, true)).NotTo(HaveOccurred())
+					// The returned generation in the test case will be 0 since we have 2 pending removals
+					// which is expected.
+					generationGap = -1
 				})
 
-				It("should keep the process counts the same", func() {
-					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
+				It("should set the generation to both reconciled and pending removal and exclude the process", func() {
+					_, err = reloadCluster(cluster)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(len(pods.Items)).To(Equal(17))
-
-					Expect(getProcessClassMap(cluster, pods.Items)).To(Equal(map[fdbv1beta2.ProcessClass]int{
-						fdbv1beta2.ProcessClassStorage:           4,
-						fdbv1beta2.ProcessClassLog:               4,
-						fdbv1beta2.ProcessClassStateless:         8,
-						fdbv1beta2.ProcessClassClusterController: 1,
+					Expect(cluster.Status.Generations).To(Equal(fdbv1beta2.ClusterGenerationStatus{
+						Reconciled:        2,
+						HasPendingRemoval: 2,
 					}))
-				})
 
-				It("should replace one of the pods", func() {
-					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(len(pods.Items)).To(Equal(17))
-
-					sortPodsByName(pods)
-
-					Expect(pods.Items[firstStorageIndex].Name).To(Equal(originalPods.Items[firstStorageIndex+1].Name))
-					Expect(pods.Items[firstStorageIndex+1].Name).To(Equal(originalPods.Items[firstStorageIndex+2].Name))
-					Expect(pods.Items[firstStorageIndex+2].Name).To(Equal(originalPods.Items[firstStorageIndex+3].Name))
-					Expect(pods.Items[firstStorageIndex+3].Name).To(Equal("operator-test-1-storage-5"))
-				})
-
-				It("should exclude and re-include the process group", func() {
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(adminClient).NotTo(BeNil())
-					Expect(adminClient.ExcludedAddresses).To(BeEmpty())
-
-					Expect(adminClient.ReincludedAddresses).To(Equal(map[string]bool{
-						originalPods.Items[firstStorageIndex].Status.PodIP: true,
-					}))
-				})
-
-				It("should not change the connection string", func() {
-					Expect(cluster.Status.ConnectionString).To(Equal(originalConnectionString))
-				})
-
-				It("should clear the removal list", func() {
-					Expect(cluster.Spec.ProcessGroupsToRemove).To(Equal([]fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(originalPods.Items[firstStorageIndex].ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-					}))
-				})
-
-				It("should clear removals from the process group status", func() {
-					processGroups := cluster.Status.ProcessGroups
-					Expect(len(processGroups)).To(Equal(len(originalPods.Items)))
-
-					Expect(fdbv1beta2.ContainsProcessGroupID(processGroups, "storage-5")).To(BeTrue())
-					oldID := originalPods.Items[firstStorageIndex].ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]
-					Expect(fdbv1beta2.ContainsProcessGroupID(processGroups, fdbv1beta2.ProcessGroupID(oldID))).To(BeFalse())
-
-					for _, group := range processGroups {
-						Expect(group.IsMarkedForRemoval()).To(BeFalse())
-					}
-				})
-
-				Context("with a pod stuck in terminating", func() {
-					BeforeEach(func() {
-						pod := originalPods.Items[firstStorageIndex]
-						for _, processGroup := range cluster.Status.ProcessGroups {
-							if processGroup.ProcessGroupID == fdbv1beta2.ProcessGroupID(pod.ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]) {
-								processGroup.UpdateCondition(fdbv1beta2.MissingProcesses, true)
-							}
-						}
-
-						err = k8sClient.Status().Update(context.TODO(), cluster)
-						Expect(err).NotTo(HaveOccurred())
-
-						err = k8sClient.MockStuckTermination(&pod, true)
-						Expect(err).NotTo(HaveOccurred())
-						// The returned generation in the test case will be 0 since we have 2 pending removals
-						// which is expected.
-						generationGap = -1
-					})
-
-					It("should set the generation to both reconciled and pending removal", func() {
-						_, err = reloadCluster(cluster)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(cluster.Status.Generations).To(Equal(fdbv1beta2.ClusterGenerationStatus{
-							Reconciled:        2,
-							HasPendingRemoval: 2,
-						}))
-					})
-
-					It("should exclude but not re-include the process group", func() {
-						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(adminClient).NotTo(BeNil())
-						Expect(adminClient.ReincludedAddresses).To(HaveLen(0))
-						Expect(adminClient.ExcludedAddresses).To(HaveLen(1))
-						Expect(adminClient.ExcludedAddresses).To(HaveKey(
-							originalPods.Items[firstStorageIndex].Status.PodIP,
-						))
-					})
-				})
-
-				Context("with a PVC stuck in terminating", func() {
-					BeforeEach(func() {
-						originalPod := &originalPods.Items[firstStorageIndex]
-						for _, processGroup := range cluster.Status.ProcessGroups {
-							if processGroup.ProcessGroupID == fdbv1beta2.ProcessGroupID(originalPod.ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]) {
-								processGroup.UpdateCondition(fdbv1beta2.MissingProcesses, true)
-							}
-						}
-
-						pvc := &corev1.PersistentVolumeClaim{}
-						err = k8sClient.Get(context.TODO(), client.ObjectKey{
-							Namespace: originalPod.Namespace,
-							Name:      fmt.Sprintf("%s-data", originalPod.Name),
-						}, pvc)
-						Expect(err).NotTo(HaveOccurred())
-
-						err = k8sClient.Status().Update(context.TODO(), cluster)
-						Expect(err).NotTo(HaveOccurred())
-
-						err = k8sClient.MockStuckTermination(pvc, true)
-						Expect(err).NotTo(HaveOccurred())
-						// The returned generation in the test case will be 0 since we have 2 pending removals
-						// which is expected.
-						generationGap = -1
-					})
-
-					It("should set the generation to both reconciled and pending removal", func() {
-						_, err = reloadCluster(cluster)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(cluster.Status.Generations).To(Equal(fdbv1beta2.ClusterGenerationStatus{
-							Reconciled:        2,
-							HasPendingRemoval: 2,
-						}))
-					})
-
-					It("should exclude but not re-include the process group", func() {
-						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(adminClient).NotTo(BeNil())
-						Expect(adminClient.ReincludedAddresses).To(HaveLen(0))
-						Expect(adminClient.ExcludedAddresses).To(HaveLen(1))
-						Expect(adminClient.ExcludedAddresses).To(HaveKey(
-							originalPods.Items[firstStorageIndex].Status.PodIP,
-						))
-					})
+					Expect(adminClient.ReincludedAddresses).To(HaveLen(0))
+					Expect(adminClient.ExcludedAddresses).To(HaveLen(1))
+					Expect(adminClient.ExcludedAddresses).To(HaveKey(
+						replacedProcessGroup.Addresses[0],
+					))
 				})
 			})
 
-			Context("with cluster skip enabled", func() {
+			When("a PVC is stuck in terminating", func() {
+				BeforeEach(func() {
+					replacedProcessGroup.UpdateCondition(fdbv1beta2.MissingProcesses, true)
+					Expect(k8sClient.Status().Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+
+					pvc := &corev1.PersistentVolumeClaim{}
+					err = k8sClient.Get(context.TODO(), client.ObjectKey{
+						Namespace: cluster.Namespace,
+						Name:      fmt.Sprintf("%s-data", replacedProcessGroup.GetPodName(cluster)),
+					}, pvc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Status().Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+					Expect(k8sClient.MockStuckTermination(pvc, true)).NotTo(HaveOccurred())
+					// The returned generation in the test case will be 0 since we have 2 pending removals
+					// which is expected.
+					generationGap = -1
+				})
+
+				It("should set the generation to both reconciled and pending removal and exclude the process", func() {
+					_, err = reloadCluster(cluster)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(cluster.Status.Generations).To(Equal(fdbv1beta2.ClusterGenerationStatus{
+						Reconciled:        2,
+						HasPendingRemoval: 2,
+					}))
+
+					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(adminClient).NotTo(BeNil())
+					Expect(adminClient.ReincludedAddresses).To(HaveLen(0))
+					Expect(adminClient.ExcludedAddresses).To(HaveLen(1))
+					Expect(adminClient.ExcludedAddresses).To(HaveKey(
+						replacedProcessGroup.Addresses[0],
+					))
+				})
+			})
+
+			When("the cluster skip setting is enabled", func() {
 				BeforeEach(func() {
 					cluster.Spec.Skip = true
-					// Since we don't Reconcile we don't expect a generationGap
+					Expect(k8sClient.Update(context.Background(), cluster)).NotTo(HaveOccurred())
 					generationGap = 0
 				})
 
-				Context("with an entry in the process groups to remove list", func() {
-					BeforeEach(func() {
-						cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{
-							fdbv1beta2.ProcessGroupID(originalPods.Items[firstStorageIndex].ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-						}
-						err := k8sClient.Update(context.TODO(), cluster)
-						Expect(err).NotTo(HaveOccurred())
-					})
-
-					It("should not replace the pod", func() {
-						pods := &corev1.PodList{}
-						err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(len(pods.Items)).To(Equal(17))
-
-						sortPodsByName(pods)
-
-						for i := 0; i < 4; i++ {
-							Expect(pods.Items[firstStorageIndex+i].Name).To(Equal(originalPods.Items[firstStorageIndex+i].Name))
-						}
-					})
-				})
-			})
-
-			Context("with a missing pod IP", func() {
-				var podIP string
-
-				BeforeEach(func() {
-					podIP = originalPods.Items[firstStorageIndex].Status.PodIP
-
-					err := k8sClient.RemovePodIP(&originalPods.Items[firstStorageIndex])
-					Expect(err).NotTo(HaveOccurred())
-
-					cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(originalPods.Items[firstStorageIndex].ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-					}
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("should replace one of the pods", func() {
+				It("should not replace the pod", func() {
 					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(len(pods.Items)).To(Equal(17))
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(pods.Items).To(HaveLen(17))
 
 					sortPodsByName(pods)
 
-					Expect(pods.Items[firstStorageIndex].Name).To(Equal(originalPods.Items[firstStorageIndex+1].Name))
-					Expect(pods.Items[firstStorageIndex+1].Name).To(Equal(originalPods.Items[firstStorageIndex+2].Name))
-					Expect(pods.Items[firstStorageIndex+2].Name).To(Equal(originalPods.Items[firstStorageIndex+3].Name))
-					Expect(pods.Items[firstStorageIndex+3].Name).To(Equal("operator-test-1-storage-5"))
+					for i := 0; i < 17; i++ {
+						Expect(pods.Items[i].Name).To(Equal(originalPods.Items[i].Name))
+					}
+				})
+			})
+
+			When("the pod has a missing pod IP", func() {
+				var podIP string
+
+				BeforeEach(func() {
+					pod := &corev1.Pod{}
+					Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: replacedProcessGroup.GetPodName(cluster), Namespace: cluster.Namespace}, pod))
+					podIP = pod.Status.PodIP
+					Expect(k8sClient.RemovePodIP(pod)).NotTo(HaveOccurred())
 				})
 
-				It("should exclude and re-include the process group", func() {
+				It("should replace the pod and exclude and include it", func() {
+					pods := &corev1.PodList{}
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(pods.Items).To(HaveLen(17))
+
+					processGroupIDs := make([]string, 17)
+					for idx, pod := range pods.Items {
+						processGroupIDs[idx] = pod.Labels[fdbv1beta2.FDBProcessGroupIDLabel]
+					}
+					Expect(processGroupIDs).NotTo(ContainElements(string(replacedProcessGroup.ProcessGroupID)))
+
+					// Check for the exclusion and inclusion
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(adminClient).NotTo(BeNil())
 					Expect(adminClient.ExcludedAddresses).To(BeEmpty())
-
-					Expect(adminClient.ReincludedAddresses).To(Equal(map[string]bool{podIP: true}))
-				})
-
-				It("should clear the removal list", func() {
-					Expect(cluster.Spec.ProcessGroupsToRemove).To(Equal([]fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(originalPods.Items[firstStorageIndex].ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-					}))
+					Expect(adminClient.ReincludedAddresses).To(HaveKeyWithValue(podIP, true))
 				})
 			})
 
 			Context("with a removal with no exclusion", func() {
 				BeforeEach(func() {
-					err := k8sClient.RemovePodIP(&originalPods.Items[firstStorageIndex])
-					Expect(err).NotTo(HaveOccurred())
-					cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = []fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(originalPods.Items[firstStorageIndex].ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-					}
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					pod := &corev1.Pod{}
+					Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: replacedProcessGroup.GetPodName(cluster), Namespace: cluster.Namespace}, pod))
+					Expect(k8sClient.RemovePodIP(pod)).NotTo(HaveOccurred())
+					cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = []fdbv1beta2.ProcessGroupID{replacedProcessGroup.ProcessGroupID}
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+					generationGap++
 				})
 
-				It("should replace one of the pods", func() {
+				It("should replace the pod", func() {
 					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(len(pods.Items)).To(Equal(17))
+					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(pods.Items).To(HaveLen(17))
 
-					sortPodsByName(pods)
+					processGroupIDs := make([]string, 17)
+					for idx, pod := range pods.Items {
+						processGroupIDs[idx] = pod.Labels[fdbv1beta2.FDBProcessGroupIDLabel]
+					}
+					Expect(processGroupIDs).NotTo(ContainElements(string(replacedProcessGroup.ProcessGroupID)))
 
-					Expect(pods.Items[firstStorageIndex].Name).To(Equal(originalPods.Items[firstStorageIndex+1].Name))
-					Expect(pods.Items[firstStorageIndex+1].Name).To(Equal(originalPods.Items[firstStorageIndex+2].Name))
-					Expect(pods.Items[firstStorageIndex+2].Name).To(Equal(originalPods.Items[firstStorageIndex+3].Name))
-					Expect(pods.Items[firstStorageIndex+3].Name).To(Equal("operator-test-1-storage-5"))
-				})
-
-				It("should not exclude anything", func() {
+					// Check for the exclusion and inclusion
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(adminClient).NotTo(BeNil())
 					Expect(adminClient.ExcludedAddresses).To(BeEmpty())
 					Expect(adminClient.ReincludedAddresses).To(BeEmpty())
 				})
-
-				It("should clear the removal list", func() {
-					Expect(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion).To(Equal([]fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(originalPods.Items[firstStorageIndex].ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-					}))
-				})
 			})
 		})
 
-		Context("with a missing process", func() {
+		When("a process is missing", func() {
 			var adminClient *mock.AdminClient
+			var processGroupID fdbv1beta2.ProcessGroupID
+			var podName string
 
 			BeforeEach(func() {
 				adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
 				Expect(err).NotTo(HaveOccurred())
 
-				adminClient.MockMissingProcessGroup("storage-1", true)
+				pickedProcessGroup := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
+				processGroupID = pickedProcessGroup.ProcessGroupID
+				podName = pickedProcessGroup.GetPodName(cluster)
+				adminClient.MockMissingProcessGroup(processGroupID, true)
 
 				// Run a single reconciliation to detect the missing process.
 				result, err := reconcileObject(clusterReconciler, cluster.ObjectMeta, 1)
@@ -857,7 +791,7 @@ var _ = Describe("cluster_controller", func() {
 				// Tweak the time on the missing process to make it eligible for replacement.
 				_, err = reloadCluster(cluster)
 				Expect(err).NotTo(HaveOccurred())
-				processGroup := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, "storage-1")
+				processGroup := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, processGroupID)
 				Expect(processGroup).NotTo(BeNil())
 				Expect(len(processGroup.ProcessGroupConditions)).To(Equal(1))
 				Expect(processGroup.ProcessGroupConditions[0].ProcessGroupConditionType).To(Equal(fdbv1beta2.MissingProcesses))
@@ -869,79 +803,62 @@ var _ = Describe("cluster_controller", func() {
 			})
 
 			It("should replace the pod", func() {
-				err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				pod := &corev1.Pod{}
+				err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: podName, Namespace: cluster.Namespace}, pod)
+				Expect(err).To(HaveOccurred())
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 
 				pods := &corev1.PodList{}
-				err = k8sClient.List(context.TODO(), pods, internal.GetSinglePodListOptions(cluster, "storage-1")...)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(len(pods.Items)).To(Equal(0))
-
-				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(len(pods.Items)).To(Equal(17))
-
-				sortPodsByName(pods)
-
-				Expect(pods.Items[firstStorageIndex].Name).To(Equal(originalPods.Items[firstStorageIndex+1].Name))
-				Expect(pods.Items[firstStorageIndex+1].Name).To(Equal(originalPods.Items[firstStorageIndex+2].Name))
-				Expect(pods.Items[firstStorageIndex+2].Name).To(Equal(originalPods.Items[firstStorageIndex+3].Name))
-				Expect(pods.Items[firstStorageIndex+3].Name).To(Equal("operator-test-1-storage-5"))
+				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+				Expect(pods.Items).To(HaveLen(17))
 			})
 		})
 
-		Context("with multiple replacements", func() {
+		When("multiple replacements are present", func() {
+			var replacedPods []string
+
 			BeforeEach(func() {
+				picked := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
 				cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{
-					fdbv1beta2.ProcessGroupID(originalPods.Items[firstStorageIndex].ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-					"storage-5",
+					picked[0].ProcessGroupID,
+					picked[1].ProcessGroupID,
 				}
-				err := k8sClient.Update(context.TODO(), cluster)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+
+				replacedPods = []string{picked[0].GetPodName(cluster), picked[1].GetPodName(cluster)}
 			})
 
-			It("should replace one of the pods", func() {
+			It("should replace the pods", func() {
 				pods := &corev1.PodList{}
-				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(len(pods.Items)).To(Equal(17))
+				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+				Expect(pods.Items).To(HaveLen(17))
 
-				sortPodsByName(pods)
-
-				Expect(pods.Items[firstStorageIndex].Name).To(Equal(originalPods.Items[firstStorageIndex+1].Name))
-				Expect(pods.Items[firstStorageIndex+1].Name).To(Equal(originalPods.Items[firstStorageIndex+2].Name))
-				Expect(pods.Items[firstStorageIndex+2].Name).To(Equal(originalPods.Items[firstStorageIndex+3].Name))
-				Expect(pods.Items[firstStorageIndex+3].Name).To(Equal("operator-test-1-storage-6"))
+				for _, podName := range replacedPods {
+					pod := &corev1.Pod{}
+					err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: podName, Namespace: cluster.Namespace}, pod)
+					Expect(err).To(HaveOccurred())
+					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				}
 			})
 		})
 
-		Context("with a pod that gets deleted", func() {
-			var pod corev1.Pod
-			BeforeEach(func() {
-				err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
-				Expect(err).NotTo(HaveOccurred())
+		When("a pod gets deleted", func() {
+			var pod *corev1.Pod
 
+			BeforeEach(func() {
 				generationGap = 0
 
-				pods := &corev1.PodList{}
-				err = k8sClient.List(context.TODO(), pods, internal.GetSinglePodListOptions(cluster, "storage-1")...)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(len(pods.Items)).To(Equal(1))
-				pod = pods.Items[0]
-				err := k8sClient.Delete(context.TODO(), &pod)
-				Expect(err).NotTo(HaveOccurred())
+				picked := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
+				pod = &corev1.Pod{}
+				Expect(k8sClient.Get(context.TODO(), client.ObjectKey{Name: picked.GetPodName(cluster), Namespace: cluster.Namespace}, pod)).NotTo(HaveOccurred())
+				Expect(k8sClient.Delete(context.TODO(), pod)).NotTo(HaveOccurred())
 			})
 
 			It("should replace the pod", func() {
-				err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				pods := &corev1.PodList{}
-				err = k8sClient.List(context.TODO(), pods, internal.GetSinglePodListOptions(cluster, "storage-1")...)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(len(pods.Items)).To(Equal(1))
-				Expect(pods.Items[0].ObjectMeta.UID).NotTo(Equal(pod.ObjectMeta.UID))
-				Expect(pods.Items[0].Name).To(Equal("operator-test-1-storage-1"))
+				newPod := &corev1.Pod{}
+				Expect(k8sClient.Get(context.TODO(), client.ObjectKey{Name: pod.Name, Namespace: cluster.Namespace}, newPod)).NotTo(HaveOccurred())
+				Expect(pod.UID).NotTo(Equal(newPod.UID))
+				Expect(pod.Name).To(Equal(newPod.Name))
 			})
 		})
 
@@ -1257,13 +1174,16 @@ var _ = Describe("cluster_controller", func() {
 		})
 
 		Context("with annotations on pod", func() {
+			var pickedPod string
+
 			BeforeEach(func() {
+				picked := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
+				pickedPod = picked.GetPodName(cluster)
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: "operator-test-1-storage-1"}, pod)
+				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: pickedPod}, pod)
 				Expect(err).NotTo(HaveOccurred())
 				pod.Annotations["foundationdb.org/existing-annotation"] = "test-value"
-				err = k8sClient.Update(context.TODO(), pod)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Update(context.TODO(), pod)).NotTo(HaveOccurred())
 
 				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1275,47 +1195,43 @@ var _ = Describe("cluster_controller", func() {
 						Containers: []corev1.Container{},
 					},
 				}}}
-				err := k8sClient.Update(context.TODO(), cluster)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 			})
 
 			It("should set the annotations on the pod", func() {
 				pods := &corev1.PodList{}
-				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
 
-				err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				for _, item := range pods.Items {
+				for _, pod := range pods.Items {
 					hash, err := internal.GetPodSpecHash(cluster, &fdbv1beta2.ProcessGroupStatus{
-						ProcessGroupID: fdbv1beta2.ProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-						ProcessClass:   internal.ProcessClassFromLabels(cluster, item.Labels),
+						ProcessGroupID: fdbv1beta2.ProcessGroupID(pod.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
+						ProcessClass:   internal.ProcessClassFromLabels(cluster, pod.Labels),
 					}, nil)
 					Expect(err).NotTo(HaveOccurred())
 
-					configMapHash, err := getConfigMapHash(cluster, internal.GetProcessClassFromMeta(cluster, item.ObjectMeta), &item)
+					configMapHash, err := getConfigMapHash(cluster, internal.GetProcessClassFromMeta(cluster, pod.ObjectMeta), &pod)
 					Expect(err).NotTo(HaveOccurred())
-					if item.Labels[fdbv1beta2.FDBProcessGroupIDLabel] == "storage-1" {
-						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
+					if pod.Name == pickedPod {
+						Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
 							fdbv1beta2.LastConfigMapKey:            configMapHash,
 							fdbv1beta2.LastSpecKey:                 hash,
 							fdbv1beta2.PublicIPSourceAnnotation:    "pod",
 							"foundationdb.org/existing-annotation": "test-value",
 							"fdb-annotation":                       "value1",
-							fdbv1beta2.NodeAnnotation:              item.Spec.NodeName,
+							fdbv1beta2.NodeAnnotation:              pod.Spec.NodeName,
 							fdbv1beta2.ImageTypeAnnotation:         string(fdbv1beta2.ImageTypeSplit),
 						}))
-					} else {
-						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-							fdbv1beta2.LastConfigMapKey:         configMapHash,
-							fdbv1beta2.LastSpecKey:              hash,
-							fdbv1beta2.PublicIPSourceAnnotation: "pod",
-							"fdb-annotation":                    "value1",
-							fdbv1beta2.NodeAnnotation:           item.Spec.NodeName,
-							fdbv1beta2.ImageTypeAnnotation:      string(fdbv1beta2.ImageTypeSplit),
-						}))
+						continue
 					}
+
+					Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
+						fdbv1beta2.LastConfigMapKey:         configMapHash,
+						fdbv1beta2.LastSpecKey:              hash,
+						fdbv1beta2.PublicIPSourceAnnotation: "pod",
+						"fdb-annotation":                    "value1",
+						fdbv1beta2.NodeAnnotation:           pod.Spec.NodeName,
+						fdbv1beta2.ImageTypeAnnotation:      string(fdbv1beta2.ImageTypeSplit),
+					}))
 				}
 			})
 
@@ -1348,8 +1264,7 @@ var _ = Describe("cluster_controller", func() {
 							},
 						},
 					}}}
-					err := k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
 				It("should update the labels on the PVCs", func() {
@@ -1382,10 +1297,13 @@ var _ = Describe("cluster_controller", func() {
 
 		Context("with a change to PVC annotations", func() {
 			Context("with the fields from the processes", func() {
+				var pickedPvc string
+
 				BeforeEach(func() {
+					picked := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
+					pickedPvc = picked.GetPodName(cluster) + "-data"
 					pvc := &corev1.PersistentVolumeClaim{}
-					err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: "operator-test-1-storage-1-data"}, pvc)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: pickedPvc}, pvc)).NotTo(HaveOccurred())
 					pvc.Annotations["foundationdb.org/existing-annotation"] = "test-value"
 					err = k8sClient.Update(context.TODO(), pvc)
 					Expect(err).NotTo(HaveOccurred())
@@ -1397,8 +1315,7 @@ var _ = Describe("cluster_controller", func() {
 							},
 						},
 					}}}
-					err := k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
 				It("should update the annotations on the PVCs", func() {
@@ -1406,27 +1323,24 @@ var _ = Describe("cluster_controller", func() {
 					err = k8sClient.List(context.TODO(), pvcs, getListOptions(cluster)...)
 					Expect(err).NotTo(HaveOccurred())
 					for _, item := range pvcs.Items {
-						if item.ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel] == "storage-1" {
+						if item.Name == pickedPvc {
 							Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
 								"fdb-annotation":                       "value1",
 								"foundationdb.org/existing-annotation": "test-value",
 								fdbv1beta2.LastSpecKey:                 "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
 							}))
-						} else {
-							Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
-								"fdb-annotation":       "value1",
-								fdbv1beta2.LastSpecKey: "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
-							}))
-
+							continue
 						}
+						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
+							"fdb-annotation":       "value1",
+							fdbv1beta2.LastSpecKey: "f0c8a45ea6c3dd26c2dc2b5f3c699f38d613dab273d0f8a6eae6abd9a9569063",
+						}))
+
 					}
 				})
 
 				It("should not update the annotations on other resources", func() {
 					pods := &corev1.PodList{}
-
-					err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
-					Expect(err).NotTo(HaveOccurred())
 
 					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
 					Expect(err).NotTo(HaveOccurred())
@@ -2530,8 +2444,7 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should replace the process groups", func() {
 				pods := &corev1.PodList{}
-				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
 
 				originalNames := make([]string, 0, len(originalPods.Items))
 				for _, pod := range originalPods.Items {
@@ -2544,15 +2457,9 @@ var _ = Describe("cluster_controller", func() {
 				}
 
 				Expect(currentNames).NotTo(ContainElements(originalNames))
-			})
-
-			It("should generate process group IDs with the new prefix", func() {
-				pods := &corev1.PodList{}
-				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
-
-				sortPodsByName(pods)
-				Expect(pods.Items[0].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("dev-cluster_controller-2"))
-				Expect(pods.Items[1].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("dev-log-5"))
+				for _, processGroup := range cluster.Status.ProcessGroups {
+					Expect(string(processGroup.ProcessGroupID)).To(HavePrefix("dev"))
+				}
 			})
 		})
 
@@ -2955,11 +2862,15 @@ var _ = Describe("cluster_controller", func() {
 
 		When("When a process have an incorrect commandline", func() {
 			var adminClient *mock.AdminClient
+			var first, second *fdbv1beta2.ProcessGroupStatus
 
 			BeforeEach(func() {
+				picked := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
+				first = picked[0]
+				second = picked[1]
 				adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
 				Expect(err).NotTo(HaveOccurred())
-				adminClient.MockIncorrectCommandLine("storage-1", true)
+				adminClient.MockIncorrectCommandLine(first.ProcessGroupID, true)
 				generationGap = 0
 				shouldCompleteReconciliation = false
 			})
@@ -2969,12 +2880,12 @@ var _ = Describe("cluster_controller", func() {
 				_, err = reloadClusterGenerations(cluster)
 				Expect(err).NotTo(HaveOccurred())
 				incorrectProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectCommandLine, false)
-				Expect(incorrectProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{"storage-1"}))
+				Expect(incorrectProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{first.ProcessGroupID}))
 			})
 
 			When("When an additional process have an incorrect commandline", func() {
 				BeforeEach(func() {
-					adminClient.MockIncorrectCommandLine("storage-2", true)
+					adminClient.MockIncorrectCommandLine(second.ProcessGroupID, true)
 					generationGap = 0
 					shouldCompleteReconciliation = false
 				})
@@ -2984,7 +2895,7 @@ var _ = Describe("cluster_controller", func() {
 					_, err = reloadClusterGenerations(cluster)
 					Expect(err).NotTo(HaveOccurred())
 					incorrectProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectCommandLine, false)
-					Expect(incorrectProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{"storage-1", "storage-2"}))
+					Expect(incorrectProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{first.ProcessGroupID, second.ProcessGroupID}))
 				})
 			})
 		})

--- a/controllers/exclude_processes_test.go
+++ b/controllers/exclude_processes_test.go
@@ -99,13 +99,15 @@ var _ = Describe("exclude_processes", func() {
 							})
 
 							When("there are failed processes", func() {
-								BeforeEach(func() {
+								var processGroupID fdbv1beta2.ProcessGroupID
 
+								BeforeEach(func() {
 									for idx, processGroup := range cluster.Status.ProcessGroups {
 										if processGroup.ProcessClass != processClass {
 											continue
 										}
 
+										processGroupID = processGroup.ProcessGroupID
 										cluster.Status.ProcessGroups[idx].UpdateCondition(fdbv1beta2.MissingProcesses, true)
 										cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().Add(-10 * time.Minute).Unix()
 										break
@@ -114,7 +116,7 @@ var _ = Describe("exclude_processes", func() {
 
 								It("should not allow the exclusion", func() {
 									Expect(allowedExclusions).To(BeZero())
-									Expect(missingProcesses).To(ConsistOf(fdbv1beta2.ProcessGroupID("storage-1")))
+									Expect(missingProcesses).To(ConsistOf(processGroupID))
 								})
 							})
 						})
@@ -130,13 +132,15 @@ var _ = Describe("exclude_processes", func() {
 							})
 
 							When("there are failed processes", func() {
-								BeforeEach(func() {
+								var processGroupID fdbv1beta2.ProcessGroupID
 
+								BeforeEach(func() {
 									for idx, processGroup := range cluster.Status.ProcessGroups {
 										if processGroup.ProcessClass != processClass {
 											continue
 										}
 
+										processGroupID = processGroup.ProcessGroupID
 										cluster.Status.ProcessGroups[idx].UpdateCondition(fdbv1beta2.MissingProcesses, true)
 										cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().Add(-10 * time.Minute).Unix()
 										break
@@ -145,7 +149,7 @@ var _ = Describe("exclude_processes", func() {
 
 								It("should allow the exclusion", func() {
 									Expect(allowedExclusions).To(BeNumerically("==", cluster.DesiredFaultTolerance()-1))
-									Expect(missingProcesses).To(ConsistOf(fdbv1beta2.ProcessGroupID("storage-1")))
+									Expect(missingProcesses).To(ConsistOf(processGroupID))
 								})
 							})
 						})
@@ -346,7 +350,7 @@ var _ = Describe("exclude_processes", func() {
 
 					It("should not allow the exclusion", func() {
 						Expect(allowedExclusions).To(BeNumerically("==", 0))
-						Expect(missingProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{"storage-1", "storage-10", "storage-11", "storage-12", "storage-13"}))
+						Expect(missingProcesses).To(HaveLen(5))
 					})
 				})
 			})

--- a/controllers/update_pod_config_test.go
+++ b/controllers/update_pod_config_test.go
@@ -42,7 +42,7 @@ var _ = Describe("updatePodConfig", func() {
 		cluster = internal.CreateDefaultCluster()
 		Expect(setupClusterForTest(cluster)).NotTo(HaveOccurred())
 
-		processGroup := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, "storage-1")
+		processGroup := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
 		Expect(processGroup).NotTo(BeNil())
 		pod, err = clusterReconciler.PodLifecycleManager.GetPod(context.TODO(), clusterReconciler, cluster, processGroup.GetPodName(cluster))
 		Expect(err).NotTo(HaveOccurred())
@@ -54,7 +54,6 @@ var _ = Describe("updatePodConfig", func() {
 
 	JustBeforeEach(func() {
 		req = updatePodConfig{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Context("with a reconciled cluster", func() {

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -22,19 +22,17 @@ package controllers
 
 import (
 	"context"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
-
 	"k8s.io/utils/pointer"
-
-	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 
@@ -42,20 +40,18 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("update_status", func() {
-	var storageOneProcessGroupID fdbv1beta2.ProcessGroupID = "storage-1"
 	logger := logf.Log.WithName("testController")
+	var pickedProcessGroup *fdbv1beta2.ProcessGroupStatus
 
 	Context("validate process group on taint node", func() {
 		var cluster *fdbv1beta2.FoundationDBCluster
 		var err error
-		var pod *corev1.Pod                                   // Pod to be tainted
-		var processGroupStatus *fdbv1beta2.ProcessGroupStatus // Target pod's processGroup
-		var node *corev1.Node                                 // Target pod's node
-		var pvc *corev1.PersistentVolumeClaim                 // Target pod's pvc
+		var pod *corev1.Pod                   // Pod to be tainted
+		var node *corev1.Node                 // Target pod's node
+		var pvc *corev1.PersistentVolumeClaim // Target pod's pvc
 		taintKeyWildcard := "*"
 		taintKeyWildcardDuration := int64(20)
 		taintKeyMaintenance := "foundationdb/maintenance"
@@ -79,22 +75,22 @@ var _ = Describe("update_status", func() {
 				},
 			}
 
-			processGroupStatus = fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, storageOneProcessGroupID)
-			pod, err = clusterReconciler.PodLifecycleManager.GetPod(context.TODO(), clusterReconciler, cluster, processGroupStatus.GetPodName(cluster))
+			pickedProcessGroup = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
+			pod, err = clusterReconciler.PodLifecycleManager.GetPod(context.TODO(), clusterReconciler, cluster, pickedProcessGroup.GetPodName(cluster))
 			Expect(err).NotTo(HaveOccurred())
 			node = &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: pod.Spec.NodeName},
 			}
 
 			allPvcs := &corev1.PersistentVolumeClaimList{}
-			err = clusterReconciler.List(context.TODO(), allPvcs, internal.GetPodListOptions(cluster, processGroupStatus.ProcessClass, string(processGroupStatus.ProcessGroupID))...)
+			err = clusterReconciler.List(context.TODO(), allPvcs, internal.GetPodListOptions(cluster, pickedProcessGroup.ProcessClass, string(pickedProcessGroup.ProcessGroupID))...)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(allPvcs.Items).To(HaveLen(1))
 			pvc = &allPvcs.Items[0]
 
-			globalControllerLogger.Info("Target processGroupStatus Info", "ProcessGroupID", processGroupStatus.ProcessGroupID,
-				"Conditions size", len(processGroupStatus.ProcessGroupConditions),
-				"Conditions", processGroupStatus.ProcessGroupConditions)
+			globalControllerLogger.Info("Target processGroupStatus Info", "ProcessGroupID", pickedProcessGroup.ProcessGroupID,
+				"Conditions size", len(pickedProcessGroup.ProcessGroupConditions),
+				"Conditions", pickedProcessGroup.ProcessGroupConditions)
 		})
 
 		When("process group's node is tainted", func() {
@@ -102,7 +98,7 @@ var _ = Describe("update_status", func() {
 				globalControllerLogger.Info("Taint node", "Node name", pod.Name, "Node taints", node.Spec.Taints)
 				Expect(k8sClient.Update(context.TODO(), node)).NotTo(HaveOccurred())
 
-				err = validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pvc, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], processGroupStatus, cluster.IsTaintFeatureDisabled(), logger)
+				err = validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pvc, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], pickedProcessGroup, cluster.IsTaintFeatureDisabled(), logger)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -119,8 +115,8 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("should get NodeTaintDetected condition", func() {
-					Expect(len(processGroupStatus.ProcessGroupConditions)).To(Equal(1))
-					Expect(processGroupStatus.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(Equal(nil))
+					Expect(len(pickedProcessGroup.ProcessGroupConditions)).To(Equal(1))
+					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(Equal(nil))
 				})
 			})
 
@@ -137,9 +133,9 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("should get both NodeTaintDetected and NodeTaintReplacing condition", func() {
-					Expect(processGroupStatus.ProcessGroupConditions).To(HaveLen(2))
-					Expect(processGroupStatus.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(Equal(nil))
-					Expect(processGroupStatus.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(Equal(nil))
+					Expect(pickedProcessGroup.ProcessGroupConditions).To(HaveLen(2))
+					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(Equal(nil))
+					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(Equal(nil))
 				})
 			})
 
@@ -159,7 +155,7 @@ var _ = Describe("update_status", func() {
 
 				It("should enable cluster taint feature", func() {
 					// Check taint feature is disabled
-					Expect(processGroupStatus.ProcessGroupConditions).To(HaveLen(0))
+					Expect(pickedProcessGroup.ProcessGroupConditions).To(HaveLen(0))
 
 					// Enable taint feature
 					cluster.Spec.AutomationOptions.Replacements.TaintReplacementOptions = []fdbv1beta2.TaintReplacementOption{
@@ -173,11 +169,11 @@ var _ = Describe("update_status", func() {
 						},
 					}
 
-					err = validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pvc, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], processGroupStatus, cluster.IsTaintFeatureDisabled(), logger)
+					err = validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pvc, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], pickedProcessGroup, cluster.IsTaintFeatureDisabled(), logger)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(processGroupStatus.ProcessGroupConditions).To(HaveLen(2))
-					Expect(processGroupStatus.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(Equal(nil))
-					Expect(processGroupStatus.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(Equal(nil))
+					Expect(pickedProcessGroup.ProcessGroupConditions).To(HaveLen(2))
+					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(Equal(nil))
+					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(Equal(nil))
 				})
 			})
 
@@ -197,7 +193,7 @@ var _ = Describe("update_status", func() {
 
 				It("should disable taint feature", func() {
 					Expect(err).NotTo(HaveOccurred())
-					Expect(processGroupStatus.ProcessGroupConditions).To(HaveLen(0))
+					Expect(pickedProcessGroup.ProcessGroupConditions).To(HaveLen(0))
 				})
 			})
 
@@ -221,7 +217,7 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("pods on the node should not be tainted", func() {
-					Expect(len(processGroupStatus.ProcessGroupConditions)).To(Equal(0))
+					Expect(len(pickedProcessGroup.ProcessGroupConditions)).To(Equal(0))
 					// Add taintKeyUnhealthy to handle the node's taint key
 					cluster.Spec.AutomationOptions.Replacements.TaintReplacementOptions = []fdbv1beta2.TaintReplacementOption{
 						{
@@ -234,11 +230,11 @@ var _ = Describe("update_status", func() {
 						},
 					}
 
-					err = validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pvc, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], processGroupStatus, cluster.IsTaintFeatureDisabled(), logger)
+					err = validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pvc, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], pickedProcessGroup, cluster.IsTaintFeatureDisabled(), logger)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(processGroupStatus.ProcessGroupConditions).To(HaveLen(2))
-					Expect(processGroupStatus.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(BeNil())
-					Expect(processGroupStatus.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(BeNil())
+					Expect(pickedProcessGroup.ProcessGroupConditions).To(HaveLen(2))
+					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(BeNil())
+					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(BeNil())
 				})
 			})
 
@@ -255,23 +251,23 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("shouldn't keep NodeTaintReplacing condition", func() {
-					Expect(len(processGroupStatus.ProcessGroupConditions)).To(Equal(2))
-					Expect(processGroupStatus.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(BeNil())
-					Expect(processGroupStatus.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(BeNil())
+					Expect(len(pickedProcessGroup.ProcessGroupConditions)).To(Equal(2))
+					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(BeNil())
+					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(BeNil())
 
 					// Remove the node taint
 					node.Spec.Taints = nil
 					Expect(k8sClient.Update(context.TODO(), node)).NotTo(HaveOccurred())
 					globalControllerLogger.Info("Remove node taint", "Node name", pod.Name, "Node taints", node.Spec.Taints, "Now", time.Now())
 
-					Expect(validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pvc, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], processGroupStatus, cluster.IsTaintFeatureDisabled(), logger)).NotTo(HaveOccurred())
-					Expect(processGroupStatus.ProcessGroupConditions).To(BeEmpty())
+					Expect(validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pvc, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], pickedProcessGroup, cluster.IsTaintFeatureDisabled(), logger)).NotTo(HaveOccurred())
+					Expect(pickedProcessGroup.ProcessGroupConditions).To(BeEmpty())
 				})
 			})
 		})
 	})
 
-	Context("validate process group", func() {
+	When("validating process groups", func() {
 		var cluster *fdbv1beta2.FoundationDBCluster
 		var configMap *corev1.ConfigMap
 		var adminClient *mock.AdminClient
@@ -284,9 +280,8 @@ var _ = Describe("update_status", func() {
 			cluster = internal.CreateDefaultCluster()
 			Expect(setupClusterForTest(cluster)).NotTo(HaveOccurred())
 
-			processGroup := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, storageOneProcessGroupID)
-
-			storagePod, err = clusterReconciler.PodLifecycleManager.GetPod(context.TODO(), clusterReconciler, cluster, processGroup.GetPodName(cluster))
+			pickedProcessGroup = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
+			storagePod, err = clusterReconciler.PodLifecycleManager.GetPod(context.TODO(), clusterReconciler, cluster, pickedProcessGroup.GetPodName(cluster))
 			Expect(err).NotTo(HaveOccurred())
 			for _, container := range storagePod.Spec.Containers {
 				storagePod.Status.ContainerStatuses = append(storagePod.Status.ContainerStatuses, corev1.ContainerStatus{Ready: true, Name: container.Name})
@@ -318,7 +313,7 @@ var _ = Describe("update_status", func() {
 
 		When("process group has no Pod", func() {
 			It("should be added to the failing Pods", func() {
-				processGroupStatus := fdbv1beta2.NewProcessGroupStatus("storage-1337", fdbv1beta2.ProcessClassStorage, []string{"1.1.1.1"})
+				processGroupStatus := fdbv1beta2.NewProcessGroupStatus("storage-100000", fdbv1beta2.ProcessClassStorage, []string{"1.1.1.1"})
 				// Reset the status to only tests for the missing Pod
 				processGroupStatus.ProcessGroupConditions = []*fdbv1beta2.ProcessGroupCondition{}
 				Expect(validateProcessGroup(context.TODO(), clusterReconciler, cluster, nil, nil, "", processGroupStatus, cluster.IsTaintFeatureDisabled(), logger)).NotTo(HaveOccurred())
@@ -331,10 +326,10 @@ var _ = Describe("update_status", func() {
 			It("should not get any condition assigned", func() {
 				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPvcs, logger, "")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-				processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-				Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-				Expect(len(cluster.Status.ProcessGroups[0].ProcessGroupConditions)).To(Equal(0))
+				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
+				for _, processGroup := range cluster.Status.ProcessGroups {
+					Expect(processGroup.ProcessGroupConditions).To(HaveLen(0))
+				}
 			})
 		})
 
@@ -350,12 +345,8 @@ var _ = Describe("update_status", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				missingProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.MissingPod, false)
-				Expect(missingProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{storageOneProcessGroupID}))
-
-				Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-				processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-				Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-				Expect(len(processGroup.ProcessGroupConditions)).To(Equal(1))
+				Expect(missingProcesses).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 		})
 
@@ -367,17 +358,16 @@ var _ = Describe("update_status", func() {
 			It("should get the ProcessIsMarkedAsExcluded condition", func() {
 				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPvcs, logger, "")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-				processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-				Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-				Expect(processGroup.ProcessGroupConditions).To(HaveLen(1))
-				Expect(processGroup.ProcessGroupConditions[0].ProcessGroupConditionType).To(Equal(fdbv1beta2.ProcessIsMarkedAsExcluded))
+
+				incorrectProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.ProcessIsMarkedAsExcluded, false)
+				Expect(incorrectProcesses).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 		})
 
 		When("a process group has the wrong command line", func() {
 			BeforeEach(func() {
-				adminClient.MockIncorrectCommandLine(storageOneProcessGroupID, true)
+				adminClient.MockIncorrectCommandLine(pickedProcessGroup.ProcessGroupID, true)
 			})
 
 			It("should get a condition assigned", func() {
@@ -385,17 +375,13 @@ var _ = Describe("update_status", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				incorrectProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectCommandLine, false)
-				Expect(incorrectProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{storageOneProcessGroupID}))
-
-				Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-				processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-				Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-				Expect(len(processGroup.ProcessGroupConditions)).To(Equal(1))
+				Expect(incorrectProcesses).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 
 			When("the process group is marked for removal", func() {
 				BeforeEach(func() {
-					cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{storageOneProcessGroupID}
+					cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}
 				})
 
 				It("should get a condition assigned", func() {
@@ -403,20 +389,15 @@ var _ = Describe("update_status", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					incorrectProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectCommandLine, false)
-					Expect(incorrectProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{storageOneProcessGroupID}))
-
-					Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-					processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-					Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-					Expect(len(processGroup.ProcessGroupConditions)).To(Equal(1))
-					Expect(processGroup.IsMarkedForRemoval()).To(BeTrue())
+					Expect(incorrectProcesses).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+					Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 				})
 			})
 		})
 
 		When("a process group is not reporting to the cluster", func() {
 			BeforeEach(func() {
-				adminClient.MockMissingProcessGroup(storageOneProcessGroupID, true)
+				adminClient.MockMissingProcessGroup(pickedProcessGroup.ProcessGroupID, true)
 			})
 
 			It("should get a condition assigned", func() {
@@ -424,12 +405,8 @@ var _ = Describe("update_status", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				missingProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.MissingProcesses, false)
-				Expect(missingProcesses).To(ConsistOf(storageOneProcessGroupID))
-
-				Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-				processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-				Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-				Expect(processGroup.ProcessGroupConditions).To(HaveLen(1))
+				Expect(missingProcesses).To(ConsistOf(pickedProcessGroup.ProcessGroupID))
+				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 
 			When("no processes are provided in the process map", func() {
@@ -439,11 +416,6 @@ var _ = Describe("update_status", func() {
 
 					missingProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.MissingProcesses, false)
 					Expect(missingProcesses).To(BeEmpty())
-
-					Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-					processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-					Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-					Expect(processGroup.ProcessGroupConditions).To(BeEmpty())
 				})
 			})
 		})
@@ -451,8 +423,7 @@ var _ = Describe("update_status", func() {
 		When("the pod has the wrong spec", func() {
 			BeforeEach(func() {
 				storagePod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = "bad"
-				err = k8sClient.Update(context.TODO(), storagePod)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Update(context.TODO(), storagePod)).NotTo(HaveOccurred())
 			})
 
 			It("should get a condition assigned", func() {
@@ -460,12 +431,8 @@ var _ = Describe("update_status", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				incorrectPods := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectPodSpec, false)
-				Expect(incorrectPods).To(Equal([]fdbv1beta2.ProcessGroupID{storageOneProcessGroupID}))
-
-				Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-				processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-				Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-				Expect(len(processGroup.ProcessGroupConditions)).To(Equal(1))
+				Expect(incorrectPods).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 		})
 
@@ -484,12 +451,8 @@ var _ = Describe("update_status", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				missingProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.PodFailing, false)
-				Expect(missingProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{storageOneProcessGroupID}))
-
-				Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-				processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-				Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-				Expect(len(processGroup.ProcessGroupConditions)).To(Equal(1))
+				Expect(missingProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 		})
 
@@ -505,12 +468,8 @@ var _ = Describe("update_status", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				failingPods := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.PodFailing, false)
-				Expect(failingPods).To(Equal([]fdbv1beta2.ProcessGroupID{storageOneProcessGroupID}))
-
-				Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-				processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-				Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-				Expect(len(processGroup.ProcessGroupConditions)).To(Equal(1))
+				Expect(failingPods).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 		})
 
@@ -525,12 +484,8 @@ var _ = Describe("update_status", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				failingPods := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.PodFailing, false)
-				Expect(failingPods).To(Equal([]fdbv1beta2.ProcessGroupID{storageOneProcessGroupID}))
-
-				Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-				processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-				Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-				Expect(len(processGroup.ProcessGroupConditions)).To(Equal(1))
+				Expect(failingPods).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 
 			When("the process group is under maintenance", func() {
@@ -540,22 +495,16 @@ var _ = Describe("update_status", func() {
 
 					failingPods := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.PodFailing, false)
 					Expect(failingPods).To(BeEmpty())
-
-					Expect(len(cluster.Status.ProcessGroups)).To(BeNumerically(">", 4))
-					Expect(processGroup.ProcessGroupID).To(Equal(storageOneProcessGroupID))
-					Expect(len(processGroup.ProcessGroupConditions)).To(BeZero())
+					Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 				})
 			})
 		})
 
 		When("adding a process group to the ProcessGroupsToRemove list", func() {
-			var removedProcessGroup fdbv1beta2.ProcessGroupID
-
 			BeforeEach(func() {
-				removedProcessGroup = storageOneProcessGroupID
 				storagePod.Status.Phase = corev1.PodFailed
 				Expect(k8sClient.Update(context.TODO(), storagePod)).NotTo(HaveOccurred())
-				cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{removedProcessGroup}
+				cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}
 			})
 
 			It("should mark the process group for removal", func() {
@@ -564,7 +513,7 @@ var _ = Describe("update_status", func() {
 
 				removalCount := 0
 				for _, processGroup := range cluster.Status.ProcessGroups {
-					if processGroup.ProcessGroupID == removedProcessGroup {
+					if processGroup.ProcessGroupID == pickedProcessGroup.ProcessGroupID {
 						Expect(processGroup.IsMarkedForRemoval()).To(BeTrue())
 						Expect(processGroup.ExclusionSkipped).To(BeFalse())
 						removalCount++
@@ -579,14 +528,11 @@ var _ = Describe("update_status", func() {
 		})
 
 		When("adding a process group to the ProcessGroupsToRemoveWithoutExclusion list", func() {
-			var removedProcessGroup fdbv1beta2.ProcessGroupID
-
 			BeforeEach(func() {
-				removedProcessGroup = storageOneProcessGroupID
 				storagePod.Status.Phase = corev1.PodFailed
 				err = k8sClient.Update(context.TODO(), storagePod)
 				Expect(err).NotTo(HaveOccurred())
-				cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = []fdbv1beta2.ProcessGroupID{removedProcessGroup}
+				cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = []fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}
 			})
 
 			It("should be mark the process group for removal without exclusion", func() {
@@ -595,7 +541,7 @@ var _ = Describe("update_status", func() {
 
 				removalCount := 0
 				for _, processGroup := range cluster.Status.ProcessGroups {
-					if processGroup.ProcessGroupID == removedProcessGroup {
+					if processGroup.ProcessGroupID == pickedProcessGroup.ProcessGroupID {
 						Expect(processGroup.IsMarkedForRemoval()).To(BeTrue())
 						Expect(processGroup.ExclusionSkipped).To(BeTrue())
 						removalCount++

--- a/docs/manual/resources.md
+++ b/docs/manual/resources.md
@@ -32,9 +32,17 @@ The only stateful process classes are `storage`, `log`, and `transaction`. Pods 
 
 ## Resource Names
 
-Process groups have a naming convention that is different from the pod name. Process group IDs are intended to be unique within an FDB cluster, across all Kubernetes Clusters. Process groups for different FDB clusters can have the same process group ID. These IDs have the form `$prefix-$class-$number`. `$prefix` is set by the `processGroupIDPrefix` field, and if this field is omitted the IDs will have no prefix and will begin with the `$class`. The `$class` field is set to the process class, e.g. `storage` or `log`. `$number` is set to the lowest number that is greater than `0` and is not used for any existing process group with the same process class. This convention is similar to the convention used by `StatefulSet`, but there is an important distinction: process groups are not guaranteed to be numbered from `1-N`. When a process group is replaced, we will add a new process group and then remove the old process group, and this will create a gap in the process group numbers. If the operator later has to create another process group, it will re-use the number in that gap before trying to use a new, higher number. If a process class has an underscore in it, such as `cluster_controller`, that underscore will be retained inside the process group ID.
+Process groups have a naming convention that is different from the pod name. Process group IDs are intended to be unique within an FDB cluster, across all Kubernetes Clusters.
+Process groups for different FDB clusters can have the same process group ID.
+These IDs have the form `$prefix-$class-$number`. `$prefix` is set by the `processGroupIDPrefix` field, and if this field is omitted the IDs will have no prefix and will begin with the `$class`.
+The `$class` field is set to the process class, e.g. `storage` or `log`.
+`$number` is chosen randomly in the interval `[1, 99999]` and is not used for any existing process group with the same process class.
+When a process group is replaced, we will add a new process group and then remove the old process group.
+If a process class has an underscore in it, such as `cluster_controller`, that underscore will be retained inside the process group ID.
 
-Pod names are intended to be unique within a namespace and Kubernetes Cluster. Pods for a single FDB cluster that run in different Kubernetes Clusters can have the same pod name. Pod names have the format `$cluster-$class-$number`. `$cluster` is the name of the cluster. `$class` and `$number` have the same meaning and value as they have in the process group name. If the process class has an underscore, it will be replaced with a dash.
+Pod names are intended to be unique within a namespace and Kubernetes Cluster.
+Pods for a single FDB cluster that run in different Kubernetes Clusters can have the same pod name. Pod names have the format `$cluster-$class-$number`.
+`$cluster` is the name of the cluster. `$class` and `$number` have the same meaning and value as they have in the process group name. If the process class has an underscore, it will be replaced with a dash.
 
 Volume claims have the same name as a pod, with a suffix taken from the name in the `processes.volumeClaimTemplate` field in the cluster spec. If this field is not set, we will use the suffix `data`.
 

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -173,8 +173,8 @@ func (factory *Factory) CreateFdbClusterFromSpec(
 	log.Println(
 		"FoundationDB cluster created (at version",
 		cluster.cluster.Spec.Version,
-		") in minutes",
-		time.Since(startTime).Minutes(),
+		") in",
+		time.Since(startTime).String(),
 	)
 
 	return cluster

--- a/e2e/test_operator_ha/operator_ha_test.go
+++ b/e2e/test_operator_ha/operator_ha_test.go
@@ -149,6 +149,13 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 			for _, cluster := range fdbCluster.GetAllClusters() {
 				tmpCluster := cluster
 				Eventually(func() string {
+					// The unified image has a mechanism to propagate changes in the cluster file, this allows multi-region
+					// clusters to reconcile faster. In the case of the split image we need "external" events in Kubernetes
+					// to trigger a reconciliation.
+					if !tmpCluster.GetCluster().UseUnifiedImage() {
+						tmpCluster.ForceReconcile()
+					}
+
 					return tmpCluster.GetCluster().Status.ConnectionString
 				}).WithTimeout(5 * time.Minute).WithPolling(2 * time.Second).ShouldNot(Equal(initialConnectionString))
 			}

--- a/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			clusterSetup(beforeVersion)
 			Expect(fdbCluster.SetAutoReplacements(false, 5*time.Minute)).ToNot(HaveOccurred())
 			// Ensure the operator is not skipping the process because it's missing for too long
-			fdbCluster.SetIgnoreMissingProcessesSeconds(5 * time.Minute)
+			fdbCluster.SetIgnoreMissingProcessesSeconds(30 * time.Minute)
 
 			// 1. Introduce network partition b/w Pod and cluster.
 			partitionedPod := fixtures.ChooseRandomPod(fdbCluster.GetStoragePods())
@@ -164,9 +164,6 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 				Consistently(func() bool {
 					return fdbCluster.GetCluster().Status.RunningVersion == beforeVersion
 				}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(BeTrue())
-			} else {
-				// Simulate the 2 minute wait otherwise the auto replacement might not succeed in time.
-				time.Sleep(2 * time.Minute)
 			}
 
 			// Enable the auto replacement feature again, but don't wait for reconciliation, otherwise we wait

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -118,3 +118,21 @@ func GenerateRandomString(n int) string {
 
 	return res.String()
 }
+
+// PickProcessGroups will pick a number of process groups for the specified process class.
+func PickProcessGroups(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, count int) []*fdbv1beta2.ProcessGroupStatus {
+	pickedProcessGroups := make([]*fdbv1beta2.ProcessGroupStatus, 0, count)
+
+	for _, processGroup := range cluster.Status.ProcessGroups {
+		if processGroup.ProcessClass != processClass {
+			continue
+		}
+
+		pickedProcessGroups = append(pickedProcessGroups, processGroup)
+		if len(pickedProcessGroups) >= count {
+			break
+		}
+	}
+
+	return pickedProcessGroups
+}


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2071. The issue was talking about another option, but I thought a bit more about it and using a randomized approach should be the best to prevent potential conflicts.

The PR is split in two commits: 1.) The actual code changes 2.) Test changes for all tests that assumed a deterministic setup.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

As described in the issue, reusing the same process group ID, can be confusing in cases where a new process group is created with a process group ID that was just recently used.

## Testing

Updated all unit tests and CI will run e2e tests.

## Documentation

I will screen the docs to see if we have to adjust them.

## Follow-up

-
