### PR TITLE
Fix the case where the process group gets removed without the addresses being included

### DIFF
--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -132,9 +132,8 @@ func (u removeProcessGroups) reconcile(ctx context.Context, r *FoundationDBClust
 	removedProcessGroups := r.removeProcessGroups(ctx, logger, cluster, zoneRemovals, zonedRemovals[removals.TerminatingZone])
 	err = includeProcessGroup(ctx, logger, r, cluster, removedProcessGroups, status, adminClient)
 	if err != nil {
-		delay := time.Duration(int(r.MinimumRecoveryTimeForInclusion-status.Cluster.RecoveryState.SecondsSinceLastRecovered)) * time.Second
-		_ = delay
-		return &requeue{curError: err, delayedRequeue: true, delay: 0}
+		// If the inclusion is blocked or another issues happened we will retry in 60 seconds.
+		return &requeue{curError: err, delayedRequeue: true, delay: 60 * time.Second}
 	}
 
 	return nil

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -640,7 +640,7 @@ var _ = Describe("remove_process_groups", func() {
 					removedProcessGroups[removedProcessGroup.ProcessGroupID] = true
 				})
 
-				It("should include one process", func() {
+				It("should include two process addresses", func() {
 					processesToInclude, newProcessGroups, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(processesToInclude).To(HaveLen(2))

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -560,7 +560,7 @@ var _ = Describe("remove_process_groups", func() {
 			})
 
 			When("including no process", func() {
-				FIt("should not include any process", func() {
+				It("should not include any process", func() {
 					processesToInclude, newProcessGroups, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(processesToInclude).To(BeEmpty())

--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -560,11 +560,12 @@ var _ = Describe("remove_process_groups", func() {
 			})
 
 			When("including no process", func() {
-				It("should not include any process", func() {
-					processesToInclude, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
+				FIt("should not include any process", func() {
+					processesToInclude, newProcessGroups, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(len(processesToInclude)).To(Equal(0))
-					Expect(len(cluster.Status.ProcessGroups)).To(Equal(16))
+					Expect(processesToInclude).To(BeEmpty())
+					Expect(newProcessGroups).To(BeEmpty())
+					Expect(cluster.Status.ProcessGroups).To(HaveLen(16))
 				})
 			})
 
@@ -580,11 +581,12 @@ var _ = Describe("remove_process_groups", func() {
 				})
 
 				It("should include one process", func() {
-					fdbProcessesToInclude, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
+					processesToInclude, newProcessGroups, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(len(fdbProcessesToInclude)).To(Equal(1))
-					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToInclude, " ")).To(Equal("1.1.1.1"))
-					Expect(len(cluster.Status.ProcessGroups)).To(Equal(15))
+					Expect(processesToInclude).To(HaveLen(1))
+					Expect(fdbv1beta2.ProcessAddressesString(processesToInclude, " ")).To(Equal("1.1.1.1"))
+					Expect(newProcessGroups).To(HaveLen(15))
+					Expect(cluster.Status.ProcessGroups).To(HaveLen(16))
 				})
 			})
 		})
@@ -596,10 +598,11 @@ var _ = Describe("remove_process_groups", func() {
 
 			When("including no process", func() {
 				It("should not include any process", func() {
-					fdbProcessesToInclude, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
+					processesToInclude, newProcessGroups, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(len(fdbProcessesToInclude)).To(Equal(0))
-					Expect(len(cluster.Status.ProcessGroups)).To(Equal(16))
+					Expect(processesToInclude).To(BeEmpty())
+					Expect(newProcessGroups).To(BeEmpty())
+					Expect(cluster.Status.ProcessGroups).To(HaveLen(16))
 				})
 			})
 
@@ -615,11 +618,12 @@ var _ = Describe("remove_process_groups", func() {
 				})
 
 				It("should include one process", func() {
-					fdbProcessesToInclude, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
+					processesToInclude, newProcessGroups, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(len(fdbProcessesToInclude)).To(Equal(1))
-					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToInclude, " ")).To(Equal(removedProcessGroup.GetExclusionString()))
-					Expect(len(cluster.Status.ProcessGroups)).To(Equal(15))
+					Expect(processesToInclude).To(HaveLen(1))
+					Expect(fdbv1beta2.ProcessAddressesString(processesToInclude, " ")).To(Equal(removedProcessGroup.GetExclusionString()))
+					Expect(newProcessGroups).To(HaveLen(15))
+					Expect(cluster.Status.ProcessGroups).To(HaveLen(16))
 				})
 			})
 
@@ -637,11 +641,12 @@ var _ = Describe("remove_process_groups", func() {
 				})
 
 				It("should include one process", func() {
-					fdbProcessesToInclude, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
+					processesToInclude, newProcessGroups, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(len(fdbProcessesToInclude)).To(Equal(2))
-					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToInclude, " ")).To(Equal(fmt.Sprintf("%s %s", removedProcessGroup.GetExclusionString(), removedProcessGroup.Addresses[0])))
-					Expect(len(cluster.Status.ProcessGroups)).To(Equal(15))
+					Expect(processesToInclude).To(HaveLen(2))
+					Expect(fdbv1beta2.ProcessAddressesString(processesToInclude, " ")).To(Equal(fmt.Sprintf("%s %s", removedProcessGroup.GetExclusionString(), removedProcessGroup.Addresses[0])))
+					Expect(newProcessGroups).To(HaveLen(15))
+					Expect(cluster.Status.ProcessGroups).To(HaveLen(16))
 				})
 			})
 
@@ -663,11 +668,12 @@ var _ = Describe("remove_process_groups", func() {
 				})
 
 				It("should include one process", func() {
-					fdbProcessesToInclude, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
+					processesToInclude, newProcessGroups, err := getProcessesToInclude(logr.Logger{}, cluster, removedProcessGroups, status)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(len(fdbProcessesToInclude)).To(Equal(1))
-					Expect(fdbv1beta2.ProcessAddressesString(fdbProcessesToInclude, " ")).To(Equal(removedProcessGroup2.GetExclusionString()))
-					Expect(len(cluster.Status.ProcessGroups)).To(Equal(14))
+					Expect(processesToInclude).To(HaveLen(1))
+					Expect(fdbv1beta2.ProcessAddressesString(processesToInclude, " ")).To(Equal(removedProcessGroup2.GetExclusionString()))
+					Expect(newProcessGroups).To(HaveLen(14))
+					Expect(cluster.Status.ProcessGroups).To(HaveLen(16))
 				})
 			})
 		})

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -268,10 +268,6 @@ func StartManager(
 		clusterReconciler.MaintenanceListWaitDuration = operatorOpts.MaintenanceListWaitDuration
 		clusterReconciler.MinimumRecoveryTimeForInclusion = operatorOpts.MinimumRecoveryTimeForInclusion
 		clusterReconciler.MinimumRecoveryTimeForExclusion = operatorOpts.MinimumRecoveryTimeForExclusion
-		clusterReconciler.MaintenanceListStaleDuration = operatorOpts.MaintenanceListStaleDuration
-		clusterReconciler.MaintenanceListWaitDuration = operatorOpts.MaintenanceListWaitDuration
-		clusterReconciler.MinimumRecoveryTimeForInclusion = operatorOpts.MinimumRecoveryTimeForInclusion
-		clusterReconciler.MinimumRecoveryTimeForExclusion = operatorOpts.MinimumRecoveryTimeForExclusion
 		clusterReconciler.ClusterLabelKeyForNodeTrigger = strings.Trim(operatorOpts.ClusterLabelKeyForNodeTrigger, "\"")
 		clusterReconciler.Namespace = operatorOpts.WatchNamespace
 


### PR DESCRIPTION
# Description

Fixes a bug where the process group gets removed from the `FoundationDBCluster` status without getting the addresses included. The side effect of this bug is that some addresses in the cluster are not included again. The issue will only happen if multiple process groups should be replaced across different zones.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Updated the test cases and ran the e2e test for this with an extended inclusion delay.

## Documentation

-

## Follow-up

-
