### PR TITLE
Add a new label for running a quick upgrade test case

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -131,6 +131,20 @@ nightly-tests: GINKGO_LABEL_FILTER=--ginkgo.label-filter="pr || nightly"
 # Run the actual nightly tests
 nightly-tests: run
 
+# Only run tests that are labeled with the "foundationdb-pr" label, this is used for the cluster tests in the
+# foundationdb repo.
+foundationdb-pr-tests: GINKGO_LABEL_FILTER=--ginkgo.label-filter="foundationdb-pr"
+
+# Run the actual foundationdb-pr tests.
+foundationdb-pr-tests: run
+
+# Only run tests that are labeled with the "foundationdb-nightly" or "foundationdb-pr"  label, this is used for the cluster tests in the
+# foundationdb repo.
+foundationdb-nightly-tests: GINKGO_LABEL_FILTER=--ginkgo.label-filter="foundationdb-pr || foundationdb-nightly"
+
+# Run the actual foundationdb-nightly tests.
+foundationdb-nightly-tests: run
+
 %.run: %
 	@sleep $$(shuf -i 1-10 -n 1)
 	go test -timeout=$(TIMEOUT) $(VERBOSE) ./$< \

--- a/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
+++ b/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 	// this setup allows to dynamically generate the table entries that will be executed e.g. to test different upgrades
 	// for different versions without hard coding or having multiple flags.
 	DescribeTable(
-		"upgrading a cluster without chaos", Label("quick"),
+		"upgrading a cluster without chaos", Label("foundationdb-pr"),
 		func(beforeVersion string, targetVersion string) {
 			performUpgrade(testConfig{
 				beforeVersion: beforeVersion,

--- a/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
+++ b/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 	// this setup allows to dynamically generate the table entries that will be executed e.g. to test different upgrades
 	// for different versions without hard coding or having multiple flags.
 	DescribeTable(
-		"upgrading a cluster without chaos",
+		"upgrading a cluster without chaos", Label("quick"),
 		func(beforeVersion string, targetVersion string) {
 			performUpgrade(testConfig{
 				beforeVersion: beforeVersion,


### PR DESCRIPTION
# Description

Adding a new Ginkgo label for running a single test (right now) to perform an upgrade/downgrade test. In the future we could be adding more test cases.

## Type of change

- Other

## Discussion

-

## Testing

Manually ran the tests with an e2e test selector.

## Documentation

-

## Follow-up

-
