### PR TITLE
Disable unified image tests until image is updated

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2409,7 +2409,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 	})
 
-	When("enabling the node watch feature", func() {
+	// The current nightly use a version of the unified image that doesn't support this feature yet. Once we update the
+	// image we should also enable this test again.
+	PWhen("enabling the node watch feature", func() {
 		var initialParameters fdbv1beta2.FoundationDBCustomParameters
 
 		BeforeEach(func() {
@@ -2488,7 +2490,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 	})
 
-	When("the Pod is set into isolate mode", func() {
+	// The current nightly use a version of the unified image that doesn't support this feature yet. Once we update the
+	// image we should also enable this test again.
+	PWhen("the Pod is set into isolate mode", func() {
 		var isolatedPod corev1.Pod
 
 		BeforeEach(func() {

--- a/e2e/test_operator_velocity/operator_velocity_test.go
+++ b/e2e/test_operator_velocity/operator_velocity_test.go
@@ -232,6 +232,11 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 				),
 			).NotTo(HaveOccurred())
 
+			// Make sure to wait for the cluster to become available again.
+			Eventually(func() bool {
+				return fdbCluster.GetPrimary().IsAvailable()
+			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(BeTrue())
+
 			cluster := fdbCluster.GetPrimary().GetCluster()
 			CheckKnobRollout(
 				fdbCluster,

--- a/internal/node_predicate.go
+++ b/internal/node_predicate.go
@@ -64,7 +64,9 @@ func (n NodeTaintChangedPredicate) Update(event event.UpdateEvent) bool {
 	}
 
 	taintsChanged := !equality.Semantic.DeepEqual(oldNode.Spec.Taints, newNode.Spec.Taints)
-	n.Logger.V(1).Info("Got an UpdateEvent", "node", oldNode.Name, "taintsChanged", taintsChanged, "oldTaints", oldNode.Spec.Taints, "newTaints", newNode.Spec.Taints)
+	if taintsChanged {
+		n.Logger.V(1).Info("Node taints have changed", "node", oldNode.Name, "taintsChanged", taintsChanged, "oldTaints", oldNode.Spec.Taints, "newTaints", newNode.Spec.Taints)
+	}
 
 	return taintsChanged
 }


### PR DESCRIPTION
# Description

Disable some unified image tests that use features that are not yet present in the image used by the nightlies. 
I sneaked in some minor changes to the test reliability, e.g. to print the status of the data loader pods and increase the wait time.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

-

## Documentation

-

## Follow-up

-
