### PR TITLE
Privateclusterfile

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -687,8 +687,7 @@ func (client *cliAdminClient) GetRestoreStatus() (string, error) {
 
 // Close cleans up any pending resources.
 func (client *cliAdminClient) Close() error {
-	// Allow to reuse the same file.
-	return nil
+	return os.Remove(client.clusterFilePath)
 }
 
 // GetCoordinatorSet gets the current coordinators from the status

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -490,17 +490,11 @@ func (client *cliAdminClient) ChangeCoordinators(addresses []fdbv1beta2.ProcessA
 	if err != nil {
 		return "", err
 	}
-
-	connectionStringBytes, err := os.ReadFile(client.clusterFilePath)
+	connectionString, err := client.GetConnectionString()
 	if err != nil {
 		return "", err
 	}
-
-	connectionString, err := fdbv1beta2.ParseConnectionString(string(connectionStringBytes))
-	if err != nil {
-		return "", err
-	}
-	return connectionString.String(), nil
+	return connectionString, nil
 }
 
 // cleanConnectionStringOutput is a helper method to remove unrelated output from the get command in the connection string

--- a/fdbclient/common_test.go
+++ b/fdbclient/common_test.go
@@ -44,35 +44,7 @@ var _ = Describe("common_test", func() {
 
 		When("the cluster file doesn't exist", func() {
 			It("should create the cluster file with the correct content", func() {
-				Expect(clusterFile).To(Equal(path.Join(tmpDir, uid)))
-				content, err := os.ReadFile(clusterFile)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(content)).To(Equal(connectionString))
-			})
-		})
-
-		When("the cluster file exist with the wrong content", func() {
-			BeforeEach(func() {
-				err := os.WriteFile(path.Join(os.TempDir(), uid), []byte("wrong"), 0777)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("should update the cluster file with the correct content", func() {
-				Expect(clusterFile).To(Equal(path.Join(tmpDir, uid)))
-				content, err := os.ReadFile(clusterFile)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(content)).To(Equal(connectionString))
-			})
-		})
-
-		When("the cluster file exist with the correct content", func() {
-			BeforeEach(func() {
-				err := os.WriteFile(path.Join(os.TempDir(), uid), []byte(connectionString), 0777)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("should keep the cluster file with the correct content", func() {
-				Expect(clusterFile).To(Equal(path.Join(tmpDir, uid)))
+				Expect(clusterFile).To(HavePrefix(path.Join(tmpDir, uid+"-")))
 				content, err := os.ReadFile(clusterFile)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(content)).To(Equal(connectionString))


### PR DESCRIPTION
# Description

FoundationDB Operator creates cluster files in the temp directory so that fdbcli and the FoundationDB client library can connect to the cluster. The cluster file name is deterministically derived from the cluster UID.

Three different actors write to and read from this file without synchronization:

1. fdbcli whenever it learns from the cluster that the connection string has changed,
2. the FDB client library whenever it learns from the cluster that the connection string has changed,
3. FoundationDB Operator when setting up a new admin client.  tryConnectionOptions() routinely writes the outdated seed connection string into the file in case of transient errors, without actively restoring the correct one.

While the cluster controller is single-threaded, the library may be writing in the background. Since introduction of backup and restore controllers, there can be multiple active instances of admin client at the same time. The cluster controller is holding an instance of admin client while the subreconcilers are creating other instances, though I think it is inactive during reconciliation and this last point is not an actual problem.

If a race occurs, e.g. the reader finds the cluster file in a transient state where the file is truncated or temporarily overwritten with the now-invalid seed connection string, or a writer overwrites a legitimate new file), this could go wrong. For example, when changing coordinators, we read back the file after fdbcli exits, assuming it contains the new connection string. 

To prevent this class of problems, the proposed change will create a unique cluster file for each instance of admin client and delete it when done. It instantiates a singleton database instance with its private cluster file for each cluster UID and keeps it around. To be extra safe, read the new connection string from the cluster instead of from the cluster file after changing coordinators to get an authoritative result.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

We experienced an incident where the operator and subsequently all clients lost contact with the cluster, and I believe this was due to such a race. We have seen connection strings running out of sync before in a less catastrophic way. Our setup is a bit unusual and maybe that exposes us more than others: Our cluster runs in three_data_hall mode, which means a "cluster"'s coordinators are occasionally changing unexpectedly because we change coordinators on another data hall - the three "clusters" are a single FDB cluster with a shared coordinator set after all. And we are running coordinators on dedicated servers, using a custom class, so the servers actually shut down after losing the coordinator role.

The singleton database may be a bit confusing, because the FDB client library internally keeps a singleton map like this, too.  They use the cluster file name as key. We need this because with the unique cluster file names, we'd now create more and more databases in the library's cache that never get cleaned up, leading to a memory leak.  Alternative approaches could be to keep a single cluster file for the library, and only use temporary files for fdbcli invocations. We could ask the cluster (via the libarary) for the current connection string each time to write a guaranteed-correct cluster file for fdbcli. These are more involved code changes, please advise.

## Testing

Unit tests pass. Still working on my local e2e test setup.

Does this change look reasonable? Then I can try it in our staging systems for a while.

## Documentation

n/a

## Follow-up

n/a
