### PR TITLE
Make sure the fdb-kubernetes-operator is forcing the ownership of the status subresource

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -543,7 +543,7 @@ func (r *FoundationDBClusterReconciler) updateOrApply(ctx context.Context, clust
 			return err
 		}
 
-		return r.Status().Patch(ctx, unstructuredPatch, client.Apply, client.FieldOwner("fdb-operator")) //, client.ForceOwnership)
+		return r.Status().Patch(ctx, unstructuredPatch, client.Apply, client.FieldOwner("fdb-operator"), client.ForceOwnership)
 	}
 
 	return r.Status().Update(ctx, cluster)


### PR DESCRIPTION
# Description

Since our e2e tests cases are now running (randomly) with server-side apply enabled, we observed a bug in the operator where the operator is not able to reclaim the ownership:

```text
Apply failed with 1 conflict: conflict with \"test_operator.test\" with subresource \"status\" using apps.foundationdb.org/v1beta2: .status.processGroups 
```

The fix for this is to force the ownership again.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

I ran the affected test case manually and I didn't observe the issue.

## Documentation

-

## Follow-up

-