### PR TITLE
Restart processes only once when doing a setting rollout and include uptime from processes

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2653,18 +2653,14 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		It("should update the locality with the substituted environment variable", func() {
-			localityKey := "testing"
 			Eventually(func(g Gomega) bool {
 				for _, process := range fdbCluster.GetStatus().Cluster.Processes {
-					// We change the knob only for stateless processes.
+					// We change the knob only for storage processes.
 					if process.ProcessClass != fdbv1beta2.ProcessClassStorage {
 						continue
 					}
 
-					g.Expect(process.Locality).NotTo(BeEmpty())
-					g.Expect(process.Locality).To(HaveKey(localityKey))
-					g.Expect(process.Locality).To(HaveKey(fdbv1beta2.FDBLocalityInstanceIDKey))
-					g.Expect(process.Locality[localityKey]).To(Equal(process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]))
+					g.Expect(process.CommandLine).To(ContainSubstring("knob_read_sampling_enabled"))
 				}
 
 				return true

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2623,4 +2623,52 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			Expect(factory.GetControllerRuntimeClient().Update(context.Background(), pod)).NotTo(HaveOccurred())
 		})
 	})
+
+	When("a new knob for storage servers is rolled out to the cluster", func() {
+		var initialCustomParameters fdbv1beta2.FoundationDBCustomParameters
+
+		BeforeEach(func() {
+			initialCustomParameters = fdbCluster.GetCustomParameters(
+				fdbv1beta2.ProcessClassStorage,
+			)
+
+			Expect(
+				fdbCluster.SetCustomParameters(
+					fdbv1beta2.ProcessClassStorage,
+					append(
+						initialCustomParameters,
+						"knob_read_sampling_enabled=true",
+					),
+					false,
+				),
+			).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			Expect(fdbCluster.SetCustomParameters(
+				fdbv1beta2.ProcessClassStorage,
+				initialCustomParameters,
+				true,
+			)).NotTo(HaveOccurred())
+		})
+
+		It("should update the locality with the substituted environment variable", func() {
+			localityKey := "testing"
+			Eventually(func(g Gomega) bool {
+				for _, process := range fdbCluster.GetStatus().Cluster.Processes {
+					// We change the knob only for stateless processes.
+					if process.ProcessClass != fdbv1beta2.ProcessClassStorage {
+						continue
+					}
+
+					g.Expect(process.Locality).NotTo(BeEmpty())
+					g.Expect(process.Locality).To(HaveKey(localityKey))
+					g.Expect(process.Locality).To(HaveKey(fdbv1beta2.FDBLocalityInstanceIDKey))
+					g.Expect(process.Locality[localityKey]).To(Equal(process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]))
+				}
+
+				return true
+			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
+		})
+	})
 })

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -442,7 +442,7 @@ func getKillCommand(addresses []fdbv1beta2.ProcessAddress, isUpgrade bool) strin
 	killCmd.WriteString(addrString)
 
 	if isUpgrade {
-		killCmd.WriteString("; sleep 1; kill")
+		killCmd.WriteString("; sleep 1; kill ")
 		killCmd.WriteString(addrString)
 	}
 	killCmd.WriteString("; sleep 5")

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -434,18 +434,43 @@ func (client *cliAdminClient) CanSafelyRemove(addresses []fdbv1beta2.ProcessAddr
 	return fdbstatus.CanSafelyRemoveFromStatus(client.log, client, addresses, status)
 }
 
