### PR TITLE
Ensure that the ConfigMap name for the cluster can't be modified

### DIFF
--- a/internal/configmap_helper.go
+++ b/internal/configmap_helper.go
@@ -130,13 +130,13 @@ func getConfigMapMetadata(cluster *fdbv1beta2.FoundationDBCluster) metav1.Object
 		metadata = GetObjectMetadata(cluster, nil, "", "")
 	}
 
-	if metadata.Name == "" {
-		metadata.Name = fmt.Sprintf("%s-config", cluster.Name)
-	} else {
-		metadata.Name = fmt.Sprintf("%s-%s", cluster.Name, metadata.Name)
-	}
+	metadata.Name = getConfigMapName(cluster.Name)
 
 	return metadata
+}
+
+func getConfigMapName(clusterName string) string {
+	return fmt.Sprintf("%s-config", clusterName)
 }
 
 func getDataForMonitorConf(cluster *fdbv1beta2.FoundationDBCluster, imageType fdbv1beta2.ImageType, pClass fdbv1beta2.ProcessClass, serversPerPod int) (string, []byte, error) {

--- a/internal/configmap_helper_test.go
+++ b/internal/configmap_helper_test.go
@@ -314,20 +314,6 @@ var _ = Describe("configmap_helper", func() {
 			})
 		})
 
-		Context("with a custom configmap", func() {
-			BeforeEach(func() {
-				cluster.Spec.ConfigMap = &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "name1",
-					},
-				}
-			})
-
-			It("should use the configmap name as suffix", func() {
-				Expect(configMap.Name).To(Equal(fmt.Sprintf("%s-%s", cluster.Name, "name1")))
-			})
-		})
-
 		Context("without a configmap", func() {
 			It("should use the default suffix", func() {
 				Expect(configMap.Name).To(Equal(fmt.Sprintf("%s-%s", cluster.Name, "config")))

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -303,7 +303,7 @@ var _ = Describe("pod_models", func() {
 			It("should have the sidecar container", func() {
 				sidecarContainer := spec.Containers[1]
 				Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainerName))
-				Expect(sidecarContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
+				Expect(sidecarContainer.Image).To(Equal(fmt.Sprintf("%s:%s-1", fdbv1beta2.FoundationDBSidecarBaseImage, cluster.Spec.Version)))
 				Expect(sidecarContainer.Args).To(Equal([]string{
 					"--copy-file",
 					"fdb.cluster",
@@ -2386,18 +2386,6 @@ var _ = Describe("pod_models", func() {
 			})
 		})
 
-		Context("with custom map", func() {
-			BeforeEach(func() {
-				cluster.Spec.ConfigMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "config1"}}
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("adds config-map volume that refers to custom map", func() {
-				Expect(spec.Volumes[2].VolumeSource.ConfigMap.LocalObjectReference.Name).To(Equal(fmt.Sprintf("%s-%s", cluster.Name, "config1")))
-			})
-		})
-
 		Context("with no custom map", func() {
 			BeforeEach(func() {
 				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
@@ -3374,7 +3362,7 @@ var _ = Describe("pod_models", func() {
 				Expect(deployment.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 				Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 
-				Expect(deployment.Spec.Template.Spec.InitContainers[0].Image).To(HavePrefix("foundationdb/foundationdb-kubernetes"))
+				Expect(deployment.Spec.Template.Spec.InitContainers[0].Image).To(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage))
 				Expect(deployment.Spec.Template.Spec.InitContainers[0].Args).To(ConsistOf(
 					"--copy-file",
 					"fdb.cluster",
@@ -3386,7 +3374,7 @@ var _ = Describe("pod_models", func() {
 					"/var/output-files",
 					"--input-dir",
 					"/var/input-files"))
-				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(HavePrefix("foundationdb/foundationdb-kubernetes"))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage))
 			})
 		})
 	})


### PR DESCRIPTION
# Description

Ensure that the ConfigMap name for the cluster can't be modified. Before this change the `ConfigMap` name could be changed but those changes had a few issues and bugs, so it's better to completely remote this option and ensure that the `ConfigMap` name is always the same. Also fixed a small bug in the `imageConfig` for backup.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Discussion

Part of 2.0 release.

## Testing

Unit tests + CI will run e2e tests.

## Documentation

Will be updated in a follow up PR.

## Follow-up

-
