### PR TITLE
Add an upgrade test case where a single fdb-kubernetes-monitor is not able to connect to the Kubernetes API

### DIFF
--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -650,4 +650,75 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
+
+	DescribeTable(
+		"one process cannot connect to the Kubernetes API",
+		func(beforeVersion string, targetVersion string) {
+			if !factory.ChaosTestsEnabled() {
+				Skip("Chaos tests are skipped for the operator")
+			}
+
+			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
+				Skip("this test only affects version incompatible upgrades")
+			}
+
+			// If we are not using the unified image, we can skip this test.
+			if !factory.UseUnifiedImage() {
+				Skip("The sidecar image doesn't require connectivity to the Kubernetes API")
+			}
+
+			clusterSetup(beforeVersion, true)
+
+			selectedPod := factory.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
+
+			var kubernetesServiceHost string
+			Eventually(func(g Gomega) error {
+				std, _, err := factory.ExecuteCmdOnPod(
+					&selectedPod,
+					fdbv1beta2.MainContainerName,
+					"printenv KUBERNETES_SERVICE_HOST",
+					false,
+				)
+
+				g.Expect(std).NotTo(BeEmpty())
+				kubernetesServiceHost = strings.TrimSpace(std)
+
+				return err
+			}, 5*time.Minute).ShouldNot(HaveOccurred())
+
+			exp := factory.InjectPartitionWithExternalTargets(fixtures.PodSelector(&selectedPod), []string{kubernetesServiceHost})
+			// Make sure that the partition takes effect.
+			Eventually(func() error {
+				_, _, err := factory.ExecuteCmdOnPod(
+					&selectedPod,
+					fdbv1beta2.MainContainerName,
+					fmt.Sprintf("nc -vz -w 2 %s 443", kubernetesServiceHost),
+					false,
+				)
+
+				return err
+			}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(HaveOccurred())
+
+			// Update the cluster version.
+			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+
+			if !fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
+				// If the upgrade is version incompatible it will block the upgrade process.
+				// Otherwise, the operator will recreate the Pods.
+				Consistently(func() bool {
+					return fdbCluster.GetCluster().Status.RunningVersion == beforeVersion
+				}).WithTimeout(3 * time.Minute).WithPolling(2 * time.Second).Should(BeTrue())
+			}
+
+			factory.DeleteChaosMeshExperimentSafe(exp)
+
+			// Make sure the cluster is upgraded
+			fdbCluster.VerifyVersion(targetVersion)
+
+			// Make sure the cluster has no data loss.
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+		},
+		EntryDescription("Upgrade from %[1]s to %[2]s"),
+		fixtures.GenerateUpgradeTableEntries(testOptions),
+	)
 })

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -658,10 +658,6 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				Skip("Chaos tests are skipped for the operator")
 			}
 
-			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
-				Skip("this test only affects version incompatible upgrades")
-			}
-
 			// If we are not using the unified image, we can skip this test.
 			if !factory.UseUnifiedImage() {
 				Skip("The sidecar image doesn't require connectivity to the Kubernetes API")
@@ -708,9 +704,9 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				Consistently(func() bool {
 					return fdbCluster.GetCluster().Status.RunningVersion == beforeVersion
 				}).WithTimeout(3 * time.Minute).WithPolling(2 * time.Second).Should(BeTrue())
-			}
 
-			factory.DeleteChaosMeshExperimentSafe(exp)
+				factory.DeleteChaosMeshExperimentSafe(exp)
+			}
 
 			// Make sure the cluster is upgraded
 			fdbCluster.VerifyVersion(targetVersion)


### PR DESCRIPTION
# Description

As expected the upgrade will be stuck until the fdb-kubernetes-monitor can communicate to the K8s API again.

## Type of change

*Please select one of the options below.*

- Other

## Discussion

-

## Testing

Ran the test manually:

```text
• [377.644 seconds]
------------------------------
[AfterSuite]
/Users/jscheuermann/go/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_upgrades/operator_upgrades_test.go:55
[AfterSuite] PASSED [0.000 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.004 seconds]
------------------------------

Ran 1 of 11 Specs in 377.644 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 10 Skipped
PASS | FOCUSED
FAIL    github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_upgrades      378.067s
FAIL
```

## Documentation

-

## Follow-up

-
