### PR TITLE
Update the e2e tests to reflect the new defaults

### DIFF
--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -107,8 +107,8 @@ func recreateService(ctx context.Context, r *FoundationDBClusterReconciler, curr
 	if err != nil {
 		return err
 	}
-	err = r.Create(ctx, newService)
-	return err
+
+	return r.Create(ctx, newService)
 }
 
 // updateServices updates selected safe fields on a service based on a new
@@ -134,5 +134,6 @@ func updateService(ctx context.Context, logger logr.Logger, cluster *fdbv1beta2.
 		logger.Info("Updating service")
 		return r.Update(ctx, currentService)
 	}
+
 	return nil
 }

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -34,8 +34,8 @@ CLOUD_PROVIDER?=
 UPGRADE_VERSIONS?="$(FDB_VERSION):$(NEXT_FDB_VERSION)"
 # Those are feature flags for the operator tests. Enable a feature if you want to run the operator tests with a specific
 # feature enabled e.g. like DNS.
-FEATURE_DNS?=false
-FEATURE_LOCALITIES?=false
+FEATURE_DNS?=
+FEATURE_LOCALITIES?=
 # Allows to specify the tag for a specific FDB version. Format is 7.1.57:7.1.57-testing,7.3.35:7.3.35-debugging
 FDB_VERSION_TAG_MAPPING?=
 # If the FEATURE_SERVER_SIDE_APPLY environment variable is not defined the test suite will be randomly enable (1) or disable (0)
@@ -145,6 +145,14 @@ foundationdb-nightly-tests: GINKGO_LABEL_FILTER=--ginkgo.label-filter="foundatio
 # Run the actual foundationdb-nightly tests.
 foundationdb-nightly-tests: run
 
+ifdef FEATURE_LOCALITIES
+  FEATURE_LOCALITIES_FLAG=--feature-localities=$(FEATURE_LOCALITIES)
+endif
+
+ifdef FEATURE_DNS
+  FEATURE_DNS_FLAG=--feature-dns=$(FEATURE_DNS)
+endif
+
 %.run: %
 	@sleep $$(shuf -i 1-10 -n 1)
 	go test -timeout=$(TIMEOUT) $(VERBOSE) ./$< \
@@ -167,8 +175,6 @@ foundationdb-nightly-tests: run
 	  --enable-chaos-tests=$(ENABLE_CHAOS_TESTS) \
 	  --upgrade-versions=$(UPGRADE_VERSIONS) \
 	  --feature-unified-image=$(FEATURE_UNIFIED_IMAGE) \
-	  --feature-localities=$(FEATURE_LOCALITIES) \
-	  --feature-dns=$(FEATURE_DNS) \
 	  --cloud-provider=$(CLOUD_PROVIDER) \
 	  --dump-operator-state=$(DUMP_OPERATOR_STATE) \
 	  --cluster-name=$(CLUSTER_NAME) \
@@ -176,5 +182,5 @@ foundationdb-nightly-tests: run
 	  --fdb-version-tag-mapping=$(FDB_VERSION_TAG_MAPPING) \
 	  --unified-fdb-image=$(UNIFIED_FDB_IMAGE) \
 	  --feature-server-side-apply=$(FEATURE_SERVER_SIDE_APPLY) \
-	  --seaweedfs-image=$(SEAWEEDFS_IMAGE) \
+	  --seaweedfs-image=$(SEAWEEDFS_IMAGE) $(FEATURE_LOCALITIES_FLAG) $(FEATURE_DNS) \
 	  | grep -v 'constructing many client instances from the same exec auth config can cause performance problems during cert rotation' &> $(BASE_DIR)/../logs/$<.log