+func getKillCommand(addresses []fdbv1beta2.ProcessAddress, isUpgrade bool) string {
+	var killCmd strings.Builder
+
+	addrString := fdbv1beta2.ProcessAddressesStringWithoutFlags(addresses, " ")
+	killCmd.WriteString("kill; kill ")
+	killCmd.WriteString(addrString)
+
+	if isUpgrade {
+		killCmd.WriteString("; sleep 1; kill")
+		killCmd.WriteString(addrString)
+	}
+	killCmd.WriteString("; sleep 5")
+
+	return killCmd.String()
+}
+
 // KillProcesses restarts processes
 func (client *cliAdminClient) KillProcesses(addresses []fdbv1beta2.ProcessAddress) error {
 	if len(addresses) == 0 {
 		return nil
 	}
 
-	killCommand := fmt.Sprintf(
-		"kill; kill %[1]s; sleep 1; kill %[1]s; sleep 5",
-		fdbv1beta2.ProcessAddressesStringWithoutFlags(addresses, " "),
-	)
 	// Run the kill command once with the max timeout to reduce the risk of multiple recoveries happening.
-	_, err := client.runCommand(cliCommand{command: killCommand, timeout: client.getTimeout()})
+	_, err := client.runCommand(cliCommand{command: getKillCommand(addresses, false), timeout: client.getTimeout()})
+
+	return err
+}
+
+// KillProcessesForUpgrade restarts processes for upgrades, this will issue 2 kill commands to make sure all
+// processes are restarted.
+func (client *cliAdminClient) KillProcessesForUpgrade(addresses []fdbv1beta2.ProcessAddress) error {
+	if len(addresses) == 0 {
+		return nil
+	}
+
+	// Run the kill command once with the max timeout to reduce the risk of multiple recoveries happening.
+	_, err := client.runCommand(cliCommand{command: getKillCommand(addresses, true), timeout: client.getTimeout()})
 
 	return err
 }

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -1293,4 +1293,19 @@ protocol fdb00b071010000`,
 			})
 		})
 	})
+
+	When("getting the kill command", func() {
+		addresses := []fdbv1beta2.ProcessAddress{{
+			IPAddress: net.ParseIP("192.168.0.2"),
+			Port:      4500,
+		}}
+
+		When("the cluster is upgraded ", func() {
+			Expect(getKillCommand(addresses, true)).To(Equal("kill; kill 192.168.0.2:4500; sleep 1; kill 192.168.0.2:4500; sleep 5"))
+		})
+
+		When("the cluster is not upgraded", func() {
+			Expect(getKillCommand(addresses, false)).To(Equal("kill; kill 192.168.0.2:4500; sleep 5"))
+		})
+	})
 })

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -56,6 +56,10 @@ type AdminClient interface {
 	// KillProcesses restarts processes
 	KillProcesses(addresses []fdbv1beta2.ProcessAddress) error
 
+	// KillProcessesForUpgrade restarts processes for upgrades, this will issue 2 kill commands to make sure all
+	// processes are restarted.
+	KillProcessesForUpgrade(addresses []fdbv1beta2.ProcessAddress) error
+
 	// ChangeCoordinators changes the coordinator set
 	ChangeCoordinators(addresses []fdbv1beta2.ProcessAddress) (string, error)
 

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -702,6 +702,12 @@ func (client *AdminClient) KillProcesses(addresses []fdbv1beta2.ProcessAddress) 
 	return nil
 }
 
+// KillProcessesForUpgrade restarts processes for upgrades, this will issue 2 kill commands to make sure all
+// processes are restarted.
+func (client *AdminClient) KillProcessesForUpgrade(addresses []fdbv1beta2.ProcessAddress) error {
+	return client.KillProcesses(addresses)
+}
+
 // ChangeCoordinators changes the coordinator set
 func (client *AdminClient) ChangeCoordinators(addresses []fdbv1beta2.ProcessAddress) (string, error) {
 	adminClientMutex.Lock()

--- a/pkg/fdbstatus/status_checks_test.go
+++ b/pkg/fdbstatus/status_checks_test.go
@@ -842,7 +842,7 @@ var _ = Describe("status_checks", func() {
 					},
 				},
 			}),
-		Entry("when recovered since is enabled and version supports it",
+		Entry("when recovered since is enabled and version supports it it should use the minimum of recovered since or process uptime",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
 					Version: fdbv1beta2.Versions.SupportsRecoveryState.String(),
@@ -866,7 +866,7 @@ var _ = Describe("status_checks", func() {
 				},
 			},
 			true,
-			90.0,
+			30.0,
 			map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.ProcessAddress{
 				"test": {
 					{

--- a/pkg/fdbstatus/status_checks_test.go
+++ b/pkg/fdbstatus/status_checks_test.go
@@ -842,7 +842,7 @@ var _ = Describe("status_checks", func() {
 					},
 				},
 			}),
-		Entry("when recovered since is enabled and version supports it it should use the minimum of recovered since or process uptime",
+		Entry("when recovered since is enabled and version supports it, it should use the minimum of recovered since or process uptime",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
 					Version: fdbv1beta2.Versions.SupportsRecoveryState.String(),


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2161

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

I added a new operator test and performed some manual tests and monitored the fdb-monitor-log:

```text
Time="1731500867.138682" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Could not remove inotify conf file watch, continuing...
Time="1731500867.138731" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Watching conf file /var/dynamic-conf/fdbmonitor.conf
Time="1731500867.138742" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Watching conf dir /var/dynamic-conf/ (10)
Time="1731500867.138749" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Loading configuration /var/dynamic-conf/fdbmonitor.conf
Time="1731500867.138925" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Starting fdbserver.1
Time="1731500867.139186" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Starting fdbserver.2
Time="1731500867.139418" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbserver.1": Launching /usr/bin/fdbserver (27) for fdbserver.1
Time="1731500867.139462" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbserver.2": Launching /usr/bin/fdbserver (28) for fdbserver.2
Time="1731500867.189768" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbserver.2": FDBD joined cluster.
Time="1731500867.190228" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbserver.1": FDBD joined cluster.
Time="1731500914.453225" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Could not remove inotify conf file watch, continuing...
Time="1731500914.453272" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Watching conf file /var/dynamic-conf/fdbmonitor.conf
Time="1731500914.453283" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Watching conf dir /var/dynamic-conf/ (12)
Time="1731500914.453289" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Loading configuration /var/dynamic-conf/fdbmonitor.conf
Time="1731500914.453415" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Updated configuration for fdbserver.2
Time="1731500914.453485" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Updated configuration for fdbserver.1
Time="1731500931.652931" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Could not remove inotify conf file watch, continuing...
Time="1731500931.652976" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Watching conf file /var/dynamic-conf/fdbmonitor.conf
Time="1731500931.652985" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Watching conf dir /var/dynamic-conf/ (14)
Time="1731500931.652993" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Loading configuration /var/dynamic-conf/fdbmonitor.conf
Time="1731500931.653108" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Found new configuration for fdbserver.2
Time="1731500931.653156" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbmonitor": Found new configuration for fdbserver.1
Time="1731501053.633942" Severity="20" LogGroup="jscheuermann-jdev" Process="fdbserver.1": Process 27 exited 0, restarting in 0 seconds
Time="1731501053.634312" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbserver.1": Launching /usr/bin/fdbserver (217) for fdbserver.1
Time="1731501053.634625" Severity="20" LogGroup="jscheuermann-jdev" Process="fdbserver.2": Process 28 exited 0, restarting in 0 seconds
Time="1731501053.634899" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbserver.2": Launching /usr/bin/fdbserver (218) for fdbserver.2
Time="1731501053.679621" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbserver.1": FDBD joined cluster.
Time="1731501053.680075" Severity="10" LogGroup="jscheuermann-jdev" Process="fdbserver.2": FDBD joined cluster.
```

## Documentation

-

## Follow-up

-
