### PR TITLE
Minor bug fixes for the e2e test suite

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -108,6 +108,7 @@ nightly-tests: GINKGO_LABEL_FILTER=--ginkgo.label-filter="pr || nightly"
 nightly-tests: run
 
 %.run: %
+	@sleep $$(shuf -i 1-10 -n 1)
 	go test -timeout=$(TIMEOUT) $(VERBOSE) ./$< \
 	${NO_COLOR} ${GINKGO_VERBOSE} \
 	  $(GINKGO_LABEL_FILTER) \

--- a/e2e/fixtures/certificate_generator.go
+++ b/e2e/fixtures/certificate_generator.go
@@ -48,7 +48,7 @@ func hashKeyID(n *big.Int) ([]byte, error) {
 
 // GenerateCertificate generates a Kubernetes Secret that contains a valid certificate, key and ca.pem. This method can
 // be used to create e2e test FDB clusters.
-func GenerateCertificate() (*corev1.Secret, error) {
+func (factory *Factory) GenerateCertificate() (*corev1.Secret, error) {
 	caPrivateKey, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
 		return nil, err
@@ -147,7 +147,7 @@ func GenerateCertificate() (*corev1.Secret, error) {
 	return &corev1.Secret{
 		Type: corev1.SecretTypeTLS,
 		ObjectMeta: metav1.ObjectMeta{
-			Name: RandStringRunes(32),
+			Name: factory.RandStringRunes(32),
 		},
 		// Let the Kubernetes API do the base64 encoding
 		StringData: map[string]string{

--- a/e2e/fixtures/chaos_disk.go
+++ b/e2e/fixtures/chaos_disk.go
@@ -43,7 +43,7 @@ func (factory *Factory) InjectDiskFailure(selector chaosmesh.PodSelectorSpec) *C
 func (factory *Factory) InjectDiskFailureWithPath(selector chaosmesh.PodSelectorSpec, volumePath string, path string, methods []chaosmesh.IoMethod, containers []string) *ChaosMeshExperiment {
 	return factory.CreateExperiment(&chaosmesh.IOChaos{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      RandStringRunes(32),
+			Name:      factory.RandStringRunes(32),
 			Namespace: factory.GetChaosNamespace(),
 			Labels:    factory.GetDefaultLabels(),
 		},
@@ -70,7 +70,7 @@ func (factory *Factory) InjectDiskFailureWithPath(selector chaosmesh.PodSelector
 func (factory *Factory) InjectIOLatency(selector chaosmesh.PodSelectorSpec, delay string) *ChaosMeshExperiment {
 	return factory.CreateExperiment(&chaosmesh.IOChaos{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      RandStringRunes(32),
+			Name:      factory.RandStringRunes(32),
 			Namespace: factory.GetChaosNamespace(),
 			Labels:    factory.GetDefaultLabels(),
 		},

--- a/e2e/fixtures/chaos_http.go
+++ b/e2e/fixtures/chaos_http.go
@@ -31,7 +31,7 @@ import (
 func (factory *Factory) InjectHTTPClientChaosWrongResultFdbMonitorConf(selector chaosmeshv1alpha1.PodSelectorSpec, namespace string) *ChaosMeshExperiment {
 	return factory.CreateExperiment(&chaosmeshv1alpha1.HTTPChaos{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      RandStringRunes(32),
+			Name:      factory.RandStringRunes(32),
 			Namespace: factory.GetChaosNamespace(),
 			Labels:    factory.GetDefaultLabels(),
 		},

--- a/e2e/fixtures/chaos_network.go
+++ b/e2e/fixtures/chaos_network.go
@@ -49,7 +49,7 @@ func (factory *Factory) InjectNetworkLoss(lossPercentage string, source chaosmes
 
 	return factory.CreateExperiment(&chaosmesh.NetworkChaos{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      RandStringRunes(32),
+			Name:      factory.RandStringRunes(32),
 			Namespace: factory.GetChaosNamespace(),
 			Labels:    factory.GetDefaultLabels(),
 		},
@@ -140,7 +140,7 @@ func (factory *Factory) injectPartitionBetween(
 
 	return factory.CreateExperiment(&chaosmesh.NetworkChaos{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      RandStringRunes(32),
+			Name:      factory.RandStringRunes(32),
 			Namespace: factory.GetChaosNamespace(),
 			Labels:    factory.GetDefaultLabels(),
 		},

--- a/e2e/fixtures/chaos_pod.go
+++ b/e2e/fixtures/chaos_pod.go
@@ -34,7 +34,7 @@ func (factory *Factory) ScheduleInjectPodKill(target chaosmesh.PodSelectorSpec, 
 		},
 		schedule,
 		chaosmesh.PodKillAction,
-		RandStringRunes(32))
+		factory.RandStringRunes(32))
 }
 
 // ScheduleInjectPodKillWithName schedules a Pod Kill action with the specified name.

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -51,25 +52,41 @@ const (
 
 // Factory is a helper struct to organize tests.
 type Factory struct {
-	*singleton
-	shutdownHooks          ShutdownHooks
-	chaosExperiments       []ChaosMeshExperiment
-	invariantShutdownHooks ShutdownHooks
-	beforeVersion          string
-	shutdownInProgress     bool
-	options                *FactoryOptions
+	shutdownHooks           ShutdownHooks
+	chaosExperiments        []ChaosMeshExperiment
+	invariantShutdownHooks  ShutdownHooks
+	shutdownInProgress      bool
+	beforeVersion           string
+	namespace               string
+	userName                string
+	options                 *FactoryOptions
+	randomGenerator         *rand.Rand
+	certificate             *corev1.Secret
+	namespaces              []string
+	controllerRuntimeClient client.Client
+	kubernetesClient        *kubernetes.Clientset
+	config                  *rest.Config
+	fdbVersion              fdbv1beta2.Version
 }
 
 // CreateFactory will create a factory based on the provided options.
 func CreateFactory(options *FactoryOptions) *Factory {
-	singleton, err := getSingleton(options)
+	configuration, err := getSingleton(options)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+	// TODO (johscheuer): Add an option to make use of ginkgo.GinkgoRandomSeed() to have a deterministic setup with
+	// the pseudo-random-generator seed from Ginkgo.
 	return &Factory{
-		singleton:              singleton,
-		options:                options,
-		shutdownHooks:          ShutdownHooks{},
-		invariantShutdownHooks: ShutdownHooks{},
+		options:                 options,
+		shutdownHooks:           ShutdownHooks{},
+		invariantShutdownHooks:  ShutdownHooks{},
+		randomGenerator:         rand.New(rand.NewSource(time.Now().Unix())),
+		namespace:               options.namespace,
+		userName:                configuration.userName,
+		controllerRuntimeClient: configuration.controllerRuntimeClient,
+		fdbVersion:              configuration.fdbVersion,
+		kubernetesClient:        configuration.client,
+		config:                  configuration.config,
 	}
 }
 
@@ -95,17 +112,24 @@ func (factory *Factory) GetChaosNamespace() string {
 }
 
 func (factory *Factory) getCertificate() *corev1.Secret {
-	return factory.singleton.certificate
+	if factory.certificate != nil {
+		return factory.certificate
+	}
+
+	certificate, err := factory.GenerateCertificate()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	factory.certificate = certificate
+	return certificate
 }
 
 // GetControllerRuntimeClient returns the controller runtime client.
 func (factory *Factory) GetControllerRuntimeClient() client.Client {
-	return factory.singleton.controllerRuntimeClient
+	return factory.controllerRuntimeClient
 }
 
 // GetSecretName returns the secret name that contains the certificates used for the current test run.
 func (factory *Factory) GetSecretName() string {
-	return factory.singleton.certificate.Name
+	return factory.getCertificate().Name
 }
 
 // GetBackupSecretName returns the name of the backup secret.
@@ -114,11 +138,11 @@ func (factory *Factory) GetBackupSecretName() string {
 }
 
 func (factory *Factory) getConfig() *rest.Config {
-	return factory.singleton.config
+	return factory.config
 }
 
 func (factory *Factory) getClient() *kubernetes.Clientset {
-	return factory.singleton.client
+	return factory.kubernetesClient
 }
 
 // DeletePod deletes the provided Pod
@@ -136,7 +160,7 @@ func (factory *Factory) GetPod(namespace string, name string) (*corev1.Pod, erro
 
 // GetFDBVersion returns the parsed FDB version.
 func (factory *Factory) GetFDBVersion() fdbv1beta2.Version {
-	return factory.singleton.fdbVersion
+	return factory.fdbVersion
 }
 
 // GetFDBVersionAsString returns the FDB version as string.
@@ -196,8 +220,8 @@ func (factory *Factory) CreateFdbHaCluster(
 	log.Println(
 		"FoundationDB HA cluster created (at version",
 		cluster.GetPrimary().cluster.Spec.Version,
-		") in minutes",
-		time.Since(startTime).Minutes(),
+		") in",
+		time.Since(startTime).String(),
 	)
 
 	return cluster
@@ -271,7 +295,7 @@ func (factory *Factory) GetSidecarContainerOverrides(debugSymbols bool) fdbv1bet
 
 func (factory *Factory) getClusterName() string {
 	if factory.options.clusterName == "" {
-		return fmt.Sprintf("fdb-cluster-%s", RandStringRunes(8))
+		return fmt.Sprintf("fdb-cluster-%s", factory.RandStringRunes(8))
 	}
 
 	return factory.options.clusterName
@@ -402,8 +426,8 @@ func (factory *Factory) startFDBFromClusterSpec(
 
 	fdbCluster, err := factory.ensureFdbClusterExists(spec, config)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cluster was not created in the expected time")
-	factory.singleton.namespaces = append(
-		factory.singleton.namespaces,
+	factory.namespaces = append(
+		factory.namespaces,
 		fdbCluster.cluster.Namespace,
 	)
 
@@ -912,4 +936,9 @@ func (factory *Factory) getStorageEngine() fdbv1beta2.StorageEngine {
 	}
 
 	return fdbv1beta2.StorageEngine(factory.options.storageEngine)
+}
+
+// Intn wrapper around Intn with the current random generator of the factory.
+func (factory *Factory) Intn(n int) int {
+	return factory.randomGenerator.Intn(n)
 }

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -74,13 +74,13 @@ func CreateFactory(options *FactoryOptions) *Factory {
 	configuration, err := getSingleton(options)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	// TODO (johscheuer): Add an option to make use of ginkgo.GinkgoRandomSeed() to have a deterministic setup with
-	// the pseudo-random-generator seed from Ginkgo.
+	seed := time.Now().Unix()
+	log.Println("using seed:", seed, "for factory")
 	return &Factory{
 		options:                 options,
 		shutdownHooks:           ShutdownHooks{},
 		invariantShutdownHooks:  ShutdownHooks{},
-		randomGenerator:         rand.New(rand.NewSource(time.Now().Unix())),
+		randomGenerator:         rand.New(rand.NewSource(seed)),
 		namespace:               options.namespace,
 		userName:                configuration.userName,
 		controllerRuntimeClient: configuration.controllerRuntimeClient,

--- a/e2e/fixtures/fdb_operator_fixtures.go
+++ b/e2e/fixtures/fdb_operator_fixtures.go
@@ -185,8 +185,7 @@ func (factory *Factory) ensureHAFdbClusterExists(
 		options,
 	)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	err = fdb.WaitForReconciliation(CreationTrackerLoggerOption(config.CreationTracker))
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Expect(fdb.WaitForReconciliation(CreationTrackerLoggerOption(config.CreationTracker))).ToNot(gomega.HaveOccurred())
 	log.Printf("primary cluster is reconciled in namespaces=%s", namespaces)
 
 	cluster, err := factory.getClusterStatus(fdb.GetPrimary().Name(), fdb.GetPrimary().Namespace())

--- a/e2e/fixtures/random_string.go
+++ b/e2e/fixtures/random_string.go
@@ -20,17 +20,13 @@
 
 package fixtures
 
-import (
-	"math/rand"
-)
-
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz123456789")
 
 // RandStringRunes randomly generates a string of length n.
-func RandStringRunes(n int) string {
+func (factory *Factory) RandStringRunes(n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		b[i] = letterRunes[factory.randomGenerator.Intn(len(letterRunes))]
 	}
 	return string(b)
 }

--- a/e2e/fixtures/singleton.go
+++ b/e2e/fixtures/singleton.go
@@ -21,7 +21,9 @@
 package fixtures
 
 import (
+	"fmt"
 	"os/user"
+	"sync"
 
 	chaosmesh "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,97 +35,108 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	controllerRuntimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type singleton struct {
 	options                 *FactoryOptions
 	userName                string
-	certificate             *corev1.Secret
 	config                  *rest.Config
 	client                  *kubernetes.Clientset
-	controllerRuntimeClient controllerRuntimeClient.Client
+	controllerRuntimeClient client.Client
 	fdbVersion              fdbv1beta2.Version
-	namespaces              []string
 }
 
+var (
+	once             = sync.Once{}
+	currentSingleton *singleton
+)
+
 func getSingleton(options *FactoryOptions) (*singleton, error) {
-	err := options.validateFlags()
-	if err != nil {
-		return nil, err
-	}
-
-	var userName string
-	if options.username == "" {
-		var u *user.User
-		u, err = user.Current()
+	var err error
+	// Setup the singleton once per test suite.
+	once.Do(func() {
+		err = options.validateFlags()
 		if err != nil {
-			return nil, err
+			return
 		}
-		userName = u.Username
-	} else {
-		userName = options.username
+
+		var userName string
+		if options.username == "" {
+			var u *user.User
+			u, err = user.Current()
+			if err != nil {
+				return
+			}
+			userName = u.Username
+		} else {
+			userName = options.username
+		}
+
+		var kubeConfig *rest.Config
+		kubeConfig, err = config.GetConfigWithContext(options.context)
+		if err != nil {
+			return
+		}
+		var kubernetesClient *kubernetes.Clientset
+		kubernetesClient, err = kubernetes.NewForConfig(kubeConfig)
+		if err != nil {
+			return
+		}
+		var fdbVersion fdbv1beta2.Version
+		fdbVersion, err = fdbv1beta2.ParseFdbVersion(options.fdbVersion)
+		if err != nil {
+			return
+		}
+
+		// Also add Apps v1 and Core v1 to allow to use the controller runtime client
+		// to modify Pods, Deployments etc.
+		curScheme := runtime.NewScheme()
+		err = scheme.AddToScheme(curScheme)
+		if err != nil {
+			return
+		}
+		err = appsv1.AddToScheme(curScheme)
+		if err != nil {
+			return
+		}
+		err = corev1.AddToScheme(curScheme)
+		if err != nil {
+			return
+		}
+		err = fdbv1beta2.AddToScheme(curScheme)
+		if err != nil {
+			return
+		}
+		err = batchv1.AddToScheme(curScheme)
+		if err != nil {
+			return
+		}
+		err = chaosmesh.AddToScheme(curScheme)
+		if err != nil {
+			return
+		}
+
+		var controllerClient client.Client
+		controllerClient, err = LoadControllerRuntimeFromContext(options.context, curScheme)
+		if err != nil {
+			return
+		}
+
+		currentSingleton = &singleton{
+			options:                 options,
+			userName:                userName,
+			config:                  kubeConfig,
+			client:                  kubernetesClient,
+			fdbVersion:              fdbVersion,
+			controllerRuntimeClient: controllerClient,
+		}
+	})
+
+	if currentSingleton == nil {
+		return nil, fmt.Errorf("singleton was not initialized")
 	}
 
-	certificate, _ := GenerateCertificate()
-	if err != nil {
-		return nil, err
-	}
-
-	kubeConfig, err := config.GetConfigWithContext(options.context)
-	if err != nil {
-		return nil, err
-	}
-	client, err := kubernetes.NewForConfig(kubeConfig)
-	if err != nil {
-		return nil, err
-	}
-	fdbVersion, err := fdbv1beta2.ParseFdbVersion(options.fdbVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	// Also add Apps v1 and Core v1 to allow to use the controller runtime client
-	// to modify Pods, Deployments etc.
-	curScheme := runtime.NewScheme()
-	err = scheme.AddToScheme(curScheme)
-	if err != nil {
-		return nil, err
-	}
-	err = appsv1.AddToScheme(curScheme)
-	if err != nil {
-		return nil, err
-	}
-	err = corev1.AddToScheme(curScheme)
-	if err != nil {
-		return nil, err
-	}
-	err = fdbv1beta2.AddToScheme(curScheme)
-	if err != nil {
-		return nil, err
-	}
-	err = batchv1.AddToScheme(curScheme)
-	if err != nil {
-		return nil, err
-	}
-	err = chaosmesh.AddToScheme(curScheme)
-	if err != nil {
-		return nil, err
-	}
-
-	controllerClient, err := LoadControllerRuntimeFromContext(options.context, curScheme)
-	if err != nil {
-		return nil, err
-	}
-
-	return &singleton{
-		options:                 options,
-		userName:                userName,
-		config:                  kubeConfig,
-		client:                  client,
-		fdbVersion:              fdbVersion,
-		certificate:             certificate,
-		controllerRuntimeClient: controllerClient,
-	}, nil
+	return currentSingleton, err
 }

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -91,7 +91,7 @@ func (fdbCluster *FdbCluster) RunFdbCliCommandInOperatorWithoutRetry(
 	printOutput bool,
 	timeout int,
 ) (string, string, error) {
-	pod := ChooseRandomPod(fdbCluster.factory.GetOperatorPods(fdbCluster.Namespace()))
+	pod := fdbCluster.factory.ChooseRandomPod(fdbCluster.factory.GetOperatorPods(fdbCluster.Namespace()))
 	cluster, err := fdbCluster.factory.getClusterStatus(
 		fdbCluster.Name(),
 		fdbCluster.Namespace(),

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -35,7 +35,6 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"math/rand"
 	"strings"
 	"time"
 
@@ -184,7 +183,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		When("cluster enables taint feature on focused maintenance taint key", func() {
 			It("should remove the targeted Pod whose Node is tainted", func() {
-				replacedPod := fixtures.RandomPickOnePod(initialPods.Items)
+				replacedPod := factory.RandomPickOnePod(initialPods.Items)
 				// Taint replacePod's node
 				taintedNode = fdbCluster.GetNode(replacedPod.Spec.NodeName)
 				taintedNode.Spec.Taints = []corev1.Taint{
@@ -206,7 +205,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			})
 
 			It("should remove all Pods whose Nodes are tainted", func() {
-				replacedPods := fixtures.RandomPickPod(initialPods.Items, numNodesTainted)
+				replacedPods := factory.RandomPickPod(initialPods.Items, numNodesTainted)
 				for _, pod := range replacedPods {
 					// Taint replacePod's node
 					node := fdbCluster.GetNode(pod.Spec.NodeName)
@@ -215,7 +214,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 							Key:       taintKeyMaintenance,
 							Value:     "rack_maintenance",
 							Effect:    corev1.TaintEffectPreferNoSchedule,
-							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Millisecond * time.Duration(taintKeyMaintenanceDuration*1000+int64(rand.Intn(1000))))},
+							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Millisecond * time.Duration(taintKeyMaintenanceDuration*1000+int64(factory.Intn(1000))))},
 						},
 					}
 					log.Printf("Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n", pod.Name,
@@ -255,7 +254,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			})
 
 			It("should eventually remove the targeted Pod whose Node is tainted", func() {
-				replacedPod := fixtures.RandomPickOnePod(initialPods.Items)
+				replacedPod := factory.RandomPickOnePod(initialPods.Items)
 				// Taint replacePod's node
 				node := fdbCluster.GetNode(replacedPod.Spec.NodeName)
 				node.Spec.Taints = []corev1.Taint{
@@ -277,7 +276,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			})
 
 			It("should eventually remove all Pods whose Nodes are tainted", func() {
-				replacedPods := fixtures.RandomPickPod(initialPods.Items, numNodesTainted)
+				replacedPods := factory.RandomPickPod(initialPods.Items, numNodesTainted)
 				for _, pod := range replacedPods {
 					// Taint replacePod's node
 					node := fdbCluster.GetNode(pod.Spec.NodeName)
@@ -286,7 +285,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 							Key:       taintKeyMaintenance,
 							Value:     "rack_maintenance",
 							Effect:    corev1.TaintEffectPreferNoSchedule,
-							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Millisecond * time.Duration(taintKeyStarDuration*1000+int64(rand.Intn(1000))))},
+							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Millisecond * time.Duration(taintKeyStarDuration*1000+int64(factory.Intn(1000))))},
 						},
 					}
 					log.Printf("Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n", pod.Name,
@@ -319,7 +318,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			})
 
 			It("should not remove any Pod whose Nodes are tainted", func() {
-				targetPods := fixtures.RandomPickPod(initialPods.Items, numNodesTainted)
+				targetPods := factory.RandomPickPod(initialPods.Items, numNodesTainted)
 				var targetPodProcessGroupIDs []fdbv1beta2.ProcessGroupID
 				for _, pod := range targetPods {
 					targetPodProcessGroupIDs = append(targetPodProcessGroupIDs, internal.GetProcessGroupIDFromMeta(fdbCluster.GetCluster(), pod.ObjectMeta))
@@ -330,7 +329,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 							Key:       taintKeyMaintenance,
 							Value:     "rack_maintenance",
 							Effect:    corev1.TaintEffectPreferNoSchedule,
-							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Millisecond * time.Duration(taintKeyStarDuration*1000+int64(rand.Intn(1000))))},
+							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Millisecond * time.Duration(taintKeyStarDuration*1000+int64(factory.Intn(1000))))},
 						},
 					}
 					log.Printf("Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n", pod.Name,
@@ -376,7 +375,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		JustBeforeEach(func() {
 			initialPods := fdbCluster.GetStatelessPods()
-			replacedPod = fixtures.RandomPickOnePod(initialPods.Items)
+			replacedPod = factory.RandomPickOnePod(initialPods.Items)
 			fdbCluster.ReplacePod(replacedPod, true)
 		})
 
@@ -543,7 +542,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		BeforeEach(func() {
 			initialPods := fdbCluster.GetStatelessPods()
-			failedPod = fixtures.RandomPickOnePod(initialPods.Items)
+			failedPod = factory.RandomPickOnePod(initialPods.Items)
 			log.Printf("Setting pod %s to unschedulable.", failedPod.Name)
 			Expect(fdbCluster.SetPodAsUnschedulable(failedPod)).NotTo(HaveOccurred())
 			fdbCluster.ReplacePod(failedPod, true)
@@ -564,8 +563,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var podToReplace *corev1.Pod
 
 		BeforeEach(func() {
-			failedPod = fixtures.ChooseRandomPod(fdbCluster.GetStatelessPods())
-			podToReplace = fixtures.ChooseRandomPod(fdbCluster.GetStatelessPods())
+			failedPod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
+			podToReplace = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
 			log.Println(
 				"Failed (unscheduled) Pod:",
 				failedPod.Name,
@@ -596,7 +595,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		It("should not reconcile and keep the cluster in the same generation", func() {
 			initialStoragePods := fdbCluster.GetStoragePods()
-			podToDelete := fixtures.ChooseRandomPod(initialStoragePods)
+			podToDelete := factory.ChooseRandomPod(initialStoragePods)
 			log.Printf("deleting storage pod %s/%s", podToDelete.Namespace, podToDelete.Name)
 			factory.DeletePod(podToDelete)
 			Eventually(func() int {
@@ -684,7 +683,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var deleteTime time.Time
 
 		BeforeEach(func() {
-			podToDelete = fixtures.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
+			podToDelete = factory.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
 			log.Printf("deleting storage pod %s/%s", podToDelete.Namespace, podToDelete.Name)
 			deleteTime = time.Now()
 			factory.DeletePod(&podToDelete)
@@ -717,7 +716,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			var partitionedPod *corev1.Pod
 
 			BeforeEach(func() {
-				partitionedPod = fixtures.ChooseRandomPod(fdbCluster.GetStatelessPods())
+				partitionedPod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
 				log.Printf("partition Pod: %s", partitionedPod.Name)
 				exp = factory.InjectPartitionBetween(
 					fixtures.PodSelector(partitionedPod),
@@ -761,7 +760,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				Expect(fdbCluster.SetAutoReplacements(false, 30*time.Second)).ShouldNot(HaveOccurred())
 
 				// Pick 2 Pods, so the operator has to replace them one after another
-				partitionedPods = fixtures.RandomPickPod(fdbCluster.GetStatelessPods().Items, 3)
+				partitionedPods = factory.RandomPickPod(fdbCluster.GetStatelessPods().Items, 3)
 				for _, partitionedPod := range partitionedPods {
 					pod := partitionedPod
 					log.Printf("partition Pod: %s", pod.Name)
@@ -833,7 +832,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}
 			availabilityCheck = false
 			initialPods := fdbCluster.GetLogPods()
-			podWithIOError = fixtures.RandomPickOnePod(initialPods.Items)
+			podWithIOError = factory.RandomPickOnePod(initialPods.Items)
 			log.Printf("Injecting I/O chaos to %s", podWithIOError.Name)
 			exp = factory.InjectDiskFailure(fixtures.PodSelector(&podWithIOError))
 
@@ -871,7 +870,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}
 			availabilityCheck = false
 			initialPods := fdbCluster.GetLogPods()
-			podWithIOError = fixtures.RandomPickOnePod(initialPods.Items)
+			podWithIOError = factory.RandomPickOnePod(initialPods.Items)
 			log.Printf("injecting iochaos to %s", podWithIOError.Name)
 			exp = factory.InjectIOLatency(fixtures.PodSelector(&podWithIOError), "2s")
 			log.Printf("iochaos injected to %s", podWithIOError.Name)
@@ -923,7 +922,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var replacedPods []corev1.Pod
 
 		BeforeEach(func() {
-			fdbCluster.ReplacePods(fixtures.RandomPickPod(fdbCluster.GetStatelessPods().Items, 4), true)
+			fdbCluster.ReplacePods(factory.RandomPickPod(fdbCluster.GetStatelessPods().Items, 4), true)
 		})
 
 		AfterEach(func() {
@@ -944,7 +943,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		BeforeEach(func() {
 			podsBeforeReplacement = fdbCluster.GetPodsNames()
-			replacePod = fixtures.ChooseRandomPod(fdbCluster.GetPods())
+			replacePod = factory.ChooseRandomPod(fdbCluster.GetPods())
 			factory.SetFinalizerForPod(replacePod, []string{"foundationdb.org/test"})
 			fdbCluster.ReplacePod(*replacePod, true)
 		})
@@ -1146,7 +1145,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				candidates = append(candidates, storageClass.Name)
 			}
 
-			targetStorageClass = candidates[rand.Intn(len(candidates))]
+			targetStorageClass = candidates[factory.Intn(len(candidates))]
 
 			Expect(fdbCluster.UpdateStorageClass(
 				targetStorageClass,
@@ -1172,7 +1171,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var pvc corev1.PersistentVolumeClaim
 
 		BeforeEach(func() {
-			replacePod = fixtures.ChooseRandomPod(fdbCluster.GetLogPods())
+			replacePod = factory.ChooseRandomPod(fdbCluster.GetLogPods())
 			volClaimName := fixtures.GetPvc(replacePod)
 			initialVolumeClaims = fdbCluster.GetVolumeClaimsForProcesses(
 				fdbv1beta2.ProcessClassLog,
@@ -1255,7 +1254,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				fdbv1beta2.FoundationDBCustomParameter(newKnob),
 			)
 
-			pickedPod = fixtures.ChooseRandomPod(fdbCluster.GetStatelessPods())
+			pickedPod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
 			log.Println("Selected Pod:", pickedPod.Name, " to be skipped during the restart")
 			fdbCluster.SetIgnoreDuringRestart(
 				[]fdbv1beta2.ProcessGroupID{fixtures.GetProcessGroupID(*pickedPod)},
@@ -1306,7 +1305,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		BeforeEach(func() {
 			initialPods := fdbCluster.GetStatelessPods()
-			podMarkedForRemoval = fixtures.RandomPickOnePod(initialPods.Items)
+			podMarkedForRemoval = factory.RandomPickOnePod(initialPods.Items)
 			log.Println("Setting Pod", podMarkedForRemoval.Name, "to be blocked to be removed and mark it for removal.")
 			processGroupID = fixtures.GetProcessGroupID(podMarkedForRemoval)
 			fdbCluster.SetBuggifyBlockRemoval([]fdbv1beta2.ProcessGroupID{processGroupID})
@@ -1362,7 +1361,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			// Make sure the new Pod will be stuck in unschedulable.
 			fdbCluster.SetProcessGroupsAsUnschedulable([]fdbv1beta2.ProcessGroupID{processGroupID})
 			// Now replace a random Pod for replacement to force the cluster to create a new Pod.
-			fdbCluster.ReplacePod(fixtures.RandomPickOnePod(fdbCluster.GetStatelessPods().Items), false)
+			fdbCluster.ReplacePod(factory.RandomPickOnePod(fdbCluster.GetStatelessPods().Items), false)
 
 			// Allow the operator again to reconcile.
 			fdbCluster.SetSkipReconciliation(false)
@@ -1589,7 +1588,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			)) * time.Second
 			Expect(fdbCluster.SetAutoReplacements(true, 30*time.Second)).ShouldNot(HaveOccurred())
 
-			pod = fixtures.ChooseRandomPod(fdbCluster.GetStatelessPods())
+			pod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
 			log.Printf("exclude Pod: %s", pod.Name)
 			Expect(pod.Status.PodIP).NotTo(BeEmpty())
 			_, _ = fdbCluster.RunFdbCliCommandInOperator(fmt.Sprintf("exclude %s", pod.Status.PodIP), false, 30)
@@ -2288,7 +2287,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				Skip("Chaos tests are skipped for the operator")
 			}
 
-			selectedPod = fixtures.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
+			selectedPod = factory.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
 			for _, status := range selectedPod.Status.ContainerStatuses {
 				initialRestarts += int(status.RestartCount)
 			}

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -29,7 +29,6 @@ Each test will create a new HA FoundationDB cluster which will be upgraded.
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -422,11 +421,11 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 					return true
 				}
 
-				randomCluster := clusters[rand.Intn(len(clusters))]
+				randomCluster := factory.RandomPickOneCluster(clusters)
 				// Make sure we are not deleting coordinator Pods
 				var randomPod *corev1.Pod
 				Eventually(func() bool {
-					randomPod = fixtures.ChooseRandomPod(randomCluster.GetPods())
+					randomPod = factory.ChooseRandomPod(randomCluster.GetPods())
 					_, ok := coordinatorMap[randomPod.UID]
 					if ok {
 						log.Println("Skipping pod: ", randomPod.Name, "as it is a coordinator")

--- a/e2e/test_operator_maintenance_mode/operator_maintenance_mode_test.go
+++ b/e2e/test_operator_maintenance_mode/operator_maintenance_mode_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 		var faultDomain fdbv1beta2.FaultDomain
 
 		BeforeEach(func() {
-			failingStoragePod = fixtures.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
+			failingStoragePod = factory.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
 
 			// Set maintenance mode for this Pod
 			for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {

--- a/e2e/test_operator_stress/operator_stress_test.go
+++ b/e2e/test_operator_stress/operator_stress_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Operator Stress", Label("e2e"), func() {
 			// Since Ginkgo doesn't support what we want, we run this multiple times.
 			for i := 0; i < 10; i++ {
 				Expect(fdbCluster.ClearProcessGroupsToRemove()).ShouldNot(HaveOccurred())
-				pod := fixtures.ChooseRandomPod(fdbCluster.GetPods())
+				pod := factory.ChooseRandomPod(fdbCluster.GetPods())
 				fdbCluster.ReplacePod(*pod, true)
 			}
 		})

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 					return true
 				}
 
-				selectedPod := fixtures.RandomPickOnePod(pods)
+				selectedPod := factory.RandomPickOnePod(pods)
 				log.Println("deleting pod: ", selectedPod.Name)
 				factory.DeletePod(&selectedPod)
 				Expect(fdbCluster.WaitForPodRemoval(&selectedPod)).ShouldNot(HaveOccurred())
@@ -249,7 +249,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			Expect(fdbCluster.SetAutoReplacements(false, 20*time.Minute)).ToNot(HaveOccurred())
 
 			// 1. Introduce crash-loop into sidecar container to artificially create a partition.
-			pickedPod := fixtures.ChooseRandomPod(fdbCluster.GetStoragePods())
+			pickedPod := factory.ChooseRandomPod(fdbCluster.GetStoragePods())
 			log.Println("Injecting container fault to crash-loop sidecar process:", pickedPod.Name)
 
 			fdbCluster.SetCrashLoopContainers([]fdbv1beta2.CrashLoopContainerObject{
@@ -372,14 +372,14 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			// processes during the restart command.
 			statelessPods := fdbCluster.GetStatelessPods()
 			Expect(statelessPods.Items).NotTo(BeEmpty())
-			selectedStatelessPods := fixtures.RandomPickPod(
+			selectedStatelessPods := factory.RandomPickPod(
 				statelessPods.Items,
 				len(statelessPods.Items)/2,
 			)
 
 			logPods := fdbCluster.GetLogPods()
 			Expect(logPods.Items).NotTo(BeEmpty())
-			selectedLogPods := fixtures.RandomPickPod(logPods.Items, len(logPods.Items)/2)
+			selectedLogPods := factory.RandomPickPod(logPods.Items, len(logPods.Items)/2)
 
 			ignoreDuringRestart := make(
 				[]fdbv1beta2.ProcessGroupID,
@@ -479,7 +479,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 			// Select one Pod, this Pod will be marked to be removed but the actual removal will be blocked. The intention
 			// is to simulate a Pods that should be removed but the removal is not completed yet and an upgrade will be started.
-			podMarkedForRemoval := fixtures.RandomPickOnePod(fdbCluster.GetPods().Items)
+			podMarkedForRemoval := factory.RandomPickOnePod(fdbCluster.GetPods().Items)
 			processGroupMarkedForRemoval := fixtures.GetProcessGroupID(podMarkedForRemoval)
 			log.Println("picked Pod", podMarkedForRemoval.Name, "to be marked for removal")
 			// Use the buggify option to block the actual removal.
@@ -546,7 +546,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 			// Select one Pod, this Pod will be marked to be removed but the actual removal will be blocked. The intention
 			// is to simulate a Pods that should be removed but the removal is not completed yet and an upgrade will be started.
-			podMarkedForRemoval := fixtures.RandomPickOnePod(fdbCluster.GetPods().Items)
+			podMarkedForRemoval := factory.RandomPickOnePod(fdbCluster.GetPods().Items)
 			processGroupMarkedForRemoval := fixtures.GetProcessGroupID(podMarkedForRemoval)
 			log.Println("picked Pod", podMarkedForRemoval.Name, "to be marked for removal")
 			// Set a finalizer for this Pod to make sure the Pod object cannot be garbage collected
@@ -592,7 +592,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 		"upgrading a cluster with a pending pod",
 		func(beforeVersion string, targetVersion string) {
 			clusterSetup(beforeVersion, true)
-			pendingPod := fixtures.RandomPickOnePod(fdbCluster.GetPods().Items)
+			pendingPod := factory.RandomPickOnePod(fdbCluster.GetPods().Items)
 			// Set the pod in pending state.
 			Expect(fdbCluster.SetPodAsUnschedulable(pendingPod)).NotTo(HaveOccurred())
 			fdbCluster.UpgradeAndVerify(targetVersion)

--- a/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			// Inject chaos only to storage Pods to reduce the risk of a long recovery because a transaction
 			// system Pod was partitioned. The test still has the same checks that will be performed.
 			// Once we have a better availability check for upgrades we can target all pods again.
-			partitionedPod := fixtures.ChooseRandomPod(fdbCluster.GetStoragePods())
+			partitionedPod := factory.ChooseRandomPod(fdbCluster.GetStoragePods())
 			log.Println("Injecting network partition to pod: ", partitionedPod.Name)
 			exp := factory.InjectPartitionBetween(
 				fixtures.PodSelector(partitionedPod),
@@ -143,7 +143,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			fdbCluster.SetIgnoreMissingProcessesSeconds(30 * time.Minute)
 
 			// 1. Introduce network partition b/w Pod and cluster.
-			partitionedPod := fixtures.ChooseRandomPod(fdbCluster.GetStoragePods())
+			partitionedPod := factory.ChooseRandomPod(fdbCluster.GetStoragePods())
 			log.Println("Injecting network partition to pod: ", partitionedPod.Name)
 			_ = factory.InjectPartitionBetween(
 				fixtures.PodSelector(partitionedPod),
@@ -205,7 +205,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			log.Println("Injecting packet loss b/w pod")
 			allPods := fdbCluster.GetAllPods()
 
-			pickedPods := fixtures.RandomPickPod(allPods.Items, len(allPods.Items)/5)
+			pickedPods := factory.RandomPickPod(allPods.Items, len(allPods.Items)/5)
 			Expect(pickedPods).ToNot(BeEmpty())
 			for _, pod := range pickedPods {
 				log.Println("Picked Pod", pod.Name)
@@ -260,7 +260,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 
 			// Select one Pod, this Pod will mount the fdbmonitor config file as read-only.
 			// This should block the upgrade.
-			faultyPod := fixtures.RandomPickOnePod(fdbCluster.GetPods().Items)
+			faultyPod := factory.RandomPickOnePod(fdbCluster.GetPods().Items)
 
 			// We have to update the sidecar before the operator is doing it. If we don't do this here the operator
 			// will update the sidecar and then the I/O chaos will be gone. So we prepare the faulty Pod to already
@@ -374,7 +374,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 
 			// Select one Pod, this Pod will miss the new fdbserver binary.
 			// This should block the upgrade.
-			faultyPod := fixtures.RandomPickOnePod(fdbCluster.GetPods().Items)
+			faultyPod := factory.RandomPickOnePod(fdbCluster.GetPods().Items)
 
 			// We have to update the sidecar before the operator is doing it. If we don't do this here the operator
 			// will update the sidecar and then the sidecar will copy the binaries at start-up. So we prepare the faulty Pod to already

--- a/e2e/test_operator_velocity/operator_velocity_test.go
+++ b/e2e/test_operator_velocity/operator_velocity_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 				fdbCluster.GetPrimary().SetAutoReplacements(false, 1*time.Hour),
 			).NotTo(HaveOccurred())
 			// Partition a storage Pod from the rest of the cluster
-			pod := fixtures.ChooseRandomPod(fdbCluster.GetPrimary().GetStoragePods())
+			pod := factory.ChooseRandomPod(fdbCluster.GetPrimary().GetStoragePods())
 			log.Printf("partition Pod: %s", pod.Name)
 			exp = factory.InjectPartition(fixtures.PodSelector(pod))
 		})
@@ -300,7 +300,7 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 	When("a knob is changed and a single pod in the primary region is replaced", func() {
 		BeforeEach(func() {
 			// Start replacement of a random storage Pod.
-			pod := fixtures.ChooseRandomPod(fdbCluster.GetPrimary().GetStoragePods())
+			pod := factory.ChooseRandomPod(fdbCluster.GetPrimary().GetStoragePods())
 			log.Println("Start replacing", pod.Name)
 			fdbCluster.GetPrimary().ReplacePod(*pod, false)
 		})


### PR DESCRIPTION
# Description

Fix a few minor bugs in the e2e test suite where some global variables were used instead of the factory scoped variables. This caused that some tests reused the same namespace and in some rare cases it could cause independent test suites to use the same namespace, which obviously caused conflicts.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran tests manually.

## Documentation

-

## Follow-up

-
