### PR TITLE
Refactor exec code to share same code and add plugin e2e test suite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,10 @@ COPY fdbclient/ fdbclient/
 COPY internal/ internal/
 COPY pkg/ pkg/
 COPY mock-kubernetes-client/ mock-kubernetes-client/
+COPY kubectl-fdb/ kubectl-fdb/
 
 # Build
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on make manager
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on make manager plugin-go
 
 # Create user and group here since we don't have the tools
 # in distroless
@@ -67,6 +68,7 @@ RUN set -eux && \
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
 COPY --chown=fdb:fdb --from=builder /workspace/bin/manager .
+COPY --chown=fdb:fdb --from=builder /workspace/bin/kubectl-fdb /usr/local/bin/kubectl-fdb
 COPY --chown=fdb:fdb --from=builder /var/log/fdb/.keep /var/log/fdb/.keep
 
 # Set to the numeric UID of fdb user to satisfy PodSecurityPolices which enforce runAsNonRoot

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ manager: bin/manager
 bin/manager: ${GO_SRC}
 	go build -ldflags="-s -w -X github.com/FoundationDB/fdb-kubernetes-operator/setup.operatorVersion=${TAG}" -o bin/manager main.go
 
+plugin-go:
+	go build -ldflags="-s -w -X github.com/FoundationDB/fdb-kubernetes-operator/kubectl-fdb/cmd.pluginVersion=${TAG}" -o bin/kubectl-fdb ./kubectl-fdb/main.go
+
 # Build kubectl-fdb binary
 plugin: bin/kubectl-fdb
 

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -21,7 +21,6 @@
 package fixtures
 
 import (
-	"bytes"
 	ctx "context"
 	"fmt"
 	"golang.org/x/net/context"
@@ -34,15 +33,13 @@ import (
 	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	kubeHelper "github.com/FoundationDB/fdb-kubernetes-operator/internal/kubernetes"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/duration"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -65,7 +62,6 @@ type Factory struct {
 	certificate             *corev1.Secret
 	namespaces              []string
 	controllerRuntimeClient client.Client
-	kubernetesClient        *kubernetes.Clientset
 	config                  *rest.Config
 	fdbVersion              fdbv1beta2.Version
 }
@@ -86,7 +82,6 @@ func CreateFactory(options *FactoryOptions) *Factory {
 		userName:                configuration.userName,
 		controllerRuntimeClient: configuration.controllerRuntimeClient,
 		fdbVersion:              configuration.fdbVersion,
-		kubernetesClient:        configuration.client,
 		config:                  configuration.config,
 	}
 }
