### PR TITLE
Fix the unified image setup during bootstrap when a custom environment variable is used for the zone

### DIFF
--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -47,7 +47,7 @@ func (g generateInitialClusterFile) reconcile(ctx context.Context, r *Foundation
 	}
 
 	logger.Info("Generating initial cluster file")
-	r.Recorder.Event(cluster, corev1.EventTypeNormal, "ChangingCoordinators", "Choosing initial coordinators")
+	r.Recorder.Event(cluster, corev1.EventTypeNormal, "GenerateInitialCoordinators", "Choosing initial coordinators")
 
 	processCounts, err := cluster.GetProcessCountsWithDefaults()
 	if err != nil {
@@ -130,8 +130,7 @@ func (g generateInitialClusterFile) reconcile(ctx context.Context, r *Foundation
 	}
 
 	coordinators, err := locality.ChooseDistributedProcesses(cluster, processLocality, count, locality.ProcessSelectionConstraint{
-		HardLimits:            locality.GetHardLimits(cluster),
-		SelectingCoordinators: true,
+		HardLimits: locality.GetHardLimits(cluster),
 	})
 	if err != nil {
 		return &requeue{curError: err}

--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -78,6 +78,9 @@ type ClusterConfig struct {
 	UseDNS bool
 	// If enabled the cluster will be setup with the unified image.
 	UseUnifiedImage *bool
+	// SimulateCustomFaultDomainEnv will simulate the use case that a user has set a custom environment variable to
+	// be used as zone ID.
+	SimulateCustomFaultDomainEnv bool
 	// CreationTracker if specified will be used to log the time between the creations steps.
 	CreationTracker CreationTrackerLogger
 	// Number of machines, this is used for calculating the number of Pods and is not correlated to the actual number

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -48,6 +48,14 @@ func (factory *Factory) createFDBClusterSpec(
 		imageType = fdbv1beta2.ImageTypeUnified
 	}
 
+	faultDomain := fdbv1beta2.FoundationDBClusterFaultDomain{
+		Key: "foundationdb.org/none",
+	}
+	if config.SimulateCustomFaultDomainEnv {
+		faultDomain.ValueFrom = "$" + fdbv1beta2.EnvNameInstanceID
+		faultDomain.Key = corev1.LabelHostname
+	}
+
 	return &fdbv1beta2.FoundationDBCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Name,
@@ -64,9 +72,7 @@ func (factory *Factory) createFDBClusterSpec(
 			MainContainer:                 factory.GetMainContainerOverrides(config.DebugSymbols, useUnifiedImage),
 			ImageType:                     &imageType,
 			SidecarContainer:              factory.GetSidecarContainerOverrides(config.DebugSymbols),
-			FaultDomain: fdbv1beta2.FoundationDBClusterFaultDomain{
-				Key: "foundationdb.org/none",
-			},
+			FaultDomain:                   faultDomain,
 			AutomationOptions: fdbv1beta2.FoundationDBClusterAutomationOptions{
 				// We have to wait long enough to ensure the operator is not recreating too many Pods at the same time.
 				WaitBetweenRemovalsSeconds: pointer.Int(0),

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -115,8 +115,7 @@ func selectCoordinatorsLocalities(logger logr.Logger, cluster *fdbv1beta2.Founda
 	}
 
 	coordinators, err := locality.ChooseDistributedProcesses(cluster, candidates, coordinatorCount, locality.ProcessSelectionConstraint{
-		HardLimits:            locality.GetHardLimits(cluster),
-		SelectingCoordinators: true,
+		HardLimits: locality.GetHardLimits(cluster),
 	})
 
 	logger.Info("Current coordinators", "coordinators", coordinators, "error", err)

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -434,8 +434,6 @@ func GetSubstitutionsFromClusterAndPod(logger logr.Logger, cluster *fdbv1beta2.F
 
 		if faultDomainSource == "spec.nodeName" {
 			substitutions[fdbv1beta2.EnvNameZoneID] = pod.Spec.NodeName
-		} else {
-			return nil, fmt.Errorf("unsupported fault domain source %s", faultDomainSource)
 		}
 	}
 
@@ -450,6 +448,7 @@ func GetSubstitutionsFromClusterAndPod(logger logr.Logger, cluster *fdbv1beta2.F
 	copyableSubstitutions := map[string]fdbv1beta2.None{
 		fdbv1beta2.EnvNameDNSName:    {},
 		fdbv1beta2.EnvNameInstanceID: {},
+		"CUSTOM_ENV":                 {},
 	}
 	for _, container := range pod.Spec.Containers {
 		for _, envVar := range container.Env {


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2155

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Created a new test setup. I decided to add the new test case to the upgrade test as this includes creating a new cluster.

## Documentation

-

## Follow-up

-
