### PR TITLE
Configure TLSPolicy to allow connection to s3.

### DIFF
--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -1615,7 +1615,7 @@ func (fdbCluster *FdbCluster) CreateTesterDeployment(replicas int) *appsv1.Deplo
 								},
 								{
 									Name:  fdbv1beta2.EnvNameTLSVerifyPeers,
-									Value: "I.CN=localhost,I.O=Example Inc.,S.CN=localhost,S.O=Example Inc.",
+									Value: "I.CN=localhost,I.O=Example Inc.,S.CN=localhost,S.O=Example Inc.|Subject.CN=*.s3-us-west-2.amazonaws.com",
 								},
 								{
 									Name:  fdbv1beta2.EnvNameFDBTraceLogDirPath,

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -234,7 +234,7 @@ func (factory *Factory) createPodTemplate(
 						},
 						{
 							Name:  fdbv1beta2.EnvNameTLSVerifyPeers,
-							Value: "I.CN=localhost,I.O=Example Inc.,S.CN=localhost,S.O=Example Inc.",
+							Value: "I.CN=localhost,I.O=Example Inc.,S.CN=localhost,S.O=Example Inc.|Subject.CN=*.s3-us-west-2.amazonaws.com",
 						},
 						{
 							Name:  fdbv1beta2.EnvNameFDBTraceLogDirPath,
@@ -281,7 +281,7 @@ func (factory *Factory) createPodTemplate(
 						},
 						{
 							Name:  fdbv1beta2.EnvNameTLSVerifyPeers,
-							Value: "I.CN=localhost,I.O=Example Inc.,S.CN=localhost,S.O=Example Inc.",
+							Value: "I.CN=localhost,I.O=Example Inc.,S.CN=localhost,S.O=Example Inc.|Subject.CN=*.s3-us-west-2.amazonaws.com",
 						},
 					},
 					VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
Connections fail with

`{"Severity":"20","Time":"1738351052.623735","DateTime":"2025-01-31T19:17:32Z","Type":"TLSPolicyFailure00","ID":"0000000000000000","SuppressedEventCount":"0","PeerAddress":"X.X.X.X:443:tls(fromHostname)","Reason":"Rule.Cert.Subject.Name.NameMismatch[Name=CN = *.s3-us-west-2.amazonaws.com]","Rule":"Rule{ verify_cert=1, verify_time=1, Subject=[ { NID=13, Criteria=localhost}, { NID=17, Criteria=Example Inc.}, ], Issuer=[ { NID=13, Criteria=localhost}, { NID=17, Criteria=Example Inc.}, ], Root=[ ] }","ThreadID":"5910391733478456937","Machine":"X.X.X.X:4503","LogGroup":"stack-bulkload-s","Roles":"SS"}`

With this PR in place, the TLS succeeds with:

`{"Severity":"10","Time":"1738350130.244901","DateTime":"2025-01-31T19:02:10Z","Type":"TLSPolicySuccess","ID":"0000000000000000","SuppressedEventCount":"0","PeerAddress":"X.X.X.X:443:tls(fromHostname)","Reason":"Rule matched successfully","ThreadID":"14264278264711433099","Machine":"X.X.X.X:4503","LogGroup":"stack-bulkload-s","Roles":"SS"}`