@@ -140,10 +135,6 @@ func (factory *Factory) GetBackupSecretName() string {
 
 func (factory *Factory) getConfig() *rest.Config {
 	return factory.config
-}
-
-func (factory *Factory) getClient() *kubernetes.Clientset {
-	return factory.kubernetesClient
 }
 
 // DeletePod deletes the provided Pod
@@ -448,7 +439,14 @@ func (factory *Factory) ExecuteCmdOnPod(
 	command string,
 	printOutput bool,
 ) (string, string, error) {
-	return factory.ExecuteCmd(ctx, pod.Namespace, pod.Name, container, command, printOutput)
+	return kubeHelper.ExecuteCommandOnPod(
+		context.Background(),
+		factory.GetControllerRuntimeClient(),
+		factory.getConfig(),
+		pod,
+		container,
+		command,
+		printOutput)
 }
 
 // ExecuteCmd executes command in the default container of a Pod with shell, returns stdout and stderr.
@@ -460,32 +458,15 @@ func (factory *Factory) ExecuteCmd(
 	command string,
 	printOutput bool,
 ) (string, string, error) {
-	cmd := []string{
-		"/bin/bash",
-		"-c",
+	return kubeHelper.ExecuteCommand(
+		context.Background(),
+		factory.GetControllerRuntimeClient(),
+		factory.getConfig(),
+		namespace,
+		name,
+		container,
 		command,
-	}
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	err := factory.ExecuteCommandRaw(ctx, namespace, name, container, cmd, nil, &stdout, &stderr, false)
-	sout := stdout.String()
-	serr := stderr.String()
-	// TODO: Stream these to our own stdout as we run.
-	if printOutput {
-		if sout != "" && !strings.Contains(serr, "constructing many client") {
-			log.Println(sout)
-		}
-		// Callers of this used to skip printing serr if err was nil, but we never populate serr
-		// if err is nil; always print for now.
-		if serr != "" &&
-			!strings.Contains(
-				serr,
-				"constructing many client",
-			) { // ignoring constructing many client message
-			log.Println(serr)
-		}
-	}
-	return sout, serr, err
+		printOutput)
 }
 
 // ExecuteCommandRaw will run the command without putting it into a shell.
@@ -500,105 +481,36 @@ func (factory *Factory) ExecuteCommandRaw(
 	stderr io.Writer,
 	isTty bool,
 ) error {
-	req := factory.getClient().CoreV1().RESTClient().Post().
-		Resource("pods").Name(name).
-		Namespace(namespace).SubResource("exec")
-	option := &corev1.PodExecOptions{
-		Command:   command,
-		Container: container,
-		Stdin:     stdin != nil,
-		Stdout:    stdout != nil,
-		Stderr:    stderr != nil,
-		TTY:       isTty,
-	}
-	req.VersionedParams(
-		option,
-		scheme.ParameterCodec,
-	)
-	spdyExec, err := remotecommand.NewSPDYExecutor(factory.getConfig(), "POST", req.URL())
-	if err != nil {
-		return err
-	}
-	return spdyExec.StreamWithContext(ctx,
-		remotecommand.StreamOptions{
-			Stdin:  stdin,
-			Stdout: stdout,
-			Stderr: stderr,
-		})
-}
-
-// DownloadFile will download the file from the provided Pod/container into w.
-func (factory *Factory) DownloadFile(ctx context.Context, target *corev1.Pod, container string, src string, w io.Writer) error {
-	errOut := bytes.NewBuffer([]byte{})
-	reader, writer := io.Pipe()
-	defer func() {
-		log.Println("Done downloading file")
-		_ = writer.Close()
-	}()
-
-	// Copy the content from stdout of the container to the new file.
-	go func() {
-		defer func() {
-			_ = writer.Close()
-		}()
-		_, err := io.Copy(w, reader)
-		if err != nil {
-			log.Println("DownloadFile copy, err:", err)
-		}
-	}()
-
-	err := factory.ExecuteCommandRaw(ctx, target.Namespace, target.Name, container, []string{"/bin/cp", src, "/dev/stdout"}, nil, writer, errOut, false)
-	if err != nil {
-		log.Println(errOut.String())
-	}
-
-	return err
-}
-
-// UploadFile uploads a file from src into the Pod/container dst.
-func (factory *Factory) UploadFile(ctx context.Context, target *corev1.Pod, container string, src io.Reader, dst string) error {
-	out := bytes.NewBuffer([]byte{})
-	errOut := bytes.NewBuffer([]byte{})
-	reader, writer := io.Pipe()
-	defer func() {
-		log.Println("Done uploading file")
-		_ = reader.Close()
-	}()
-
-	// Read the file provided via src and pipe it to the reader.
-	go func(r io.Reader, writer *io.PipeWriter) {
-		defer func() {
-			_ = writer.Close()
-		}()
-		_, err := io.Copy(writer, r)
-		if err != nil {
-			log.Println("UploadFile copy, err:", err)
-		}
-	}(src, writer)
-
-	err := factory.ExecuteCommandRaw(ctx, target.Namespace, target.Name, container, []string{"tee", "-a", dst}, reader, out, errOut, false)
-	if err != nil {
-		log.Println(errOut.String())
-	}
-
-	return err
+	return kubeHelper.ExecuteCommandRaw(
+		context.Background(),
+		factory.GetControllerRuntimeClient(),
+		factory.getConfig(),
+		namespace,
+		name,
+		container,
+		command,
+		stdin,
+		stdout,
+		stderr,
+		isTty)
 }
 
 // GetLogsFromPod returns the logs for the provided Pod and container
 func (factory *Factory) GetLogsFromPod(pod *corev1.Pod, container string) string {
-	req := factory.getClient().CoreV1().RESTClient().Get().
-		Namespace(pod.Namespace).
-		Name(pod.Name).
-		Resource("pods").
-		SubResource("log").
-		Param("container", container)
-	readCloser, err := req.Stream(ctx.Background())
+	logs, err := kubeHelper.GetLogsFromPod(context.Background(), factory.GetControllerRuntimeClient(), factory.getConfig(), pod, container, pointer.Int64(pod.CreationTimestamp.Unix()))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	defer func() { _ = readCloser.Close() }()
-	var out bytes.Buffer
-	_, err = io.Copy(&out, readCloser)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	return out.String()
+
+	return logs
+}
+
+// GetLogsForPod will fetch the logs for the specified Pod and container since the provided seconds.
+func (factory *Factory) GetLogsForPod(pod *corev1.Pod, container string, since *int64) string {
+	logs, err := kubeHelper.GetLogsFromPod(context.Background(), factory.GetControllerRuntimeClient(), factory.getConfig(), pod, container, since)
+	if err != nil {
+		log.Println(err)
+	}
+
+	return logs
 }
 
 // GetDefaultLabels returns the default labels set to all resources.
@@ -807,37 +719,9 @@ func (factory *Factory) DumpState(fdbCluster *FdbCluster) {
 
 	// Printout the logs of the operator Pods for the last 90 seconds.
 	for _, pod := range operatorPods {
-		log.Println(factory.GetLogsForPod(pod, "manager", pointer.Int64(300)))
+		targetPod := pod
+		log.Println(factory.GetLogsForPod(&targetPod, "manager", pointer.Int64(300)))
 	}
-}
-
-// GetLogsForPod will fetch the logs for the specified Pod and container since the provided seconds.
-func (factory *Factory) GetLogsForPod(pod corev1.Pod, container string, since *int64) string {
-	req := factory.getClient().CoreV1().
-		Pods(pod.Namespace).
-		GetLogs(pod.Name, &corev1.PodLogOptions{
-			Container:    container,
-			Follow:       false,
-			SinceSeconds: since,
-		})
-
-	readCloser, err := req.Stream(ctx.Background())
-	if err != nil {
-		log.Println(err)
-		return ""
-	}
-
-	logs, err := io.ReadAll(readCloser)
-	if err != nil {
-		log.Println(err)
-		_ = readCloser.Close()
-		return ""
-	}
-	if len(logs) == 0 {
-		return ""
-	}
-
-	return string(logs)
 }
 
 // DumpStateHaCluster can be used to dump the state of the HA cluster. This includes the Kubernetes custom resource

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -500,7 +500,7 @@ func (factory *Factory) DownloadFile(
 	target *corev1.Pod,
 	container string,
 	src string,
-	w io.Writer) error {
+	dst io.Writer) error {
 	return kubeHelper.DownloadFile(
 		ctx,
 		factory.GetControllerRuntimeClient(),
@@ -508,7 +508,7 @@ func (factory *Factory) DownloadFile(
 		target,
 		container,
 		src,
-		w)
+		dst)
 }
 
 // UploadFile uploads a file from src into the Pod/container dst.

--- a/e2e/fixtures/singleton.go
+++ b/e2e/fixtures/singleton.go
@@ -33,7 +33,6 @@ import (
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -43,7 +42,6 @@ type singleton struct {
 	options                 *FactoryOptions
 	userName                string
 	config                  *rest.Config
-	client                  *kubernetes.Clientset
 	controllerRuntimeClient client.Client
 	fdbVersion              fdbv1beta2.Version
 }
@@ -76,11 +74,6 @@ func getSingleton(options *FactoryOptions) (*singleton, error) {
 
 		var kubeConfig *rest.Config
 		kubeConfig, initializedError = config.GetConfigWithContext(options.context)
-		if initializedError != nil {
-			return
-		}
-		var kubernetesClient *kubernetes.Clientset
-		kubernetesClient, initializedError = kubernetes.NewForConfig(kubeConfig)
 		if initializedError != nil {
 			return
 		}
@@ -128,7 +121,6 @@ func getSingleton(options *FactoryOptions) (*singleton, error) {
 			options:                 options,
 			userName:                userName,
 			config:                  kubeConfig,
-			client:                  kubernetesClient,
 			fdbVersion:              fdbVersion,
 			controllerRuntimeClient: controllerClient,
 		}

--- a/e2e/test_operator_plugin/operator__plugin_test.go
+++ b/e2e/test_operator_plugin/operator__plugin_test.go
@@ -1,0 +1,87 @@
+/*
+ * operator_plugin_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package operator
+
+/*
+This test suite includes functional tests for the kubectl-fdb plugin.
+*/
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	factory     *fixtures.Factory
+	fdbCluster  *fixtures.FdbCluster
+	testOptions *fixtures.FactoryOptions
+)
+
+func init() {
+	testOptions = fixtures.InitFlags()
+}
+
+var _ = BeforeSuite(func() {
+	factory = fixtures.CreateFactory(testOptions)
+	fdbCluster = factory.CreateFdbCluster(
+		fixtures.DefaultClusterConfig(false),
+		factory.GetClusterOptions()...,
+	)
+})
+
+var _ = AfterSuite(func() {
+	if CurrentSpecReport().Failed() {
+		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
+	}
+	factory.Shutdown()
+})
+
+var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			factory.DumpState(fdbCluster)
+		}
+		Expect(fdbCluster.WaitForReconciliation()).ToNot(HaveOccurred())
+		factory.StopInvariantCheck()
+		// Make sure all data is present in the cluster
+		fdbCluster.EnsureTeamTrackersAreHealthy()
+		fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+	})
+
+	When("getting the plugin version from the operator pod", func() {
+		It("should print the version", func() {
+			// Pick one operator pod and execute the kubectl version command to ensure that kubectl-fdb is present
+			// and can be executed.
+			operatorPod := factory.RandomPickOnePod(factory.GetOperatorPods(fdbCluster.Namespace()).Items)
+			log.Println("operatorPod", operatorPod.Name)
+			Eventually(func(g Gomega) string {
+				stdout, stderr, err := factory.ExecuteCmdOnPod(&operatorPod, "manager", fmt.Sprintf("kubectl-fdb -n %s version", fdbCluster.Namespace()), false)
+				g.Expect(err).NotTo(HaveOccurred(), stderr)
+				return stdout
+			}).WithTimeout(10 * time.Minute).WithPolling(2 * time.Second).Should(And(ContainSubstring("kubectl-fdb:"), ContainSubstring("foundationdb-operator:")))
+		})
+	})
+})

