### PR TITLE
Enable unified image tests

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2494,9 +2494,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 	})
 
-	// The current nightly use a version of the unified image that doesn't support this feature yet. Once we update the
-	// image we should also enable this test again.
-	PWhen("enabling the node watch feature", func() {
+	When("enabling the node watch feature", func() {
 		var initialParameters fdbv1beta2.FoundationDBCustomParameters
 
 		BeforeEach(func() {
@@ -2575,9 +2573,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 	})
 
-	// The current nightly use a version of the unified image that doesn't support this feature yet. Once we update the
-	// image we should also enable this test again.
-	PWhen("the Pod is set into isolate mode", func() {
+	When("the Pod is set into isolate mode", func() {
 		var isolatedPod corev1.Pod
 
 		BeforeEach(func() {


### PR DESCRIPTION
# Description

Since the unified image is released, we can run those tests always with the unified image.

## Type of change

- Other

## Discussion

-

## Testing

Ran the tests manually:

```text
ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.003 seconds]
------------------------------

Ran 2 of 54 Specs in 609.901 seconds
SUCCESS! -- 2 Passed | 0 Failed | 9 Pending | 43 Skipped
PASS | FOCUSED
FAIL    github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator       610.511s
FAIL
```

## Documentation

-

## Follow-up

-
