### PR TITLE
Ensure reconcilation is requeued for restore controller if the restore is not completed

### DIFF
--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -25,15 +25,12 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
-
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
-	"k8s.io/utils/pointer"
-
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/fdbadminclient/mock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("admin_client_test", func() {
@@ -372,30 +369,29 @@ var _ = Describe("admin_client_test", func() {
 	})
 
 	Describe("restore status", func() {
-		var status string
+		var restoreStatus string
 
 		Context("with no restore running", func() {
 			BeforeEach(func() {
-				status, err = mockAdminClient.GetRestoreStatus()
+				restoreStatus, err = mockAdminClient.GetRestoreStatus()
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should be empty", func() {
-				Expect(status).To(Equal("\n"))
+				Expect(restoreStatus).To(BeEmpty())
 			})
 		})
 
 		Context("with a restore running", func() {
 			BeforeEach(func() {
-				err = mockAdminClient.StartRestore("blobstore://test@test-service/test-backup", nil)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(mockAdminClient.StartRestore("blobstore://test@test-service/test-backup", nil)).To(Succeed())
 
-				status, err = mockAdminClient.GetRestoreStatus()
+				restoreStatus, err = mockAdminClient.GetRestoreStatus()
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should contain the backup URL", func() {
-				Expect(status).To(Equal("blobstore://test@test-service/test-backup\n"))
+				Expect(restoreStatus).To(ContainSubstring("blobstore://test@test-service/test-backup\n"))
 			})
 		})
 	})

--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -391,7 +391,7 @@ var _ = Describe("admin_client_test", func() {
 			})
 
 			It("should contain the backup URL", func() {
-				Expect(restoreStatus).To(ContainSubstring("blobstore://test@test-service/test-backup\n"))
+				Expect(restoreStatus).To(ContainSubstring("blobstore://test@test-service/test-backup"))
 			})
 		})
 	})

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -91,7 +91,7 @@ var _ = Describe("restore_controller", func() {
 			It("should start a restore", func() {
 				status, err := adminClient.GetRestoreStatus()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(status).To(ContainSubstring("blobstore://test@test-service:443/test-backup?bucket=fdb-backups\n"))
+				Expect(status).To(ContainSubstring("blobstore://test@test-service:443/test-backup?bucket=fdb-backups"))
 			})
 		})
 

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -83,18 +83,15 @@ var _ = Describe("restore_controller", func() {
 			result, err := reconcileRestore(restore)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
-
-			err = reloadRestore(restore)
-			Expect(err).NotTo(HaveOccurred())
-			err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: restore.Namespace, Name: restore.Name}, cluster)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(reloadRestore(restore)).To(Succeed())
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: restore.Namespace, Name: restore.Name}, cluster)).To(Succeed())
 		})
 
-		Context("when reconciling a new restore", func() {
+		When("reconciling a new restore", func() {
 			It("should start a restore", func() {
 				status, err := adminClient.GetRestoreStatus()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(status).To(Equal("blobstore://test@test-service:443/test-backup?bucket=fdb-backups\n"))
+				Expect(status).To(ContainSubstring("blobstore://test@test-service:443/test-backup?bucket=fdb-backups\n"))
 			})
 		})
 
@@ -103,8 +100,7 @@ var _ = Describe("restore_controller", func() {
 				restore.Spec.CustomParameters = fdbv1beta2.FoundationDBCustomParameters{
 					"knob_http_verbose_level=3",
 				}
-				err = k8sClient.Update(context.TODO(), restore)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Update(context.TODO(), restore)).To(Succeed())
 			})
 
 			It("should append the custom parameters to the command", func() {

--- a/e2e/fixtures/fdb_restore.go
+++ b/e2e/fixtures/fdb_restore.go
@@ -23,9 +23,10 @@ package fixtures
 import (
 	"context"
 	"log"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	"github.com/onsi/gomega"
@@ -84,6 +85,16 @@ func waitForRestoreToComplete(backup *FdbBackup) {
 				context.Background(),
 				restore,
 				patch)).To(gomega.Succeed())
+
+			out, _, err := backup.fdbCluster.ExecuteCmdOnPod(
+				*backup.GetBackupPod(),
+				fdbv1beta2.MainContainerName,
+				"fdbrestore status --dest_cluster_file $FDB_CLUSTER_FILE",
+				false,
+			)
+
+			log.Println(out)
+			g.Expect(err).To(gomega.Succeed())
 		}
 
 		return restore.Status.State

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -905,7 +905,11 @@ func (client *AdminClient) GetRestoreStatus() (string, error) {
 		return "", client.mockError
 	}
 
-	return fmt.Sprintf("%s\n", client.restoreURL), nil
+	if client.restoreURL == "" {
+		return "", nil
+	}
+
+	return fmt.Sprintf("%s, State: completed\n", client.restoreURL), nil
 }
 
 // MockClientVersion returns a mocked client version


### PR DESCRIPTION
# Description

Ensure the the restore controller requeues the restore resource if the restore is not completed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran the backup e2e tests manually.

## Documentation

-

## Follow-up

-
