### PR TITLE
Correct init container setup for unified image with backups

### DIFF
--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -3354,6 +3354,17 @@ var _ = Describe("pod_models", func() {
 				Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 
 				Expect(deployment.Spec.Template.Spec.InitContainers[0].Image).To(HavePrefix("foundationdb/foundationdb-kubernetes"))
+				Expect(deployment.Spec.Template.Spec.InitContainers[0].Args).To(ConsistOf(
+					"--copy-file",
+					"fdb.cluster",
+					"--require-not-empty",
+					"fdb.cluster",
+					"--mode",
+					"init",
+					"--output-dir",
+					"/var/output-files",
+					"--input-dir",
+					"/var/input-files"))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(HavePrefix("foundationdb/foundationdb-kubernetes"))
 			})
 		})


### PR DESCRIPTION
# Description

Correct init container setup for unified image with backups.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran the backup e2e test manually:

```text

[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.001 seconds]
------------------------------

Ran 1 of 1 Specs in 182.198 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestOperator (182.20s)
PASS
ok      github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_backups       182.750s
```

## Documentation

-

## Follow-up

-