--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -77,9 +77,9 @@ type ClusterConfig struct {
 	// UseMaintenanceMode if enabled the FoundationDBCluster resource will enable the maintenance mode.
 	UseMaintenanceMode bool
 	// UseLocalityBasedExclusions if enabled the FoundationDBCluster resource will enable the locality based exclusions.
-	UseLocalityBasedExclusions bool
+	UseLocalityBasedExclusions *bool
 	// UseDNS if enabled the FoundationDBCluster resource will enable the DNS feature.
-	UseDNS bool
+	UseDNS *bool
 	// If enabled the cluster will be setup with the unified image.
 	UseUnifiedImage *bool
 	// SimulateCustomFaultDomainEnv will simulate the use case that a user has set a custom environment variable to

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -169,8 +169,7 @@ func (factory *Factory) CreateFdbCluster(
 	config *ClusterConfig,
 	options ...ClusterOption,
 ) *FdbCluster {
-	spec := factory.GenerateFDBClusterSpec(config)
-	return factory.CreateFdbClusterFromSpec(spec, config, options...)
+	return factory.CreateFdbClusterFromSpec(factory.GenerateFDBClusterSpec(config), config, options...)
 }
 
 // CreateFdbClusterFromSpec creates a FDB cluster. This method can be used in combination with the GenerateFDBClusterSpec method.

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -1451,7 +1451,7 @@ func (fdbCluster *FdbCluster) EnsureTeamTrackersAreHealthy() {
 		}
 
 		return true
-	}).WithTimeout(1 * time.Minute).WithPolling(1 * time.Second).MustPassRepeatedly(5).Should(gomega.BeTrue())
+	}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).MustPassRepeatedly(5).Should(gomega.BeTrue())
 }
 
 // EnsureTeamTrackersHaveMinReplicas will check if the machine-readable status suggest that the team trackers min_replicas

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -676,6 +676,7 @@ func (fdbCluster *FdbCluster) SetTransactionServerPerPod(
 
 // ReplacePod replaces the provided Pod if it's part of the FoundationDBCluster.
 func (fdbCluster *FdbCluster) ReplacePod(pod corev1.Pod, waitForReconcile bool) {
+	cluster := fdbCluster.GetCluster()
 	fdbCluster.cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{GetProcessGroupID(pod)}
 	fdbCluster.UpdateClusterSpec()
 
@@ -683,7 +684,7 @@ func (fdbCluster *FdbCluster) ReplacePod(pod corev1.Pod, waitForReconcile bool) 
 		return
 	}
 
-	gomega.Expect(fdbCluster.WaitForReconciliation(SoftReconcileOption(true))).NotTo(gomega.HaveOccurred())
+	gomega.Expect(fdbCluster.WaitForReconciliation(SoftReconcileOption(true), MinimumGenerationOption(cluster.Generation+1))).NotTo(gomega.HaveOccurred())
 }
 
 // ReplacePods replaces the provided Pods in the current FoundationDBCluster.

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -99,10 +99,10 @@ func (factory *Factory) createFDBClusterSpec(
 				IgnoreLogGroupsForUpgrade: []fdbv1beta2.LogGroup{
 					"fdb-kubernetes-operator",
 				},
-				UseLocalitiesForExclusion: pointer.Bool(config.UseLocalityBasedExclusions),
+				UseLocalitiesForExclusion: config.UseLocalityBasedExclusions,
 			},
 			Routing: fdbv1beta2.RoutingConfig{
-				UseDNSInClusterFile: pointer.Bool(config.UseDNS),
+				UseDNSInClusterFile: config.UseDNS,
 				HeadlessService: pointer.Bool(
 					true,
 				), // to make switching between hostname <-> IP smooth

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -486,8 +486,8 @@ spec:
           # We are setting low values here as the e2e test are taking down processes multiple times
           # and having a high wait time between recoveries will increase the reliability of the cluster but also
           # increase the time our e2e test take.
-          - --minimum-recovery-time-for-inclusion=1.0
-          - --minimum-recovery-time-for-exclusion=1.0
+          - --minimum-recovery-time-for-inclusion=30.0
+          - --minimum-recovery-time-for-exclusion=30.0
           - --cluster-label-key-for-node-trigger=foundationdb.org/fdb-cluster-name
           - --enable-node-index
           - --replace-on-security-context-change

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2203,7 +2203,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				_, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(cmd, true, 20)
 
 				return err
-			}).WithTimeout(2 * time.Minute).ShouldNot(HaveOccurred())
+			}).WithTimeout(5 * time.Minute).WithPolling(15 * time.Second).ShouldNot(HaveOccurred())
 
 			command := fmt.Sprintf("maintenance on %s %s", pickedProcessGroup.FaultDomain, "3600")
 			_, _ = fdbCluster.RunFdbCliCommandInOperator(command, false, 20)

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -557,7 +557,6 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			}
 
 			clusterConfig := fixtures.DefaultClusterConfigWithHaMode(fixtures.HaFourZoneSingleSat, false)
