### PR TITLE
Improve logging for fdbclient and lock client to see what subreconciler issued the command

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -43,12 +43,12 @@ import (
 type bounceProcesses struct{}
 
 // reconcile runs the reconciler's work.
-func (bounceProcesses) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (c bounceProcesses) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	if !pointer.BoolDeref(cluster.Spec.AutomationOptions.KillProcesses, true) {
 		return nil
 	}
 
-	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
+	adminClient, err := r.getAdminClient(logger, cluster)
 	if err != nil {
 		return &requeue{curError: err}
 	}
@@ -111,7 +111,7 @@ func (bounceProcesses) reconcile(_ context.Context, r *FoundationDBClusterReconc
 	var lockClient fdbadminclient.LockClient
 	useLocks := cluster.ShouldUseLocks()
 	if useLocks {
-		lockClient, err = r.getLockClient(cluster)
+		lockClient, err = r.getLockClient(logger, cluster)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -41,7 +41,7 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 		return nil
 	}
 
-	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
+	adminClient, err := r.getAdminClient(logger, cluster)
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}

--- a/controllers/check_client_compatibility.go
+++ b/controllers/check_client_compatibility.go
@@ -65,7 +65,7 @@ func (c checkClientCompatibility) reconcile(_ context.Context, r *FoundationDBCl
 		return nil
 	}
 
-	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
+	adminClient, err := r.getAdminClient(logger, cluster)
 	if err != nil {
 		return &requeue{curError: err}
 	}

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -56,7 +56,7 @@ func (c chooseRemovals) reconcile(ctx context.Context, r *FoundationDBClusterRec
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {
-		adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
+		adminClient, err := r.getAdminClient(logger, cluster)
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2516,7 +2516,7 @@ var _ = Describe("cluster_controller", func() {
 			})
 
 			It("should update the deny list", func() {
-				lockClient, err := clusterReconciler.getLockClient(cluster)
+				lockClient, err := clusterReconciler.getLockClient(testLogger, cluster)
 				Expect(err).NotTo(HaveOccurred())
 				list, err := lockClient.GetDenyList()
 				Expect(err).NotTo(HaveOccurred())

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -33,12 +33,12 @@ import (
 type maintenanceModeChecker struct{}
 
 // reconcile runs the reconciler's work.
-func (maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (c maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	if !cluster.ResetMaintenanceMode() {
 		return nil
 	}
 
-	adminClient, err := r.DatabaseClientProvider.GetAdminClient(cluster, r)
+	adminClient, err := r.getAdminClient(logger, cluster)
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}

--- a/controllers/remove_incompatible_processes.go
+++ b/controllers/remove_incompatible_processes.go
@@ -36,7 +36,7 @@ import (
 type removeIncompatibleProcesses struct{}
 
 // reconcile runs the reconciler's work.
-func (removeIncompatibleProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (c removeIncompatibleProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	err := processIncompatibleProcesses(ctx, r, logger, cluster, status)
 
 	if err != nil {
@@ -64,7 +64,7 @@ func processIncompatibleProcesses(ctx context.Context, r *FoundationDBClusterRec
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {
-		adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r.Client)
+		adminClient, err := r.getAdminClient(logger, cluster)
 		if err != nil {
 			return err
 		}

--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -46,7 +46,7 @@ func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *Foundation
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {
-		adminClient, err := r.DatabaseClientProvider.GetAdminClient(cluster, r)
+		adminClient, err := r.getAdminClient(logger, cluster)
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -46,7 +46,7 @@ func (u updateDatabaseConfiguration) reconcile(_ context.Context, r *FoundationD
 		return nil
 	}
 
-	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
+	adminClient, err := r.getAdminClient(logger, cluster)
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}

--- a/controllers/update_lock_configuration.go
+++ b/controllers/update_lock_configuration.go
@@ -33,12 +33,12 @@ import (
 type updateLockConfiguration struct{}
 
 // reconcile runs the reconciler's work.
-func (updateLockConfiguration) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, _ logr.Logger) *requeue {
+func (updateLockConfiguration) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	if len(cluster.Spec.LockOptions.DenyList) == 0 || !cluster.ShouldUseLocks() || !cluster.Status.Configured {
 		return nil
 	}
 
-	lockClient, err := r.getLockClient(cluster)
+	lockClient, err := r.getLockClient(logger, cluster)
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -42,7 +42,7 @@ import (
 type updatePods struct{}
 
 // reconcile runs the reconciler's work.
-func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (u updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	// TODO(johscheuer): Remove the pvc map an make direct calls.
 	pvcs := &corev1.PersistentVolumeClaimList{}
 	err := r.List(ctx, pvcs, internal.GetPodListOptions(cluster, "", "")...)
@@ -72,7 +72,7 @@ func (updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconcile
 		return nil
 	}
 
-	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r.Client)
+	adminClient, err := r.getAdminClient(logger, cluster)
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -49,7 +49,7 @@ import (
 type updateStatus struct{}
 
 // reconcile runs the reconciler's work.
-func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, databaseStatus *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (c updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, databaseStatus *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	originalStatus := cluster.Status.DeepCopy()
 	clusterStatus := fdbv1beta2.FoundationDBClusterStatus{}
 	clusterStatus.Generations.Reconciled = cluster.Status.Generations.Reconciled
@@ -209,7 +209,7 @@ func (updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	}
 
 	if len(cluster.Spec.LockOptions.DenyList) > 0 && cluster.ShouldUseLocks() && clusterStatus.Configured {
-		lockClient, err := r.getLockClient(cluster)
+		lockClient, err := r.getLockClient(logger, cluster)
 		if err != nil {
 			return &requeue{curError: err}
 		}
@@ -308,7 +308,7 @@ func tryConnectionOptions(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCl
 	for _, connectionString := range connectionStrings {
 		logger.Info("Attempting to get connection string from cluster", "connectionString", connectionString)
 		cluster.Status.ConnectionString = connectionString
-		adminClient, clientErr := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
+		adminClient, clientErr := r.getAdminClient(logger, cluster)
 		if clientErr != nil {
 			return originalConnectionString, clientErr
 		}

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -95,13 +95,12 @@ type cliAdminClient struct {
 }
 
 // NewCliAdminClient generates an Admin client for a cluster
-func NewCliAdminClient(cluster *fdbv1beta2.FoundationDBCluster, _ client.Client, log logr.Logger) (fdbadminclient.AdminClient, error) {
+func NewCliAdminClient(cluster *fdbv1beta2.FoundationDBCluster, _ client.Client, logger logr.Logger) (fdbadminclient.AdminClient, error) {
 	clusterFile, err := createClusterFile(cluster)
 	if err != nil {
 		return nil, err
 	}
 
-	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name)
 	return &cliAdminClient{
 		Cluster:         cluster,
 		clusterFilePath: clusterFile,

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -149,9 +149,19 @@ type realDatabaseClientProvider struct {
 	log logr.Logger
 }
 
+func (p *realDatabaseClientProvider) GetAdminClientWithLogger(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client, logger logr.Logger) (fdbadminclient.AdminClient, error) {
+	return NewCliAdminClient(cluster, kubernetesClient, logger.WithName("fdbclient"))
+}
+
 // GetLockClient generates a client for working with locks through the database.
 func (p *realDatabaseClientProvider) GetLockClient(cluster *fdbv1beta2.FoundationDBCluster) (fdbadminclient.LockClient, error) {
 	return NewRealLockClient(cluster, p.log)
+}
+
+// GetLockClientWithLogger generates a client for working with locks through the database.
+// The provided logger will be used as logger for the LockClient.
+func (p *realDatabaseClientProvider) GetLockClientWithLogger(cluster *fdbv1beta2.FoundationDBCluster, logger logr.Logger) (fdbadminclient.LockClient, error) {
+	return NewRealLockClient(cluster, logger.WithName("fdbclient"))
 }
 
 // GetAdminClient generates a client for performing administrative actions

--- a/internal/locality/locality.go
+++ b/internal/locality/locality.go
@@ -377,8 +377,17 @@ func CheckCoordinatorValidity(logger logr.Logger, cluster *fdbv1beta2.Foundation
 			coordinatorAddress = dnsAddress.String()
 		}
 
-		if coordinatorAddress != "" && !process.Excluded && !process.UnderMaintenance {
-			coordinatorStatus[coordinatorAddress] = true
+		if coordinatorAddress != "" {
+			if process.Excluded {
+				pLogger.Info("Coordinator process is excluded, marking it as unhealthy", "class", process.ProcessClass, "address", coordinatorAddress)
+			} else {
+				// The process is not excluded and has an address, so we assume that the coordinator is healthy.
+				coordinatorStatus[coordinatorAddress] = true
+			}
+
+			if process.UnderMaintenance {
+				pLogger.Info("Coordinator process is under maintenance", "class", process.ProcessClass, "address", coordinatorAddress)
+			}
 		}
 
 		if coordinatorAddress != "" {

--- a/pkg/fdbadminclient/database_provider.go
+++ b/pkg/fdbadminclient/database_provider.go
@@ -22,6 +22,7 @@ package fdbadminclient
 
 import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -31,7 +32,15 @@ type DatabaseClientProvider interface {
 	// GetLockClient generates a client for working with locks through the database.
 	GetLockClient(cluster *fdbv1beta2.FoundationDBCluster) (LockClient, error)
 
+	// GetLockClientWithLogger generates a client for working with locks through the database.
+	// The provided logger will be used as logger for the LockClient.
+	GetLockClientWithLogger(cluster *fdbv1beta2.FoundationDBCluster, logger logr.Logger) (LockClient, error)
+
 	// GetAdminClient generates a client for performing administrative actions
 	// against the database.
 	GetAdminClient(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client) (AdminClient, error)
+
+	// GetAdminClientWithLogger generates a client for performing administrative actions
+	// against the database. The provided logger will be used as logger for the AdminClient.
+	GetAdminClientWithLogger(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client, logger logr.Logger) (AdminClient, error)
 }

--- a/pkg/fdbadminclient/mock/database_provider.go
+++ b/pkg/fdbadminclient/mock/database_provider.go
@@ -23,6 +23,7 @@ package mock
 import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient"
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -34,8 +35,20 @@ func (p DatabaseClientProvider) GetLockClient(cluster *fdbv1beta2.FoundationDBCl
 	return NewMockLockClient(cluster)
 }
 
+// GetLockClientWithLogger generates a client for working with locks through the database.
+// The provided logger will be used as logger for the LockClient.
+func (p DatabaseClientProvider) GetLockClientWithLogger(cluster *fdbv1beta2.FoundationDBCluster, _ logr.Logger) (fdbadminclient.LockClient, error) {
+	return NewMockLockClient(cluster)
+}
+
 // GetAdminClient generates a client for performing administrative actions
 // against the database.
 func (p DatabaseClientProvider) GetAdminClient(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client) (fdbadminclient.AdminClient, error) {
+	return NewMockAdminClient(cluster, kubernetesClient)
+}
+
+// GetAdminClientWithLogger generates a client for performing administrative actions
+// against the database.
+func (p DatabaseClientProvider) GetAdminClientWithLogger(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client, _ logr.Logger) (fdbadminclient.AdminClient, error) {
 	return NewMockAdminClient(cluster, kubernetesClient)
 }

--- a/pkg/fdbstatus/status_checks.go
+++ b/pkg/fdbstatus/status_checks.go
@@ -536,10 +536,8 @@ func canSafelyExcludeOrIncludeProcesses(cluster *fdbv1beta2.FoundationDBCluster,
 
 	// In the case of inclusions we also want to make sure we only change the list of excluded server if the cluster is
 	// in a good shape, otherwise the CC might crash: https://github.com/apple/foundationdb/blob/release-7.1/fdbserver/ClusterRecovery.actor.cpp#L575-L579
-	if inclusion {
-		if !recoveryStateAllowsInclusion(status) {
-			return fmt.Errorf("cannot: %s, cluster recovery state is %s, but it must be \"fully_recovered\" or \"all_logs_recruited\"", action, status.Cluster.RecoveryState.Name)
-		}
+	if inclusion && !recoveryStateAllowsInclusion(status) {
+		return fmt.Errorf("cannot: %s, cluster recovery state is %s, but it must be \"fully_recovered\" or \"all_logs_recruited\"", action, status.Cluster.RecoveryState.Name)
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Those changes make use of the same logger that the (sub)reconciler uses, that way it's easier to track back which reconciler issued the command. In addition I added a trace ID field to make it easier to track a single reconcile run.

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2118

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Ran unit tests and e2e test will be running.

## Documentation

-

## Follow-up

-