--- a/e2e/test_operator_plugin/operator_plugin_test.go
+++ b/e2e/test_operator_plugin/operator_plugin_test.go
@@ -25,6 +25,7 @@ This test suite includes functional tests for the kubectl-fdb plugin.
 */
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -78,7 +79,7 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 			operatorPod := factory.RandomPickOnePod(factory.GetOperatorPods(fdbCluster.Namespace()).Items)
 			log.Println("operatorPod", operatorPod.Name)
 			Eventually(func(g Gomega) string {
-				stdout, stderr, err := factory.ExecuteCmdOnPod(&operatorPod, "manager", fmt.Sprintf("kubectl-fdb -n %s version", fdbCluster.Namespace()), false)
+				stdout, stderr, err := factory.ExecuteCmdOnPod(context.Background(), &operatorPod, "manager", fmt.Sprintf("kubectl-fdb -n %s version", fdbCluster.Namespace()), false)
 				g.Expect(err).NotTo(HaveOccurred(), stderr)
 				return stdout
 			}).WithTimeout(10 * time.Minute).WithPolling(2 * time.Second).Should(And(ContainSubstring("kubectl-fdb:"), ContainSubstring("foundationdb-operator:")))

--- a/e2e/test_operator_plugin/suite_test.go
+++ b/e2e/test_operator_plugin/suite_test.go
@@ -1,9 +1,9 @@
 /*
- * main.go
+ * suite_test.go
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,22 +18,18 @@
  * limitations under the License.
  */
 
