### PR TITLE
Ensure that the generation ID is used in the cluster file path to allow different cluster files to be used

### DIFF
--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -43,13 +43,15 @@ func (a addPods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler
 	}
 	existingConfigMap := &corev1.ConfigMap{}
 	err = r.Get(ctx, types.NamespacedName{Namespace: configMap.Namespace, Name: configMap.Name}, existingConfigMap)
-	if err != nil && k8serrors.IsNotFound(err) {
-		logger.Info("Creating config map", "name", configMap.Name)
-		err = r.Create(ctx, configMap)
-		if err != nil {
-			return &requeue{curError: err}
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.Info("Creating config map", "name", configMap.Name)
+			err = r.Create(ctx, configMap)
+			if err != nil {
+				return &requeue{curError: err}
+			}
 		}
-	} else if err != nil {
+
 		return &requeue{curError: err}
 	}
 

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -56,6 +56,10 @@ func (a addProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterR
 				return &requeue{curError: err, delayedRequeue: true}
 			}
 
+			defer func() {
+				_ = adminClient.Close()
+			}()
+
 			status, err = adminClient.GetStatus()
 			if err != nil {
 				return &requeue{curError: err, delayedRequeue: true}

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -45,7 +45,9 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer adminClient.Close()
+	defer func() {
+		_ = adminClient.Close()
+	}()
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {

--- a/controllers/check_client_compatibility.go
+++ b/controllers/check_client_compatibility.go
@@ -67,9 +67,11 @@ func (c checkClientCompatibility) reconcile(_ context.Context, r *FoundationDBCl
 
 	adminClient, err := r.getAdminClient(logger, cluster)
 	if err != nil {
-		return &requeue{curError: err}
+		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer adminClient.Close()
+	defer func() {
+		_ = adminClient.Close()
+	}()
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -60,7 +60,9 @@ func (c chooseRemovals) reconcile(ctx context.Context, r *FoundationDBClusterRec
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}
-		defer adminClient.Close()
+		defer func() {
+			_ = adminClient.Close()
+		}()
 
 		status, err = adminClient.GetStatus()
 		if err != nil {

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -43,6 +43,10 @@ func (c maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBClus
 		return &requeue{curError: err, delayedRequeue: true}
 	}
 
+	defer func() {
+		_ = adminClient.Close()
+	}()
+
 	// If the status is not cached, we have to fetch it.
 	if status == nil {
 		status, err = adminClient.GetStatus()

--- a/controllers/modify_backup.go
+++ b/controllers/modify_backup.go
@@ -41,9 +41,11 @@ func (s modifyBackup) reconcile(ctx context.Context, r *FoundationDBBackupReconc
 	if backup.Status.BackupDetails.SnapshotPeriodSeconds != snapshotPeriod {
 		adminClient, err := r.adminClientForBackup(ctx, backup)
 		if err != nil {
-			return &requeue{curError: err}
+			return &requeue{curError: err, delayedRequeue: true}
 		}
-		defer adminClient.Close()
+		defer func() {
+			_ = adminClient.Close()
+		}()
 
 		err = adminClient.ModifyBackup(snapshotPeriod)
 		if err != nil {

--- a/controllers/remove_incompatible_processes.go
+++ b/controllers/remove_incompatible_processes.go
@@ -68,7 +68,9 @@ func processIncompatibleProcesses(ctx context.Context, r *FoundationDBClusterRec
 		if err != nil {
 			return err
 		}
-		defer adminClient.Close()
+		defer func() {
+			_ = adminClient.Close()
+		}()
 
 		status, err = adminClient.GetStatus()
 		if err != nil {

--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -50,7 +50,9 @@ func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *Foundation
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}
-		defer adminClient.Close()
+		defer func() {
+			_ = adminClient.Close()
+		}()
 
 		status, err = adminClient.GetStatus()
 		if err != nil {

--- a/controllers/start_backup.go
+++ b/controllers/start_backup.go
@@ -38,9 +38,11 @@ func (s startBackup) reconcile(ctx context.Context, r *FoundationDBBackupReconci
 
 	adminClient, err := r.adminClientForBackup(ctx, backup)
 	if err != nil {
-		return &requeue{curError: err}
+		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer adminClient.Close()
+	defer func() {
+		_ = adminClient.Close()
+	}()
 
 	err = adminClient.StartBackup(backup.BackupURL(), backup.SnapshotPeriodSeconds())
 	if err != nil {

--- a/controllers/start_restore.go
+++ b/controllers/start_restore.go
@@ -35,9 +35,11 @@ type startRestore struct {
 func (s startRestore) reconcile(ctx context.Context, r *FoundationDBRestoreReconciler, restore *fdbv1beta2.FoundationDBRestore) *requeue {
 	adminClient, err := r.adminClientForRestore(ctx, restore)
 	if err != nil {
-		return &requeue{curError: err}
+		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer adminClient.Close()
+	defer func() {
+		_ = adminClient.Close()
+	}()
 
 	status, err := adminClient.GetRestoreStatus()
 	if err != nil {

--- a/controllers/stop_backup.go
+++ b/controllers/stop_backup.go
@@ -38,9 +38,11 @@ func (s stopBackup) reconcile(ctx context.Context, r *FoundationDBBackupReconcil
 
 	adminClient, err := r.adminClientForBackup(ctx, backup)
 	if err != nil {
-		return &requeue{curError: err}
+		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer adminClient.Close()
+	defer func() {
+		_ = adminClient.Close()
+	}()
 
 	err = adminClient.StopBackup(backup.BackupURL())
 	if err != nil {

--- a/controllers/toggle_backup_paused.go
+++ b/controllers/toggle_backup_paused.go
@@ -42,9 +42,11 @@ func (s toggleBackupPaused) reconcile(ctx context.Context, r *FoundationDBBackup
 	if backup.ShouldBePaused() && !backup.Status.BackupDetails.Paused {
 		adminClient, err := r.adminClientForBackup(ctx, backup)
 		if err != nil {
-			return &requeue{curError: err}
+			return &requeue{curError: err, delayedRequeue: true}
 		}
-		defer adminClient.Close()
+		defer func() {
+			_ = adminClient.Close()
+		}()
 
 		err = adminClient.PauseBackups()
 		if err != nil {
@@ -56,7 +58,9 @@ func (s toggleBackupPaused) reconcile(ctx context.Context, r *FoundationDBBackup
 		if err != nil {
 			return &requeue{curError: err}
 		}
-		defer adminClient.Close()
+		defer func() {
+			_ = adminClient.Close()
+		}()
 
 		err = adminClient.ResumeBackups()
 		if err != nil {

--- a/controllers/update_backup_status.go
+++ b/controllers/update_backup_status.go
@@ -81,9 +81,11 @@ func (s updateBackupStatus) reconcile(ctx context.Context, r *FoundationDBBackup
 
 	adminClient, err := r.adminClientForBackup(ctx, backup)
 	if err != nil {
-		return &requeue{curError: err}
+		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer adminClient.Close()
+	defer func() {
+		_ = adminClient.Close()
+	}()
 
 	liveStatus, err := adminClient.GetBackupStatus()
 	if err != nil {

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -50,7 +50,9 @@ func (u updateDatabaseConfiguration) reconcile(_ context.Context, r *FoundationD
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer adminClient.Close()
+	defer func() {
+		_ = adminClient.Close()
+	}()
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {

--- a/controllers/update_lock_configuration.go
+++ b/controllers/update_lock_configuration.go
@@ -43,6 +43,10 @@ func (updateLockConfiguration) reconcile(_ context.Context, r *FoundationDBClust
 		return &requeue{curError: err, delayedRequeue: true}
 	}
 
+	defer func() {
+		_ = lockClient.Close()
+	}()
+
 	err = lockClient.UpdateDenyList(cluster.Spec.LockOptions.DenyList)
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -69,7 +69,9 @@ func (u updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer adminClient.Close()
+	defer func() {
+		_ = adminClient.Close()
+	}()
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {

--- a/controllers/update_restore_status.go
+++ b/controllers/update_restore_status.go
@@ -35,9 +35,11 @@ type updateRestoreStatus struct {
 func (updateRestoreStatus) reconcile(ctx context.Context, r *FoundationDBRestoreReconciler, restore *fdbv1beta2.FoundationDBRestore) *requeue {
 	adminClient, err := r.adminClientForRestore(ctx, restore)
 	if err != nil {
-		return &requeue{curError: err}
+		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer adminClient.Close()
+	defer func() {
+		_ = adminClient.Close()
+	}()
 
 	status, err := adminClient.GetRestoreStatus()
 	if err != nil {

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -305,7 +305,7 @@ func tryConnectionOptions(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCl
 		cluster.Status.ConnectionString = connectionString
 		adminClient, clientErr := r.getAdminClient(logger, cluster)
 		if clientErr != nil {
-			return originalConnectionString, clientErr
+			return "", clientErr
 		}
 
 		// If the cluster is not yet configured, we can reduce the timeout to make sure the initial reconcile steps
@@ -329,7 +329,7 @@ func tryConnectionOptions(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCl
 		logger.Error(err, "Error getting connection string from cluster", "connectionString", connectionString)
 	}
 
-	return originalConnectionString, nil
+	return "", fmt.Errorf("could not determine valid connection string")
 }
 
 // checkAndSetProcessStatus checks the status of the Process and if missing or incorrect add it to the related status field

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -119,7 +119,7 @@ func (fdbCluster *FdbCluster) RunFdbCliCommandInOperatorWithoutRetry(
 		)
 	}
 
-	clusterFile := fmt.Sprintf("/tmp/%s", cluster.Name)
+	clusterFile := fmt.Sprintf("/tmp/%s.fdbcli", cluster.Name)
 
 	var timeoutArgs string
 	if timeout > 0 {

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -47,7 +47,7 @@ func (fdbClient *realFdbLibClient) getValueFromDBUsingKey(fdbKey string, timeout
 	defer func() {
 		fdbClient.logger.Info("Done fetching values from FDB", "key", fdbKey)
 	}()
-	database, err := getFDBDatabase(fdbClient.cluster)
+	database, _, err := getFDBDatabase(fdbClient.cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -47,7 +47,7 @@ func (fdbClient *realFdbLibClient) getValueFromDBUsingKey(fdbKey string, timeout
 	defer func() {
 		fdbClient.logger.Info("Done fetching values from FDB", "key", fdbKey)
 	}()
-	database, _, err := getFDBDatabase(fdbClient.cluster)
+	database, _, err := getFDBDatabase(fdbClient.logger, fdbClient.cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -410,12 +410,6 @@ func (err invalidLockValue) Error() string {
 
 // Close cleans up any pending resources.
 func (client *realLockClient) Close() error {
-	clientMutex.Lock()
-	defer func() {
-		clientMutex.Unlock()
-	}()
-
-	// Allow to reuse the same file.
 	return closeClient(client.log, client.identifier, client.clusterFilePath)
 }
 
@@ -434,7 +428,7 @@ func NewRealLockClient(cluster *fdbv1beta2.FoundationDBCluster, logger logr.Logg
 		return nil, errors.New("cluster does not have a connection string")
 	}
 
-	database, clusterFile, err := getFDBDatabase(cluster)
+	database, clusterFile, err := getFDBDatabase(logger, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,9 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+// TODO (johscheuer): Update this before merging and once the upstream PR is merged.
+replace github.com/apple/foundationdb/bindings/go => github.com/johscheuer/foundationdb/bindings/go v0.0.0-20250220102233-c776de82d5fb
+
 require golang.org/x/sync v0.10.0
 
 require golang.org/x/net v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,6 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
-github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c h1:Nnun3T50beIpO6YKDZInHuZMgnNtYJafSlQAvkXwOWc=
-github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=
 github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20250115161953-f1ab8147ed1c h1:soTXYmkZfzTDDooU4vTFHYK5pcA/gEDM/3qKc1/bFWM=
 github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20250115161953-f1ab8147ed1c/go.mod h1:o+Nph7J4aa1boTEl2qhs/p0qy1mtY01P/3dpFh4Xt4w=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -226,6 +224,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/johscheuer/foundationdb/bindings/go v0.0.0-20250220102233-c776de82d5fb h1:JYYDzmK3jTzT+soNCTXPPKB8p07YeH2gnJcfRC1TSjg=
+github.com/johscheuer/foundationdb/bindings/go v0.0.0-20250220102233-c776de82d5fb/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/pkg/fdbadminclient/lock_client.go
+++ b/pkg/fdbadminclient/lock_client.go
@@ -53,4 +53,7 @@ type LockClient interface {
 
 	// UpdateDenyList updates the deny list to match a list of entries.
 	UpdateDenyList(locks []fdbv1beta2.LockDenyListEntry) error
+
+	// Close cleans up any pending resources.
+	Close() error
 }

--- a/pkg/fdbadminclient/mock/lock_client.go
+++ b/pkg/fdbadminclient/mock/lock_client.go
@@ -145,3 +145,8 @@ func (client *LockClient) ClearPendingUpgrades() error {
 func ClearMockLockClients() {
 	lockClientCache = map[string]*LockClient{}
 }
+
+// Close cleans up any pending resources.
+func (client *LockClient) Close() error {
+	return nil
+}


### PR DESCRIPTION
# Description

Follow up of: https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2200
Follow up of: https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2204

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

The idea behind the new changes is to include the unique generation ID from the cluster in the cluster file path, that way every connection string gets their own cluster file. In addition we added a reference counter to ensure the cluster file is not deleted as long as at least one client is not yet closed.

## Testing

Unit tests and CI for e2e tests.

## Documentation

I'll add some more documentation for those changes inside the code, just wanted to kick off the CI.

## Follow-up

We should update the go bindings for 7.1 to allow to close a database to prevent a potential memory leak.