### PR TITLE
Improve the tester handling when a cluster is upgraded

### DIFF
--- a/controllers/bounce_processes_test.go
+++ b/controllers/bounce_processes_test.go
@@ -38,204 +38,349 @@ import (
 )
 
 var _ = Describe("bounceProcesses", func() {
-	var cluster *fdbv1beta2.FoundationDBCluster
-	var adminClient *mock.AdminClient
-	var lockClient *mock.LockClient
-	var requeue *requeue
-	var err error
-
-	BeforeEach(func() {
-		cluster = internal.CreateDefaultCluster()
-		cluster.Spec.LockOptions.DisableLocks = pointer.Bool(false)
-		Expect(setupClusterForTest(cluster)).NotTo(HaveOccurred())
-
-		adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
-		Expect(err).NotTo(HaveOccurred())
-
-		lockClient = mock.NewMockLockClientUncast(cluster)
-	})
-
-	JustBeforeEach(func() {
-		requeue = bounceProcesses{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
-	})
-
-	Context("with a reconciled cluster", func() {
-		It("should not requeue", func() {
-			Expect(err).NotTo(HaveOccurred())
-			Expect(requeue).To(BeNil())
-		})
-
-		It("should not kill any processes", func() {
-			Expect(adminClient.KilledAddresses).To(BeEmpty())
-		})
-	})
-
-	When("two processes have the IncorrectCommandLine condition", func() {
-		var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
+	When("bouncing processes", func() {
+		var cluster *fdbv1beta2.FoundationDBCluster
+		var adminClient *mock.AdminClient
+		var lockClient *mock.LockClient
+		var requeue *requeue
+		var err error
 
 		BeforeEach(func() {
-			pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
+			cluster = internal.CreateDefaultCluster()
+			cluster.Spec.LockOptions.DisableLocks = pointer.Bool(false)
+			Expect(setupClusterForTest(cluster)).NotTo(HaveOccurred())
 
-			for _, processGroup := range pickedProcessGroups {
-				processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
-			}
+			adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
+			Expect(err).NotTo(HaveOccurred())
+
+			lockClient = mock.NewMockLockClientUncast(cluster)
 		})
 
-		It("should not requeue", func() {
-			Expect(requeue).To(BeNil())
+		JustBeforeEach(func() {
+			requeue = bounceProcesses{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
 		})
 
-		It("should kill the targeted processes", func() {
-			addresses := make(map[string]fdbv1beta2.None, 2)
-			for _, processGroup := range pickedProcessGroups {
-				for _, address := range processGroup.Addresses {
-					addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
-				}
-			}
-			Expect(adminClient.KilledAddresses).To(Equal(addresses))
-		})
-
-		When("one process is marked for removal", func() {
-			BeforeEach(func() {
-				pickedProcessGroups[0].MarkForRemoval()
-			})
-
+		Context("with a reconciled cluster", func() {
 			It("should not requeue", func() {
+				Expect(err).NotTo(HaveOccurred())
 				Expect(requeue).To(BeNil())
 			})
 
-			It("should kill the targeted processes", func() {
-				addresses := make(map[string]fdbv1beta2.None, 1)
-				for _, processGroup := range pickedProcessGroups {
-					for _, address := range processGroup.Addresses {
-						addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
-					}
-				}
-				Expect(adminClient.KilledAddresses).To(Equal(addresses))
+			It("should not kill any processes", func() {
+				Expect(adminClient.KilledAddresses).To(BeEmpty())
 			})
 		})
 
-		When("one process was manually excluded", func() {
+		When("two processes have the IncorrectCommandLine condition", func() {
+			var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
+
 			BeforeEach(func() {
-				for _, address := range pickedProcessGroups[0].Addresses {
-					err := adminClient.ExcludeProcesses([]fdbv1beta2.ProcessAddress{{StringAddress: address, Port: 4501}})
-					Expect(err).To(BeNil())
-				}
-			})
+				pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
 
-			It("should not requeue", func() {
-				Expect(requeue).To(BeNil())
-			})
-
-			It("should kill the targeted processes", func() {
-				addresses := make(map[string]fdbv1beta2.None, 1)
 				for _, processGroup := range pickedProcessGroups {
-					for _, address := range processGroup.Addresses {
-						addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
-					}
-				}
-				Expect(adminClient.KilledAddresses).To(Equal(addresses))
-			})
-		})
-	})
-
-	Context("with Pod in pending state", func() {
-		var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
-
-		BeforeEach(func() {
-			pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)
-
-			for _, processGroup := range pickedProcessGroups {
-				processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
-				processGroup.UpdateCondition(fdbv1beta2.PodPending, true)
-			}
-
-			cluster.Spec.AutomationOptions.IgnorePendingPodsDuration = 1 * time.Nanosecond
-		})
-
-		It("should not requeue", func() {
-			Expect(requeue).To(BeNil())
-		})
-
-		It("should not kill the pending process", func() {
-			for _, address := range pickedProcessGroups[0].Addresses {
-				addr := fmt.Sprintf("%s:4501", address)
-				Expect(adminClient.KilledAddresses).NotTo(HaveKey(addr))
-			}
-		})
-	})
-
-	When("a process group has the MissingProcess condition", func() {
-		var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
-
-		BeforeEach(func() {
-			pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
-
-			for _, processGroup := range pickedProcessGroups {
-				processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
-			}
-
-			pickedProcessGroups[0].ProcessGroupConditions = append(pickedProcessGroups[0].ProcessGroupConditions, &fdbv1beta2.ProcessGroupCondition{
-				ProcessGroupConditionType: fdbv1beta2.MissingProcesses,
-				Timestamp:                 time.Now().Add(-2 * time.Minute).Unix(),
-			})
-		})
-
-		It("should not requeue", func() {
-			Expect(requeue).To(BeNil())
-		})
-
-		It("should not kill the missing process but all other processes", func() {
-			Expect(adminClient.KilledAddresses).To(HaveLen(1))
-			for _, address := range pickedProcessGroups[0].Addresses {
-				addr := fmt.Sprintf("%s:4501", address)
-				Expect(adminClient.KilledAddresses).NotTo(HaveKey(addr))
-			}
-		})
-	})
-
-	When("using multiple storage servers per pod", func() {
-		var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
-
-		BeforeEach(func() {
-			cluster.Spec.StorageServersPerPod = 2
-			Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
-			result, err := reconcileCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
-			_, err = reloadCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-
-			pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
-			for _, processGroup := range pickedProcessGroups {
-				processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
-			}
-		})
-
-		It("should not requeue", func() {
-			Expect(requeue).To(BeNil())
-		})
-
-		It("should kill the targeted processes", func() {
-			addresses := make(map[string]fdbv1beta2.None, 2)
-			for _, processGroup := range pickedProcessGroups {
-				for _, address := range processGroup.Addresses {
-					addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
-					addresses[fmt.Sprintf("%s:4503", address)] = fdbv1beta2.None{}
-				}
-			}
-			Expect(adminClient.KilledAddresses).To(Equal(addresses))
-		})
-
-		When("doing an upgrade", func() {
-			BeforeEach(func() {
-				cluster.Spec.Version = fdbv1beta2.Versions.NextMajorVersion.String()
-				for _, processGroup := range cluster.Status.ProcessGroups {
 					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
 				}
 			})
 
-			When("all processes are reporting", func() {
+			It("should not requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			It("should kill the targeted processes", func() {
+				addresses := make(map[string]fdbv1beta2.None, 2)
+				for _, processGroup := range pickedProcessGroups {
+					for _, address := range processGroup.Addresses {
+						addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
+					}
+				}
+				Expect(adminClient.KilledAddresses).To(Equal(addresses))
+			})
+
+			When("one process is marked for removal", func() {
+				BeforeEach(func() {
+					pickedProcessGroups[0].MarkForRemoval()
+				})
+
+				It("should not requeue", func() {
+					Expect(requeue).To(BeNil())
+				})
+
+				It("should kill the targeted processes", func() {
+					addresses := make(map[string]fdbv1beta2.None, 1)
+					for _, processGroup := range pickedProcessGroups {
+						for _, address := range processGroup.Addresses {
+							addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
+						}
+					}
+					Expect(adminClient.KilledAddresses).To(Equal(addresses))
+				})
+			})
+
+			When("one process was manually excluded", func() {
+				BeforeEach(func() {
+					for _, address := range pickedProcessGroups[0].Addresses {
+						err := adminClient.ExcludeProcesses([]fdbv1beta2.ProcessAddress{{StringAddress: address, Port: 4501}})
+						Expect(err).To(BeNil())
+					}
+				})
+
+				It("should not requeue", func() {
+					Expect(requeue).To(BeNil())
+				})
+
+				It("should kill the targeted processes", func() {
+					addresses := make(map[string]fdbv1beta2.None, 1)
+					for _, processGroup := range pickedProcessGroups {
+						for _, address := range processGroup.Addresses {
+							addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
+						}
+					}
+					Expect(adminClient.KilledAddresses).To(Equal(addresses))
+				})
+			})
+		})
+
+		Context("with Pod in pending state", func() {
+			var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
+
+			BeforeEach(func() {
+				pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)
+
+				for _, processGroup := range pickedProcessGroups {
+					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
+					processGroup.UpdateCondition(fdbv1beta2.PodPending, true)
+				}
+
+				cluster.Spec.AutomationOptions.IgnorePendingPodsDuration = 1 * time.Nanosecond
+			})
+
+			It("should not requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			It("should not kill the pending process", func() {
+				for _, address := range pickedProcessGroups[0].Addresses {
+					addr := fmt.Sprintf("%s:4501", address)
+					Expect(adminClient.KilledAddresses).NotTo(HaveKey(addr))
+				}
+			})
+		})
+
+		When("a process group has the MissingProcess condition", func() {
+			var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
+
+			BeforeEach(func() {
+				pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
+
+				for _, processGroup := range pickedProcessGroups {
+					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
+				}
+
+				pickedProcessGroups[0].ProcessGroupConditions = append(pickedProcessGroups[0].ProcessGroupConditions, &fdbv1beta2.ProcessGroupCondition{
+					ProcessGroupConditionType: fdbv1beta2.MissingProcesses,
+					Timestamp:                 time.Now().Add(-2 * time.Minute).Unix(),
+				})
+			})
+
+			It("should not requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			It("should not kill the missing process but all other processes", func() {
+				Expect(adminClient.KilledAddresses).To(HaveLen(1))
+				for _, address := range pickedProcessGroups[0].Addresses {
+					addr := fmt.Sprintf("%s:4501", address)
+					Expect(adminClient.KilledAddresses).NotTo(HaveKey(addr))
+				}
+			})
+		})
+
+		When("using multiple storage servers per pod", func() {
+			var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
+
+			BeforeEach(func() {
+				cluster.Spec.StorageServersPerPod = 2
+				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+				result, err := reconcileCluster(cluster)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Requeue).To(BeFalse())
+				_, err = reloadCluster(cluster)
+				Expect(err).NotTo(HaveOccurred())
+
+				pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
+				for _, processGroup := range pickedProcessGroups {
+					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
+				}
+			})
+
+			It("should not requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			It("should kill the targeted processes", func() {
+				addresses := make(map[string]fdbv1beta2.None, 2)
+				for _, processGroup := range pickedProcessGroups {
+					for _, address := range processGroup.Addresses {
+						addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
+						addresses[fmt.Sprintf("%s:4503", address)] = fdbv1beta2.None{}
+					}
+				}
+				Expect(adminClient.KilledAddresses).To(Equal(addresses))
+			})
+
+			When("doing an upgrade", func() {
+				BeforeEach(func() {
+					cluster.Spec.Version = fdbv1beta2.Versions.NextMajorVersion.String()
+					for _, processGroup := range cluster.Status.ProcessGroups {
+						processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
+					}
+				})
+
+				When("all processes are reporting", func() {
+					It("should requeue", func() {
+						Expect(requeue).NotTo(BeNil())
+					})
+
+					It("should kill all the processes", func() {
+						addresses := make(map[string]fdbv1beta2.None, len(cluster.Status.ProcessGroups))
+						for _, processGroup := range cluster.Status.ProcessGroups {
+							for _, address := range processGroup.Addresses {
+								addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
+								if processGroup.ProcessClass == fdbv1beta2.ProcessClassStorage {
+									addresses[fmt.Sprintf("%s:4503", address)] = fdbv1beta2.None{}
+								}
+							}
+						}
+						Expect(adminClient.KilledAddresses).To(Equal(addresses))
+					})
+
+					It("should update the running version in the status", func() {
+						_, err = reloadCluster(cluster)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(cluster.Status.RunningVersion).To(Equal(fdbv1beta2.Versions.NextMajorVersion.String()))
+					})
+
+					It("should submit pending upgrade information for all the processes", func() {
+						expectedUpgrades := make(map[fdbv1beta2.ProcessGroupID]bool, len(cluster.Status.ProcessGroups))
+						for _, processGroup := range cluster.Status.ProcessGroups {
+							expectedUpgrades[processGroup.ProcessGroupID] = true
+						}
+						pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(pendingUpgrades).To(Equal(expectedUpgrades))
+					})
+				})
+
+				When("the processes of a pod are missing", func() {
+					var missingProcessGroup *fdbv1beta2.ProcessGroupStatus
+
+					BeforeEach(func() {
+						for _, processGroup := range cluster.Status.ProcessGroups {
+							if processGroup.ProcessClass != fdbv1beta2.ProcessClassStorage {
+								continue
+							}
+
+							missingProcessGroup = processGroup
+							break
+						}
+
+						Expect(missingProcessGroup.ProcessClass).To(Equal(fdbv1beta2.ProcessClassStorage))
+						adminClient.MockMissingProcessGroup(missingProcessGroup.ProcessGroupID, true)
+						missingProcessGroup.UpdateCondition(fdbv1beta2.MissingProcesses, true)
+					})
+
+					When("they are missing for a short time", func() {
+						BeforeEach(func() {
+							missingProcessGroup.UpdateCondition(fdbv1beta2.MissingProcesses, true)
+						})
+
+						It("should requeue", func() {
+							Expect(requeue).NotTo(BeNil())
+							Expect(requeue.message).To(Equal(fmt.Sprintf("could not find address for processes: %s", []fdbv1beta2.ProcessGroupID{missingProcessGroup.ProcessGroupID})))
+						})
+
+						It("shouldn't kill any processes", func() {
+							Expect(adminClient.KilledAddresses).To(BeEmpty())
+						})
+
+						It("should not submit pending upgrade information", func() {
+							pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(pendingUpgrades).To(BeEmpty())
+						})
+					})
+
+					When("they are missing for a long time", func() {
+						BeforeEach(func() {
+							missingProcessGroup.ProcessGroupConditions = []*fdbv1beta2.ProcessGroupCondition{
+								{
+									ProcessGroupConditionType: fdbv1beta2.MissingProcesses,
+									Timestamp:                 time.Now().Add(-5 * time.Minute).Unix(),
+								},
+							}
+						})
+
+						It("should requeue", func() {
+							Expect(requeue).NotTo(BeNil())
+							Expect(requeue.message).To(Equal("fetch latest status after upgrade"))
+						})
+
+						It("should kill the processes except the missing process", func() {
+							Expect(adminClient.KilledAddresses).NotTo(BeEmpty())
+							Expect(adminClient.KilledAddresses).NotTo(ContainElement(missingProcessGroup.Addresses))
+						})
+
+						It("should not submit pending upgrade information", func() {
+							pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(pendingUpgrades).NotTo(BeEmpty())
+						})
+					})
+				})
+			})
+		})
+
+		Context("with multiple log servers per pod", func() {
+			var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
+
+			BeforeEach(func() {
+				cluster.Spec.LogServersPerPod = 2
+				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
+				result, err := reconcileCluster(cluster)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Requeue).To(BeFalse())
+				_, err = reloadCluster(cluster)
+				Expect(err).NotTo(HaveOccurred())
+
+				pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassLog, 2)
+				for _, processGroup := range pickedProcessGroups {
+					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
+				}
+			})
+
+			It("should not requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			It("should kill the targeted processes", func() {
+				addresses := make(map[string]fdbv1beta2.None, 2)
+				for _, processGroup := range pickedProcessGroups {
+					for _, address := range processGroup.Addresses {
+						addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
+						addresses[fmt.Sprintf("%s:4503", address)] = fdbv1beta2.None{}
+					}
+				}
+				Expect(adminClient.KilledAddresses).To(Equal(addresses))
+			})
+
+			When("doing an upgrade", func() {
+				BeforeEach(func() {
+					cluster.Spec.Version = fdbv1beta2.Versions.NextMajorVersion.String()
+					for _, processGroup := range cluster.Status.ProcessGroups {
+						processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
+					}
+				})
+
 				It("should requeue", func() {
 					Expect(requeue).NotTo(BeNil())
 				})
@@ -245,7 +390,7 @@ var _ = Describe("bounceProcesses", func() {
 					for _, processGroup := range cluster.Status.ProcessGroups {
 						for _, address := range processGroup.Addresses {
 							addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
-							if processGroup.ProcessClass == fdbv1beta2.ProcessClassStorage {
+							if processGroup.ProcessClass == fdbv1beta2.ProcessClassLog {
 								addresses[fmt.Sprintf("%s:4503", address)] = fdbv1beta2.None{}
 							}
 						}
@@ -269,110 +414,9 @@ var _ = Describe("bounceProcesses", func() {
 					Expect(pendingUpgrades).To(Equal(expectedUpgrades))
 				})
 			})
-
-			When("the processes of a pod are missing", func() {
-				var missingProcessGroup *fdbv1beta2.ProcessGroupStatus
-
-				BeforeEach(func() {
-					for _, processGroup := range cluster.Status.ProcessGroups {
-						if processGroup.ProcessClass != fdbv1beta2.ProcessClassStorage {
-							continue
-						}
-
-						missingProcessGroup = processGroup
-						break
-					}
-
-					Expect(missingProcessGroup.ProcessClass).To(Equal(fdbv1beta2.ProcessClassStorage))
-					adminClient.MockMissingProcessGroup(missingProcessGroup.ProcessGroupID, true)
-					missingProcessGroup.UpdateCondition(fdbv1beta2.MissingProcesses, true)
-				})
-
-				When("they are missing for a short time", func() {
-					BeforeEach(func() {
-						missingProcessGroup.UpdateCondition(fdbv1beta2.MissingProcesses, true)
-					})
-
-					It("should requeue", func() {
-						Expect(requeue).NotTo(BeNil())
-						Expect(requeue.message).To(Equal(fmt.Sprintf("could not find address for processes: %s", []fdbv1beta2.ProcessGroupID{missingProcessGroup.ProcessGroupID})))
-					})
-
-					It("shouldn't kill any processes", func() {
-						Expect(adminClient.KilledAddresses).To(BeEmpty())
-					})
-
-					It("should not submit pending upgrade information", func() {
-						pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(pendingUpgrades).To(BeEmpty())
-					})
-				})
-
-				When("they are missing for a long time", func() {
-					BeforeEach(func() {
-						missingProcessGroup.ProcessGroupConditions = []*fdbv1beta2.ProcessGroupCondition{
-							{
-								ProcessGroupConditionType: fdbv1beta2.MissingProcesses,
-								Timestamp:                 time.Now().Add(-5 * time.Minute).Unix(),
-							},
-						}
-					})
-
-					It("should requeue", func() {
-						Expect(requeue).NotTo(BeNil())
-						Expect(requeue.message).To(Equal("fetch latest status after upgrade"))
-					})
-
-					It("should kill the processes except the missing process", func() {
-						Expect(adminClient.KilledAddresses).NotTo(BeEmpty())
-						Expect(adminClient.KilledAddresses).NotTo(ContainElement(missingProcessGroup.Addresses))
-					})
-
-					It("should not submit pending upgrade information", func() {
-						pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(pendingUpgrades).NotTo(BeEmpty())
-					})
-				})
-			})
-		})
-	})
-
-	Context("with multiple log servers per pod", func() {
-		var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
-
-		BeforeEach(func() {
-			cluster.Spec.LogServersPerPod = 2
-			Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
-			result, err := reconcileCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
-			_, err = reloadCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-
-			pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassLog, 2)
-			for _, processGroup := range pickedProcessGroups {
-				processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
-			}
 		})
 
-		It("should not requeue", func() {
-			Expect(requeue).To(BeNil())
-		})
-
-		It("should kill the targeted processes", func() {
-			addresses := make(map[string]fdbv1beta2.None, 2)
-			for _, processGroup := range pickedProcessGroups {
-				for _, address := range processGroup.Addresses {
-					addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
-					addresses[fmt.Sprintf("%s:4503", address)] = fdbv1beta2.None{}
-				}
-			}
-			Expect(adminClient.KilledAddresses).To(Equal(addresses))
-		})
-
-		When("doing an upgrade", func() {
+		Context("with a pending upgrade", func() {
 			BeforeEach(func() {
 				cluster.Spec.Version = fdbv1beta2.Versions.NextMajorVersion.String()
 				for _, processGroup := range cluster.Status.ProcessGroups {
@@ -389,9 +433,6 @@ var _ = Describe("bounceProcesses", func() {
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					for _, address := range processGroup.Addresses {
 						addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
-						if processGroup.ProcessClass == fdbv1beta2.ProcessClassLog {
-							addresses[fmt.Sprintf("%s:4503", address)] = fdbv1beta2.None{}
-						}
 					}
 				}
 				Expect(adminClient.KilledAddresses).To(Equal(addresses))
@@ -412,106 +453,14 @@ var _ = Describe("bounceProcesses", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pendingUpgrades).To(Equal(expectedUpgrades))
 			})
-		})
-	})
 
-	Context("with a pending upgrade", func() {
-		BeforeEach(func() {
-			cluster.Spec.Version = fdbv1beta2.Versions.NextMajorVersion.String()
-			for _, processGroup := range cluster.Status.ProcessGroups {
-				processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
-			}
-		})
-
-		It("should requeue", func() {
-			Expect(requeue).NotTo(BeNil())
-		})
-
-		It("should kill all the processes", func() {
-			addresses := make(map[string]fdbv1beta2.None, len(cluster.Status.ProcessGroups))
-			for _, processGroup := range cluster.Status.ProcessGroups {
-				for _, address := range processGroup.Addresses {
-					addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
-				}
-			}
-			Expect(adminClient.KilledAddresses).To(Equal(addresses))
-		})
-
-		It("should update the running version in the status", func() {
-			_, err = reloadCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(cluster.Status.RunningVersion).To(Equal(fdbv1beta2.Versions.NextMajorVersion.String()))
-		})
-
-		It("should submit pending upgrade information for all the processes", func() {
-			expectedUpgrades := make(map[fdbv1beta2.ProcessGroupID]bool, len(cluster.Status.ProcessGroups))
-			for _, processGroup := range cluster.Status.ProcessGroups {
-				expectedUpgrades[processGroup.ProcessGroupID] = true
-			}
-			pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(pendingUpgrades).To(Equal(expectedUpgrades))
-		})
-
-		Context("with an unknown process", func() {
-			BeforeEach(func() {
-				adminClient.MockAdditionalProcesses([]fdbv1beta2.ProcessGroupStatus{{
-					ProcessGroupID: "dc2-storage-1",
-					ProcessClass:   "storage",
-					Addresses:      []string{"1.2.3.4"},
-				}})
-			})
-
-			It("should requeue", func() {
-				Expect(requeue).NotTo(BeNil())
-				Expect(requeue.message).To(Equal("Waiting for processes to be updated: [dc2-storage-1]"))
-			})
-
-			It("should not kill any processes", func() {
-				Expect(adminClient.KilledAddresses).To(BeEmpty())
-			})
-
-			It("should not update the running version in the status", func() {
-				_, err = reloadCluster(cluster)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cluster.Status.RunningVersion).To(Equal(fdbv1beta2.Versions.Default.String()))
-			})
-
-			It("should submit pending upgrade information for all the processes", func() {
-				expectedUpgrades := make(map[fdbv1beta2.ProcessGroupID]bool, len(cluster.Status.ProcessGroups))
-				for _, processGroup := range cluster.Status.ProcessGroups {
-					expectedUpgrades[processGroup.ProcessGroupID] = true
-				}
-				pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pendingUpgrades).To(Equal(expectedUpgrades))
-			})
-
-			Context("with a pending upgrade for the unknown process", func() {
+			Context("with an unknown process", func() {
 				BeforeEach(func() {
-					Expect(lockClient.AddPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion, []fdbv1beta2.ProcessGroupID{"dc2-storage-1"})).NotTo(HaveOccurred())
-				})
-
-				It("should requeue", func() {
-					Expect(requeue).NotTo(BeNil())
-				})
-
-				It("should kill all the processes", func() {
-					addresses := make(map[string]fdbv1beta2.None, len(cluster.Status.ProcessGroups)+1)
-					for _, processGroup := range cluster.Status.ProcessGroups {
-						for _, address := range processGroup.Addresses {
-							addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
-						}
-					}
-					addresses["1.2.3.4:4501"] = fdbv1beta2.None{}
-					Expect(adminClient.KilledAddresses).To(Equal(addresses))
-				})
-			})
-
-			Context("with a pending upgrade to an older version", func() {
-				BeforeEach(func() {
-					err = lockClient.AddPendingUpgrades(fdbv1beta2.Versions.NextPatchVersion, []fdbv1beta2.ProcessGroupID{"dc2-storage-1"})
-					Expect(err).NotTo(HaveOccurred())
+					adminClient.MockAdditionalProcesses([]fdbv1beta2.ProcessGroupStatus{{
+						ProcessGroupID: "dc2-storage-1",
+						ProcessClass:   "storage",
+						Addresses:      []string{"1.2.3.4"},
+					}})
 				})
 
 				It("should requeue", func() {
@@ -522,25 +471,103 @@ var _ = Describe("bounceProcesses", func() {
 				It("should not kill any processes", func() {
 					Expect(adminClient.KilledAddresses).To(BeEmpty())
 				})
+
+				It("should not update the running version in the status", func() {
+					_, err = reloadCluster(cluster)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(cluster.Status.RunningVersion).To(Equal(fdbv1beta2.Versions.Default.String()))
+				})
+
+				It("should submit pending upgrade information for all the processes", func() {
+					expectedUpgrades := make(map[fdbv1beta2.ProcessGroupID]bool, len(cluster.Status.ProcessGroups))
+					for _, processGroup := range cluster.Status.ProcessGroups {
+						expectedUpgrades[processGroup.ProcessGroupID] = true
+					}
+					pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(pendingUpgrades).To(Equal(expectedUpgrades))
+				})
+
+				Context("with a pending upgrade for the unknown process", func() {
+					BeforeEach(func() {
+						Expect(lockClient.AddPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion, []fdbv1beta2.ProcessGroupID{"dc2-storage-1"})).NotTo(HaveOccurred())
+					})
+
+					It("should requeue", func() {
+						Expect(requeue).NotTo(BeNil())
+					})
+
+					It("should kill all the processes", func() {
+						addresses := make(map[string]fdbv1beta2.None, len(cluster.Status.ProcessGroups)+1)
+						for _, processGroup := range cluster.Status.ProcessGroups {
+							for _, address := range processGroup.Addresses {
+								addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
+							}
+						}
+						addresses["1.2.3.4:4501"] = fdbv1beta2.None{}
+						Expect(adminClient.KilledAddresses).To(Equal(addresses))
+					})
+				})
+
+				Context("with a pending upgrade to an older version", func() {
+					BeforeEach(func() {
+						err = lockClient.AddPendingUpgrades(fdbv1beta2.Versions.NextPatchVersion, []fdbv1beta2.ProcessGroupID{"dc2-storage-1"})
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("should requeue", func() {
+						Expect(requeue).NotTo(BeNil())
+						Expect(requeue.message).To(Equal("Waiting for processes to be updated: [dc2-storage-1]"))
+					})
+
+					It("should not kill any processes", func() {
+						Expect(adminClient.KilledAddresses).To(BeEmpty())
+					})
+				})
+
+				Context("with locks disabled", func() {
+					BeforeEach(func() {
+						cluster.Spec.LockOptions.DisableLocks = pointer.Bool(true)
+					})
+
+					It("should requeue", func() {
+						Expect(requeue).NotTo(BeNil())
+					})
+
+					It("should kill all the processes", func() {
+						addresses := make(map[string]fdbv1beta2.None, len(cluster.Status.ProcessGroups))
+						for _, processGroup := range cluster.Status.ProcessGroups {
+							for _, address := range processGroup.Addresses {
+								addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
+							}
+						}
+						Expect(adminClient.KilledAddresses).To(Equal(addresses))
+					})
+
+					It("should not submit pending upgrade information", func() {
+						pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(pendingUpgrades).To(BeEmpty())
+					})
+				})
 			})
 
-			Context("with locks disabled", func() {
+			When("one process is missing for a short time", func() {
+				var missingProcessGroup *fdbv1beta2.ProcessGroupStatus
+
 				BeforeEach(func() {
-					cluster.Spec.LockOptions.DisableLocks = pointer.Bool(true)
+					missingProcessGroup = cluster.Status.ProcessGroups[0]
+					adminClient.MockMissingProcessGroup(missingProcessGroup.ProcessGroupID, true)
+					missingProcessGroup.UpdateCondition(fdbv1beta2.MissingProcesses, true)
 				})
 
 				It("should requeue", func() {
 					Expect(requeue).NotTo(BeNil())
+					Expect(requeue.message).To(Equal(fmt.Sprintf("could not find address for processes: %s", []fdbv1beta2.ProcessGroupID{missingProcessGroup.ProcessGroupID})))
 				})
 
-				It("should kill all the processes", func() {
-					addresses := make(map[string]fdbv1beta2.None, len(cluster.Status.ProcessGroups))
-					for _, processGroup := range cluster.Status.ProcessGroups {
-						for _, address := range processGroup.Addresses {
-							addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
-						}
-					}
-					Expect(adminClient.KilledAddresses).To(Equal(addresses))
+				It("shouldn't kill any processes", func() {
+					Expect(adminClient.KilledAddresses).To(BeEmpty())
 				})
 
 				It("should not submit pending upgrade information", func() {
@@ -549,138 +576,48 @@ var _ = Describe("bounceProcesses", func() {
 					Expect(pendingUpgrades).To(BeEmpty())
 				})
 			})
-		})
 
-		When("one process is missing for a short time", func() {
-			var missingProcessGroup *fdbv1beta2.ProcessGroupStatus
+			When("one process is missing is missing for a long time", func() {
+				var missingProcessGroup *fdbv1beta2.ProcessGroupStatus
 
-			BeforeEach(func() {
-				missingProcessGroup = cluster.Status.ProcessGroups[0]
-				adminClient.MockMissingProcessGroup(missingProcessGroup.ProcessGroupID, true)
-				missingProcessGroup.UpdateCondition(fdbv1beta2.MissingProcesses, true)
-			})
-
-			It("should requeue", func() {
-				Expect(requeue).NotTo(BeNil())
-				Expect(requeue.message).To(Equal(fmt.Sprintf("could not find address for processes: %s", []fdbv1beta2.ProcessGroupID{missingProcessGroup.ProcessGroupID})))
-			})
-
-			It("shouldn't kill any processes", func() {
-				Expect(adminClient.KilledAddresses).To(BeEmpty())
-			})
-
-			It("should not submit pending upgrade information", func() {
-				pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pendingUpgrades).To(BeEmpty())
-			})
-		})
-
-		When("one process is missing is missing for a long time", func() {
-			var missingProcessGroup *fdbv1beta2.ProcessGroupStatus
-
-			BeforeEach(func() {
-				missingProcessGroup = cluster.Status.ProcessGroups[0]
-				adminClient.MockMissingProcessGroup(missingProcessGroup.ProcessGroupID, true)
-				missingProcessGroup.ProcessGroupConditions = []*fdbv1beta2.ProcessGroupCondition{
-					{
-						ProcessGroupConditionType: fdbv1beta2.MissingProcesses,
-						Timestamp:                 time.Now().Add(-5 * time.Minute).Unix(),
-					},
-				}
-			})
-
-			It("should requeue", func() {
-				Expect(requeue).NotTo(BeNil())
-				Expect(requeue.message).To(Equal("fetch latest status after upgrade"))
-			})
-
-			It("should kill the processes except the missing process", func() {
-				Expect(adminClient.KilledAddresses).NotTo(BeEmpty())
-				Expect(adminClient.KilledAddresses).NotTo(ContainElement(missingProcessGroup.Addresses))
-			})
-
-			It("should not submit pending upgrade information", func() {
-				pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pendingUpgrades).NotTo(BeEmpty())
-			})
-		})
-	})
-
-	When("the buggify option ignoreDuringRestart is set", func() {
-		var ignoredProcessGroup *fdbv1beta2.ProcessGroupStatus
-
-		BeforeEach(func() {
-			ignoredProcessGroup = cluster.Status.ProcessGroups[0]
-			cluster.Spec.Buggify.IgnoreDuringRestart = []fdbv1beta2.ProcessGroupID{ignoredProcessGroup.ProcessGroupID}
-			for _, processGroup := range cluster.Status.ProcessGroups {
-				processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
-			}
-		})
-
-		It("should not requeue", func() {
-			Expect(err).NotTo(HaveOccurred())
-			Expect(requeue).To(BeNil())
-		})
-
-		It("should not kill any processes", func() {
-			ignoredAddress := ignoredProcessGroup.Addresses[0]
-
-			for address := range adminClient.KilledAddresses {
-				Expect(address).NotTo(HavePrefix(ignoredAddress))
-			}
-
-			Expect(adminClient.KilledAddresses).To(HaveLen(len(cluster.Status.ProcessGroups) - 1))
-		})
-
-		When("filtering process groups for buggify", func() {
-			var filteredAddresses []fdbv1beta2.ProcessAddress
-			var removed bool
-
-			BeforeEach(func() {
-				status, err := adminClient.GetStatus()
-				Expect(err).NotTo(HaveOccurred())
-				processAddresses := make([]fdbv1beta2.ProcessAddress, 0, len(cluster.Status.ProcessGroups))
-				for _, process := range status.Cluster.Processes {
-					processAddresses = append(processAddresses, process.Address)
-				}
-
-				filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(cluster, processAddresses, status)
-			})
-
-			It("should filter the ignored address", func() {
-				Expect(removed).To(BeTrue())
-				Expect(len(filteredAddresses)).To(BeNumerically("==", len(cluster.Status.ProcessGroups)-1))
-			})
-		})
-
-		When("buggify ignore processes is set and only this process has the IncorrectCommandLine condition", func() {
-			var filteredAddresses []fdbv1beta2.ProcessAddress
-			var removed bool
-
-			BeforeEach(func() {
-				for _, processGroup := range cluster.Status.ProcessGroups {
-					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, processGroup.ProcessGroupID == ignoredProcessGroup.ProcessGroupID)
-				}
-
-				status, err := adminClient.GetStatus()
-				Expect(err).NotTo(HaveOccurred())
-				processAddresses := make([]fdbv1beta2.ProcessAddress, 0, len(cluster.Status.ProcessGroups))
-				for _, process := range status.Cluster.Processes {
-					if fdbv1beta2.ProcessGroupID(process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]) != ignoredProcessGroup.ProcessGroupID {
-						continue
+				BeforeEach(func() {
+					missingProcessGroup = cluster.Status.ProcessGroups[0]
+					adminClient.MockMissingProcessGroup(missingProcessGroup.ProcessGroupID, true)
+					missingProcessGroup.ProcessGroupConditions = []*fdbv1beta2.ProcessGroupCondition{
+						{
+							ProcessGroupConditionType: fdbv1beta2.MissingProcesses,
+							Timestamp:                 time.Now().Add(-5 * time.Minute).Unix(),
+						},
 					}
+				})
 
-					processAddresses = append(processAddresses, process.Address)
-				}
+				It("should requeue", func() {
+					Expect(requeue).NotTo(BeNil())
+					Expect(requeue.message).To(Equal("fetch latest status after upgrade"))
+				})
 
-				filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(cluster, processAddresses, status)
+				It("should kill the processes except the missing process", func() {
+					Expect(adminClient.KilledAddresses).NotTo(BeEmpty())
+					Expect(adminClient.KilledAddresses).NotTo(ContainElement(missingProcessGroup.Addresses))
+				})
+
+				It("should not submit pending upgrade information", func() {
+					pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(pendingUpgrades).NotTo(BeEmpty())
+				})
 			})
+		})
 
-			It("should filter the ignored address", func() {
-				Expect(removed).To(BeTrue())
-				Expect(filteredAddresses).To(BeEmpty())
+		When("the buggify option ignoreDuringRestart is set", func() {
+			var ignoredProcessGroup *fdbv1beta2.ProcessGroupStatus
+
+			BeforeEach(func() {
+				ignoredProcessGroup = cluster.Status.ProcessGroups[0]
+				cluster.Spec.Buggify.IgnoreDuringRestart = []fdbv1beta2.ProcessGroupID{ignoredProcessGroup.ProcessGroupID}
+				for _, processGroup := range cluster.Status.ProcessGroups {
+					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
+				}
 			})
 
 			It("should not requeue", func() {
@@ -689,80 +626,218 @@ var _ = Describe("bounceProcesses", func() {
 			})
 
 			It("should not kill any processes", func() {
-				Expect(adminClient.KilledAddresses).To(BeEmpty())
-			})
-		})
-	})
+				ignoredAddress := ignoredProcessGroup.Addresses[0]
 
-	When("when there are unreachable processes", func() {
-		When("the unreachable processes include at least one tester process", func() {
-			BeforeEach(func() {
-				adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
-				Expect(err).NotTo(HaveOccurred())
-
-				adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
-					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
-						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
-							Available: true,
-						},
-					},
-					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
-						Messages: []fdbv1beta2.FoundationDBStatusMessage{
-							{
-								Name: "status_incomplete",
-							},
-							{
-								Name: "unreachable_processes",
-								UnreachableProcesses: []fdbv1beta2.FoundationDBUnreachableProcess{
-									{
-										Address: "192.168.0.1:4500:tls",
-									},
-								},
-							},
-						},
-						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
-							"1": {
-								ProcessClass: fdbv1beta2.ProcessClassStateless,
-								Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
-								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
-									{
-										Role: string(fdbv1beta2.ProcessRoleClusterController),
-									},
-								},
-								UptimeSeconds: 61.0,
-								Locality: map[string]string{
-									fdbv1beta2.FDBLocalityInstanceIDKey: "1",
-								},
-							},
-							"2": {
-								ProcessClass:  fdbv1beta2.ProcessClassTest,
-								Address:       fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.1:4500:tls"},
-								UptimeSeconds: 61.0,
-								Locality: map[string]string{
-									fdbv1beta2.FDBLocalityInstanceIDKey: "2",
-								},
-							},
-						},
-					},
+				for address := range adminClient.KilledAddresses {
+					Expect(address).NotTo(HavePrefix(ignoredAddress))
 				}
+
+				Expect(adminClient.KilledAddresses).To(HaveLen(len(cluster.Status.ProcessGroups) - 1))
 			})
 
-			It("should not requeue", func() {
-				Expect(err).NotTo(HaveOccurred())
-				Expect(requeue).To(BeNil())
-			})
+			When("filtering process groups for buggify", func() {
+				var filteredAddresses []fdbv1beta2.ProcessAddress
+				var removed bool
 
-			It("should kill the cluster controller", func() {
-				Expect(adminClient.KilledAddresses).To(HaveKey("192.168.0.2:4500:tls"))
-			})
-
-			When("the minimum required uptime is bigger than the current uptime", func() {
 				BeforeEach(func() {
-					clusterReconciler.MinimumRequiredUptimeCCBounce = 2 * time.Minute
+					status, err := adminClient.GetStatus()
+					Expect(err).NotTo(HaveOccurred())
+					processAddresses := make([]fdbv1beta2.ProcessAddress, 0, len(cluster.Status.ProcessGroups))
+					for _, process := range status.Cluster.Processes {
+						processAddresses = append(processAddresses, process.Address)
+					}
+
+					filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(cluster, processAddresses, status)
 				})
 
-				AfterEach(func() {
-					clusterReconciler.MinimumRequiredUptimeCCBounce = 0
+				It("should filter the ignored address", func() {
+					Expect(removed).To(BeTrue())
+					Expect(len(filteredAddresses)).To(BeNumerically("==", len(cluster.Status.ProcessGroups)-1))
+				})
+			})
+
+			When("buggify ignore processes is set and only this process has the IncorrectCommandLine condition", func() {
+				var filteredAddresses []fdbv1beta2.ProcessAddress
+				var removed bool
+
+				BeforeEach(func() {
+					for _, processGroup := range cluster.Status.ProcessGroups {
+						processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, processGroup.ProcessGroupID == ignoredProcessGroup.ProcessGroupID)
+					}
+
+					status, err := adminClient.GetStatus()
+					Expect(err).NotTo(HaveOccurred())
+					processAddresses := make([]fdbv1beta2.ProcessAddress, 0, len(cluster.Status.ProcessGroups))
+					for _, process := range status.Cluster.Processes {
+						if fdbv1beta2.ProcessGroupID(process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]) != ignoredProcessGroup.ProcessGroupID {
+							continue
+						}
+
+						processAddresses = append(processAddresses, process.Address)
+					}
+
+					filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(cluster, processAddresses, status)
+				})
+
+				It("should filter the ignored address", func() {
+					Expect(removed).To(BeTrue())
+					Expect(filteredAddresses).To(BeEmpty())
+				})
+
+				It("should not requeue", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeue).To(BeNil())
+				})
+
+				It("should not kill any processes", func() {
+					Expect(adminClient.KilledAddresses).To(BeEmpty())
+				})
+			})
+		})
+
+		When("when there are unreachable processes", func() {
+			When("the unreachable processes include at least one tester process", func() {
+				BeforeEach(func() {
+					adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
+					Expect(err).NotTo(HaveOccurred())
+
+					adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
+						Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+							DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+								Available: true,
+							},
+						},
+						Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+							Messages: []fdbv1beta2.FoundationDBStatusMessage{
+								{
+									Name: "status_incomplete",
+								},
+								{
+									Name: "unreachable_processes",
+									UnreachableProcesses: []fdbv1beta2.FoundationDBUnreachableProcess{
+										{
+											Address: "192.168.0.1:4500:tls",
+										},
+									},
+								},
+							},
+							Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+								"1": {
+									ProcessClass: fdbv1beta2.ProcessClassStateless,
+									Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+									Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+										{
+											Role: string(fdbv1beta2.ProcessRoleClusterController),
+										},
+									},
+									UptimeSeconds: 61.0,
+									Locality: map[string]string{
+										fdbv1beta2.FDBLocalityInstanceIDKey: "1",
+									},
+								},
+								"2": {
+									ProcessClass:  fdbv1beta2.ProcessClassTest,
+									Address:       fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.1:4500:tls"},
+									UptimeSeconds: 61.0,
+									Locality: map[string]string{
+										fdbv1beta2.FDBLocalityInstanceIDKey: "2",
+									},
+								},
+							},
+						},
+					}
+				})
+
+				It("should not requeue", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeue).To(BeNil())
+				})
+
+				It("should kill the cluster controller", func() {
+					Expect(adminClient.KilledAddresses).To(HaveKey("192.168.0.2:4500:tls"))
+				})
+
+				When("the minimum required uptime is bigger than the current uptime", func() {
+					BeforeEach(func() {
+						clusterReconciler.MinimumRequiredUptimeCCBounce = 2 * time.Minute
+					})
+
+					AfterEach(func() {
+						clusterReconciler.MinimumRequiredUptimeCCBounce = 0
+					})
+
+					It("should not requeue", func() {
+						Expect(err).NotTo(HaveOccurred())
+						Expect(requeue).To(BeNil())
+					})
+
+					It("should not kill the cluster controller", func() {
+						Expect(adminClient.KilledAddresses).To(BeEmpty())
+					})
+				})
+
+				When("the FDB version automatically removes old tester processes", func() {
+					var previousVersion string
+
+					BeforeEach(func() {
+						previousVersion = cluster.Status.RunningVersion
+						cluster.Spec.Version = "7.1.57"
+						cluster.Status.RunningVersion = "7.1.57"
+					})
+
+					AfterEach(func() {
+						cluster.Status.RunningVersion = previousVersion
+						cluster.Spec.Version = previousVersion
+					})
+
+					It("should not requeue", func() {
+						Expect(err).NotTo(HaveOccurred())
+						Expect(requeue).To(BeNil())
+					})
+
+					It("should not kill the cluster controller", func() {
+						Expect(adminClient.KilledAddresses).To(BeEmpty())
+					})
+				})
+			})
+
+			When("the unreachable processes include no tester processes", func() {
+				BeforeEach(func() {
+					adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
+					Expect(err).NotTo(HaveOccurred())
+
+					adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
+						Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+							Messages: []fdbv1beta2.FoundationDBStatusMessage{
+								{
+									Name: "status_incomplete",
+								},
+								{
+									Name: "unreachable_processes",
+									UnreachableProcesses: []fdbv1beta2.FoundationDBUnreachableProcess{
+										{
+											Address: "192.168.0.1:4500:tls",
+										},
+									},
+								},
+							},
+							Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+								"1": {
+									ProcessClass: fdbv1beta2.ProcessClassStateless,
+									Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+									Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+										{
+											Role: string(fdbv1beta2.ProcessRoleClusterController),
+										},
+									},
+								},
+								"2": {
+									ProcessClass: fdbv1beta2.ProcessClassStorage,
+									Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.1:4500:tls"},
+								},
+							},
+						},
+					}
 				})
 
 				It("should not requeue", func() {
@@ -775,18 +850,40 @@ var _ = Describe("bounceProcesses", func() {
 				})
 			})
 
-			When("the FDB version automatically removes old tester processes", func() {
-				var previousVersion string
-
+			When("the cluster message does not contain unreachable processes", func() {
 				BeforeEach(func() {
-					previousVersion = cluster.Status.RunningVersion
-					cluster.Spec.Version = "7.1.57"
-					cluster.Status.RunningVersion = "7.1.57"
-				})
+					adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
+					Expect(err).NotTo(HaveOccurred())
 
-				AfterEach(func() {
-					cluster.Status.RunningVersion = previousVersion
-					cluster.Spec.Version = previousVersion
+					adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
+						Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+							DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+								Available: true,
+							},
+						},
+						Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+							Messages: []fdbv1beta2.FoundationDBStatusMessage{
+								{
+									Name: "status_incomplete",
+								},
+							},
+							Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+								"1": {
+									ProcessClass: fdbv1beta2.ProcessClassStateless,
+									Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+									Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
+										{
+											Role: string(fdbv1beta2.ProcessRoleClusterController),
+										},
+									},
+								},
+								"2": {
+									ProcessClass: fdbv1beta2.ProcessClassTest,
+									Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.1:4500:tls"},
+								},
+							},
+						},
+					}
 				})
 
 				It("should not requeue", func() {
@@ -799,100 +896,196 @@ var _ = Describe("bounceProcesses", func() {
 				})
 			})
 		})
-
-		When("the unreachable processes include no tester processes", func() {
-			BeforeEach(func() {
-				adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
-				Expect(err).NotTo(HaveOccurred())
-
-				adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
-					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
-						Messages: []fdbv1beta2.FoundationDBStatusMessage{
-							{
-								Name: "status_incomplete",
-							},
-							{
-								Name: "unreachable_processes",
-								UnreachableProcesses: []fdbv1beta2.FoundationDBUnreachableProcess{
-									{
-										Address: "192.168.0.1:4500:tls",
-									},
-								},
-							},
-						},
-						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
-							"1": {
-								ProcessClass: fdbv1beta2.ProcessClassStateless,
-								Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
-								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
-									{
-										Role: string(fdbv1beta2.ProcessRoleClusterController),
-									},
-								},
-							},
-							"2": {
-								ProcessClass: fdbv1beta2.ProcessClassStorage,
-								Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.1:4500:tls"},
-							},
-						},
-					},
-				}
-			})
-
-			It("should not requeue", func() {
-				Expect(err).NotTo(HaveOccurred())
-				Expect(requeue).To(BeNil())
-			})
-
-			It("should not kill the cluster controller", func() {
-				Expect(adminClient.KilledAddresses).To(BeEmpty())
-			})
-		})
-
-		When("the cluster message does not contain unreachable processes", func() {
-			BeforeEach(func() {
-				adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
-				Expect(err).NotTo(HaveOccurred())
-
-				adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
-					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
-						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
-							Available: true,
-						},
-					},
-					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
-						Messages: []fdbv1beta2.FoundationDBStatusMessage{
-							{
-								Name: "status_incomplete",
-							},
-						},
-						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
-							"1": {
-								ProcessClass: fdbv1beta2.ProcessClassStateless,
-								Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
-								Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
-									{
-										Role: string(fdbv1beta2.ProcessRoleClusterController),
-									},
-								},
-							},
-							"2": {
-								ProcessClass: fdbv1beta2.ProcessClassTest,
-								Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.1:4500:tls"},
-							},
-						},
-					},
-				}
-			})
-
-			It("should not requeue", func() {
-				Expect(err).NotTo(HaveOccurred())
-				Expect(requeue).To(BeNil())
-			})
-
-			It("should not kill the cluster controller", func() {
-				Expect(adminClient.KilledAddresses).To(BeEmpty())
-			})
-		})
 	})
