### PR TITLE
Disable version check for e2e plugin test

### DIFF
--- a/e2e/test_operator_plugin/operator_plugin_test.go
+++ b/e2e/test_operator_plugin/operator_plugin_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 			operatorPod := factory.RandomPickOnePod(factory.GetOperatorPods(fdbCluster.Namespace()).Items)
 			log.Println("operatorPod", operatorPod.Name)
 			Eventually(func(g Gomega) string {
-				stdout, stderr, err := factory.ExecuteCmdOnPod(context.Background(), &operatorPod, "manager", fmt.Sprintf("kubectl-fdb -n %s version", fdbCluster.Namespace()), false)
+				stdout, stderr, err := factory.ExecuteCmdOnPod(context.Background(), &operatorPod, "manager", fmt.Sprintf("kubectl-fdb -n %s version --version-check=false", fdbCluster.Namespace()), false)
 				g.Expect(err).NotTo(HaveOccurred(), stderr)
 				return stdout
 			}).WithTimeout(10 * time.Minute).WithPolling(2 * time.Second).Should(And(ContainSubstring("kubectl-fdb:"), ContainSubstring("foundationdb-operator:")))


### PR DESCRIPTION
# Description

Fix for https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2122#issuecomment-2328109728.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

The version check makes a call to the GitHub API< if the GitHub API is not reachable that test will fail.

## Testing

Ran the test manually.

## Documentation

-

## Follow-up

-
