### PR TITLE
Streamline lock client usage

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -135,7 +135,7 @@ func (c bounceProcesses) reconcile(_ context.Context, r *FoundationDBClusterReco
 		}
 	}
 
-	_, err = r.takeLock(logger, cluster, fmt.Sprintf("bouncing processes: %v", addresses))
+	err = r.takeLock(logger, cluster, fmt.Sprintf("bouncing processes: %v", addresses))
 	if err != nil {
 		return &requeue{curError: err}
 	}

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -75,7 +75,7 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 		return nil
 	}
 
-	_, err = r.takeLock(logger, cluster, "changing coordinators")
+	err = r.takeLock(logger, cluster, "changing coordinators")
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -467,22 +467,14 @@ func (r *FoundationDBClusterReconciler) getLockClient(logger logr.Logger, cluste
 }
 
 // takeLock attempts to acquire a lock.
-func (r *FoundationDBClusterReconciler) takeLock(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, action string) (bool, error) {
+func (r *FoundationDBClusterReconciler) takeLock(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, action string) error {
 	logger.Info("Taking lock on cluster", "action", action)
 	lockClient, err := r.getLockClient(logger, cluster)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	hasLock, err := lockClient.TakeLock()
-	if err != nil {
-		return false, err
-	}
-
-	if !hasLock {
-		r.Recorder.Event(cluster, corev1.EventTypeNormal, "LockAcquisitionFailed", fmt.Sprintf("Lock required before %s", action))
-	}
-	return hasLock, nil
+	return lockClient.TakeLock()
 }
 
 // releaseLock attempts to release a lock.

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -73,12 +73,7 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 
 	// Make sure the exclusions are coordinated across multiple operator instances.
 	if cluster.ShouldUseLocks() {
-		lockClient, err := r.getLockClient(logger, cluster)
-		if err != nil {
-			return &requeue{curError: err}
-		}
-
-		_, err = lockClient.TakeLock()
+		err = r.takeLock(logger, cluster, "exclude processes")
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -90,8 +90,8 @@ func (c maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBClus
 	}
 
 	// Make sure we take a lock before we continue.
-	hasLock, err := r.takeLock(logger, cluster, "maintenance mode check")
-	if !hasLock {
+	err = r.takeLock(logger, cluster, "maintenance mode check")
+	if err != nil {
 		return &requeue{curError: err}
 	}
 

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -278,12 +278,7 @@ func includeProcessGroup(ctx context.Context, logger logr.Logger, r *FoundationD
 
 	// Make sure the inclusion are coordinated across multiple operator instances.
 	if cluster.ShouldUseLocks() {
-		lockClient, err := r.getLockClient(logger, cluster)
-		if err != nil {
-			return err
-		}
-
-		_, err = lockClient.TakeLock()
+		err = r.takeLock(logger, cluster, "remove process groups")
 		if err != nil {
 			return err
 		}

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -95,9 +95,9 @@ func (u updateDatabaseConfiguration) reconcile(_ context.Context, r *FoundationD
 		}
 
 		if !initialConfig {
-			hasLock, err := r.takeLock(logger, cluster,
+			err := r.takeLock(logger, cluster,
 				fmt.Sprintf("reconfiguring the database to `%s`", configurationString))
-			if !hasLock {
+			if err != nil {
 				return &requeue{curError: err, delayedRequeue: true}
 			}
 		}

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -377,7 +377,7 @@ func deletePodsForUpdates(ctx context.Context, r *FoundationDBClusterReconciler,
 	// Only lock the cluster if we are not running in the delete "All" mode.
 	// Otherwise, we want to delete all Pods and don't require a lock to sync with other clusters.
 	if deletionMode != fdbv1beta2.PodUpdateModeAll {
-		_, err := r.takeLock(logger, cluster, "updating pods")
+		err := r.takeLock(logger, cluster, "updating pods")
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -120,7 +120,7 @@ func (client *realLockClient) takeLockInTransaction(transaction fdb.Transaction)
 	newOwnerDenied := transaction.Get(client.getDenyListKey(ownerID)).MustGet() != nil
 	if newOwnerDenied {
 		logger.Info("Failed to get lock due to deny list")
-		return nil
+		return fmt.Errorf("failed to get lock due to deny list, owner ID: %s is on deny list", ownerID)
 	}
 
 	oldOwnerDenied := transaction.Get(client.getDenyListKey(currentLockOwnerID)).MustGet() != nil

--- a/pkg/fdbadminclient/lock_client.go
+++ b/pkg/fdbadminclient/lock_client.go
@@ -30,7 +30,7 @@ type LockClient interface {
 	Disabled() bool
 
 	// TakeLock attempts to acquire a lock.
-	TakeLock() (bool, error)
+	TakeLock() error
 
 	// ReleaseLock will release the current lock. The method will only release the lock if the current
 	// operator is the lock holder.

--- a/pkg/fdbadminclient/mock/lock_client.go
+++ b/pkg/fdbadminclient/mock/lock_client.go
@@ -43,8 +43,8 @@ type LockClient struct {
 }
 
 // TakeLock attempts to acquire a lock.
-func (client *LockClient) TakeLock() (bool, error) {
-	return true, nil
+func (client *LockClient) TakeLock() error {
+	return nil
 }
 
 // Disabled determines if the client should automatically grant locks.

--- a/pkg/fdbadminclient/mock/lock_client_test.go
+++ b/pkg/fdbadminclient/mock/lock_client_test.go
@@ -40,9 +40,7 @@ var _ = Describe("lock_client_test", func() {
 
 	Describe("TakeLock", func() {
 		It("returns true", func() {
-			success, err := lockClient.TakeLock()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(success).To(BeTrue())
+			Expect(lockClient.TakeLock()).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
# Description

This PR changes the lock client interface and not getting a lock will result in an error too. We could create a dedicated error type for this, but I think it's easier to work with the lock client this way instead of having two values which were checked differently.

Based on https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2212

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Unit tests + CI e2e

## Documentation

-

## Follow-up

-
