### PR TITLE
Add the restore state to the restore CRD

### DIFF
--- a/api/v1beta2/foundationdbrestore_types.go
+++ b/api/v1beta2/foundationdbrestore_types.go
@@ -24,6 +24,7 @@ import (
 // +kubebuilder:resource:shortName=fdbrestore
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
 // +kubebuilder:storageversion
 
 // FoundationDBRestore is the Schema for the foundationdbrestores API
@@ -65,7 +66,31 @@ type FoundationDBRestoreSpec struct {
 type FoundationDBRestoreStatus struct {
 	// Running describes whether the restore is currently running.
 	Running bool `json:"running,omitempty"`
+	// State describes the FoundationDBRestoreState state.
+	State FoundationDBRestoreState `json:"state,omitempty"`
 }
+
+// FoundationDBRestoreState represents the states for a restore in FDB:
+// https://github.com/apple/foundationdb/blob/fe47ce24d361a8c2d625c4d549f86ff98363de9e/fdbclient/FileBackupAgent.actor.cpp#L120-L140
+// +kubebuilder:validation:MaxLength=50
+type FoundationDBRestoreState string
+
+const (
+	// UninitializedFoundationDBRestoreState represents the uninitialized state.
+	UninitializedFoundationDBRestoreState FoundationDBRestoreState = "uninitialized"
+	// QueuedFoundationDBRestoreState represents the queued state.
+	QueuedFoundationDBRestoreState FoundationDBRestoreState = "queued"
+	// StartingFoundationDBRestoreState represents the starting state.
+	StartingFoundationDBRestoreState FoundationDBRestoreState = "starting"
+	// RunningFoundationDBRestoreState represents the running state.
+	RunningFoundationDBRestoreState FoundationDBRestoreState = "running"
+	// CompletedFoundationDBRestoreState represents the completed state.
+	CompletedFoundationDBRestoreState FoundationDBRestoreState = "completed"
+	// AbortedFoundationDBRestoreState represents the aborted state.
+	AbortedFoundationDBRestoreState FoundationDBRestoreState = "aborted"
+	// UnknownFoundationDBRestoreState represents the unknown state.
+	UnknownFoundationDBRestoreState FoundationDBRestoreState = "Unknown"
+)
 
 // FoundationDBKeyRange describes a range of keys for a command.
 //

--- a/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
@@ -95,6 +95,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.state
+      name: State
+      type: string
     name: v1beta2
     schema:
       openAPIV3Schema:
@@ -157,6 +160,9 @@ spec:
             properties:
               running:
                 type: boolean
+              state:
+                maxLength: 50
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -70,7 +70,9 @@ func (r *FoundationDBRestoreReconciler) Reconcile(ctx context.Context, request c
 	restoreLog := globalControllerLogger.WithValues("namespace", restore.Namespace, "restore", restore.Name)
 
 	subReconcilers := []restoreSubReconciler{
+		updateRestoreStatus{},
 		startRestore{},
+		updateRestoreStatus{},
 	}
 
 	for _, subReconciler := range subReconcilers {

--- a/controllers/start_restore.go
+++ b/controllers/start_restore.go
@@ -44,6 +44,7 @@ func (s startRestore) reconcile(ctx context.Context, r *FoundationDBRestoreRecon
 		return &requeue{curError: err}
 	}
 
+	// TODO (johscheuer): Change this back later to make use of the restore status in the custom resource.
 	if len(strings.TrimSpace(status)) == 0 {
 		err = adminClient.StartRestore(restore.BackupURL(), restore.Spec.KeyRanges)
 		if err != nil {
@@ -55,6 +56,8 @@ func (s startRestore) reconcile(ctx context.Context, r *FoundationDBRestoreRecon
 		if err != nil {
 			return &requeue{curError: err}
 		}
+
+		return nil
 	}
 
 	return nil

--- a/controllers/start_restore.go
+++ b/controllers/start_restore.go
@@ -44,7 +44,7 @@ func (s startRestore) reconcile(ctx context.Context, r *FoundationDBRestoreRecon
 		return &requeue{curError: err}
 	}
 
-	// TODO (johscheuer): Change this back later to make use of the restore status in the custom resource.
+	// TODO (johscheuer): Make use of the status.state setting to see if the restore was started.
 	if len(strings.TrimSpace(status)) == 0 {
 		err = adminClient.StartRestore(restore.BackupURL(), restore.Spec.KeyRanges)
 		if err != nil {

--- a/controllers/update_restore_status.go
+++ b/controllers/update_restore_status.go
@@ -1,0 +1,77 @@
+/*
+ * update_restore_status.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2018-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import (
+	"context"
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"regexp"
+	"strings"
+)
+
+// updateRestoreStatus provides a reconciliation step for updating the restore status.
+type updateRestoreStatus struct {
+}
+
+// reconcile runs the reconciler's work.
+func (updateRestoreStatus) reconcile(ctx context.Context, r *FoundationDBRestoreReconciler, restore *fdbv1beta2.FoundationDBRestore) *requeue {
+	adminClient, err := r.adminClientForRestore(ctx, restore)
+	if err != nil {
+		return &requeue{curError: err}
+	}
+	defer adminClient.Close()
+
+	status, err := adminClient.GetRestoreStatus()
+	if err != nil {
+		return &requeue{curError: err}
+	}
+
+	parsedState := parseRestoreStatus(status)
+	// If the correct status is already present, we can ignore it.
+	if restore.Status.State == parsedState {
+		return nil
+	}
+
+	restore.Status.State = parsedState
+	err = r.updateOrApply(ctx, restore)
+	if err != nil {
+		return &requeue{curError: err}
+	}
+
+	return nil
+}
+
+// parseRestoreStatus returns the restore state based on the restore status output
+func parseRestoreStatus(status string) fdbv1beta2.FoundationDBRestoreState {
+	if strings.TrimSpace(status) == "" {
+		return fdbv1beta2.UnknownFoundationDBRestoreState
+	}
+
+	statusRe := regexp.MustCompile(`State:\s([\w]*)`)
+	result := statusRe.FindStringSubmatch(status)
+
+	// Expected to find exact one state in the status.
+	if len(result) != 2 {
+		return fdbv1beta2.UnknownFoundationDBRestoreState
+	}
+
+	return fdbv1beta2.FoundationDBRestoreState(result[1])
+}

--- a/controllers/update_restore_status.go
+++ b/controllers/update_restore_status.go
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2018-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2018-2025 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controllers/update_restore_status_test.go
+++ b/controllers/update_restore_status_test.go
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2018-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2018-2025 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/controllers/update_restore_status_test.go
+++ b/controllers/update_restore_status_test.go
@@ -1,0 +1,36 @@
+/*
+ * update_restore_status_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2018-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import (
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("update_restore_status_test", func() {
+	DescribeTable("when parsing the status from the restore status output", func(input string, expected fdbv1beta2.FoundationDBRestoreState) {
+		Expect(parseRestoreStatus(input)).To(Equal(expected))
+	},
+		Entry("empty status", "", fdbv1beta2.UnknownFoundationDBRestoreState),
+		Entry("completed status", "Tag: default  UID: 3213  State: completed  Blocks: 5/5  BlocksInProgress: 0  Files: 74  BytesWritten: 2303  CurrentVersion: 123 FirstConsistentVersion: 321  ApplyVersionLag: 0  LastError: None  URL: blobstore://.. Range: ''-'\xff'  Range: '\xff\x02/blobRange/'-'\xff\x02/blobRange0'  Range: '\xff/metacluster/clusterRegistration'-'\xff/metacluster/clusterRegistration\x00'  Range: '\xff/tagQuota/'-'\xff/tagQuota0'  Range: '\xff/tenant/'-'\xff/tenant0'  AddPrefix: ''  RemovePrefix: ''  Version: 123", fdbv1beta2.CompletedFoundationDBRestoreState),
+	)
+})

--- a/docs/manual/backup.md
+++ b/docs/manual/backup.md
@@ -1,6 +1,8 @@
 # Managing Backups through the Operator
 
-FoundationDB has out-of-the-box support for backing up to an S3-compatible object store, and the operator supports this through a special resource type for backup and restore. These backups run continuously, and simultaneously build new snapshots while backing up new mutations. You can restore to any point in time after the end of the first snapshot.
+FoundationDB has out-of-the-box support for backing up to an S3-compatible object store, and the operator supports this through a special resource type for backup and restore.
+These backups run continuously, and simultaneously build new snapshots while backing up new mutations.
+You can restore to any point in time after the end of the first snapshot.
 
 You can find more information about the backup feature in the [FoundationDB Backup documentation](https://apple.github.io/foundationdb/backups.html).
 
@@ -10,7 +12,8 @@ You can find more information about the backup feature in the [FoundationDB Back
 
 This is a sample configuration for running a continuous backup of a cluster.
 
-This sample assumes some configuration that you will need to fill in based on the details of your environment. Those assumptions are explained in comments below.
+This sample assumes some configuration that you will need to fill in based on the details of your environment.
+Those assumptions are explained in comments below.
 
 ```yaml
 apiVersion: apps.foundationdb.org/v1beta2
@@ -118,11 +121,13 @@ spec:
 
 ## Configuring the Operator
 
-The operator will run `fdbbackup` commands to manage the backup, so the operator needs to have access to the object store as well. You can configure that access the same way as you do for the backup agents, by defining the environment variables `FDB_BLOB_CREDENTIALS`, `FDB_TLS_CERTIFICATE_FILE`, `FDB_TLS_KEY_FILE`, and `FDB_TLS_CA_FILE`.
+The operator will run `fdbbackup` commands to manage the backup, so the operator needs to have access to the object store as well.
+You can configure that access the same way as you do for the backup agents, by defining the environment variables `FDB_BLOB_CREDENTIALS`, `FDB_TLS_CERTIFICATE_FILE`, `FDB_TLS_KEY_FILE`, and `FDB_TLS_CA_FILE`.
 
 ## Restoring a Backup
 
-You can start a restore by creating a restore object. Here is an example restore, using the same account as the backup example above:
+You can start a restore by creating a restore object.
+Here is an example restore, using the same account as the backup example above:
 
 ```yaml
 apiVersion: apps.foundationdb.org/v1beta2
@@ -137,9 +142,107 @@ spec:
     bucketName: bucket=fdb-backups
 ```
 
-This will tell the operator to run an `fdbrestore` command targeting the cluster `sample-cluster`. The cluster must be empty before this command can be run. This will restore to the last restorable point in the backup you are using, and will restore the entire keyspace.
+This will tell the operator to run an `fdbrestore` command targeting the cluster `sample-cluster`. The cluster must be empty before this command can be run.
+This will restore to the last restorable point in the backup you are using, and will restore the entire keyspace.
 
 You can track the progress of the restore through the `fdbrestore status` command. The destination cluster will be locked until the restore completes.
+
+### Backup agents for restore
+
+When you start the restore against a new cluster, you have to ensure that backup agents are created by the `operator`.
+If you don't want to backup the cluster directly you can add the `backupState: Stopped` under the `BackupSpec`, this will ensure that the backup agents are created but no backup is started:
+
+```yaml
+apiVersion: apps.foundationdb.org/v1beta2
+kind: FoundationDBBackup
+metadata:
+  name: sample-cluster
+spec:
+  backupState: Stopped
+  version: 7.1.26
+  clusterName: sample-cluster
+  blobStoreConfiguration:
+    accountName: account@object-store.example:443
+  podTemplateSpec:
+    spec:
+      volumes:
+        - name: backup-credentials
+          secret:
+            secretName: backup-credentials
+        - name: fdb-certs
+          secret:
+            secretName: fdb-certs
+      containers:
+        - name: foundationdb
+          env:
+            - name: FDB_BLOB_CREDENTIALS
+              value: /var/backup-credentials/credentials
+            - name: FDB_TLS_CERTIFICATE_FILE
+              value: /var/fdb-certs/cert.pem
+            - name: FDB_TLS_CA_FILE
+              value: /var/fdb-certs/ca.pem
+            - name: FDB_TLS_KEY_FILE
+              value: /var/fdb-certs/key.pem
+          volumeMounts:
+            - name: fdb-certs
+              mountPath: /var/fdb-certs
+            - name: backup-credentials
+              mountPath: /var/backup-credentials
+```
+
+### Debugging restores
+
+In some cases it can happen that a restore is not properly started, in this case look at the operator logs for the according `FoundationDBRestore` resource.
+Look for a message like `"Error from FDB command"` and verify the `stdout` of the command, if the destination cluster is not empty the restore command will return an error:
+
+```text
+No restore target version given, will use maximum restorable version from backup description.
+Using target restore version 123
+Backup Description
+URL: blobstore://my-awesome-blobstore
+Restorable: true
+Partitioned logs: false
+...
+Restoring backup to version: 123
+ERROR: Attempted to restore into a non-empty destination database
+Fatal Error: Attempted to restore into a non-empty destination database
+```
+
+In this case check the content of the cluster e.g. by running:
+
+```text
+fdb> getrange "" \xff
+
+Range limited to 25 keys
+...
+```
+
+If the data is not required and should be removed run the following command:
+**WARNING**: This will delete all user data from the cluster and cannot be undone.
+
+```text
+fdb> writemode on; clearrange "" \xff
+```
+
+After this check again that the cluster is empty:
+
+```text
+fdb> getrange "" \xff
+
+Range limited to 25 keys
+```
+
+### Confirm restore is complete
+
+You can run the `fdbrestore` command inside any FDB pod:
+
+```text
+$ fdbrestore status --dest_cluster_file ${FDB_CLUSTER_FILE}
+Tag: default  UID: ...  State: completed  ...
+```
+
+The output will contain additional information about the restore, but the most interesting one is the `state`.
+Once the restore is complete, the `state` changes to `completed`.
 
 ## Next
 

--- a/docs/restore_spec.md
+++ b/docs/restore_spec.md
@@ -58,6 +58,12 @@ FoundationDBRestoreSpec describes the desired state of the backup for a cluster.
 
 [Back to TOC](#table-of-contents)
 
+## FoundationDBRestoreState
+
+FoundationDBRestoreState represents the states for a restore in FDB: https://github.com/apple/foundationdb/blob/fe47ce24d361a8c2d625c4d549f86ff98363de9e/fdbclient/FileBackupAgent.actor.cpp#L120-L140
+
+[Back to TOC](#table-of-contents)
+
 ## FoundationDBRestoreStatus
 
 FoundationDBRestoreStatus describes the current status of the restore for a cluster.
@@ -65,6 +71,7 @@ FoundationDBRestoreStatus describes the current status of the restore for a clus
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | running | Running describes whether the restore is currently running. | bool | false |
+| state | State describes the FoundationDBRestoreState state. | [FoundationDBRestoreState](#foundationdbrestorestate) | false |
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
# Description

Adding some additional visibility to the restore state and add additional docs on how to debug a stuck restore.

## Type of change

- New feature (non-breaking change which adds functionality)


## Discussion

-

## Testing

Updated the e2e test and ran it manually:

```text
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.003 seconds]
------------------------------

Ran 1 of 1 Specs in 222.060 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestOperator (222.06s)
PASS
ok      github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_backups       222.673s
```

## Documentation

-

## Follow-up

-
