### PR TITLE
Single primary cluster file per cluster

### DIFF
--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -52,9 +52,6 @@ func (c bounceProcesses) reconcile(_ context.Context, r *FoundationDBClusterReco
 	if err != nil {
 		return &requeue{curError: err}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -45,9 +45,6 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {

--- a/controllers/check_client_compatibility.go
+++ b/controllers/check_client_compatibility.go
@@ -69,9 +69,6 @@ func (c checkClientCompatibility) reconcile(_ context.Context, r *FoundationDBCl
 	if err != nil {
 		return &requeue{curError: err}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -60,9 +60,6 @@ func (c chooseRemovals) reconcile(ctx context.Context, r *FoundationDBClusterRec
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}
-		defer func() {
-			_ = adminClient.Close()
-		}()
 
 		status, err = adminClient.GetStatus()
 		if err != nil {

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -147,9 +147,6 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	err = cluster.Validate()
 	if err != nil {
@@ -560,7 +557,6 @@ func (r *FoundationDBClusterReconciler) getStatusFromClusterOrDummyStatus(logger
 	if err != nil {
 		return nil, err
 	}
-	defer adminClient.Close()
 	// If the cluster is not yet configured, we can reduce the timeout to make sure the initial reconcile steps
 	// are faster.
 	if !cluster.Status.Configured {

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -48,9 +48,6 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 	if err != nil {
 		return &requeue{curError: err}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	adminClient.WithValues()
 	// If the status is not cached, we have to fetch it.

--- a/controllers/modify_backup.go
+++ b/controllers/modify_backup.go
@@ -43,9 +43,6 @@ func (s modifyBackup) reconcile(ctx context.Context, r *FoundationDBBackupReconc
 		if err != nil {
 			return &requeue{curError: err}
 		}
-		defer func() {
-			_ = adminClient.Close()
-		}()
 
 		err = adminClient.ModifyBackup(snapshotPeriod)
 		if err != nil {

--- a/controllers/remove_incompatible_processes.go
+++ b/controllers/remove_incompatible_processes.go
@@ -68,9 +68,6 @@ func processIncompatibleProcesses(ctx context.Context, r *FoundationDBClusterRec
 		if err != nil {
 			return err
 		}
-		defer func() {
-			_ = adminClient.Close()
-		}()
 
 		status, err = adminClient.GetStatus()
 		if err != nil {

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -50,9 +50,6 @@ func (u removeProcessGroups) reconcile(ctx context.Context, r *FoundationDBClust
 	if err != nil {
 		return &requeue{curError: err}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {

--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -50,9 +50,6 @@ func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *Foundation
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}
-		defer func() {
-			_ = adminClient.Close()
-		}()
 
 		status, err = adminClient.GetStatus()
 		if err != nil {

--- a/controllers/start_backup.go
+++ b/controllers/start_backup.go
@@ -40,9 +40,6 @@ func (s startBackup) reconcile(ctx context.Context, r *FoundationDBBackupReconci
 	if err != nil {
 		return &requeue{curError: err}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	err = adminClient.StartBackup(backup.BackupURL(), backup.SnapshotPeriodSeconds())
 	if err != nil {

--- a/controllers/start_restore.go
+++ b/controllers/start_restore.go
@@ -37,9 +37,6 @@ func (s startRestore) reconcile(ctx context.Context, r *FoundationDBRestoreRecon
 	if err != nil {
 		return &requeue{curError: err}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	status, err := adminClient.GetRestoreStatus()
 	if err != nil {

--- a/controllers/stop_backup.go
+++ b/controllers/stop_backup.go
@@ -40,9 +40,6 @@ func (s stopBackup) reconcile(ctx context.Context, r *FoundationDBBackupReconcil
 	if err != nil {
 		return &requeue{curError: err}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	err = adminClient.StopBackup(backup.BackupURL())
 	if err != nil {

--- a/controllers/toggle_backup_paused.go
+++ b/controllers/toggle_backup_paused.go
@@ -44,9 +44,6 @@ func (s toggleBackupPaused) reconcile(ctx context.Context, r *FoundationDBBackup
 		if err != nil {
 			return &requeue{curError: err}
 		}
-		defer func() {
-			_ = adminClient.Close()
-		}()
 
 		err = adminClient.PauseBackups()
 		if err != nil {
@@ -58,9 +55,6 @@ func (s toggleBackupPaused) reconcile(ctx context.Context, r *FoundationDBBackup
 		if err != nil {
 			return &requeue{curError: err}
 		}
-		defer func() {
-			_ = adminClient.Close()
-		}()
 
 		err = adminClient.ResumeBackups()
 		if err != nil {

--- a/controllers/update_backup_status.go
+++ b/controllers/update_backup_status.go
@@ -83,9 +83,6 @@ func (s updateBackupStatus) reconcile(ctx context.Context, r *FoundationDBBackup
 	if err != nil {
 		return &requeue{curError: err}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	liveStatus, err := adminClient.GetBackupStatus()
 	if err != nil {

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -50,9 +50,6 @@ func (u updateDatabaseConfiguration) reconcile(_ context.Context, r *FoundationD
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -69,9 +69,6 @@ func (u updatePods) reconcile(ctx context.Context, r *FoundationDBClusterReconci
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	// If the status is not cached, we have to fetch it.
 	if status == nil {

--- a/controllers/update_restore_status.go
+++ b/controllers/update_restore_status.go
@@ -37,9 +37,6 @@ func (updateRestoreStatus) reconcile(ctx context.Context, r *FoundationDBRestore
 	if err != nil {
 		return &requeue{curError: err}
 	}
-	defer func() {
-		_ = adminClient.Close()
-	}()
 
 	status, err := adminClient.GetRestoreStatus()
 	if err != nil {

--- a/docs/design/better_coordination_multi_operator.md
+++ b/docs/design/better_coordination_multi_operator.md
@@ -194,7 +194,6 @@ func (reconciler operatorCoordination) reconcile(ctx context.Context, r *Foundat
 	if err != nil {
 		return &requeue{curError: err}
 	}
-	defer adminClient.Close()
 
 	// Read all data from the lists to get the current state. If a prefix is provided to the get methods, only
 	// process groups with the additional sub path will be returned.

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -91,9 +91,10 @@ type cliAdminClient struct {
 	timeout time.Duration
 }
 
-// NewCliAdminClient generates an Admin client for a cluster
+// NewCliAdminClient generates a new Admin client for a cluster, using the seed connection string.
+// Generally use the dtabase provider's GetAdminClient to retrieve the existing admin client for a cluster.
 func NewCliAdminClient(cluster *fdbv1beta2.FoundationDBCluster, _ client.Client, logger logr.Logger) (fdbadminclient.AdminClient, error) {
-	_, err := createClusterFile(cluster)
+	_, err := ensureClusterFileIsPresent(os.TempDir(), string(cluster.UID), cluster.Spec.SeedConnectionString)
 	if err != nil {
 		return nil, err
 	}

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -681,12 +681,6 @@ func (client *cliAdminClient) GetRestoreStatus() (string, error) {
 	})
 }
 
-// Close cleans up any pending resources.
-func (client *cliAdminClient) Close() error {
-	// Allow to reuse the same file.
-	return nil
-}
-
 // GetCoordinatorSet gets the current coordinators from the status
 func (client *cliAdminClient) GetCoordinatorSet() (map[string]fdbv1beta2.None, error) {
 	status, err := client.GetStatus()

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -94,7 +94,7 @@ type cliAdminClient struct {
 // NewCliAdminClient generates a new Admin client for a cluster, using the seed connection string.
 // Generally use the dtabase provider's GetAdminClient to retrieve the existing admin client for a cluster.
 func NewCliAdminClient(cluster *fdbv1beta2.FoundationDBCluster, _ client.Client, logger logr.Logger) (fdbadminclient.AdminClient, error) {
-	_, err := ensureClusterFileIsPresent(os.TempDir(), string(cluster.UID), cluster.Spec.SeedConnectionString)
+	_, err := ensureClusterFileIsPresent(logger, os.TempDir(), string(cluster.UID), cluster.Spec.SeedConnectionString)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (client *cliAdminClient) getArgsAndTimeout(command cliCommand) ([]string, t
 		return nil, 0, err
 	}
 
-	tempClusterFilePath, err := ensureClusterFileIsPresent(os.TempDir(), fmt.Sprintf("%06d", rand.Uint32N(1000000)), connectionString)
+	tempClusterFilePath, err := ensureClusterFileIsPresent(client.log, os.TempDir(), fmt.Sprintf("%06d", rand.Uint32N(1000000)), connectionString)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -739,7 +739,7 @@ func (client *cliAdminClient) getTimeout() time.Duration {
 // GetProcessesUnderMaintenance will return all process groups that are currently stored to be under maintenance.
 // The result is a map with the process group ID as key and the start of the maintenance as value.
 func (client *cliAdminClient) GetProcessesUnderMaintenance() (map[fdbv1beta2.ProcessGroupID]int64, error) {
-	db, err := getFDBDatabase(client.Cluster)
+	db, err := getFDBDatabase(client.log, client.Cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -795,7 +795,7 @@ func (client *cliAdminClient) GetProcessesUnderMaintenance() (map[fdbv1beta2.Pro
 // RemoveProcessesUnderMaintenance will remove the provided process groups from the list of processes that
 // are planned to be taken down for maintenance.
 func (client *cliAdminClient) RemoveProcessesUnderMaintenance(processGroupIDs []fdbv1beta2.ProcessGroupID) error {
-	db, err := getFDBDatabase(client.Cluster)
+	db, err := getFDBDatabase(client.log, client.Cluster)
 	if err != nil {
 		return err
 	}
@@ -821,7 +821,7 @@ func (client *cliAdminClient) RemoveProcessesUnderMaintenance(processGroupIDs []
 // SetProcessesUnderMaintenance will add the provided process groups to the list of processes that will be taken
 // down for maintenance. The value will be the provided time stamp.
 func (client *cliAdminClient) SetProcessesUnderMaintenance(processGroupIDs []fdbv1beta2.ProcessGroupID, timestamp int64) error {
-	db, err := getFDBDatabase(client.Cluster)
+	db, err := getFDBDatabase(client.log, client.Cluster)
 	if err != nil {
 		return err
 	}

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -38,6 +38,20 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func normalizeClusterfileName(args []string) []string {
+	result := args
+	for i, arg := range result {
+		if arg == "-C" || arg == "--dest_cluster_file" {
+			result[i+1] = "<placeholder>"
+		}
+	}
+	return result
+}
+
+func newMockFdbLibClientForGetConnectionString() *mockFdbLibClient {
+	return &mockFdbLibClient{mockedKeyValue: map[string][]byte{"\xff/coordinators": []byte("mockConnectionString:abcd@127.0.0.1:4500")}}
+}
+
 var _ = Describe("admin_client_test", func() {
 	When("parsing the connection string", func() {
 		DescribeTable("it should return the correct connection string",
@@ -202,9 +216,10 @@ var _ = Describe("admin_client_test", func() {
 			GinkgoT().Setenv("FDB_NETWORK_OPTION_TRACE_FORMAT", traceFormat)
 		}
 
-		args, timeout := client.getArgsAndTimeout(command)
+		args, timeout, err := client.getArgsAndTimeout(command)
+		Expect(err).To(Not(HaveOccurred()))
 		Expect(timeout).To(Equal(expectedTimeout))
-		Expect(args).To(HaveExactElements(expectedArgs))
+		Expect(normalizeClusterfileName(args)).To(HaveExactElements(normalizeClusterfileName(expectedArgs)))
 	},
 		Entry("using fdbcli and trace options are disabled",
 			cliCommand{
@@ -213,9 +228,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster:      nil,
+				log:          logr.Discard(),
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"",
 			"",
@@ -233,9 +248,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster:      nil,
+				log:          logr.Discard(),
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"",
 			"",
@@ -256,9 +271,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster:      nil,
+				log:          logr.Discard(),
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"/tmp",
 			"",
@@ -284,9 +299,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster:      nil,
+				log:          logr.Discard(),
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"/tmp",
 			"json",
@@ -312,10 +327,10 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				knobs:           []string{"--knob-testing=1"},
+				Cluster:      nil,
+				log:          logr.Discard(),
+				knobs:        []string{"--knob-testing=1"},
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"",
 			"",
@@ -338,9 +353,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster:      nil,
+				log:          logr.Discard(),
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"",
 			"",
@@ -360,9 +375,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster:      nil,
+				log:          logr.Discard(),
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"/tmp",
 			"",
@@ -385,9 +400,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster:      nil,
+				log:          logr.Discard(),
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"/tmp",
 			"json",
@@ -410,10 +425,10 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				knobs:           []string{"--knob-testing=1"},
+				Cluster:      nil,
+				log:          logr.Discard(),
+				knobs:        []string{"--knob-testing=1"},
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"",
 			"",
@@ -435,9 +450,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster:      nil,
+				log:          logr.Discard(),
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"",
 			"",
@@ -457,9 +472,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster:      nil,
+				log:          logr.Discard(),
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"/tmp",
 			"",
@@ -482,9 +497,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster:      nil,
+				log:          logr.Discard(),
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"/tmp",
 			"json",
@@ -507,10 +522,10 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				knobs:           []string{"--knob-testing=1"},
+				Cluster:      nil,
+				log:          logr.Discard(),
+				knobs:        []string{"--knob-testing=1"},
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			},
 			"",
 			"",
@@ -532,10 +547,10 @@ var _ = Describe("admin_client_test", func() {
 
 		JustBeforeEach(func() {
 			cliClient := &cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
+				Cluster:      nil,
+				log:          logr.Discard(),
+				cmdRunner:    mockRunner,
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			}
 
 			protocolVersion, err = cliClient.GetProtocolVersion("7.1.21")
@@ -609,10 +624,10 @@ protocol fdb00b071010000`,
 
 		JustBeforeEach(func() {
 			cliClient := &cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
+				Cluster:      nil,
+				log:          logr.Discard(),
+				cmdRunner:    mockRunner,
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			}
 
 			supported, err = cliClient.VersionSupported(fdbv1beta2.Versions.Default.String())
@@ -671,9 +686,9 @@ protocol fdb00b071010000`,
 						RunningVersion: fdbv1beta2.Versions.Default.String(),
 					},
 				},
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
+				log:          logr.Discard(),
+				cmdRunner:    mockRunner,
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			}
 
 			status, err = cliClient.getStatus()
@@ -782,10 +797,10 @@ protocol fdb00b071010000`,
 			}
 
 			cliClient := &cliAdminClient{
-				Cluster:         cluster,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
+				Cluster:      cluster,
+				log:          logr.Discard(),
+				cmdRunner:    mockRunner,
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			}
 
 			Expect(cliClient.ExcludeProcesses([]fdbv1beta2.ProcessAddress{{
@@ -841,15 +856,14 @@ protocol fdb00b071010000`,
 			}
 
 			cliClient := &cliAdminClient{
-				Cluster:         cluster,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
-				fdbLibClient:    mockFdbClient,
+				Cluster:      cluster,
+				log:          logr.Discard(),
+				cmdRunner:    mockRunner,
+				fdbLibClient: mockFdbClient,
 			}
 
 			result, err = cliClient.CanSafelyRemove(addressesToCheck)
-			Expect(mockFdbClient.requestedKey).To(Equal("\xff\xff/status/json"))
+			Expect(mockFdbClient.requestedKeys).To(ContainElement("\xff\xff/status/json"))
 		})
 
 		BeforeEach(func() {
@@ -913,9 +927,9 @@ protocol fdb00b071010000`,
 			statusBytes, err := json.Marshal(status)
 			Expect(err).NotTo(HaveOccurred())
 
-			mockFdbClient = &mockFdbLibClient{
-				mockedOutput: statusBytes,
-			}
+			// mock will return a fake connection string, and statusBytes on all other queries.
+			mockFdbClient = newMockFdbLibClientForGetConnectionString()
+			mockFdbClient.mockedOutput = statusBytes
 
 			mockRunner = &mockCommandRunner{
 				mockedError:  nil,
@@ -1184,9 +1198,9 @@ protocol fdb00b071010000`,
 						RunningVersion: previousVersion,
 					},
 				},
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
+				log:          logr.Discard(),
+				cmdRunner:    mockRunner,
+				fdbLibClient: newMockFdbLibClientForGetConnectionString(),
 			}
 
 			version = cliClient.GetVersionFromReachableCoordinators()

--- a/fdbclient/common_test.go
+++ b/fdbclient/common_test.go
@@ -21,6 +21,7 @@
 package fdbclient
 
 import (
+	"github.com/go-logr/logr"
 	"os"
 	"path"
 
@@ -38,7 +39,7 @@ var _ = Describe("common_test", func() {
 		JustBeforeEach(func() {
 			var err error
 			tmpDir = GinkgoT().TempDir()
-			clusterFile, err = ensureClusterFileIsPresent(tmpDir, uid, connectionString)
+			clusterFile, err = ensureClusterFileIsPresent(logr.Discard(), tmpDir, uid, connectionString)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -94,16 +94,22 @@ func (fdbClient *realFdbLibClient) getValueFromDBUsingKey(fdbKey string, timeout
 
 // mockFdbLibClient is a mock for unit testing.
 type mockFdbLibClient struct {
-	// mockedOutput is the output returned by getValueFromDBUsingKey.
+	// mockedKeyValue indicates outputs to return for specific keys in getValueFromDBUsingKey. If no entry matches,
+	// the default mockedOutput below is returned.
+	mockedKeyValue map[string][]byte
+	// mockedOutput is the default output returned by getValueFromDBUsingKey.
 	mockedOutput []byte
 	// mockedError is the error returned by getValueFromDBUsingKey.
 	mockedError error
-	// requestedKey will be the key that was used to call getValueFromDBUsingKey.
-	requestedKey string
+	// requestedKey will contain all the key that were used to call getValueFromDBUsingKey.
+	requestedKeys []string
 }
 
 func (fdbClient *mockFdbLibClient) getValueFromDBUsingKey(fdbKey string, _ time.Duration) ([]byte, error) {
-	fdbClient.requestedKey = fdbKey
-
+	fdbClient.requestedKeys = append(fdbClient.requestedKeys, fdbKey)
+	output, ok := fdbClient.mockedKeyValue[fdbKey]
+	if ok {
+		return output, nil
+	}
 	return fdbClient.mockedOutput, fdbClient.mockedError
 }

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -47,7 +47,7 @@ func (fdbClient *realFdbLibClient) getValueFromDBUsingKey(fdbKey string, timeout
 	defer func() {
 		fdbClient.logger.Info("Done fetching values from FDB", "key", fdbKey)
 	}()
-	database, err := getFDBDatabase(fdbClient.cluster)
+	database, err := getFDBDatabase(fdbClient.logger, fdbClient.cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -401,7 +401,7 @@ func NewRealLockClient(cluster *fdbv1beta2.FoundationDBCluster, log logr.Logger)
 		return &realLockClient{disableLocks: true}, nil
 	}
 
-	database, err := getFDBDatabase(cluster)
+	database, err := getFDBDatabase(log, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -102,10 +102,6 @@ type AdminClient interface {
 	// GetRestoreStatus gets the status of the current restore.
 	GetRestoreStatus() (string, error)
 
-	// Close shuts down any resources for the client once it is no longer
-	// needed.
-	Close() error
-
 	// GetCoordinatorSet returns a set of the current coordinators.
 	GetCoordinatorSet() (map[string]fdbv1beta2.None, error)
 

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -254,7 +254,7 @@ func StartManager(
 		clusterReconciler.Client = mgr.GetClient()
 		clusterReconciler.Recorder = mgr.GetEventRecorderFor("foundationdbcluster-controller")
 		clusterReconciler.DeprecationOptions = operatorOpts.DeprecationOptions
-		clusterReconciler.DatabaseClientProvider = fdbclient.NewDatabaseClientProvider(logger)
+		clusterReconciler.DatabaseClientProvider = fdbclient.GetDatabaseClientProvider(logger)
 		clusterReconciler.GetTimeout = operatorOpts.GetTimeout
 		clusterReconciler.PostTimeout = operatorOpts.PostTimeout
 		clusterReconciler.Log = logr.WithName("controllers").WithName("FoundationDBCluster")
@@ -284,7 +284,7 @@ func StartManager(
 	if backupReconciler != nil {
 		backupReconciler.Client = mgr.GetClient()
 		backupReconciler.Recorder = mgr.GetEventRecorderFor("foundationdbbackup-controller")
-		backupReconciler.DatabaseClientProvider = fdbclient.NewDatabaseClientProvider(logger)
+		backupReconciler.DatabaseClientProvider = fdbclient.GetDatabaseClientProvider(logger)
 		backupReconciler.Log = logr.WithName("controllers").WithName("FoundationDBBackup")
 		backupReconciler.ServerSideApply = operatorOpts.ServerSideApply
 
@@ -297,7 +297,7 @@ func StartManager(
 	if restoreReconciler != nil {
 		restoreReconciler.Client = mgr.GetClient()
 		restoreReconciler.Recorder = mgr.GetEventRecorderFor("foundationdbrestore-controller")
-		restoreReconciler.DatabaseClientProvider = fdbclient.NewDatabaseClientProvider(logger)
+		restoreReconciler.DatabaseClientProvider = fdbclient.GetDatabaseClientProvider(logger)
 		restoreReconciler.Log = logr.WithName("controllers").WithName("FoundationDBRestore")
 		restoreReconciler.ServerSideApply = operatorOpts.ServerSideApply
 


### PR DESCRIPTION
# Description

Follow up of: https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2200
Follow up of: https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2204
Follow up of:https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2216

Keep a single, long-lived cluster file per cluster UID that is once written and then only managed by the FDB client library.

The problem is that multiple entities are writing the cluster file, concurrently without synchronization, leading to races:
* The FDB client library through the golang binding - the golang binding maintains a singleton per cluster file.
* Each fdbcli instance that FDB operator spawns, on notification from the cluster about a generation change,
* the kubernetes operator itself e.g. when trying connection options.

To decouple the fdbcli invocations, this change will write a temporary cluster file per fdbcli invocation, synthesized from the current connection string as indicated by the FDB client library. We discard the file immediately after use.

To remove the race with trying connection options, we adjust the lifecycle of the FDB admin client. We create a singleton instance per cluster UID, maintained by a singleton database provider. The initial connection always uses the seed connection string, afterwards we only poll the FDB client library for updates to the connection string.

With that, the FDB client library can exclusively manage the cluster file.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

n/a

## Testing

Unit tests pass but I still didn't manage to run the e2e tests.

## Documentation

n/a

## Follow-up

Not sure if there are still races with the lock client accessing the same cluster file.
