### PR TITLE
Make sure to only check the isolate process group annotation if a pod was returned

### DIFF
--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -146,19 +146,21 @@ func removeProcessGroup(ctx context.Context, r *FoundationDBClusterReconciler, c
 		return err
 	}
 
-	value, ok := pod.Annotations[fdbv1beta2.IsolateProcessGroupAnnotation]
-	if ok {
-		// Ignore the parsing error here and assume the pod was not isolated.
-		isolated, _ := strconv.ParseBool(value)
-		if isolated {
-			return fmt.Errorf("not allowed to delete Pod and the assosicated resources as the Pod is isolated")
+	if err == nil {
+		value, ok := pod.Annotations[fdbv1beta2.IsolateProcessGroupAnnotation]
+		if ok {
+			// Ignore the parsing error here and assume the pod was not isolated.
+			isolated, _ := strconv.ParseBool(value)
+			if isolated {
+				return fmt.Errorf("not allowed to delete Pod and the assosicated resources as the Pod is isolated")
+			}
 		}
-	}
 
-	if err == nil && pod.DeletionTimestamp.IsZero() {
-		err = r.PodLifecycleManager.DeletePod(ctx, r, pod)
-		if err != nil {
-			deletionError = fmt.Errorf("could not delete Pod: %w", err)
+		if pod.DeletionTimestamp.IsZero() {
+			err = r.PodLifecycleManager.DeletePod(ctx, r, pod)
+			if err != nil {
+				deletionError = fmt.Errorf("could not delete Pod: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description

In most cases this check is not harmful, only in cases where someone would implement their own pod manager and that one would return a `nil` instead of a pointer to an empty pod struct.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran unit tests locally.

## Documentation

-

## Follow-up

-