### PR TITLE
Make sure the operator provides an error message when the command line is too long

### DIFF
--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -398,6 +398,14 @@ func checkAndSetProcessStatus(logger logr.Logger, r *FoundationDBClusterReconcil
 				return err
 			}
 
+			// If the new command line is longer than 10.000 characters we will throw an error to make sure the operator
+			// is not restarting the cluster the whole time.
+			// See https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2105
+			if len(commandLine) > 10000 {
+				r.Recorder.Event(cluster, corev1.EventTypeWarning, "Command line too long", "Command line exceeds 10.000 characters and will be truncated in the machine-readable status")
+				return fmt.Errorf("command line exceeds 10.000 characters and will be truncated in the machine-readable status: %s", commandLine)
+			}
+
 			// If a version compatible upgrade is in progress, skip the version check since we will run a mixed set of versions
 			// until the cluster is fully reconciled.
 			versionMatch := true

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -334,6 +334,23 @@ var _ = Describe("update_status", func() {
 			})
 		})
 
+		When("the command line is too long", func() {
+			BeforeEach(func() {
+				// Generate a random long string
+				cluster.Spec.MainContainer.PeerVerificationRules = internal.GenerateRandomString(10000)
+			})
+
+			It("should not get any condition assigned", func() {
+				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, allPvcs, logger, "")
+				Expect(err).To(HaveOccurred())
+				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
+				// We expect that no conditions are added in this case.
+				for _, processGroup := range cluster.Status.ProcessGroups {
+					Expect(processGroup.ProcessGroupConditions).To(HaveLen(0))
+				}
+			})
+		})
+
 		When("the pod for the process group is missing", func() {
 			BeforeEach(func() {
 				Expect(k8sClient.Delete(context.TODO(), storagePod)).NotTo(HaveOccurred())


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2105

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

I think the update status is the best place as we have to check the command line with the substituted env variables.

## Testing

Added a new unit test and CI will run e2e tests. I don't think an additional e2e test is required

## Documentation

-

## Follow-up

-
