### PR TITLE
Only release the lock when the cluster is reconciled

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -167,6 +167,9 @@ func (c bounceProcesses) reconcile(_ context.Context, r *FoundationDBClusterReco
 		return &requeue{curError: err}
 	}
 
+	// Reset the SecondsSinceLastRecovered sine the operator just restarted some processes, which will could cause a recovery.
+	status.Cluster.RecoveryState.SecondsSinceLastRecovered = 0.0
+
 	// If the cluster was upgraded we will requeue and let the update_status command set the correct version.
 	// Updating the version in this method has the drawback that we upgrade the version independent of the success
 	// of the kill command. The kill command is not reliable, which means that some kill request might not be

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -135,18 +135,9 @@ func (c bounceProcesses) reconcile(_ context.Context, r *FoundationDBClusterReco
 		}
 	}
 
-	hasLock, err := r.takeLock(logger, cluster, fmt.Sprintf("bouncing processes: %v", addresses))
+	_, err = r.takeLock(logger, cluster, fmt.Sprintf("bouncing processes: %v", addresses))
 	if err != nil {
 		return &requeue{curError: err}
-	}
-
-	if hasLock {
-		defer func() {
-			lockErr := r.releaseLock(logger, cluster)
-			if lockErr != nil {
-				logger.Error(lockErr, "could not release lock")
-			}
-		}()
 	}
 
 	if useLocks && upgrading {

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -82,13 +82,6 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}
-
-		defer func() {
-			lockErr := lockClient.ReleaseLock()
-			if lockErr != nil {
-				logger.Error(lockErr, "could not release lock")
-			}
-		}()
 	}
 
 	// We need the information below to check if the excluded processes are coordinators to make sure we can change the
@@ -192,6 +185,9 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 			return &requeue{curError: err, delayedRequeue: true}
 		}
 	}
+
+	// Reset the SecondsSinceLastRecovered sine the operator just excluded some processes, which will cause a recovery.
+	status.Cluster.RecoveryState.SecondsSinceLastRecovered = 0.0
 
 	return nil
 }

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -95,13 +95,6 @@ func (c maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBClus
 		return &requeue{curError: err}
 	}
 
-	defer func() {
-		lockErr := r.releaseLock(logger, cluster)
-		if lockErr != nil {
-			logger.Error(lockErr, "could not release lock")
-		}
-	}()
-
 	logger.Info("Switching off maintenance mode", "zone", status.Cluster.MaintenanceZone)
 	err = adminClient.ResetMaintenanceMode()
 	if err != nil {

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -279,13 +279,6 @@ func includeProcessGroup(ctx context.Context, logger logr.Logger, r *FoundationD
 		if err != nil {
 			return err
 		}
-
-		defer func() {
-			releaseErr := lockClient.ReleaseLock()
-			if releaseErr != nil {
-				logger.Error(releaseErr, "could not release lock")
-			}
-		}()
 	}
 
 	// Make sure it's safe to include processes.
@@ -299,6 +292,9 @@ func includeProcessGroup(ctx context.Context, logger logr.Logger, r *FoundationD
 	if err != nil {
 		return err
 	}
+
+	// Reset the SecondsSinceLastRecovered sine the operator just included some processes, which will cause a recovery.
+	status.Cluster.RecoveryState.SecondsSinceLastRecovered = 0.0
 
 	return r.updateOrApply(ctx, cluster)
 }

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -104,13 +104,6 @@ func (u updateDatabaseConfiguration) reconcile(_ context.Context, r *FoundationD
 			if !hasLock {
 				return &requeue{curError: err, delayedRequeue: true}
 			}
-
-			defer func() {
-				lockErr := r.releaseLock(logger, cluster)
-				if lockErr != nil {
-					logger.Error(lockErr, "could not release lock")
-				}
-			}()
 		}
 
 		logger.Info("Configuring database", "current configuration", currentConfiguration, "desired configuration", desiredConfiguration)

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -163,7 +163,13 @@ func (client *realLockClient) updateLock(transaction fdb.Transaction, start int6
 		start,
 		end,
 	}
-	client.log.Info("Setting new lock", "namespace", client.cluster.Namespace, "cluster", client.cluster.Name, "owner", ownerID, "lockValue", lockValue)
+	client.log.Info("Setting new lock",
+		"namespace", client.cluster.Namespace,
+		"cluster", client.cluster.Name,
+		"ownerID", ownerID,
+		"lockValue", lockValue,
+		"startTime", time.Unix(start, 0),
+		"endTime", time.Unix(end, 0))
 	transaction.Set(lockKey, lockValue.Pack())
 }
 
