### PR TITLE
Check if the newly added process group ID is already excluded

### DIFF
--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -5809,4 +5809,51 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			})
 		})
 	})
+
+	When("validating if the new process group ID is allowed", func() {
+		var valid bool
+		var cluster *FoundationDBCluster
+		var exclusions map[ProcessGroupID]None
+
+		JustBeforeEach(func() {
+			valid = cluster.newProcessGroupIDAllowed(ProcessGroupID("storage-1"), exclusions)
+		})
+
+		When("no process group is marked for removal or excluded", func() {
+			BeforeEach(func() {
+				cluster = &FoundationDBCluster{}
+			})
+
+			It("should detect the new process group ID as valid", func() {
+				Expect(valid).To(BeTrue())
+			})
+		})
+
+		When("the process group is marked for removal", func() {
+			BeforeEach(func() {
+				cluster = &FoundationDBCluster{
+					Spec: FoundationDBClusterSpec{
+						ProcessGroupsToRemove: []ProcessGroupID{ProcessGroupID("storage-1")},
+					},
+				}
+			})
+
+			It("should detect the new process group ID as invalid", func() {
+				Expect(valid).To(BeFalse())
+			})
+		})
+
+		When("the process group is excluded", func() {
+			BeforeEach(func() {
+				cluster = &FoundationDBCluster{}
+				exclusions = map[ProcessGroupID]None{
+					ProcessGroupID("storage-1"): {},
+				}
+			})
+
+			It("should detect the new process group ID as invalid", func() {
+				Expect(valid).To(BeFalse())
+			})
+		})
+	})
 })


### PR DESCRIPTION
# Description

Fixes:  https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1862

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

This change improves the add process group subreconciler to not pick an already excluded process group ID. In general those cases should be rare but it's better to not use the process group ID if the locality was already excluded, e.g. manually, otherwise the new process group will be created and then replaced.

## Testing

Added new unit tests.

## Documentation

N/A

## Follow-up

-
