### PR TITLE
Adding permissions for "nodes" resources to the helm chart (#2091)

### DIFF
--- a/charts/fdb-operator/templates/rbac/rbac_role.yaml
+++ b/charts/fdb-operator/templates/rbac/rbac_role.yaml
@@ -26,6 +26,14 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters

--- a/charts/fdb-operator/templates/rbac/rbac_role.yaml
+++ b/charts/fdb-operator/templates/rbac/rbac_role.yaml
@@ -110,6 +110,7 @@ rules:
   - update
   - patch
   - delete
+{{- if .Values.nodeReadClusterRole }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -126,3 +127,5 @@ rules:
   - get
   - watch
   - list
+{{- end }}
+

--- a/charts/fdb-operator/templates/rbac/rbac_role.yaml
+++ b/charts/fdb-operator/templates/rbac/rbac_role.yaml
@@ -26,14 +26,6 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
   - apps.foundationdb.org
   resources:
   - foundationdbclusters
@@ -118,3 +110,19 @@ rules:
   - update
   - patch
   - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "fdb-operator.fullname" . }}-clusterrole
+  labels:
+    {{- include "fdb-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list

--- a/charts/fdb-operator/templates/rbac/rbac_role_binding.yaml
+++ b/charts/fdb-operator/templates/rbac/rbac_role_binding.yaml
@@ -23,6 +23,7 @@ subjects:
   {{- if .Values.globalMode.enabled }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
+{{- if .Values.nodeReadClusterRole }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -37,3 +38,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "fdb-operator.serviceAccountName" . }}
+{{- end }}

--- a/charts/fdb-operator/templates/rbac/rbac_role_binding.yaml
+++ b/charts/fdb-operator/templates/rbac/rbac_role_binding.yaml
@@ -23,3 +23,17 @@ subjects:
   {{- if .Values.globalMode.enabled }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "fdb-operator.fullname" . }}-clusterrolebinding
+  labels:
+    {{- include "fdb-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "fdb-operator.fullname" . }}-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ include "fdb-operator.serviceAccountName" . }}

--- a/charts/fdb-operator/values.yaml
+++ b/charts/fdb-operator/values.yaml
@@ -67,3 +67,4 @@ initContainerSecurityContext:
     drop:
       - all
   readOnlyRootFilesystem: true
+nodeReadClusterRole: true


### PR DESCRIPTION
# Description
These changes add `get`, `watch`, and `list` permissions to the `fdb-operator` helm chart. These permissions are required to detect `taints` on nodes and enable  the rotation of `FDB` cluster pods when `taintReplacementOptions` are used.

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Testing
We tested these changes on our various Kubernetes clusters.