@@ -343,24 +349,44 @@ func (client *realLockClient) ReleaseLock() error {
 			return false, invalidLockValue{key: lockKey, value: lockValue}
 		}
 
-		currentLockStartTime, valid := lockTuple[1].(int64)
+		currentLockStartTimestamp, valid := lockTuple[1].(int64)
 		if !valid {
 			return false, invalidLockValue{key: lockKey, value: lockValue}
 		}
 
-		currentLockEndTime, valid := lockTuple[2].(int64)
+		currentLockEndTimestamp, valid := lockTuple[2].(int64)
 		if !valid {
 			return false, invalidLockValue{key: lockKey, value: lockValue}
 		}
 
 		ownerID := client.cluster.GetLockID()
+		logger := client.log.WithValues(
+			"namespace", client.cluster.Namespace,
+			"cluster", client.cluster.Name,
+			"ownerID", ownerID,
+			"currentLockOwnerID", currentLockOwnerID,
+			"startTime", time.Unix(currentLockStartTimestamp, 0),
+			"endTime", time.Unix(currentLockEndTimestamp, 0))
+
 		if currentLockOwnerID != ownerID {
-			client.log.Info("cannot release lock from other owner", "currentLockOwnerID", currentLockOwnerID, "ownerID", ownerID)
+			logger.Info("cannot release lock from other owner")
 			return false, nil
 		}
 
-		client.log.Info("releasing lock", "ownerID", ownerID, "lockStartTime", currentLockStartTime, "lockEndTime", currentLockEndTime)
+		// Check the timestamp of the logs and make sure to only release locks when the timestamps are valid.
+		// If the lock is not valid anymore, other operator instances can take the lock in takeLockInTransaction.
+		now := time.Now()
+		if currentLockStartTimestamp > now.Unix() {
+			logger.Info("cannot release lock that is taken in the future")
+			return false, nil
+		}
 
+		if currentLockEndTimestamp < now.Unix() {
+			logger.Info("cannot release a lock that is expired")
+			return false, nil
+		}
+
+		logger.Info("releasing lock")
 		transaction.Clear(lockKey)
 
 		return nil, nil

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -116,9 +116,6 @@ func (client *realLockClient) takeLockInTransaction(transaction fdb.Transaction)
 	ownerID := client.cluster.GetLockID()
 
 	logger := client.log.WithValues(
-		"namespace", client.cluster.Namespace,
-		"cluster", client.cluster.Name,
-		"ownerID", ownerID,
 		"currentLockOwnerID", currentLockOwnerID,
 		"startTime", time.Unix(currentLockStartTime, 0),
 		"endTime", time.Unix(currentLockEndTime, 0))
@@ -164,9 +161,6 @@ func (client *realLockClient) updateLock(transaction fdb.Transaction, start int6
 		end,
 	}
 	client.log.Info("Setting new lock",
-		"namespace", client.cluster.Namespace,
-		"cluster", client.cluster.Name,
-		"ownerID", ownerID,
 		"lockValue", lockValue,
 		"startTime", time.Unix(start, 0),
 		"endTime", time.Unix(end, 0))
@@ -361,9 +355,6 @@ func (client *realLockClient) ReleaseLock() error {
 
 		ownerID := client.cluster.GetLockID()
 		logger := client.log.WithValues(
-			"namespace", client.cluster.Namespace,
-			"cluster", client.cluster.Name,
-			"ownerID", ownerID,
 			"currentLockOwnerID", currentLockOwnerID,
 			"startTime", time.Unix(currentLockStartTimestamp, 0),
 			"endTime", time.Unix(currentLockEndTimestamp, 0))
@@ -418,5 +409,13 @@ func NewRealLockClient(cluster *fdbv1beta2.FoundationDBCluster, log logr.Logger)
 		return nil, err
 	}
 
-	return &realLockClient{cluster: cluster, database: database, log: log}, nil
+	return &realLockClient{
+		cluster:  cluster,
+		database: database,
+		log: log.WithValues(
+			"namespace", cluster.Namespace,
+			"cluster", cluster.Name,
+			"ownerID", cluster.GetLockID(),
+		),
+	}, nil
 }


### PR DESCRIPTION
# Description

In the past we added code to release the lock when the operation was performed. Doing that increases the risk of race conditions when multiple operator instances are managing a multi-region (or three data hall) FDB cluster. In order to reduce the risk of those race conditions the operator is releasing the lock only when the cluster is reconciled (or when the lock is timed out).

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

The general idea of the locking mechanism is to reduce the operations executed in parallel on the FDB cluster. When the lock is directly released after the operation we have the risk that another operator instance is directly doing another operation that could be disruptive, e.g. excluding processes.

## Testing

e2e test will be running by CI.

## Documentation

Will be updated.

## Follow-up

-
