### PR TITLE
Fix a bug where a process group with the same ID could be generated

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2957,6 +2957,8 @@ func (cluster *FoundationDBCluster) GetNextRandomProcessGroupID(processClass Pro
 			continue
 		}
 
+		// Add the newly picked process group ID.
+		processGroupIDs[idNum] = true
 		// The randomly picked process group is not in use and is not marked for removal, so we can use it.
 		break
 	}

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -56,6 +56,11 @@ func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterR
 			continue
 		}
 
+		_, ok := processGroupIDs[processClass]
+		if !ok {
+			processGroupIDs[processClass] = map[int]bool{}
+		}
+
 		hasNewProcessGroups = true
 		logger.Info("Adding new Process Groups", "processClass", processClass, "newCount", newCount, "desiredCount", desiredCount, "currentCount", processCounts[processClass])
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "AddingProcesses", fmt.Sprintf("Adding %d %s processes", newCount, processClass))


### PR DESCRIPTION
# Description

Fix a bug where the same process group ID could be generated.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

0
## Testing

Added an additional test case for this. Without the fix the test case failed.

## Documentation

-

## Follow-up

-