### PR TITLE
Improve the reliability of the pod pending test case

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -580,7 +580,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			initialPods := fdbCluster.GetStatelessPods()
 			failedPod = factory.RandomPickOnePod(initialPods.Items)
 			log.Printf("Setting pod %s to unschedulable.", failedPod.Name)
-			Expect(fdbCluster.SetPodAsUnschedulable(failedPod)).NotTo(HaveOccurred())
+			fdbCluster.SetPodAsUnschedulable(failedPod)
 			fdbCluster.ReplacePod(failedPod, true)
 		})
 
@@ -590,7 +590,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		It("should remove the targeted Pod", func() {
-			fdbCluster.EnsurePodIsDeletedWithCustomTimeout(failedPod.Name, 10)
+			fdbCluster.EnsurePodIsDeletedWithCustomTimeout(failedPod.Name, 15)
 		})
 	})
 
@@ -599,6 +599,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var podToReplace *corev1.Pod
 
 		BeforeEach(func() {
+			// We bring down two pods, which could cause some recoveries.
+			availabilityCheck = false
 			failedPod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
 			podToReplace = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
 			log.Println(
@@ -607,17 +609,17 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				", Pod to replace:",
 				podToReplace.Name,
 			)
-			Expect(fdbCluster.SetPodAsUnschedulable(*failedPod)).NotTo(HaveOccurred())
+			fdbCluster.SetPodAsUnschedulable(*failedPod)
 			fdbCluster.ReplacePod(*podToReplace, false)
 		})
-
+		// 2024/11/26 01:41:00 Failed (unscheduled) Pod: operator-test-fdnhokqf-stateless-42898 , Pod to replace: operator-test-fdnhokqf-stateless-93723
 		AfterEach(func() {
 			Expect(fdbCluster.ClearBuggifyNoSchedule(false)).NotTo(HaveOccurred())
 			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
 		})
 
 		It("should remove the targeted Pod", func() {
-			fdbCluster.EnsurePodIsDeletedWithCustomTimeout(podToReplace.Name, 10)
+			fdbCluster.EnsurePodIsDeletedWithCustomTimeout(podToReplace.Name, 15)
 		})
 	})
 

--- a/e2e/test_operator_maintenance_mode/operator_maintenance_mode_test.go
+++ b/e2e/test_operator_maintenance_mode/operator_maintenance_mode_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 			fdbCluster.RunFdbCliCommandInOperator(fmt.Sprintf("maintenance on %s 240", faultDomain), false, 60)
 
 			// Set this Pod as unschedulable to keep it pending.
-			Expect(fdbCluster.SetPodAsUnschedulable(failingStoragePod)).NotTo(HaveOccurred())
+			fdbCluster.SetPodAsUnschedulable(failingStoragePod)
 		})
 
 		AfterEach(func() {

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -595,7 +595,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			clusterSetup(beforeVersion, true)
 			pendingPod := factory.RandomPickOnePod(fdbCluster.GetPods().Items)
 			// Set the pod in pending state.
-			Expect(fdbCluster.SetPodAsUnschedulable(pendingPod)).NotTo(HaveOccurred())
+			fdbCluster.SetPodAsUnschedulable(pendingPod)
 			fdbCluster.UpgradeAndVerify(targetVersion)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s with a pending pod"),


### PR DESCRIPTION
# Description

Improve the reliability of the pod pending test case. We sometimes see that the test is timing out and it seems like the test is failing because the reconciliation is requeue:

```text
2024/11/26 01:41:00 Failed (unscheduled) Pod: operator-test-fdnhokqf-stateless-42898 , Pod to replace: operator-test-fdnhokqf-stateless-93723
...
{"level":"debug","ts":"2024-11-26T01:47:47Z","logger":"events","msg":"cannot: exclude processes, clusters last recovery was 0.00 seconds ago, wait until the last recovery was 1 seconds ago" ....}
# Roughly 4 minute break
{"level":"debug","ts":"2024-11-26T01:51:08Z","logger":"controller","msg":"Deleting pod","namespace":"nightly-2002-operator-test-irgo4uxk","cluster":"operator-test-fdnhokqf","traceID":"9ba8d86f-3d1d-4b79-ba60-09fef6771a49","reconciler":"controllers.removeProcessGroups","name":"operator-test-fdnhokqf-stateless-93723"}
```

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

CI will run the e2e test.

## Documentation

-

## Follow-up

-
