### PR TITLE
Always make use of the no_wait flag in the exclude controller to reduce the noise from exclusions that timeout

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -377,6 +377,12 @@ func (client *cliAdminClient) ResetMaintenanceMode() error {
 
 // ExcludeProcesses starts evacuating processes so that they can be removed from the database.
 func (client *cliAdminClient) ExcludeProcesses(addresses []fdbv1beta2.ProcessAddress) error {
+	return client.ExcludeProcessesWithNoWait(addresses, client.Cluster.GetUseNonBlockingExcludes())
+}
+
+// ExcludeProcessesWithNoWait starts evacuating processes so that they can be removed from the database. If noWait is
+// set to true, the exclude command will not block until all data is moved away from the processes.
+func (client *cliAdminClient) ExcludeProcessesWithNoWait(addresses []fdbv1beta2.ProcessAddress, noWait bool) error {
 	if len(addresses) == 0 {
 		return nil
 	}
@@ -388,7 +394,7 @@ func (client *cliAdminClient) ExcludeProcesses(addresses []fdbv1beta2.ProcessAdd
 
 	var excludeCommand strings.Builder
 	excludeCommand.WriteString("exclude ")
-	if version.HasNonBlockingExcludes(client.Cluster.GetUseNonBlockingExcludes()) {
+	if version.HasNonBlockingExcludes(noWait) {
 		excludeCommand.WriteString("no_wait ")
 	}
 

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -38,6 +38,10 @@ type AdminClient interface {
 	// from the database.
 	ExcludeProcesses(addresses []fdbv1beta2.ProcessAddress) error
 
+	// ExcludeProcessesWithNoWait starts evacuating processes so that they can be removed from the database. If noWait is
+	// set to true, the exclude command will not block until all data is moved away from the processes.
+	ExcludeProcessesWithNoWait(addresses []fdbv1beta2.ProcessAddress, noWait bool) error
+
 	// IncludeProcesses removes processes from the exclusion list and allows
 	// them to take on roles again.
 	IncludeProcesses(addresses []fdbv1beta2.ProcessAddress) error

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -583,6 +583,12 @@ func (client *AdminClient) ExcludeProcesses(addresses []fdbv1beta2.ProcessAddres
 	return nil
 }
 
+// ExcludeProcessesWithNoWait starts evacuating processes so that they can be removed from the database. If noWait is
+// set to true, the exclude command will not block until all data is moved away from the processes.
+func (client *AdminClient) ExcludeProcessesWithNoWait(addresses []fdbv1beta2.ProcessAddress, _ bool) error {
+	return client.ExcludeProcesses(addresses)
+}
+
 // IncludeProcesses removes processes from the exclusion list and allows
 // them to take on roles again.
 func (client *AdminClient) IncludeProcesses(addresses []fdbv1beta2.ProcessAddress) error {


### PR DESCRIPTION
# Description

Always make use of the no_wait flag in the exclude controller to reduce the noise from exclusions that timeout.

## Type of change

- New feature (non-breaking change which adds functionality)


## Discussion

-

## Testing

CI will run e2e tests.

## Documentation

-

## Follow-up

-
