### PR TITLE
Increase the replacement wait time

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -555,7 +555,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		It("should remove the targeted Pod", func() {
-			fdbCluster.EnsurePodIsDeleted(failedPod.Name)
+			fdbCluster.EnsurePodIsDeletedWithCustomTimeout(failedPod.Name, 10)
 		})
 	})
 
@@ -582,7 +582,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		It("should remove the targeted Pod", func() {
-			fdbCluster.EnsurePodIsDeleted(podToReplace.Name)
+			fdbCluster.EnsurePodIsDeletedWithCustomTimeout(podToReplace.Name, 10)
 		})
 	})
 


### PR DESCRIPTION
# Description

We have seen a few failures for those test cases where the default 5 min timeout was not enough. The failures were observed when multiple test suites were running in parallel.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

-

## Documentation

-

## Follow-up

-