### PR TITLE
Update go version to 1.22.8

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.7
+          go-version: 1.22.8
       - name: Get dependencies
         run: curl -L --fail "https://github.com/apple/foundationdb/releases/download/${FDB_VER}/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.22.7
+        go-version: 1.22.8
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Get dependencies
@@ -103,7 +103,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.22.7
+        go-version: 1.22.8
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Get dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.7
+          go-version: 1.22.8
       #  https://github.com/goreleaser/goreleaser/issues/1311
       - name: Get current semver tag
         run: echo "::set-output name=CURRENT_TAG::$(git describe --tags --match "v*" --abbrev=0)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG FDB_VERSION=6.2.29
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM docker.io/library/golang:1.22.7 AS builder
+FROM docker.io/library/golang:1.22.8 AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2151

## Type of change

- Other

## Discussion

-

## Testing

Ran unit tests and CI will run e2e tests.

## Documentation

-

## Follow-up

-
