### PR TITLE
Allow to modify the e2e peer verification string

### DIFF
--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -103,6 +103,8 @@ type ClusterConfig struct {
 	Namespace string
 	// Name of the cluster to be created, if empty a random name will be used.
 	Name string
+	// TLSPeerVerification represents the TLS peer verification that should be used for the cluster.
+	TLSPeerVerification string
 	// cloudProvider defines the cloud provider used to create the Kubernetes cluster. This value is set in the SetDefaults
 	// method.
 	cloudProvider cloudProvider
@@ -165,6 +167,10 @@ func (config *ClusterConfig) SetDefaults(factory *Factory) {
 
 	if config.cloudProvider == "" {
 		config.cloudProvider = cloudProvider(factory.options.cloudProvider)
+	}
+
+	if config.TLSPeerVerification == "" {
+		config.TLSPeerVerification = "I.CN=localhost,I.O=Example Inc.,S.CN=localhost,S.O=Example Inc."
 	}
 }
 

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -281,7 +281,7 @@ func (factory *Factory) createPodTemplate(
 						},
 						{
 							Name:  fdbv1beta2.EnvNameTLSVerifyPeers,
-							Value: "I.CN=localhost,I.O=Example Inc.,S.CN=localhost,S.O=Example Inc.",
+							Value: config.TLSPeerVerification,
 						},
 					},
 					VolumeMounts: []corev1.VolumeMount{

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -234,7 +234,7 @@ func (factory *Factory) createPodTemplate(
 						},
 						{
 							Name:  fdbv1beta2.EnvNameTLSVerifyPeers,
-							Value: "I.CN=localhost,I.O=Example Inc.,S.CN=localhost,S.O=Example Inc.",
+							Value: config.TLSPeerVerification,
 						},
 						{
 							Name:  fdbv1beta2.EnvNameFDBTraceLogDirPath,


### PR DESCRIPTION
# Description

Allow to set the peer verification string in the cluster config for testing different peer verification strings.

## Type of change

- Other

## Discussion

-

## Testing

Ran unit tests CI will run e2e tests.

## Documentation

-

## Follow-up

-
