### PR TITLE
Ensure that the tag suffix is only added when it is missing

### DIFF
--- a/e2e/fixtures/options.go
+++ b/e2e/fixtures/options.go
@@ -333,6 +333,12 @@ func getTagSuffix(isSidecar bool) string {
 // getTagWithSuffix returns the tag with the required suffix if the image is needed for the sidecar image.
 func getTagWithSuffix(tag string, isSidecar bool) string {
 	if tag != "" && isSidecar {
+		tagSuffix := getTagSuffix(isSidecar)
+		// Suffix is already present, so we don't have to add it again.
+		if strings.HasSuffix(tag, tagSuffix) {
+			return tag
+		}
+
 		return tag + getTagSuffix(isSidecar)
 	}
 


### PR DESCRIPTION
# Description

Ensure that the tag suffix is only added when it is missing. This should prevent cases like `sidecar-1-1`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran some manual e2e tests for this.

## Documentation

-

## Follow-up

-