+
+	DescribeTable("when getting all the addresses to upgrade from the current status", func(inputStatus *fdbv1beta2.FoundationDBStatus, pendingUpgrades map[fdbv1beta2.ProcessGroupID]bool, version string, expectedAddresses []fdbv1beta2.ProcessAddress, expectedNotReady []string) {
+		addresses, notReady := getUpgradeAddressesFromStatus(GinkgoLogr, inputStatus, pendingUpgrades, version)
+		Expect(addresses).To(ConsistOf(expectedAddresses))
+		Expect(notReady).To(ConsistOf(expectedNotReady))
+	},
+		Entry("no tester processes are present",
+			&fdbv1beta2.FoundationDBStatus{
+				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+					Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+						"1": {
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "1",
+							},
+							Version: "6.3.43",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+						},
+					},
+				},
+			},
+			map[fdbv1beta2.ProcessGroupID]bool{
+				"1": true,
+			},
+			"7.1.56",
+			[]fdbv1beta2.ProcessAddress{{StringAddress: "192.168.0.2:4500:tls"}},
+			[]string{},
+		),
+		Entry("a tester process is present",
+			&fdbv1beta2.FoundationDBStatus{
+				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+					Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+						"1": {
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "1",
+							},
+							Version: "6.3.43",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+						},
+						"2": {
+							ProcessClass: fdbv1beta2.ProcessClassTest,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "2",
+							},
+							Version: "6.3.43",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.3:4500:tls"},
+						},
+					},
+				},
+			},
+			map[fdbv1beta2.ProcessGroupID]bool{
+				"1": true,
+			},
+			"7.1.56",
+			[]fdbv1beta2.ProcessAddress{{StringAddress: "192.168.0.2:4500:tls"}},
+			[]string{},
+		),
+		Entry("a process with missing localities is present",
+			&fdbv1beta2.FoundationDBStatus{
+				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+					Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+						"1": {
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "1",
+							},
+							Version: "6.3.43",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+						},
+						"2": {
+							ProcessClass: fdbv1beta2.ProcessClassTest,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "2",
+							},
+							Version: "6.3.43",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.3:4500:tls"},
+						},
+						"3": {
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Locality:     map[string]string{},
+							Version:      "6.3.43",
+							Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.4:4500:tls"},
+						},
+					},
+				},
+			},
+			map[fdbv1beta2.ProcessGroupID]bool{
+				"1": true,
+			},
+			"7.1.56",
+			[]fdbv1beta2.ProcessAddress{{StringAddress: "192.168.0.2:4500:tls"}},
+			[]string{},
+		),
+		Entry("a process which is already upgraded is present",
+			&fdbv1beta2.FoundationDBStatus{
+				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+					Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+						"1": {
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "1",
+							},
+							Version: "6.3.43",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+						},
+						"2": {
+							ProcessClass: fdbv1beta2.ProcessClassTest,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "2",
+							},
+							Version: "6.3.43",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.3:4500:tls"},
+						},
+						"3": {
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Locality:     map[string]string{},
+							Version:      "6.3.43",
+							Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.4:4500:tls"},
+						},
+						"4": {
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "4",
+							},
+							Version: "7.1.56",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.5:4500:tls"},
+						},
+					},
+				},
+			},
+			map[fdbv1beta2.ProcessGroupID]bool{
+				"1": true,
+			},
+			"7.1.56",
+			[]fdbv1beta2.ProcessAddress{{StringAddress: "192.168.0.2:4500:tls"}},
+			[]string{},
+		),
+		Entry("a process is missing in the pending upgrades map",
+			&fdbv1beta2.FoundationDBStatus{
+				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+					Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+						"1": {
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "1",
+							},
+							Version: "6.3.43",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+						},
+						"2": {
+							ProcessClass: fdbv1beta2.ProcessClassTest,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "2",
+							},
+							Version: "6.3.43",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.3:4500:tls"},
+						},
+						"3": {
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Locality:     map[string]string{},
+							Version:      "6.3.43",
+							Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.4:4500:tls"},
+						},
+						"4": {
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "4",
+							},
+							Version: "7.1.56",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.5:4500:tls"},
+						},
+						"5": {
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Locality: map[string]string{
+								fdbv1beta2.FDBLocalityInstanceIDKey: "5",
+							},
+							Version: "6.3.43",
+							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.6:4500:tls"},
+						},
+					},
+				},
+			},
+			map[fdbv1beta2.ProcessGroupID]bool{
+				"1": true,
+			},
+			"7.1.56",
+			[]fdbv1beta2.ProcessAddress{{StringAddress: "192.168.0.2:4500:tls"}},
+			[]string{"5"},
+		),
+	)
 })

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -1497,7 +1497,7 @@ func (fdbCluster *FdbCluster) UpdateConnectionString(connectionString string) {
 }
 
 // CreateTesterDeployment will create a deployment that runs tester processes with the specified number of replicas.
