### PR TITLE
Ensure the the cluster reconciler status is set to be in simulation after each test

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -106,6 +106,7 @@ var _ = AfterEach(func() {
 	k8sClient.Clear()
 	mock.ClearMockAdminClients()
 	mock.ClearMockLockClients()
+	clusterReconciler.InSimulation = true
 })
 
 func createDefaultRestore(cluster *fdbv1beta2.FoundationDBCluster) *fdbv1beta2.FoundationDBRestore {

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -579,6 +579,7 @@ func (client *AdminClient) ExcludeProcesses(addresses []fdbv1beta2.ProcessAddres
 		address := pAddr.String()
 		client.ExcludedAddresses[address] = fdbv1beta2.None{}
 	}
+
 	return nil
 }
 
@@ -589,13 +590,14 @@ func (client *AdminClient) IncludeProcesses(addresses []fdbv1beta2.ProcessAddres
 	defer adminClientMutex.Unlock()
 
 	for _, address := range addresses {
-		address := address.String()
-		_, ok := client.ExcludedAddresses[address]
+		addr := address.String()
+		_, ok := client.ExcludedAddresses[addr]
 		if ok {
-			client.ReincludedAddresses[address] = true
-			delete(client.ExcludedAddresses, address)
+			client.ReincludedAddresses[addr] = true
+			delete(client.ExcludedAddresses, addr)
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
# Description

Fixes a testing bug that was introduced in https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2158/files#diff-d0ad2e8f0d701fc00f8cd16ca0799d0e7e3a6a508245c60e122770680d3498a5R897. The `clusterReconciler` is a global struct, so the value was never set back to `true`, which causes failures in some test cases.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran unit test manually with the race flag.

## Documentation

-

## Follow-up

-
