### PR TITLE
Update docs unified image

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,5 @@ The makefile supports environment variables that allow you to customize your bui
 ## Known Limitations
 
 1. Support for backups in the operator is still in development, and there are significant missing features.
-2. The unified image is still experimental, and is not recommended outside of development environments.
-3. Additional limitations can be found under [Warnings](docs/manual/warnings.md).
-4. The created FoundationDB cluster is only reachable from within the Kubernetes cluster. Except if the assigned IP addresses for the Pods are also reachable outside of the Kubernetes cluster.
+1. Additional limitations can be found under [Warnings](docs/manual/warnings.md).
+1The created FoundationDB cluster is only reachable from within the Kubernetes cluster. Except if the assigned IP addresses for the Pods are also reachable outside of the Kubernetes cluster.

--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ The makefile supports environment variables that allow you to customize your bui
 
 1. Support for backups in the operator is still in development, and there are significant missing features.
 1. Additional limitations can be found under [Warnings](docs/manual/warnings.md).
-1The created FoundationDB cluster is only reachable from within the Kubernetes cluster. Except if the assigned IP addresses for the Pods are also reachable outside of the Kubernetes cluster.
+1. The created FoundationDB cluster is only reachable from within the Kubernetes cluster. Except if the assigned IP addresses for the Pods are also reachable outside of the Kubernetes cluster.

--- a/docs/manual/customization.md
+++ b/docs/manual/customization.md
@@ -506,10 +506,8 @@ kubectl label pod,pvc,configmap,service -l foundationdb.org/fdb-cluster-name=sam
 The operator currently supports two different image types: a split image and a unified image.
 The split image provides two different images for the `foundationdb` container and the `foundationdb-kubernetes-sidecar` container.
 The unified image provides a single image which handles launching `fdbserver` processes as well as providing feedback to the operator on locality information and updates to dynamic conf.
-
-**NOTE**: The unified image is still experimental, and is not recommended outside of development environments.
-
-The default behavior in the operator is to use the split image. To switch to the unified image, set the flag in the cluster spec as follows:
+The default behavior in the operator is to use the split image.
+To switch to the unified image, set the flag in the cluster spec as follows:
 
 ```yaml
 apiVersion: apps.foundationdb.org/v1beta2

--- a/docs/manual/technical_design.md
+++ b/docs/manual/technical_design.md
@@ -448,7 +448,7 @@ The active configuration is stored on the pod under the annotation `foundationdb
 
 **NOTE**: Because the pod annotations are used to communicate the state in this flow, the pods must have a service account token that has permissions to read and write pods.
 
-fdb-kubernetes-monitor does not watch the `fdb.cluster` for updates. Changes to the connection string will be sent directly to the fdbserver processes through the `coordinators` command in the CLI.
+`fdb-kubernetes-monitor` does not watch the `fdb.cluster` for updates. Changes to the connection string will be sent directly to the fdbserver processes through the `coordinators` command in the CLI.
 
 When the operator checks the status of the cluster, it needs to check if the process start commands are an exact match for the expected values based on the cluster spec. In order to make this comparison, it needs to fill in pod-specific information like the address and node name. fdb-kubernetes-monitor provides this information through the `foundationdb.org/launcher-environment` annotation on the pod, which contains a map of environment variables to their values. The operator uses this annotation when performing this check on the start command.
 

--- a/docs/manual/technical_design.md
+++ b/docs/manual/technical_design.md
@@ -428,9 +428,10 @@ The sidecar has an important role to play in the upgrade flow. The monitor conf 
 
 ### Unified Image
 
-**NOTE**: The unified image is still experimental, and is not recommended outside of development environments.
-
-When using the unified image, the `foundationdb` container runs a `fdb-kubernetes-monitor` process, which is responsible for starting `fdbserver` processes. `fdb-kubernetes-monitor` receives its configuration in the form of a JSON file, which provides the command-line arguments in a structured form. These arguments can reference environment variables, which will be filled in by `fdb-kubernetes-monitor`. They can also reference the process number, which allows `fdb-kubernetes-monitor` to start multiple `fdbserver` processes that use different ports and different data directories.
+When using the unified image, the `foundationdb` container runs a `fdb-kubernetes-monitor` process, which is responsible for starting `fdbserver` processes.
+`fdb-kubernetes-monitor` receives its configuration in the form of a JSON file, which provides the command-line arguments in a structured form.
+These arguments can reference environment variables, which will be filled in by `fdb-kubernetes-monitor`.
+They can also reference the process number, which allows `fdb-kubernetes-monitor` to start multiple `fdbserver` processes that use different ports and different data directories.
 
 The flow for updating the monitor conf file has the following steps:
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -58,10 +58,7 @@ If those tests are running on a cluster that has no chaos-mesh installed, you ca
 
 ### Running the e2e tests with the unified image
 
-_NOTE_ The unified image is currently experimental and there are no pre-build images.
-
 The source can be found in the [FoundationDB repository](https://github.com/apple/foundationdb/tree/main/fdbkubernetesmonitor#foundationdb-kubernetes-monitor).
-You have to make sure that the image `foundationdb/fdb-kubernetes-monitor` is built and available in the Kubernetes cluster.
 
 ```bash
 FDB_IMAGE=foundationdb/fdb-kubernetes-monitor:7.3.38 \


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1036.

## Type of change

- Documentation

## Discussion

Images are pushed to: https://hub.docker.com/r/foundationdb/fdb-kubernetes-monitor

## Testing

We already had some e2e tests for the unified image.

## Documentation

-

## Follow-up

-
