### PR TITLE
Fix the update status setup when a different image type is used

### DIFF
--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -365,6 +365,7 @@ func checkAndSetProcessStatus(logger logr.Logger, r *FoundationDBClusterReconcil
 	}
 
 	versionCompatibleUpgrade := cluster.VersionCompatibleUpgradeInProgress()
+	imageType := internal.GetImageType(pod)
 	for processNumber := 1; processNumber <= processCount; processNumber++ {
 		// If the process status is present under the process group ID take that information, otherwise check if there
 		// is information available under the process_id.
@@ -392,7 +393,7 @@ func checkAndSetProcessStatus(logger logr.Logger, r *FoundationDBClusterReconcil
 				continue
 			}
 
-			commandLine, err := internal.GetStartCommandWithSubstitutions(cluster, processGroupStatus.ProcessClass, substitutions, processNumber, processCount)
+			commandLine, err := internal.GetStartCommandWithSubstitutions(cluster, processGroupStatus.ProcessClass, substitutions, processNumber, processCount, imageType)
 			if err != nil {
 				return err
 			}

--- a/internal/monitor_conf.go
+++ b/internal/monitor_conf.go
@@ -32,24 +32,22 @@ import (
 )
 
 // GetStartCommand builds the expected start command for a process group.
-func GetStartCommand(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, podClient podclient.FdbPodClient, processNumber int, processCount int) (string, error) {
+func GetStartCommand(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, podClient podclient.FdbPodClient, processNumber int, processCount int, imageType fdbv1beta2.ImageType) (string, error) {
 	substitutions, err := podClient.GetVariableSubstitutions()
 	if err != nil {
 		return "", err
 	}
 
-	return GetStartCommandWithSubstitutions(cluster, processClass, substitutions, processNumber, processCount)
+	return GetStartCommandWithSubstitutions(cluster, processClass, substitutions, processNumber, processCount, imageType)
 }
 
 // GetStartCommandWithSubstitutions will be used by GetStartCommand and for internal testing.
-func GetStartCommandWithSubstitutions(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, substitutions map[string]string, processNumber int, processCount int) (string, error) {
+func GetStartCommandWithSubstitutions(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, substitutions map[string]string, processNumber int, processCount int, imageType fdbv1beta2.ImageType) (string, error) {
 	if substitutions == nil {
 		return "", nil
 	}
 
-	imageType := cluster.DesiredImageType()
 	config := GetMonitorProcessConfiguration(cluster, processClass, processCount, imageType)
-
 	extractPlaceholderEnvVars(substitutions, config.Arguments)
 
 	config.BinaryPath = fmt.Sprintf("%s/fdbserver", substitutions[fdbv1beta2.EnvNameBinaryDir])
@@ -354,5 +352,6 @@ func buildIPArgument(parameter string, environmentVariable string, imageType fdb
 			arguments = append(arguments, monitorapi.Argument{Value: fmt.Sprintf(":%s", strings.Join(flags, ":"))})
 		}
 	}
+
 	return arguments
 }

--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -489,7 +489,7 @@ var _ = Describe("monitor_conf", func() {
 				It("should substitute the variables in the start command", func() {
 					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1)
+					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(command).To(Equal(strings.Join([]string{
@@ -516,7 +516,7 @@ var _ = Describe("monitor_conf", func() {
 
 					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1)
+					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(command).To(Equal(strings.Join([]string{
@@ -540,7 +540,7 @@ var _ = Describe("monitor_conf", func() {
 				It("should substitute the variables in the start command", func() {
 					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 2)
+					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 2, cluster.DesiredImageType())
 					Expect(err).NotTo(HaveOccurred())
 
 					id := "storage-1"
@@ -559,7 +559,7 @@ var _ = Describe("monitor_conf", func() {
 						"--seed_cluster_file=/var/dynamic-conf/fdb.cluster",
 					}, " ")))
 
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 2, 2)
+					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 2, 2, cluster.DesiredImageType())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
 						"/usr/bin/fdbserver",
@@ -585,7 +585,7 @@ var _ = Describe("monitor_conf", func() {
 
 					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, fdbv1beta2.ProcessClassStorage, substitutions, 1, 1)
+					command, err = GetStartCommandWithSubstitutions(cluster, fdbv1beta2.ProcessClassStorage, substitutions, 1, 1, cluster.DesiredImageType())
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -617,7 +617,7 @@ var _ = Describe("monitor_conf", func() {
 
 					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, fdbv1beta2.ProcessClassStorage, substitutions, 1, 1)
+					command, err = GetStartCommandWithSubstitutions(cluster, fdbv1beta2.ProcessClassStorage, substitutions, 1, 1, cluster.DesiredImageType())
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -644,7 +644,7 @@ var _ = Describe("monitor_conf", func() {
 					cluster.Status.RunningVersion = fdbv1beta2.Versions.Default.String()
 					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, fdbv1beta2.ProcessClassStorage, substitutions, 1, 1)
+					command, err = GetStartCommandWithSubstitutions(cluster, fdbv1beta2.ProcessClassStorage, substitutions, 1, 1, cluster.DesiredImageType())
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -676,7 +676,7 @@ var _ = Describe("monitor_conf", func() {
 			It("should generate the unsorted command-line", func() {
 				substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
 				Expect(err).NotTo(HaveOccurred())
-				command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1)
+				command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(command).To(Equal(strings.Join([]string{
@@ -699,7 +699,7 @@ var _ = Describe("monitor_conf", func() {
 				It("should fill in the process number", func() {
 					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 2, 3)
+					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 2, 3, cluster.DesiredImageType())
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(command).To(Equal(strings.Join([]string{
@@ -732,7 +732,7 @@ var _ = Describe("monitor_conf", func() {
 				It("should substitute the variables in the custom parameters", func() {
 					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1)
+					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
 						"/usr/bin/fdbserver",
@@ -766,7 +766,7 @@ var _ = Describe("monitor_conf", func() {
 				It("should substitute the variables in the custom parameters", func() {
 					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1)
+					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
 						"/usr/bin/fdbserver",
@@ -799,7 +799,7 @@ var _ = Describe("monitor_conf", func() {
 				It("should substitute the variables in the custom parameters", func() {
 					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1)
+					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
 						"/usr/bin/fdbserver",

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -200,7 +200,7 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 			command, hasCommandLine := client.currentCommandLines[fullAddress.StringWithoutFlags()]
 			if !hasCommandLine {
 				// We only set the command if we don't have the commandline "cached"
-				command, err = internal.GetStartCommand(client.Cluster, pClass, podClient, processIndex, processCount)
+				command, err = internal.GetStartCommand(client.Cluster, pClass, podClient, processIndex, processCount, internal.GetImageType(&pod))
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
# Description

The `GetStartCommandWithSubstitutions` method needs to create the command line based on the image type of the current pod, no the desired image type.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

e2e tests:

```text 
------------------------------

Ran 1 of 3 Specs in 969.974 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 2 Skipped
PASS | FOCUSED
FAIL    github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_migrate_image_type    970.545s
FAIL
```

## Documentation

-

## Follow-up

-