-func (fdbCluster *FdbCluster) CreateTesterDeployment(replicas int) {
+func (fdbCluster *FdbCluster) CreateTesterDeployment(replicas int) *appsv1.Deployment {
 	deploymentName := fdbCluster.Name() + "-tester"
 
 	deploymentLabels := map[string]string{
@@ -1725,4 +1725,6 @@ func (fdbCluster *FdbCluster) CreateTesterDeployment(replicas int) {
 
 		return runningReplicas
 	}).WithTimeout(10 * time.Minute).WithPolling(2 * time.Second).Should(gomega.BeNumerically(">=", replicas))
+
+	return deploy
 }

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -644,9 +644,9 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			)
 
 			// Start tester processes in the primary side
-			fdbCluster.GetPrimary().CreateTesterDeployment(4)
+			primaryTester := fdbCluster.GetPrimary().CreateTesterDeployment(4)
 			// Start tester processes in the remote side
-			fdbCluster.GetRemote().CreateTesterDeployment(4)
+			remoteTester := fdbCluster.GetRemote().CreateTesterDeployment(4)
 
 			// Start the upgrade with the tester processes present.
 			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
@@ -656,6 +656,9 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			Expect(fdbCluster.GetPrimarySatellite().WaitForReconciliation()).NotTo(HaveOccurred())
 			// Make sure the cluster has no data loss
 			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas()
+
+			factory.Delete(primaryTester)
+			factory.Delete(remoteTester)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),

--- a/go.mod
+++ b/go.mod
@@ -30,10 +30,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-require (
-	golang.org/x/net v0.23.0
-	golang.org/x/sync v0.3.0
-)
+require golang.org/x/sync v0.3.0
 
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
@@ -93,6 +90,7 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	go.uber.org/zap v1.25.0 // indirect
+	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.5.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/term v0.18.0 // indirect


### PR DESCRIPTION
# Description

A cluster that contains tester processes can block the upgrade. The changes in this PR will change this and ignore tester processes in the pending upgrade check as those processes are reporting to the cluster but cannot be restarted with `fdbcli`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

I added a new e2e test for this setup.

## Testing

Ran the test manually.

## Documentation

-

## Follow-up

-
