### PR TITLE
Correct the failure duration for unavailable checks

### DIFF
--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -391,7 +391,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 			// Keep deleting pods until all clusters are running with the new version.
 			clusters := fdbCluster.GetAllClusters()
-			Eventually(func() bool {
+			Eventually(func(g Gomega) bool {
 				coordinatorMap := map[k8sTypes.UID]corev1.Pod{}
 
 				// Are all clusters running at "targetVersion"?
@@ -405,7 +405,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 					if dbCluster.Status.RunningVersion == targetVersion {
 						log.Println(
-							"Cluster ",
+							"Cluster",
 							cluster.Name(),
 							"is running at version ",
 							targetVersion,
@@ -424,17 +424,17 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 				randomCluster := factory.RandomPickOneCluster(clusters)
 				// Make sure we are not deleting coordinator Pods
 				var randomPod *corev1.Pod
-				Eventually(func() bool {
+				g.Eventually(func() bool {
 					randomPod = factory.ChooseRandomPod(randomCluster.GetPods())
 					_, ok := coordinatorMap[randomPod.UID]
 					if ok {
-						log.Println("Skipping pod: ", randomPod.Name, "as it is a coordinator")
+						log.Println("Skipping pod:", randomPod.Name, "as it is a coordinator")
 					}
 
 					return ok
 				}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(BeFalse())
 
-				log.Println("Deleting pod: ", randomPod.Name)
+				log.Println("Deleting pod:", randomPod.Name)
 				factory.DeletePod(randomPod)
 				return false
 			}).WithTimeout(30 * time.Minute).WithPolling(2 * time.Minute).Should(BeTrue())


### PR DESCRIPTION
# Description

Fix the error reporting for the unavailability checker in cases where the cluster gets available again, e.g.:

```text
  2024/11/29 01:48:16 invariant InvariantClusterStatusAvailableWithThreshold failed for the first time
  2024/11/29 01:48:16 invariant InvariantClusterStatusAvailableWithThreshold failed: cluster is not available
  2024/11/29 01:48:31 invariant InvariantClusterStatusAvailableWithThreshold failed after: 15.223519039s
  2024/11/29 01:48:37 invariant InvariantClusterStatusAvailableWithThreshold failed after: 20.467108341s
  2024/11/29 01:48:44 invariant InvariantClusterStatusAvailableWithThreshold true again

...

Operator Upgrades [AfterEach] upgrading a cluster with a pending pod Upgrade from 7.1.57 to 7.1.63 with a pending pod [e2e, pr]
  [AfterEach] /codebuild/output/src3856629688/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_upgrades/operator_upgrades_test.go:91
  [It] /codebuild/output/src3856629688/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures/upgrade_test_configuration.go:115

  [FAILED] Unexpected error:
      <*errors.errorString | 0xc00af12930>: 
      invariant InvariantClusterStatusAvailableWithThreshold failed for 235ns
      {
          s: "invariant InvariantClusterStatusAvailableWithThreshold failed for 235ns",
      }
  occurred 
```

`invariant InvariantClusterStatusAvailableWithThreshold failed for 235ns` <- Is the wrong duration.

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

-

## Documentation

-

## Follow-up

-
