### PR TITLE
Ensure that the status checker unsets the FDB network options

### DIFF
--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -437,6 +437,8 @@ spec:
             value: "/var/log/fdb"
           - name: FDB_NETWORK_OPTION_TRACE_FORMAT
             value: json
+          - name: FDB_NETWORK_OPTION_CLIENT_THREADS_PER_VERSION
+            value: "10"
         ports:
           - name: metrics
             containerPort: 8080

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -137,7 +137,10 @@ func (fdbCluster *FdbCluster) RunFdbCliCommandInOperatorWithoutRetry(
 			pod.Name,
 			"manager",
 			fmt.Sprintf(
-				"export TIMEFORMAT='%%R' && echo '%s' > %s && time %s --log-dir \"/var/log/fdb\" --log --trace_format \"json\" %s -C %s --exec '%s'",
+				"unset %s && unset %s && unset %s && TIMEFORMAT='%%R' && echo '%s' > %s && time %s --log-dir \"/var/log/fdb\" --log --trace_format \"json\" %s -C %s --exec '%s'",
+				fdbv1beta2.EnvNameClientThreadsPerVersion,
+				fdbv1beta2.EnvNameFDBExternalClientDir,
+				fdbv1beta2.EnvNameFDBIgnoreExternalClientFailures,
 				cluster.Status.ConnectionString,
 				clusterFile,
 				fdbCliPath,


### PR DESCRIPTION
# Description

Remove the FDB network options that are only used for the fdb library. We already do that for the fdbcli calls in the operator but not for the fdbcli calls from the e2e test suite.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran an upgrade e2e test and checked the trace file for the fdbcli call and I was able to confirm that the additional copies were removed.

## Documentation

-

## Follow-up

-
