### PR TITLE
Correct the base image for the unified image and increase the memory for the FDB pods to 8GiB

### DIFF
--- a/api/v1beta2/foundationdb_constants.go
+++ b/api/v1beta2/foundationdb_constants.go
@@ -33,6 +33,15 @@ const (
 	// NoneFaultDomainKey represents the none fault domain, where every Pod is a fault domain.
 	NoneFaultDomainKey = "foundationdb.org/none"
 
+	// FoundationDBBaseImage represents the default foundationdb base image used with ImageTypeSplit for the main container.
+	FoundationDBBaseImage = "foundationdb/foundationdb"
+
+	// FoundationDBSidecarBaseImage represents the default foundationdb sidecar base image used with ImageTypeSplit for the sidecar container.
+	FoundationDBSidecarBaseImage = "foundationdb/foundationdb-kubernetes-sidecar"
+
+	// FoundationDBKubernetesBaseImage represents the default foundationdb base image used with ImageTypeUnified for the main and sidecar container.
+	FoundationDBKubernetesBaseImage = "foundationdb/fdb-kubernetes-monitor"
+
 	/*
 		Config map constants
 	*/

--- a/api/v1beta2/image_config_test.go
+++ b/api/v1beta2/image_config_test.go
@@ -12,7 +12,7 @@ var _ = Describe("[api] ImageConfig", func() {
 		It("applies chooses the first value for each field", func() {
 			configs := []ImageConfig{
 				{
-					BaseImage: "foundationdb/foundationdb",
+					BaseImage: FoundationDBBaseImage,
 					Version:   Versions.Default.String(),
 				},
 				{
@@ -25,7 +25,7 @@ var _ = Describe("[api] ImageConfig", func() {
 
 			finalConfig := SelectImageConfig(configs, Versions.Default.String())
 			Expect(finalConfig).To(Equal(ImageConfig{
-				BaseImage: "foundationdb/foundationdb",
+				BaseImage: FoundationDBBaseImage,
 				Version:   Versions.Default.String(),
 				Tag:       "abcdef",
 				TagSuffix: "-1",
@@ -35,7 +35,7 @@ var _ = Describe("[api] ImageConfig", func() {
 		It("ignores configs that are for different versions", func() {
 			configs := []ImageConfig{
 				{
-					BaseImage: "foundationdb/foundationdb",
+					BaseImage: FoundationDBBaseImage,
 					Version:   Versions.Default.String(),
 				},
 				{
@@ -49,7 +49,7 @@ var _ = Describe("[api] ImageConfig", func() {
 
 			finalConfig := SelectImageConfig(configs, Versions.Default.String())
 			Expect(finalConfig).To(Equal(ImageConfig{
-				BaseImage: "foundationdb/foundationdb",
+				BaseImage: FoundationDBBaseImage,
 				Version:   Versions.Default.String(),
 				TagSuffix: "-1",
 			}))
@@ -59,7 +59,7 @@ var _ = Describe("[api] ImageConfig", func() {
 	When("building image names", func() {
 		It("applies the fields", func() {
 			config := ImageConfig{
-				BaseImage: "foundationdb/foundationdb-kubernetes-sidecar",
+				BaseImage: FoundationDBSidecarBaseImage,
 				Version:   Versions.Default.String(),
 				TagSuffix: "-2",
 			}
@@ -69,7 +69,7 @@ var _ = Describe("[api] ImageConfig", func() {
 
 		It("uses the tag to override the version and tag suffix", func() {
 			config := ImageConfig{
-				BaseImage: "foundationdb/foundationdb-kubernetes-sidecar",
+				BaseImage: FoundationDBSidecarBaseImage,
 				Version:   Versions.Default.String(),
 				Tag:       "abcdef",
 				TagSuffix: "-2",

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -311,9 +311,9 @@ var _ = Describe("cluster_controller", func() {
 
 				for _, pod := range pods.Items {
 					Expect(pod.Spec.Containers[0].Name).To(Equal(fdbv1beta2.MainContainerName))
-					Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes:%s", fdbv1beta2.Versions.Default)))
+					Expect(pod.Spec.Containers[0].Image).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(fdbv1beta2.Versions.Default.String())))
 					Expect(pod.Spec.Containers[1].Name).To(Equal(fdbv1beta2.SidecarContainerName))
-					Expect(pod.Spec.Containers[1].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes:%s", fdbv1beta2.Versions.Default)))
+					Expect(pod.Spec.Containers[1].Image).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(fdbv1beta2.Versions.Default.String())))
 				}
 			})
 

--- a/e2e/fixtures/options.go
+++ b/e2e/fixtures/options.go
@@ -82,19 +82,19 @@ func (options *FactoryOptions) BindFlags(fs *flag.FlagSet) {
 	fs.StringVar(
 		&options.fdbImage,
 		"fdb-image",
-		"foundationdb/foundationdb",
+		fdbv1beta2.FoundationDBBaseImage,
 		"defines the FoundationDB image that should be used for testing",
 	)
 	fs.StringVar(
 		&options.unifiedFDBImage,
 		"unified-fdb-image",
-		"foundationdb/fdb-kubernetes-monitor",
+		fdbv1beta2.FoundationDBKubernetesBaseImage,
 		"defines the unified FoundationDB image that should be used for testing",
 	)
 	fs.StringVar(
 		&options.sidecarImage,
 		"sidecar-image",
-		"foundationdb/foundationdb-kubernetes-sidecar",
+		fdbv1beta2.FoundationDBSidecarBaseImage,
 		"defines the FoundationDB sidecar image that should be used for testing",
 	)
 	fs.StringVar(

--- a/internal/deprecations.go
+++ b/internal/deprecations.go
@@ -73,7 +73,7 @@ func NormalizeClusterSpec(cluster *fdbv1beta2.FoundationDBCluster, options Depre
 					// See: https://apple.github.io/foundationdb/configuration.html#system-requirements
 					container.Resources.Requests = corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("1"),
-						corev1.ResourceMemory: resource.MustParse("4Gi"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
 					}
 				}
 
@@ -136,10 +136,10 @@ func NormalizeClusterSpec(cluster *fdbv1beta2.FoundationDBCluster, options Depre
 
 func updateImageConfigs(spec *fdbv1beta2.FoundationDBClusterSpec, useUnifiedImage bool) {
 	if useUnifiedImage {
-		ensureImageConfigPresent(&spec.MainContainer.ImageConfigs, fdbv1beta2.ImageConfig{BaseImage: "foundationdb/foundationdb-kubernetes"})
+		ensureImageConfigPresent(&spec.MainContainer.ImageConfigs, fdbv1beta2.ImageConfig{BaseImage: fdbv1beta2.FoundationDBKubernetesBaseImage})
 	} else {
-		ensureImageConfigPresent(&spec.MainContainer.ImageConfigs, fdbv1beta2.ImageConfig{BaseImage: "foundationdb/foundationdb"})
-		ensureImageConfigPresent(&spec.SidecarContainer.ImageConfigs, fdbv1beta2.ImageConfig{BaseImage: "foundationdb/foundationdb-kubernetes-sidecar", TagSuffix: "-1"})
+		ensureImageConfigPresent(&spec.MainContainer.ImageConfigs, fdbv1beta2.ImageConfig{BaseImage: fdbv1beta2.FoundationDBBaseImage})
+		ensureImageConfigPresent(&spec.SidecarContainer.ImageConfigs, fdbv1beta2.ImageConfig{BaseImage: fdbv1beta2.FoundationDBSidecarBaseImage, TagSuffix: "-1"})
 	}
 }
 

--- a/internal/deprecations_test.go
+++ b/internal/deprecations_test.go
@@ -96,11 +96,11 @@ var _ = Describe("[internal] deprecations", func() {
 					Expect(containers[0].Name).To(Equal(fdbv1beta2.MainContainerName))
 					Expect(containers[0].Resources.Requests).To(Equal(corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("1"),
-						corev1.ResourceMemory: resource.MustParse("4Gi"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
 					}))
 					Expect(containers[0].Resources.Limits).To(Equal(corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("1"),
-						corev1.ResourceMemory: resource.MustParse("4Gi"),
+						corev1.ResourceMemory: resource.MustParse("8Gi"),
 					}))
 				})
 
@@ -238,11 +238,11 @@ var _ = Describe("[internal] deprecations", func() {
 				It("should append the standard image components to the image configs", func() {
 					Expect(spec.MainContainer.ImageConfigs).To(Equal([]fdbv1beta2.ImageConfig{
 						{BaseImage: "foundationdb/foundationdb-test"},
-						{BaseImage: "foundationdb/foundationdb"},
+						{BaseImage: fdbv1beta2.FoundationDBBaseImage},
 					}))
 					Expect(spec.SidecarContainer.ImageConfigs).To(Equal([]fdbv1beta2.ImageConfig{
 						{BaseImage: "foundationdb/foundationdb-kubernetes-sidecar-test"},
-						{BaseImage: "foundationdb/foundationdb-kubernetes-sidecar", TagSuffix: "-1"},
+						{BaseImage: fdbv1beta2.FoundationDBSidecarBaseImage, TagSuffix: "-1"},
 					}))
 				})
 
@@ -259,7 +259,7 @@ var _ = Describe("[internal] deprecations", func() {
 					It("should use the default image config for the unified image", func() {
 						Expect(spec.MainContainer.ImageConfigs).To(Equal([]fdbv1beta2.ImageConfig{
 							{BaseImage: "foundationdb/foundationdb-test"},
-							{BaseImage: "foundationdb/foundationdb-kubernetes"},
+							{BaseImage: fdbv1beta2.FoundationDBKubernetesBaseImage},
 						}))
 						Expect(spec.SidecarContainer.ImageConfigs).To(Equal([]fdbv1beta2.ImageConfig{
 							{BaseImage: "foundationdb/foundationdb-kubernetes-sidecar-test"},
@@ -298,11 +298,11 @@ var _ = Describe("[internal] deprecations", func() {
 				Expect(containers[0].Name).To(Equal(fdbv1beta2.MainContainerName))
 				Expect(containers[0].Resources.Requests).To(Equal(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
-					corev1.ResourceMemory: resource.MustParse("4Gi"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
 				}))
 				Expect(containers[0].Resources.Limits).To(Equal(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
-					corev1.ResourceMemory: resource.MustParse("4Gi"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
 				}))
 			})
 
@@ -436,7 +436,7 @@ var _ = Describe("[internal] deprecations", func() {
 			It("should use the default image config for the unified image", func() {
 				Expect(spec.MainContainer.ImageConfigs).To(Equal([]fdbv1beta2.ImageConfig{
 					{BaseImage: "foundationdb/foundationdb-test"},
-					{BaseImage: "foundationdb/foundationdb-kubernetes"},
+					{BaseImage: fdbv1beta2.FoundationDBKubernetesBaseImage},
 				}))
 
 				Expect(spec.SidecarContainer.ImageConfigs).To(Equal([]fdbv1beta2.ImageConfig{
@@ -450,7 +450,7 @@ var _ = Describe("[internal] deprecations", func() {
 			When("no image config is set", func() {
 				It("should be added", func() {
 					var imageConfigs []fdbv1beta2.ImageConfig
-					ensureImageConfigPresent(&imageConfigs, fdbv1beta2.ImageConfig{BaseImage: "foundationdb/foundationdb"})
+					ensureImageConfigPresent(&imageConfigs, fdbv1beta2.ImageConfig{BaseImage: fdbv1beta2.FoundationDBBaseImage})
 					Expect(imageConfigs).To(HaveLen(1))
 				})
 			})
@@ -459,11 +459,11 @@ var _ = Describe("[internal] deprecations", func() {
 				var imageConfigs []fdbv1beta2.ImageConfig
 
 				BeforeEach(func() {
-					imageConfigs = []fdbv1beta2.ImageConfig{{BaseImage: "foundationdb/foundationdb"}}
+					imageConfigs = []fdbv1beta2.ImageConfig{{BaseImage: fdbv1beta2.FoundationDBBaseImage}}
 				})
 
 				It("should not be added", func() {
-					ensureImageConfigPresent(&imageConfigs, fdbv1beta2.ImageConfig{BaseImage: "foundationdb/foundationdb"})
+					ensureImageConfigPresent(&imageConfigs, fdbv1beta2.ImageConfig{BaseImage: fdbv1beta2.FoundationDBBaseImage})
 					Expect(imageConfigs).To(HaveLen(1))
 				})
 			})

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -285,9 +285,9 @@ var _ = Describe("pod_models", func() {
 				}))
 
 				Expect(*mainContainer.Resources.Limits.Cpu()).To(Equal(resource.MustParse("1")))
-				Expect(*mainContainer.Resources.Limits.Memory()).To(Equal(resource.MustParse("4Gi")))
+				Expect(*mainContainer.Resources.Limits.Memory()).To(Equal(resource.MustParse("8Gi")))
 				Expect(*mainContainer.Resources.Requests.Cpu()).To(Equal(resource.MustParse("1")))
-				Expect(*mainContainer.Resources.Requests.Memory()).To(Equal(resource.MustParse("4Gi")))
+				Expect(*mainContainer.Resources.Requests.Memory()).To(Equal(resource.MustParse("8Gi")))
 
 				Expect(len(mainContainer.VolumeMounts)).To(Equal(3))
 
@@ -507,7 +507,7 @@ var _ = Describe("pod_models", func() {
 				It("should have the main foundationdb container", func() {
 					mainContainer := spec.Containers[0]
 					Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
-					Expect(mainContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes:%s", cluster.Spec.Version)))
+					Expect(mainContainer.Image).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(cluster.Spec.Version)))
 					Expect(mainContainer.Command).To(BeNil())
 					Expect(mainContainer.Args).To(Equal([]string{
 						"--input-dir", "/var/dynamic-conf",
@@ -543,9 +543,9 @@ var _ = Describe("pod_models", func() {
 					}))
 
 					Expect(*mainContainer.Resources.Limits.Cpu()).To(Equal(resource.MustParse("1")))
-					Expect(*mainContainer.Resources.Limits.Memory()).To(Equal(resource.MustParse("4Gi")))
+					Expect(*mainContainer.Resources.Limits.Memory()).To(Equal(resource.MustParse("8Gi")))
 					Expect(*mainContainer.Resources.Requests.Cpu()).To(Equal(resource.MustParse("1")))
-					Expect(*mainContainer.Resources.Requests.Memory()).To(Equal(resource.MustParse("4Gi")))
+					Expect(*mainContainer.Resources.Requests.Memory()).To(Equal(resource.MustParse("8Gi")))
 
 					Expect(mainContainer.VolumeMounts).To(Equal([]corev1.VolumeMount{
 						{Name: "data", MountPath: "/var/fdb/data"},
@@ -560,7 +560,7 @@ var _ = Describe("pod_models", func() {
 				It("should have the sidecar container", func() {
 					sidecarContainer := spec.Containers[1]
 					Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainerName))
-					Expect(sidecarContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes:%s", cluster.Spec.Version)))
+					Expect(sidecarContainer.Image).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(cluster.Spec.Version)))
 					Expect(sidecarContainer.Args).To(Equal([]string{
 						"--mode", "sidecar",
 						"--output-dir", "/var/fdb/shared-binaries",
@@ -1368,9 +1368,9 @@ var _ = Describe("pod_models", func() {
 				}))
 
 				Expect(*mainContainer.Resources.Limits.Cpu()).To(Equal(resource.MustParse("1")))
-				Expect(*mainContainer.Resources.Limits.Memory()).To(Equal(resource.MustParse("4Gi")))
+				Expect(*mainContainer.Resources.Limits.Memory()).To(Equal(resource.MustParse("8Gi")))
 				Expect(*mainContainer.Resources.Requests.Cpu()).To(Equal(resource.MustParse("1")))
-				Expect(*mainContainer.Resources.Requests.Memory()).To(Equal(resource.MustParse("4Gi")))
+				Expect(*mainContainer.Resources.Requests.Memory()).To(Equal(resource.MustParse("8Gi")))
 
 				Expect(len(mainContainer.VolumeMounts)).To(Equal(3))
 


### PR DESCRIPTION
# Description

Correcting the default base image for the unified image.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Added unit tests and e2e test will be running.

## Documentation

-

## Follow-up

-