### PR TITLE
Make sure that the remove cluster is skipped too and add more debugging output for the plugin

### DIFF
--- a/kubectl-fdb/cmd/recover_multi_region_cluster.go
+++ b/kubectl-fdb/cmd/recover_multi_region_cluster.go
@@ -182,6 +182,8 @@ func recoverMultiRegionCluster(cmd *cobra.Command, opts recoverMultiRegionCluste
 			return parseErr
 		}
 
+		cmd.Println("checking pod:", pod.Name, "address:", addr, "pod IPs:", pod.Status.PodIP, "machineAddr:", addr.MachineAddress())
+
 		loopPod := pod
 		if coordinatorAddr, ok := coordinators[addr.MachineAddress()]; ok {
 			cmd.Println("Found coordinator for cluster", pod.Name, "address", addr.MachineAddress())


### PR DESCRIPTION
# Description

Setting the remove cluster into the skip mode, should make the tests more reliable and reduce the risk of a race condition.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran the e2e test for the plugin manually.

## Documentation

0

## Follow-up

https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2153 (will e fixed in another PR).
