### PR TITLE
Fix some bugs in the e2e test suite when only one version mapping is provided and fix the setup of the data loader

### DIFF
--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -225,62 +225,26 @@ func (factory *Factory) GetMainContainerOverrides(debugSymbols bool, unifiedImag
 		image = factory.GetUnifiedFoundationDBImage()
 	}
 
-	mainImage, mainTag := GetBaseImageAndTag(
+	mainImage, tag := GetBaseImageAndTag(
 		GetDebugImage(debugSymbols, image),
 	)
 
-	// If the version tag mapping is defined make use of that.
-	imageConfigs := factory.options.getImageVersionConfig(mainImage, false)
-	if len(imageConfigs) == 0 {
-		// The first entry is version specific e.g. this image + tag (if specified) will be used for the provided version
-		// the second entry ensures we set the base image for e.g. upgrades independent of the version.
-		imageConfigs = []fdbv1beta2.ImageConfig{
-			{
-				BaseImage: mainImage,
-				Tag:       mainTag,
-				Version:   factory.GetFDBVersionAsString(),
-			},
-			{
-				BaseImage: mainImage,
-			},
-		}
-	}
-
 	return fdbv1beta2.ContainerOverrides{
 		EnableTLS:    false,
-		ImageConfigs: imageConfigs,
+		ImageConfigs: factory.options.getImageVersionConfig(mainImage, tag, false),
 	}
 }
 
 // GetSidecarContainerOverrides will return the sidecar container overrides. If the unified image should be used an empty
 // container override will be returned.
 func (factory *Factory) GetSidecarContainerOverrides(debugSymbols bool) fdbv1beta2.ContainerOverrides {
-	sidecarImage, sidecarTag := GetBaseImageAndTag(
+	image, tag := GetBaseImageAndTag(
 		GetDebugImage(debugSymbols, factory.GetSidecarImage()),
 	)
 
-	// If the version tag mapping is defined make use of that.
-	imageConfigs := factory.options.getImageVersionConfig(sidecarImage, true)
-	if len(imageConfigs) == 0 {
-		// The first entry is version specific e.g. this image + tag (if specified) will be used for the provided version
-		// the second entry ensures we set the base image for e.g. upgrades independent of the version.
-		imageConfigs = []fdbv1beta2.ImageConfig{
-			{
-				BaseImage: sidecarImage,
-				Tag:       sidecarTag,
-				Version:   factory.GetFDBVersionAsString(),
-				TagSuffix: "-1",
-			},
-			{
-				BaseImage: sidecarImage,
-				TagSuffix: "-1",
-			},
-		}
-	}
-
 	return fdbv1beta2.ContainerOverrides{
 		EnableTLS:    false,
-		ImageConfigs: imageConfigs,
+		ImageConfigs: factory.options.getImageVersionConfig(image, tag, true),
 	}
 }
 

--- a/e2e/fixtures/fdb_data_loader.go
+++ b/e2e/fixtures/fdb_data_loader.go
@@ -119,7 +119,7 @@ spec:
             runAsUser: 0
             runAsGroup: 0
         # Install this library in a special location to force the operator to use it as the primary library.
-        {{ if eq .FDBVersion.Compact "7.1" }}
+        {{ if .CopyAsPrimary }}
         - name: foundationdb-kubernetes-init-7-1-primary
           image: {{ .Image }}
           imagePullPolicy: {{ .ImagePullPolicy }}


### PR DESCRIPTION
# Description

Fix issues in the e2e test suite when only a single version mapping it provided (but not a mapping for the primary version) and fix an issue in the data loader.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

I manually ran those tests with the new config.

## Documentation

-

## Follow-up

-