-package main
+package operator
 
 import (
-	"os"
+	"testing"
+	"time"
 
-	"github.com/FoundationDB/fdb-kubernetes-operator/kubectl-fdb/cmd"
-	"github.com/spf13/pflag"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures"
+	"github.com/onsi/gomega"
 )
 
-func main() {
-	flags := pflag.NewFlagSet("kubectl-fdb", pflag.ExitOnError)
-	pflag.CommandLine = flags
-	root := cmd.NewRootCmd(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}, &cmd.RealVersionChecker{})
-	if err := root.Execute(); err != nil {
-		os.Exit(1)
-	}
+func TestOperator(t *testing.T) {
+	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
+	fixtures.SetTestSuiteName("operator-plugin-test")
+	fixtures.RunGinkgoTests(t, "Operator plugin test suite")
 }

--- a/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
+++ b/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
@@ -123,7 +123,7 @@ func performUpgrade(config testConfig, preUpgradeFunction func(cluster *fixtures
 
 				pod, err := factory.GetPod(cluster.Namespace, processGroup.GetPodName(cluster))
 				if err != nil {
-					log.Println("logs for", processGroup.ProcessGroupID, ":", factory.GetLogsForPod(*pod, fdbv1beta2.MainContainerName, missingTime))
+					log.Println("logs for", processGroup.ProcessGroupID, ":", factory.GetLogsForPod(pod, fdbv1beta2.MainContainerName, missingTime))
 				}
 			}
 

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -1,0 +1,226 @@
+/*
+ * kubernetes.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kubernetes
+
+import (
+	"bytes"
+	"fmt"
+	"golang.org/x/net/context"
+	"io"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/kubectl/pkg/scheme"
+	"log"
+	"math/rand"
+	"net/url"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// NewSPDYExecutor defines the NewSPDYExecutor method used for this package. For normal code you don't have to change it.
+// For unit testing you can set NewSPDYExecutor = FakeNewSPDYExecutor.
+var NewSPDYExecutor = remotecommand.NewSPDYExecutor
+
+func getRestClient(kubernetesClient client.Client, config *rest.Config) (rest.Interface, error) {
+	gvk := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Pod",
+	}
+
+	return apiutil.RESTClientForGVK(gvk, false, config, serializer.NewCodecFactory(kubernetesClient.Scheme()))
+}
+
+// ExecuteCommandRaw will run the command without putting it into a shell.
+func ExecuteCommandRaw(
+	ctx context.Context,
+	kubeClient client.Client,
+	config *rest.Config,
+	namespace string,
+	name string,
+	container string,
+	command []string,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+	isTty bool,
+) error {
+	restClient, err := getRestClient(kubeClient, config)
+	if err != nil {
+		return err
+	}
+
+	req := restClient.Post().
+		Resource("pods").
+		Name(name).
+		Namespace(namespace).
+		SubResource("exec")
+	req.VersionedParams(
+		&corev1.PodExecOptions{
+			Command:   command,
+			Container: container,
+			Stdin:     stdin != nil,
+			Stdout:    stdout != nil,
+			Stderr:    stderr != nil,
+			TTY:       isTty,
+		},
+		scheme.ParameterCodec,
+	)
+	exec, err := NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+
+	return exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+}
+
+// ExecuteCommand executes command in the default container of a Pod with shell, returns stdout and stderr.
+func ExecuteCommand(
+	ctx context.Context,
+	kubeClient client.Client,
+	config *rest.Config,
+	namespace string,
+	name string,
+	container string,
+	command string,
+	printOutput bool,
+) (string, string, error) {
+	cmd := []string{
+		"/bin/bash",
+		"-c",
+		command,
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := ExecuteCommandRaw(ctx, kubeClient, config, namespace, name, container, cmd, nil, &stdout, &stderr, false)
+	if printOutput {
+		log.Println("stdout:\n\n", stdout.String())
+		log.Println("stderr:\n\n", stderr.String())
+	}
+
+	return stdout.String(), stderr.String(), err
+}
+
+// ExecuteCommandOnPod runs a command on the provided Pod. The command will be executed inside a bash -c ”.
+func ExecuteCommandOnPod(
+	ctx context.Context,
+	kubeClient client.Client,
+	config *rest.Config,
+	pod *corev1.Pod,
+	container string,
+	command string,
+	printOutput bool,
+) (string, string, error) {
+	return ExecuteCommand(ctx, kubeClient, config, pod.Namespace, pod.Name, container, command, printOutput)
+}
+
+// GetLogsFromPod will fetch the logs for the specified Pod and container since the provided seconds.
+func GetLogsFromPod(
+	ctx context.Context,
+	kubeClient client.Client,
+	config *rest.Config,
+	pod *corev1.Pod,
+	container string,
+	since *int64) (string, error) {
+	if pod == nil {
+		return "", fmt.Errorf("provided Pod is nil")
+	}
+
+	restClient, err := getRestClient(kubeClient, config)
+	if err != nil {
+		return "", err
+	}
+
+	req := restClient.Post().
+		Resource("pods").
+		Namespace(pod.Namespace).
+		Name(pod.Name).
+		SubResource("log").
+		VersionedParams(&corev1.PodLogOptions{
+			Container:    container,
+			Follow:       false,
+			SinceSeconds: since,
+		}, scheme.ParameterCodec)
+
+	readCloser, err := req.Stream(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = readCloser.Close()
+	}()
+
+	logs, err := io.ReadAll(readCloser)
+	if err != nil {
+		return "", err
+	}
+	if len(logs) == 0 {
+		return "", err
+	}
+
+	return string(logs), err
+}
+
+// PickRandomPod will return a random Pod from the provided list
+func PickRandomPod(pods *corev1.PodList) (*corev1.Pod, error) {
+	if pods == nil || len(pods.Items) < 1 {
+		return nil, fmt.Errorf("pod list has no items")
+	}
+
+	chosen := pods.Items[rand.Intn(len(pods.Items))]
+	return &chosen, nil
+}
+
+// FakeNewSPDYExecutor can be used for unit testing. Current this will do nothing and will be extended in the future.
+var FakeNewSPDYExecutor = func(_ *rest.Config, method string, url *url.URL) (remotecommand.Executor, error) {
+	return &FakeExecutor{method: method, url: url}, nil
+}
+
+// FakeExecutor used for unit testing.
+type FakeExecutor struct {
+	method string
+	url    *url.URL
+}
+
+// Stream opens a protocol streamer to the server and streams until a client closes
+// the connection or the server disconnects.
+func (fakeExecutor *FakeExecutor) Stream(options remotecommand.StreamOptions) error {
+	if options.Stdout != nil {
+		if _, err := options.Stdout.Write([]byte{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// StreamWithContext opens a protocol streamer to the server and streams until a client closes
+// the connection or the server disconnects or the context is done.
+func (fakeExecutor *FakeExecutor) StreamWithContext(_ context.Context, options remotecommand.StreamOptions) error {
+	return fakeExecutor.Stream(options)
+}

--- a/kubectl-fdb/cmd/buggify_crash_loop.go
+++ b/kubectl-fdb/cmd/buggify_crash_loop.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	ctx "context"
 	"fmt"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/spf13/cobra"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/kubectl-fdb/cmd/buggify_crash_loop_test.go
+++ b/kubectl-fdb/cmd/buggify_crash_loop_test.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"

--- a/kubectl-fdb/cmd/buggify_no_schedule.go
+++ b/kubectl-fdb/cmd/buggify_no_schedule.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	ctx "context"
 	"fmt"
+
 	"github.com/spf13/cobra"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"

--- a/kubectl-fdb/cmd/exclusion_status_test.go
+++ b/kubectl-fdb/cmd/exclusion_status_test.go
@@ -37,5 +37,4 @@ var _ = Describe("[plugin] exclustion stats command", func() {
 		Entry("five TiB", 5*1024*1024*1024*1024, "5.00Ti"),
 		Entry("six Pib", 6*1024*1024*1024*1024*1024, "6.00Pi"),
 	)
-
 })

--- a/kubectl-fdb/cmd/exec.go
+++ b/kubectl-fdb/cmd/exec.go
@@ -21,17 +21,16 @@
 package cmd
 
 import (
+	"context"
 	"log"
 	"strings"
 
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	kubeHelper "github.com/FoundationDB/fdb-kubernetes-operator/internal/kubernetes"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 )
 
 func newExecCmd(streams genericclioptions.IOStreams) *cobra.Command {

--- a/kubectl-fdb/cmd/exec_test.go
+++ b/kubectl-fdb/cmd/exec_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 )
 
 var _ = Describe("[plugin] exec command", func() {
@@ -55,18 +56,7 @@ var _ = Describe("[plugin] exec command", func() {
 
 		DescribeTable("should execute the provided command",
 			func(input testCase) {
-				command, err := buildCommand(k8sClient, cluster, input.Context, namespace, input.Command)
-
-				if input.ExpectedError != "" {
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal(input.ExpectedError))
-				} else {
-					Expect(err).NotTo(HaveOccurred())
-					Expect(command).NotTo(Equal(""))
-					expectedArgs := []string{command.Path}
-					expectedArgs = append(expectedArgs, input.ExpectedArgs...)
-					Expect(command.Args).To(Equal(expectedArgs))
-				}
+				Expect(runExec(context.Background(), k8sClient, cluster, &rest.Config{}, input.Command)).NotTo(HaveOccurred())
 			},
 			Entry("Exec into instance with valid pod",
 				testCase{

--- a/kubectl-fdb/cmd/fix_coordinator_ips.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips.go
@@ -21,26 +21,17 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"net"
 
-	"github.com/go-logr/logr"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-
-	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"golang.org/x/net/context"
-
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 	kubeHelper "github.com/FoundationDB/fdb-kubernetes-operator/internal/kubernetes"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/kubectl-fdb/cmd/fix_coordinator_ips.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips.go
@@ -25,9 +25,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/go-logr/logr"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,9 +36,14 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"golang.org/x/net/context"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
-	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
+	kubeHelper "github.com/FoundationDB/fdb-kubernetes-operator/internal/kubernetes"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func newFixCoordinatorIPsCmd(streams genericclioptions.IOStreams) *cobra.Command {
@@ -77,12 +79,12 @@ func newFixCoordinatorIPsCmd(streams genericclioptions.IOStreams) *cobra.Command
 				return err
 			}
 
-			err = runFixCoordinatorIPs(cmd.Context(), cmd, kubeClient, cluster, *o.configFlags.Context, namespace, dryRun)
+			config, err := o.configFlags.ToRESTConfig()
 			if err != nil {
 				return err
 			}
 
-			return nil
+			return runFixCoordinatorIPs(cmd, kubeClient, cluster, config, dryRun)
 		},
 		Example: `
   # Update the coordinator IPs for the cluster
@@ -105,68 +107,9 @@ func newFixCoordinatorIPsCmd(streams genericclioptions.IOStreams) *cobra.Command
 	return cmd
 }
 
-// buildClusterFileUpdateCommands generates commands for using kubectl exec to
-// update the cluster file in the pods for a cluster.
-func buildClusterFileUpdateCommands(cluster *fdbv1beta2.FoundationDBCluster, kubeClient client.Client, kubeContext string, namespace string, kubectlPath string) ([]exec.Cmd, error) {
-	pods := &corev1.PodList{}
-
-	selector := labels.NewSelector()
-
-	err := internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	for key, value := range cluster.GetMatchLabels() {
-		requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
-		if err != nil {
-			return nil, err
-		}
-		selector = selector.Add(*requirement)
-	}
-
-	processClassRequirement, err := labels.NewRequirement(cluster.GetProcessClassLabel(), selection.Exists, nil)
-	if err != nil {
-		return nil, err
-	}
-	selector = selector.Add(*processClassRequirement)
-
-	err = kubeClient.List(context.Background(), pods,
-		client.InNamespace(namespace),
-		client.MatchingLabelsSelector{Selector: selector},
-		client.MatchingFields{"status.phase": "Running"},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	baseArgs := []string{kubectlPath, "--namespace", namespace}
-	if kubeContext != "" {
-		baseArgs = append(baseArgs, "--context", kubeContext)
-	}
-	baseArgs = append(baseArgs, "exec", "-it", "-c", fdbv1beta2.MainContainerName)
-
-	execArgs := []string{"--", "bash", "-c", fmt.Sprintf("echo %s > /var/fdb/data/fdb.cluster && pkill fdbserver", cluster.Status.ConnectionString)}
-	execCommands := make([]exec.Cmd, 0, len(pods.Items))
-
-	for _, pod := range pods.Items {
-		args := append(baseArgs, pod.Name)
-		args = append(args, execArgs...)
-		execCommands = append(execCommands, exec.Cmd{
-			Path:   kubectlPath,
-			Args:   args,
-			Stdin:  os.Stdin,
-			Stdout: os.Stdout,
-			Stderr: os.Stderr,
-		})
-	}
-
-	return execCommands, nil
-}
-
 // updateIPsInConnectionString updates the connection string in the cluster
 // status by replacing old coordinator IPs with the latest IPs.
-func updateIPsInConnectionString(ctx context.Context, cmd *cobra.Command, cluster *fdbv1beta2.FoundationDBCluster, kubeClient client.Client) error {
+func updateIPsInConnectionString(cmd *cobra.Command, cluster *fdbv1beta2.FoundationDBCluster, kubeClient client.Client) error {
 	connectionString, err := fdbv1beta2.ParseConnectionString(cluster.Status.ConnectionString)
 	if err != nil {
 		return err
@@ -215,7 +158,7 @@ func updateIPsInConnectionString(ctx context.Context, cmd *cobra.Command, cluste
 
 		// Fetch the IP address from the running Pod, if the Pod doesn't exist or is not running, we fall back to the process group address.
 		pod := &corev1.Pod{}
-		kubeErr := kubeClient.Get(ctx, client.ObjectKey{Name: processGroup.GetPodName(cluster), Namespace: cluster.Namespace}, pod)
+		kubeErr := kubeClient.Get(cmd.Context(), client.ObjectKey{Name: processGroup.GetPodName(cluster), Namespace: cluster.Namespace}, pod)
 		if k8serrors.IsNotFound(kubeErr) || len(pod.Status.PodIPs) == 0 {
 			cmd.Println("Pod for process group", processGroup.ProcessGroupID, "not found will try to read information from FoundationDBCluster status")
 			for _, address := range processGroup.Addresses {
@@ -248,34 +191,32 @@ func updateIPsInConnectionString(ctx context.Context, cmd *cobra.Command, cluste
 	return nil
 }
 
-func runFixCoordinatorIPs(ctx context.Context, cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluster, context string, namespace string, dryRun bool) error {
+func runFixCoordinatorIPs(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluster, config *rest.Config, dryRun bool) error {
 	cmd.Println("Current connection string:", cluster.Status.ConnectionString)
 	patch := client.MergeFrom(cluster.DeepCopy())
-	err := updateIPsInConnectionString(ctx, cmd, cluster, kubeClient)
+	err := updateIPsInConnectionString(cmd, cluster, kubeClient)
 	if err != nil {
 		return err
 	}
 
 	cmd.Println("New connection string:", cluster.Status.ConnectionString)
-
-	kubectlPath, err := exec.LookPath("kubectl")
+	pods, err := getRunningPodsForCluster(cmd.Context(), kubeClient, cluster)
 	if err != nil {
 		return err
 	}
 
-	commands, err := buildClusterFileUpdateCommands(cluster, kubeClient, context, namespace, kubectlPath)
-	if err != nil {
-		return err
-	}
-
-	for _, command := range commands {
+	command := fmt.Sprintf("echo %s > /var/fdb/data/fdb.cluster && pkill fdbserver", cluster.Status.ConnectionString)
+	for _, pod := range pods.Items {
 		if dryRun {
-			cmd.Println("Update command:", strings.Join(command.Args, " "))
-		} else {
-			err := command.Run()
-			if err != nil {
-				cmd.Println(err.Error())
-			}
+			log.Println("update command:", command, "on Pod:", pod.Name)
+			continue
+		}
+
+		targetPod := pod
+		_, stderr, cmdErr := kubeHelper.ExecuteCommandOnPod(cmd.Context(), kubeClient, config, &targetPod, fdbv1beta2.MainContainerName, command, false)
+
+		if cmdErr != nil {
+			log.Println(stderr)
 		}
 	}
 
@@ -286,15 +227,12 @@ func runFixCoordinatorIPs(ctx context.Context, cmd *cobra.Command, kubeClient cl
 			cmd.Println(err.Error())
 		}
 
-		kubeErr := kubeClient.Update(ctx, newConfigMap)
+		kubeErr := kubeClient.Update(cmd.Context(), newConfigMap)
 		if kubeErr != nil {
 			cmd.Print(kubeErr.Error())
 		}
 
-		kubeErr = kubeClient.Status().Patch(ctx, cluster, patch)
-		if kubeErr != nil {
-			return kubeErr
-		}
+		return kubeClient.Status().Patch(cmd.Context(), cluster, patch)
 	}
 
 	return nil

--- a/kubectl-fdb/cmd/fix_coordinator_ips_test.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips_test.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
@@ -85,7 +84,7 @@ var _ = Describe("[plugin] fix-coordinator-ips command", func() {
 				inBuffer := bytes.Buffer{}
 
 				rootCmd := NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer}, &MockVersionChecker{})
-				err := updateIPsInConnectionString(context.Background(), rootCmd, cluster, k8sClient)
+				err := updateIPsInConnectionString(rootCmd, cluster, k8sClient)
 
 				if input.ExpectedError != "" {
 					Expect(err).To(HaveOccurred())

--- a/kubectl-fdb/cmd/k8s_client_test.go
+++ b/kubectl-fdb/cmd/k8s_client_test.go
@@ -24,9 +24,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"strings"
 	"time"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
@@ -169,7 +170,7 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 		DescribeTable("should show all deprecations",
 			func(tc testCase) {
 				outBuffer := bytes.Buffer{}
-				pods, err := getAllPodsFromClusterWithCondition(&outBuffer, k8sClient, clusterName, namespace, tc.conditions)
+				pods, err := getAllPodsFromClusterWithCondition(context.Background(), &outBuffer, k8sClient, clusterName, namespace, tc.conditions)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pods).Should(ConsistOf(tc.expected))
 				Expect(strings.Split(outBuffer.String(), "\n")).Should(ConsistOf(strings.Split(tc.expectedOutputBuffer, "\n")))

--- a/kubectl-fdb/cmd/plugin_version_checker.go
+++ b/kubectl-fdb/cmd/plugin_version_checker.go
@@ -3,13 +3,14 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 // VersionChecker interface to help us mock test the version checker
@@ -71,8 +72,7 @@ func isVersionFileCreatedToday(filename string) bool {
 func writeVersionToLocalTempFile(fileName string, version string) (int, error) {
 	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
 	if err != nil {
-		// Handle the error if the file cannot be opened.
-		panic(err)
+		return 0, err
 	}
 	defer file.Close()
 	return file.WriteString(version)
@@ -103,10 +103,10 @@ func readVersionFromGitHub() (string, error) {
 		fmt.Println("Failed to fetch kubectl-fdb version from GitHub")
 		return "", err
 	}
-	if resp == nil {
-		return "", nil
-	}
-	defer resp.Body.Close()
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	body, err := io.ReadAll(resp.Body)
 
 	if err != nil {

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	kubeHelper "github.com/FoundationDB/fdb-kubernetes-operator/internal/kubernetes"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
@@ -46,6 +48,8 @@ var _ = BeforeSuite(func() {
 	Expect(fdbv1beta2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	// We have to create those indexes, otherwise the fake client is complaining.
 	k8sClient = mockclient.NewMockClientWithHooksAndIndexes(scheme.Scheme, nil, nil, true)
+	// Allow the unit tests to run the spdy executor, we can extend that later to allow better mocking.
+	kubeHelper.NewSPDYExecutor = kubeHelper.FakeNewSPDYExecutor
 })
 
 var _ = BeforeEach(func() {


### PR DESCRIPTION
# Description

Refactored the code to execute a command inside a Pod to use the same code in the plugin and the test suite and added an e2e test suite for the plugin.

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1352 (more test will be implemented in the future).

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

Ran the test manually:

```text
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.002 seconds]
------------------------------

Ran 1 of 1 Specs in 69.951 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestOperator (69.95s)
PASS
ok      github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_plugin        70.520s
```

## Documentation

-

## Follow-up

The code changes will help to test new plugin command in an e2e test setup eg. for adding a subcommand for the recovery: https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2121.