-			clusterConfig.UseLocalityBasedExclusions = true
 
 			clusterSetupWithTestConfig(
 				testConfig{

--- a/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
+++ b/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
@@ -174,6 +174,7 @@ var _ = Describe("Operator with three data hall", Label("e2e", "pr"), func() {
 				spec := fdbCluster.GetCluster().Spec.DeepCopy()
 				spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(false)
 				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				Expect(fdbCluster.GetCluster().UseLocalitiesForExclusion()).To(BeFalse())
 			})
 
 			It("should remove the targeted Pod", func() {

--- a/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
+++ b/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
@@ -259,13 +259,6 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 	DescribeTable(
 		"with locality based exclusions disabled",
 		func(beforeVersion string, targetVersion string) {
-			fdbVersion, err := fdbv1beta2.ParseFdbVersion(beforeVersion)
-			Expect(err).NotTo(HaveOccurred())
-
-			if !fdbVersion.SupportsLocalityBasedExclusions() {
-				Skip("provided FDB version: " + beforeVersion + " doesn't support locality based exclusions")
-			}
-
 			performUpgrade(testConfig{
 				beforeVersion: beforeVersion,
 				targetVersion: targetVersion,
@@ -275,7 +268,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				},
 				loadData: false,
 			}, func(cluster *fixtures.FdbCluster) {
-				Expect(cluster.GetCluster().UseLocalitiesForExclusion()).To(BeTrue())
+				Expect(cluster.GetCluster().UseLocalitiesForExclusion()).To(BeFalse())
 			})
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
@@ -294,7 +287,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				},
 				loadData: false,
 			}, func(cluster *fixtures.FdbCluster) {
-				Expect(cluster.GetCluster().UseDNSInClusterFile()).To(BeTrue())
+				Expect(cluster.GetCluster().UseDNSInClusterFile()).To(BeFalse())
 			})
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),

--- a/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
+++ b/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
@@ -31,6 +31,8 @@ import (
 	"log"
 	"time"
 
+	"k8s.io/utils/pointer"
+
 	corev1 "k8s.io/api/core/v1"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
@@ -255,7 +257,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 	)
 
 	DescribeTable(
-		"with locality based exclusions",
+		"with locality based exclusions disabled",
 		func(beforeVersion string, targetVersion string) {
 			fdbVersion, err := fdbv1beta2.ParseFdbVersion(beforeVersion)
 			Expect(err).NotTo(HaveOccurred())
@@ -269,7 +271,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				targetVersion: targetVersion,
 				clusterConfig: &fixtures.ClusterConfig{
 					DebugSymbols:               false,
-					UseLocalityBasedExclusions: true,
+					UseLocalityBasedExclusions: pointer.Bool(false),
 				},
 				loadData: false,
 			}, func(cluster *fixtures.FdbCluster) {
@@ -281,14 +283,14 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 	)
 
 	DescribeTable(
-		"with DNS in cluster file enabled",
+		"with DNS in cluster file disabled",
 		func(beforeVersion string, targetVersion string) {
 			performUpgrade(testConfig{
 				beforeVersion: beforeVersion,
 				targetVersion: targetVersion,
 				clusterConfig: &fixtures.ClusterConfig{
 					DebugSymbols: false,
-					UseDNS:       true,
+					UseDNS:       pointer.Bool(false),
 				},
 				loadData: false,
 			}, func(cluster *fixtures.FdbCluster) {
@@ -310,8 +312,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				},
 				loadData: false,
 			}, func(cluster *fixtures.FdbCluster) {
-				// Update the cluster spec to create dedicated coordinator Pods and make use of services as public IP
-				// source.
+				// Update the cluster spec to create dedicated coordinator Pods and make use DNS in the cluster file.
 				spec := cluster.GetCluster().Spec.DeepCopy()
 				spec.CoordinatorSelection = []fdbv1beta2.CoordinatorSelectionSetting{
 					{
@@ -319,11 +320,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 						ProcessClass: fdbv1beta2.ProcessClassCoordinator,
 					},
 				}
-				spec.ProcessCounts.Coordinator = fdbCluster.GetCachedCluster().DesiredCoordinatorCount()
-				publicIPSourceService := fdbv1beta2.PublicIPSourceService
-				spec.Routing = fdbv1beta2.RoutingConfig{
-					PublicIPSource: &publicIPSourceService,
-				}
+				spec.ProcessCounts.Coordinator = fdbCluster.GetCachedCluster().DesiredCoordinatorCount() + fdbCluster.GetCachedCluster().DesiredFaultTolerance()
 				fdbCluster.UpdateClusterSpecWithSpec(spec)
 				Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
 			})

--- a/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
@@ -417,7 +417,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 				_, _, err := fdbCluster.ExecuteCmdOnPod(
 					faultyPod,
 					fdbv1beta2.SidecarContainerName,
-					fmt.Sprintf("rm -f %s || true", fdbserverBinary),
+					fmt.Sprintf("rm -f %s", fdbserverBinary),
 					false)
 
 				return err

--- a/e2e/test_operator_velocity/operator_velocity_test.go
+++ b/e2e/test_operator_velocity/operator_velocity_test.go
@@ -246,7 +246,8 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 		})
 	})
 
-	When("a knob is changed and a single process in the primary region is partitioned", func() {
+	// See: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2228
+	PWhen("a knob is changed and a single process in the primary region is partitioned", func() {
 		var initialReplaceTime time.Duration
 		var exp *fixtures.ChaosMeshExperiment
 


### PR DESCRIPTION
# Description

Update the e2e tests to reflect the new defaults.

## Type of change

- Other

## Discussion

Make sure we use the same defaults in the e2e tests as we use in the operator.

## Testing

CI will be running e2e tests.

## Documentation

-

## Follow-up

-
