### PR TITLE
Check if the namespace is created by the same test suite

### DIFF
--- a/e2e/fixtures/kubernetes_fixtures.go
+++ b/e2e/fixtures/kubernetes_fixtures.go
@@ -96,20 +96,14 @@ func (factory *Factory) createNamespace(suffix string) string {
 		}
 
 		err := factory.checkIfNamespaceIsTerminating(namespace)
-		if err != nil {
-			return err
-		}
+		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		err = factory.ensureNamespaceExists(namespace)
-		if err != nil {
-			return err
-		}
+		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		namespaceResource := &corev1.Namespace{}
 		err = factory.controllerRuntimeClient.Get(ctx.Background(), client.ObjectKey{Namespace: "", Name: namespace}, namespaceResource)
-		if err != nil {
-			return err
-		}
+		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		if namespaceResource.Annotations[testSuiteNameAnnotation] != testSuiteName {
 			err = fmt.Errorf("namespace %s already in use by test suite: %s, current test suite: %s", namespace, namespaceResource.Annotations[testSuiteNameAnnotation], testSuiteName)

--- a/e2e/fixtures/kubernetes_fixtures.go
+++ b/e2e/fixtures/kubernetes_fixtures.go
@@ -105,7 +105,6 @@ func (factory *Factory) createNamespace(suffix string) string {
 			return err
 		}
 
-		log.Println("created namespace", namespace)
 		namespaceResource := &corev1.Namespace{}
 		err = factory.controllerRuntimeClient.Get(ctx.Background(), client.ObjectKey{Namespace: "", Name: namespace}, namespaceResource)
 		if err != nil {
@@ -117,6 +116,8 @@ func (factory *Factory) createNamespace(suffix string) string {
 			log.Println(err.Error())
 			return err
 		}
+
+		log.Println("created namespace", namespace)
 
 		return nil
 	}).WithTimeout(10 * time.Minute).WithPolling(1 * time.Second).ShouldNot(gomega.HaveOccurred())
@@ -188,7 +189,7 @@ func (factory *Factory) checkIfNamespaceIsTerminating(name string) error {
 		return nil
 	}
 
-	// If the namespace is in terminating, we have to check if any pod are stuck in terminating with a finalizer set.
+	// If the namespace is in terminating, we have to check if any pods are stuck in terminating with a finalizer set.
 	log.Printf("Namespace: %s is in terminating state since: %s will wait until the namespace is deleted", namespace.Name, deletionTimestamp.String())
 	podList := &corev1.PodList{}
 	err = controllerClient.List(ctx.Background(), podList, client.InNamespace(name))

