### PR TITLE
Fix race condition in e2e test suite when checking if a pod is deleted

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -749,7 +749,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			It("should replace the partitioned Pod", func() {
 				log.Printf("waiting for pod removal: %s", partitionedPod.Name)
-				Expect(fdbCluster.WaitForPodRemoval(partitionedPod)).ShouldNot(HaveOccurred())
+				fdbCluster.WaitForPodRemoval(partitionedPod)
 				exists, err := factory.DoesPodExist(*partitionedPod)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(exists).To(BeFalse())
@@ -1612,7 +1612,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		It("should replace the excluded Pod", func() {
 			log.Printf("waiting for pod removal: %s", pod.Name)
-			Expect(fdbCluster.WaitForPodRemoval(pod)).ShouldNot(HaveOccurred())
+			fdbCluster.WaitForPodRemoval(pod)
 			exists, err := factory.DoesPodExist(*pod)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(exists).To(BeFalse())

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				selectedPod := factory.RandomPickOnePod(pods)
 				log.Println("deleting pod: ", selectedPod.Name)
 				factory.DeletePod(&selectedPod)
-				Expect(fdbCluster.WaitForPodRemoval(&selectedPod)).ShouldNot(HaveOccurred())
+				fdbCluster.WaitForPodRemoval(&selectedPod)
 				return false
 			}).WithTimeout(20 * time.Minute).WithPolling(3 * time.Minute).Should(BeTrue())
 

--- a/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			// the injected partition from chaos-mesh is lost and therefore the process is reporting to the cluster again.
 			if !fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				log.Println("waiting for pod removal:", partitionedPod.Name)
-				Expect(fdbCluster.WaitForPodRemoval(partitionedPod)).ShouldNot(HaveOccurred())
+				fdbCluster.WaitForPodRemoval(partitionedPod)
 				log.Println("pod removed:", partitionedPod.Name)
 			}
 


### PR DESCRIPTION
# Description

Fix race condition in e2e test suite when checking if a pod is deleted. The race condition can happen when a pod is deleted and in between those checks the operator was recreating the pod quick enough. The additional check for the pod's UID will fix that, if the fetched pod has a new UID, we know that the fetched pod is a different pod.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Manually ran tests.

## Documentation

-

## Follow-up

-
