### PR TITLE
Don't reset the last reconciled generation

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1669,8 +1669,6 @@ func (cluster *FoundationDBCluster) CheckReconciliation(log logr.Logger) (bool, 
 
 	if reconciled {
 		cluster.Status.Generations.Reconciled = cluster.ObjectMeta.Generation
-	} else if cluster.Status.Generations.Reconciled == cluster.ObjectMeta.Generation {
-		cluster.Status.Generations.Reconciled = 0
 	}
 
 	return reconciled, nil

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -220,14 +220,13 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 			}
 
 			delayedRequeue = true
-
 			continue
 		}
 
 		return processRequeue(req, subReconciler, cluster, r.Recorder, clusterLog)
 	}
 
-	if cluster.Status.Generations.Reconciled < originalGeneration || delayedRequeue || delayedRequeueDuration > 0 {
+	if cluster.Status.Generations.Reconciled < originalGeneration || delayedRequeue {
 		clusterLog.Info("Cluster was not fully reconciled by reconciliation process", "status", cluster.Status.Generations,
 			"CurrentGeneration", cluster.Status.Generations.Reconciled,
 			"OriginalGeneration", originalGeneration,

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -238,7 +238,6 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	})
 
 	cluster.Status = clusterStatus
-
 	reconciled, err := cluster.CheckReconciliation(logger)
 	if err != nil {
 		return &requeue{curError: err}
@@ -261,6 +260,11 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 			logger.Error(err, "Error updating cluster clusterStatus")
 			return &requeue{curError: err}
 		}
+	}
+
+	// If the cluster is not reconciled, make sure we trigger a new reconciliation loop.
+	if !reconciled {
+		return &requeue{message: "cluster is not fully reconciled", delayedRequeue: true}
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/873

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

Before that we would reset the generation to 0 which can be confusing in many cases when the reconciliation drops from a precious number to 0.

## Testing

Ran unit tests and an e2e test suite.

## Documentation

Not needed.

## Follow-up

-