--- a/e2e/fixtures/kubernetes_fixtures.go
+++ b/e2e/fixtures/kubernetes_fixtures.go
@@ -22,6 +22,7 @@ package fixtures
 
 import (
 	ctx "context"
+	"fmt"
 	"log"
 	"time"
 
@@ -38,7 +39,8 @@ import (
 )
 
 const (
-	namespaceRegEx = `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	namespaceRegEx          = `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	testSuiteNameAnnotation = "foundationdb.org/test-suite"
 )
 
 // factory.getRandomizedNamespaceName() checks if the username is valid to be used in the namespace name. If so this
@@ -81,18 +83,49 @@ func (factory *Factory) SingleNamespace() string {
 }
 
 func (factory *Factory) createNamespace(suffix string) string {
-	namespace := factory.namespace
+	var namespace string
+	gomega.Eventually(func(g gomega.Gomega) error {
+		namespace = factory.namespace
 
-	if namespace == "" {
-		namespace = factory.getRandomizedNamespaceName()
-	}
+		if namespace == "" {
+			namespace = factory.getRandomizedNamespaceName()
+		}
 
-	if suffix != "" {
-		namespace = namespace + "-" + suffix
-	}
+		if suffix != "" {
+			namespace = namespace + "-" + suffix
+		}
 
-	factory.checkIfNamespaceIsTerminating(namespace)
-	factory.ensureNamespaceExists(namespace)
+		err := factory.checkIfNamespaceIsTerminating(namespace)
+		if err != nil {
+			return err
+		}
+
+		err = factory.ensureNamespaceExists(namespace)
+		if err != nil {
+			return err
+		}
+
+		log.Println("created namespace", namespace)
+		namespaceResource := &corev1.Namespace{}
+		err = factory.controllerRuntimeClient.Get(ctx.Background(), client.ObjectKey{Namespace: "", Name: namespace}, namespaceResource)
+		if err != nil {
+			return err
+		}
+
+		if namespaceResource.Annotations[testSuiteNameAnnotation] != testSuiteName {
+			err = fmt.Errorf("namespace %s already in use by test suite: %s, current test suite: %s", namespace, namespaceResource.Annotations[testSuiteNameAnnotation], testSuiteName)
+			log.Println(err.Error())
+			return err
+		}
+
+		return nil
+	}).WithTimeout(10 * time.Minute).WithPolling(1 * time.Second).ShouldNot(gomega.HaveOccurred())
+
+	secret := factory.getCertificate()
+	secret.SetNamespace(namespace)
+	secret.SetResourceVersion("")
+	gomega.Expect(factory.CreateIfAbsent(secret)).NotTo(gomega.HaveOccurred())
+
 	factory.ensureRBACSetupExists(namespace)
 	gomega.Expect(factory.ensureFDBOperatorExists(namespace)).ToNot(gomega.HaveOccurred())
 	log.Printf("using namespace %s for testing", namespace)
@@ -130,54 +163,59 @@ func (factory *Factory) createNamespace(suffix string) string {
 
 // checkIfNamespaceIsTerminating will check if the namespace has a deletionTimestamp set. If so this method will wait
 // up to 5 minutes until the namespace is deleted to prevent race conditions.
-func (factory *Factory) checkIfNamespaceIsTerminating(name string) {
+func (factory *Factory) checkIfNamespaceIsTerminating(name string) error {
 	controllerClient := factory.GetControllerRuntimeClient()
-	gomega.Eventually(func(g gomega.Gomega) *metav1.Time {
-		namespace := &corev1.Namespace{}
-		err := controllerClient.Get(ctx.Background(), client.ObjectKey{Name: name}, namespace)
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				return nil
-			}
 
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-		}
-
-		deletionTimestamp := namespace.ObjectMeta.DeletionTimestamp
-		// No deletionTimestamp is set, so we can assume the namespace is still running.
-		if deletionTimestamp == nil {
+	namespace := &corev1.Namespace{}
+	err := controllerClient.Get(ctx.Background(), client.ObjectKey{Name: name}, namespace)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 
-		// If the namespace is in terminating, we have to check if any pod are stuck in terminating with a finalizer set.
-		log.Printf("Namespace: %s is in terminating state since: %s will wait until the namespace is deleted", namespace.Name, deletionTimestamp.String())
-		podList := &corev1.PodList{}
-		err = controllerClient.List(ctx.Background(), podList, client.InNamespace(name))
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		for _, pod := range podList.Items {
-			if len(pod.Finalizers) > 0 {
-				log.Printf("Removing finalizer from Pod %s/%s\n", namespace, pod.Name)
-				factory.SetFinalizerForPod(&pod, []string{})
-			}
-		}
+		return err
+	}
 
-		return deletionTimestamp
-	}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(gomega.BeNil())
+	namespaceTestSuiteName := namespace.Annotations[testSuiteNameAnnotation]
+	// Don't touch the namespace of another test suite.
+	if namespaceTestSuiteName != testSuiteName {
+		return nil
+	}
+
+	deletionTimestamp := namespace.ObjectMeta.DeletionTimestamp
+	// No deletionTimestamp is set, so we can assume the namespace is still running.
+	if deletionTimestamp == nil {
+		return nil
+	}
+
+	// If the namespace is in terminating, we have to check if any pod are stuck in terminating with a finalizer set.
+	log.Printf("Namespace: %s is in terminating state since: %s will wait until the namespace is deleted", namespace.Name, deletionTimestamp.String())
+	podList := &corev1.PodList{}
+	err = controllerClient.List(ctx.Background(), podList, client.InNamespace(name))
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range podList.Items {
+		if len(pod.Finalizers) > 0 {
+			log.Printf("Removing finalizer from Pod %s/%s\n", namespace, pod.Name)
+			factory.SetFinalizerForPod(&pod, []string{})
+		}
+	}
+
+	return fmt.Errorf("namespace %s is still in terminating state since %s", name, deletionTimestamp.String())
 }
 
-func (factory *Factory) ensureNamespaceExists(namespace string) {
-	gomega.Expect(factory.CreateIfAbsent(&corev1.Namespace{
+func (factory *Factory) ensureNamespaceExists(namespace string) error {
+	return factory.CreateIfAbsent(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   namespace,
 			Labels: factory.GetDefaultLabels(),
+			Annotations: map[string]string{
+				testSuiteNameAnnotation: testSuiteName,
+			},
 		},
-	})).NotTo(gomega.HaveOccurred())
-
-	secret := factory.getCertificate()
-	secret.SetNamespace(namespace)
-	secret.SetResourceVersion("")
-
-	gomega.Expect(factory.CreateIfAbsent(secret)).NotTo(gomega.HaveOccurred())
+	})
 }
 
 func (factory *Factory) ensureRBACSetupExists(namespace string) {

--- a/e2e/fixtures/test_runner.go
+++ b/e2e/fixtures/test_runner.go
@@ -34,6 +34,9 @@ import (
 	"github.com/onsi/gomega"
 )
 
+// testSuiteName will be used to prevent namespace conflicts between concurrent running test suites.
+var testSuiteName string
+
 // RunGinkgoTests sets up the current test suite to run Ginkgo tests,
 // then invokes the tests.  It should be invoked by each top level Test*
 // function.
@@ -67,4 +70,10 @@ func InitFlags() *FactoryOptions {
 	flag.Parse()
 
 	return testOptions
+}
+
+// SetTestSuiteName will set the test suite name for the current test suite. You have to ensure that this test suite
+// name is unique across all test suites.
+func SetTestSuiteName(name string) {
+	testSuiteName = name
 }

--- a/e2e/test_operator/suite_test.go
+++ b/e2e/test_operator/suite_test.go
@@ -30,5 +30,6 @@ import (
 
 func TestOperator(t *testing.T) {
 	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
+	fixtures.SetTestSuiteName("operator-test")
 	fixtures.RunGinkgoTests(t, "Operator test suite")
 }

--- a/e2e/test_operator_creation_velocity/suite_test.go
+++ b/e2e/test_operator_creation_velocity/suite_test.go
@@ -30,5 +30,6 @@ import (
 
 func TestOperatorCreationVelocity(t *testing.T) {
 	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
+	fixtures.SetTestSuiteName("operator-creation-velocity")
 	fixtures.RunGinkgoTests(t, "Operator creation velocity suite")
 }

--- a/e2e/test_operator_ha/suite_test.go
+++ b/e2e/test_operator_ha/suite_test.go
@@ -30,5 +30,6 @@ import (
 
 func TestOperatorHA(t *testing.T) {
 	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
+	fixtures.SetTestSuiteName("operator-ha")
 	fixtures.RunGinkgoTests(t, "Operator HA test suite")
 }

--- a/e2e/test_operator_ha_flaky_upgrades/suite_test.go
+++ b/e2e/test_operator_ha_flaky_upgrades/suite_test.go
@@ -28,7 +28,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestOperatorHaUpgrade(t *testing.T) {
+func TestOperatorHaFlakyUpgrade(t *testing.T) {
 	SetDefaultEventuallyTimeout(3 * time.Minute)
+	fixtures.SetTestSuiteName("operator-ha-flaky")
 	fixtures.RunGinkgoTests(t, "FDB Operator HA Upgrade Test Suite")
 }

--- a/e2e/test_operator_ha_upgrades/suite_test.go
+++ b/e2e/test_operator_ha_upgrades/suite_test.go
@@ -30,5 +30,6 @@ import (
 
 func TestOperatorHaUpgrade(t *testing.T) {
 	SetDefaultEventuallyTimeout(3 * time.Minute)
+	fixtures.SetTestSuiteName("operator-ha-upgrades")
 	fixtures.RunGinkgoTests(t, "FDB Operator HA Upgrade Test Suite")
 }

--- a/e2e/test_operator_maintenance_mode/suite_test.go
+++ b/e2e/test_operator_maintenance_mode/suite_test.go
@@ -28,7 +28,8 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func TestOperatorHA(t *testing.T) {
+func TestOperatorMaintenanceMode(t *testing.T) {
 	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
+	fixtures.SetTestSuiteName("operator-maintenance-mode")
 	fixtures.RunGinkgoTests(t, "Operator maintenance mode test suite")
 }

--- a/e2e/test_operator_migrate_image_type/suite_test.go
+++ b/e2e/test_operator_migrate_image_type/suite_test.go
@@ -28,7 +28,8 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func TestOperator(t *testing.T) {
+func TestOperatorMigrateImageType(t *testing.T) {
 	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
+	fixtures.SetTestSuiteName("operator-migrate-image-type")
 	fixtures.RunGinkgoTests(t, "Operator Migrate Image Type test suite")
 }

--- a/e2e/test_operator_migrations/suite_test.go
+++ b/e2e/test_operator_migrations/suite_test.go
@@ -30,5 +30,6 @@ import (
 
 func TestOperatorMigrations(t *testing.T) {
 	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
+	fixtures.SetTestSuiteName("operator-migrations")
 	fixtures.RunGinkgoTests(t, "Operator Migration test suite")
 }

--- a/e2e/test_operator_stress/suite_test.go
+++ b/e2e/test_operator_stress/suite_test.go
@@ -30,5 +30,6 @@ import (
 
 func TestOperatorStress(t *testing.T) {
 	SetDefaultEventuallyTimeout(180 * time.Second)
+	fixtures.SetTestSuiteName("operator-stress")
 	fixtures.RunGinkgoTests(t, "FDB Operator stress test suite")
 }

--- a/e2e/test_operator_upgrades/suite_test.go
+++ b/e2e/test_operator_upgrades/suite_test.go
@@ -30,5 +30,6 @@ import (
 
 func TestOperatorUpgrade(t *testing.T) {
 	SetDefaultEventuallyTimeout(3 * time.Minute)
+	fixtures.SetTestSuiteName("operator-upgrades")
 	fixtures.RunGinkgoTests(t, "FDB Operator Upgrade Test Suite")
 }

--- a/e2e/test_operator_upgrades_variations/suite_test.go
+++ b/e2e/test_operator_upgrades_variations/suite_test.go
@@ -28,7 +28,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestOperatorUpgrade(t *testing.T) {
+func TestOperatorUpgradesVariations(t *testing.T) {
 	SetDefaultEventuallyTimeout(3 * time.Minute)
+	fixtures.SetTestSuiteName("operator-upgrades-variations")
 	fixtures.RunGinkgoTests(t, "FDB Operator Upgrade variations Test Suite")
 }

--- a/e2e/test_operator_upgrades_with_chaos/suite_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/suite_test.go
@@ -28,7 +28,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestOperatorUpgrade(t *testing.T) {
+func TestOperatorUpgradesWithChaos(t *testing.T) {
 	SetDefaultEventuallyTimeout(3 * time.Minute)
+	fixtures.SetTestSuiteName("operator-upgrades-with-chaos")
 	fixtures.RunGinkgoTests(t, "FDB Operator Upgrade Test Suite with chaos-mesh")
 }


### PR DESCRIPTION
# Description

Prevent cases where two concurrent test suites will choose the same random namespace and cluster name. This change will make sure that only one test suite will take the namespace and the other test suite will generate a new random name. This will prevent cases where those two concurrent test suites use the same namespace, which will cause a failure of both test cases.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran a manual test (the test suite was picking the same namespace as I defined it with the according environment variable):

```text
Operator Stress when creating and deleting a cluster multiple times should create a healthy and available cluster [e2e]
/Users/jscheuermann/go/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_stress/operator_stress_test.go:53
  2024/07/04 12:38:08 created namespace jscheuermann
  2024/07/04 12:38:09 namespace jscheuermann already in use by test suite: operator-test, current test suite: operator-stress
  2024/07/04 12:38:10 created namespace jscheuermann
```

## Documentation

-

## Follow-up

-
