### PR TITLE
Allow the operator to replace process groups with an I/O error

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -65,7 +65,7 @@ type FoundationDBClusterList struct {
 }
 
 var conditionsThatNeedReplacement = []ProcessGroupConditionType{MissingProcesses, PodFailing, MissingPod, MissingPVC,
-	MissingService, PodPending, NodeTaintReplacing, ProcessIsMarkedAsExcluded}
+	MissingService, PodPending, NodeTaintReplacing, ProcessIsMarkedAsExcluded, ProcessHasIOError}
 
 const (
 	oneHourDuration = 1 * time.Hour
@@ -942,6 +942,8 @@ const (
 	NodeTaintReplacing ProcessGroupConditionType = "NodeTaintReplacing"
 	// ProcessIsMarkedAsExcluded represents a process group where at least one process is excluded.
 	ProcessIsMarkedAsExcluded ProcessGroupConditionType = "ProcessIsMarkedAsExcluded"
+	// ProcessHasIOError represents a process group that has an I/O error.
+	ProcessHasIOError ProcessGroupConditionType = "ProcessHasIOError"
 )
 
 // AllProcessGroupConditionTypes returns all ProcessGroupConditionType
@@ -961,6 +963,7 @@ func AllProcessGroupConditionTypes() []ProcessGroupConditionType {
 		NodeTaintDetected,
 		NodeTaintReplacing,
 		ProcessIsMarkedAsExcluded,
+		ProcessHasIOError,
 	}
 }
 
@@ -997,6 +1000,8 @@ func GetProcessGroupConditionType(processGroupConditionType string) (ProcessGrou
 		return NodeTaintReplacing, nil
 	case "ProcessIsMarkedAsExcluded":
 		return ProcessIsMarkedAsExcluded, nil
+	case "ProcessHasIOError":
+		return ProcessHasIOError, nil
 	}
 
 	return "", fmt.Errorf("unknown process group condition type: %s", processGroupConditionType)

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -345,7 +345,7 @@ func checkAndSetProcessStatus(logger logr.Logger, r *FoundationDBClusterReconcil
 		return nil
 	}
 
-	var excluded, hasIncorrectCommandLine, hasMissingProcesses, sidecarUnreachable bool
+	var excluded, hasIncorrectCommandLine, hasMissingProcesses, sidecarUnreachable, hasIOError bool
 	var substitutions map[string]string
 	var err error
 
@@ -383,6 +383,10 @@ func checkAndSetProcessStatus(logger logr.Logger, r *FoundationDBClusterReconcil
 			// Check if the process is reporting any messages, those will normally include error messages.
 			if len(process.Messages) > 0 {
 				logger.Info("found error message(s) for the process", "processGroupID", processGroupStatus.ProcessGroupID, "messages", process.Messages)
+
+				if !hasIOError {
+					hasIOError = checkProcessMessagesForIOError(process.Messages)
+				}
 			}
 
 			if !excluded {
@@ -425,6 +429,7 @@ func checkAndSetProcessStatus(logger logr.Logger, r *FoundationDBClusterReconcil
 		return nil
 	}
 	processGroupStatus.UpdateCondition(fdbv1beta2.ProcessIsMarkedAsExcluded, excluded)
+	processGroupStatus.UpdateCondition(fdbv1beta2.ProcessHasIOError, hasIOError)
 	// If the sidecar is unreachable we are not able to compute the desired commandline.
 	if sidecarUnreachable {
 		return nil
@@ -432,6 +437,18 @@ func checkAndSetProcessStatus(logger logr.Logger, r *FoundationDBClusterReconcil
 	processGroupStatus.UpdateCondition(fdbv1beta2.IncorrectCommandLine, hasIncorrectCommandLine)
 
 	return nil
+}
+
+// checkProcessMessagesForIOError will return true if the provided slice of process messages contains at least one message
+// with io_timeout or io_error.
+func checkProcessMessagesForIOError(messages []fdbv1beta2.FoundationDBStatusProcessMessage) bool {
+	for _, message := range messages {
+		if message.Name == "io_timeout" || message.Name == "io_error" {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Validate and set progressGroup's status


### PR DESCRIPTION
# Description

Allow the operator to replace process groups with an I/O error.

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

Performed testing with the e2e tests. Modified an existing test for this use case.

## Documentation

-

## Follow-up

-
