### PR TITLE
Update cluster file usage.

### DIFF
--- a/controllers/update_config_map.go
+++ b/controllers/update_config_map.go
@@ -24,7 +24,7 @@ import (
 	"context"
 	"reflect"
 
-	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -38,7 +38,7 @@ import (
 type updateConfigMap struct{}
 
 // reconcile runs the reconciler's work.
-func (u updateConfigMap) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbtypes.FoundationDBCluster, _ *fdbtypes.FoundationDBStatus, logger logr.Logger) *requeue {
+func (u updateConfigMap) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
 	configMap, err := internal.GetConfigMap(cluster)
 	if err != nil {
 		return &requeue{curError: err}

--- a/docs/manual/debugging.md
+++ b/docs/manual/debugging.md
@@ -190,6 +190,13 @@ Once the annotations are updated the user should trigger a replacement of those 
 The replacement will make sure that the operator is starting new Pods for the isolated Pods.
 When the debugging is finished just remove the `foundationdb.org/isolate-process-group` annotation or set it to `false` and the operator will remove the associated resources.
 
+## Operator stuck with old connection string
+
+If more than one operator instance is used to manage a FoundationDB cluster, e.g. in case of a multi-region cluster, there can be cases where an operator instance was partitioned for a long time.
+In this case the operator might not be able to connect again to the cluster because the coordinators have changed and none of the old coordinators are still running.
+In this case use the [kubectl-fdb plugin](../../kubectl-fdb/Readme.md) to update the connection string in the `FoundationDBCluster` resource status and restart the operator pod.
+You can use the `kubectl update connection-string` command to update the connection string for a cluster.
+
 ## Next
 
 You can continue on to the [next section](more.md) or go back to the [table of contents](index.md).

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -29,6 +29,9 @@ import (
 	"path"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
 	"k8s.io/utils/pointer"
 
 	"github.com/go-logr/logr"
@@ -202,7 +205,7 @@ var _ = Describe("admin_client_test", func() {
 			GinkgoT().Setenv("FDB_NETWORK_OPTION_TRACE_FORMAT", traceFormat)
 		}
 
-		args, timeout := client.getArgsAndTimeout(command)
+		args, timeout := client.getArgsAndTimeout(command, "test")
 		Expect(timeout).To(Equal(expectedTimeout))
 		Expect(args).To(HaveExactElements(expectedArgs))
 	},
@@ -213,9 +216,8 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster: nil,
+				log:     logr.Discard(),
 			},
 			"",
 			"",
@@ -233,9 +235,8 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster: nil,
+				log:     logr.Discard(),
 			},
 			"",
 			"",
@@ -256,9 +257,8 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster: nil,
+				log:     logr.Discard(),
 			},
 			"/tmp",
 			"",
@@ -284,9 +284,8 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster: nil,
+				log:     logr.Discard(),
 			},
 			"/tmp",
 			"json",
@@ -312,10 +311,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				knobs:           []string{"--knob-testing=1"},
+				Cluster: nil,
+				log:     logr.Discard(),
+				knobs:   []string{"--knob-testing=1"},
 			},
 			"",
 			"",
@@ -338,9 +336,8 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster: nil,
+				log:     logr.Discard(),
 			},
 			"",
 			"",
@@ -360,9 +357,8 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster: nil,
+				log:     logr.Discard(),
 			},
 			"/tmp",
 			"",
@@ -385,9 +381,8 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster: nil,
+				log:     logr.Discard(),
 			},
 			"/tmp",
 			"json",
@@ -410,10 +405,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				knobs:           []string{"--knob-testing=1"},
+				Cluster: nil,
+				log:     logr.Discard(),
+				knobs:   []string{"--knob-testing=1"},
 			},
 			"",
 			"",
@@ -435,9 +429,8 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster: nil,
+				log:     logr.Discard(),
 			},
 			"",
 			"",
@@ -457,9 +450,8 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster: nil,
+				log:     logr.Discard(),
 			},
 			"/tmp",
 			"",
@@ -482,9 +474,8 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
+				Cluster: nil,
+				log:     logr.Discard(),
 			},
 			"/tmp",
 			"json",
@@ -507,10 +498,9 @@ var _ = Describe("admin_client_test", func() {
 				timeout: 1 * time.Second,
 			},
 			&cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				knobs:           []string{"--knob-testing=1"},
+				Cluster: nil,
+				log:     logr.Discard(),
+				knobs:   []string{"--knob-testing=1"},
 			},
 			"",
 			"",
@@ -532,10 +522,13 @@ var _ = Describe("admin_client_test", func() {
 
 		JustBeforeEach(func() {
 			cliClient := &cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
+				Cluster: &fdbv1beta2.FoundationDBCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: types.UID("1234"),
+					},
+				},
+				log:       logr.Discard(),
+				cmdRunner: mockRunner,
 			}
 
 			protocolVersion, err = cliClient.GetProtocolVersion("7.1.21")
@@ -609,10 +602,9 @@ protocol fdb00b071010000`,
 
 		JustBeforeEach(func() {
 			cliClient := &cliAdminClient{
-				Cluster:         nil,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
+				Cluster:   nil,
+				log:       logr.Discard(),
+				cmdRunner: mockRunner,
 			}
 
 			supported, err = cliClient.VersionSupported(fdbv1beta2.Versions.Default.String())
@@ -671,9 +663,8 @@ protocol fdb00b071010000`,
 						RunningVersion: fdbv1beta2.Versions.Default.String(),
 					},
 				},
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
+				log:       logr.Discard(),
+				cmdRunner: mockRunner,
 			}
 
 			status, err = cliClient.getStatus()
@@ -782,10 +773,9 @@ protocol fdb00b071010000`,
 			}
 
 			cliClient := &cliAdminClient{
-				Cluster:         cluster,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
+				Cluster:   cluster,
+				log:       logr.Discard(),
+				cmdRunner: mockRunner,
 			}
 
 			Expect(cliClient.ExcludeProcesses([]fdbv1beta2.ProcessAddress{{
@@ -841,11 +831,10 @@ protocol fdb00b071010000`,
 			}
 
 			cliClient := &cliAdminClient{
-				Cluster:         cluster,
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
-				fdbLibClient:    mockFdbClient,
+				Cluster:      cluster,
+				log:          logr.Discard(),
+				cmdRunner:    mockRunner,
+				fdbLibClient: mockFdbClient,
 			}
 
 			result, err = cliClient.CanSafelyRemove(addressesToCheck)
@@ -1184,9 +1173,8 @@ protocol fdb00b071010000`,
 						RunningVersion: previousVersion,
 					},
 				},
-				clusterFilePath: "test",
-				log:             logr.Discard(),
-				cmdRunner:       mockRunner,
+				log:       logr.Discard(),
+				cmdRunner: mockRunner,
 			}
 
 			version = cliClient.GetVersionFromReachableCoordinators()

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -151,12 +151,12 @@ func createClusterFileForCommandLine(cluster *fdbv1beta2.FoundationDBCluster) (*
 		return nil, err
 	}
 
-	randomFile, err := os.CreateTemp(tmpDir, "")
+	tempClusterFile, err := os.CreateTemp(tmpDir, "")
 	if err != nil {
 		return nil, err
 	}
 
-	return randomFile, os.WriteFile(randomFile.Name(), []byte(cluster.Status.ConnectionString), 0777)
+	return tempClusterFile, os.WriteFile(tempClusterFile.Name(), []byte(cluster.Status.ConnectionString), 0777)
 }
 
 // getConnectionStringFromDB gets the database's connection string directly from the system key

--- a/fdbclient/common_test.go
+++ b/fdbclient/common_test.go
@@ -38,7 +38,7 @@ var _ = Describe("common_test", func() {
 		JustBeforeEach(func() {
 			var err error
 			tmpDir = GinkgoT().TempDir()
-			clusterFile, err = ensureClusterFileIsPresent(tmpDir, uid, connectionString)
+			clusterFile, err = ensureClusterFileIsPresent(path.Join(tmpDir, uid), connectionString)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -53,7 +53,7 @@ var _ = Describe("common_test", func() {
 
 		When("the cluster file exist with the wrong content", func() {
 			BeforeEach(func() {
-				err := os.WriteFile(path.Join(os.TempDir(), uid), []byte("wrong"), 0777)
+				err := os.WriteFile(path.Join(GinkgoT().TempDir(), uid), []byte("wrong"), 0777)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -67,7 +67,7 @@ var _ = Describe("common_test", func() {
 
 		When("the cluster file exist with the correct content", func() {
 			BeforeEach(func() {
-				err := os.WriteFile(path.Join(os.TempDir(), uid), []byte(connectionString), 0777)
+				err := os.WriteFile(path.Join(GinkgoT().TempDir(), uid), []byte(connectionString), 0777)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/fdbclient/common_test.go
+++ b/fdbclient/common_test.go
@@ -21,8 +21,13 @@
 package fdbclient
 
 import (
+	"fmt"
 	"os"
 	"path"
+
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -77,6 +82,35 @@ var _ = Describe("common_test", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(content)).To(Equal(connectionString))
 			})
+		})
+	})
+
+	When("creating the cluster for cli", func() {
+		var tmpDir string
+		uid := "testuid"
+		var file *os.File
+
+		BeforeEach(func() {
+			tmpDir = GinkgoT().TempDir()
+			GinkgoT().Setenv("TMPDIR", tmpDir)
+
+			var err error
+			file, err = createClusterFileForCommandLine(&fdbv1beta2.FoundationDBCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID(uid),
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			Expect(file.Close()).To(Succeed())
+		})
+
+		It("should create the temp cluster file for the cli", func() {
+			expectedDir := path.Join(tmpDir, fmt.Sprintf("%s-cli", uid))
+			Expect(expectedDir).To(BeADirectory())
+			Expect(file.Name()).To(BeAnExistingFile())
 		})
 	})
 })

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -92,6 +92,7 @@ func NewRootCmd(streams genericclioptions.IOStreams, pluginVersionChecker Versio
 		newGetCmd(streams),
 		newBuggifyCmd(streams),
 		newRecoverMultiRegionClusterCmd(streams),
+		newUpdateCmd(streams),
 	)
 
 	return cmd

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -77,6 +77,7 @@ func generateClusterStruct(name string, namespace string) *fdbv1beta2.Foundation
 			ProcessGroupIDPrefix: name,
 		},
 		Status: fdbv1beta2.FoundationDBClusterStatus{
+			ConnectionString: "test:id1234@127.0.0.1:4500",
 			ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
 				{
 					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-" + string(fdbv1beta2.ProcessClassStorage) + "-1"),

--- a/kubectl-fdb/cmd/update.go
+++ b/kubectl-fdb/cmd/update.go
@@ -1,0 +1,55 @@
+/*
+ * update.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2018-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/spf13/cobra"
+)
+
+func newUpdateCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newFDBOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Subcommand to update the configuration for a given cluster",
+		Long:  "Subcommand to update the configuration for a given cluster",
+		RunE: func(c *cobra.Command, _ []string) error {
+			return c.Help()
+		},
+		Example: `
+# Updates the connection string for a cluster in the current namespace
+kubectl fdb update connection-string -c cluster test:cluster@192.168.0.1:4500
+
+# Updates the connection string for a cluster in the namespace default
+kubectl fdb -n default update connection-string -c cluster test:cluster@192.168.0.1:4500
+`,
+	}
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
+	cmd.SetIn(o.In)
+
+	cmd.AddCommand(newUpdateConnectionStringCmd(streams))
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}

--- a/kubectl-fdb/cmd/update_connection_string.go
+++ b/kubectl-fdb/cmd/update_connection_string.go
@@ -1,0 +1,92 @@
+/*
+ * update_connection_string.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2018-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newUpdateConnectionStringCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newFDBOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "connection-string",
+		Short: "Updates the connection string in the FoundationDBCluster resource status with the provided connection string",
+		Long:  "Updates the connection string in the FoundationDBCluster resource status with the provided connection string",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clusterName, err := cmd.Flags().GetString("fdb-cluster")
+			if err != nil {
+				return err
+			}
+			namespace, err := getNamespace(*o.configFlags.Namespace)
+			if err != nil {
+				return err
+			}
+
+			kubeClient, err := getKubeClient(cmd.Context(), o)
+			if err != nil {
+				return err
+			}
+
+			cluster := &fdbv1beta2.FoundationDBCluster{}
+			err = kubeClient.Get(cmd.Context(), client.ObjectKey{Name: clusterName, Namespace: namespace}, cluster)
+			if err != nil {
+				return err
+			}
+
+			return updateConnectionStringCmd(cmd, kubeClient, cluster, args[0])
+		},
+		Example: `
+# Updates the connection string for a cluster in the current namespace
+kubectl fdb update connection-string -c cluster test:cluster@192.168.0.1:4500
+
+# Updates the connection string for a cluster in the namespace default
+kubectl fdb -n default update connection-string -c cluster test:cluster@192.168.0.1:4500`,
+	}
+
+	cmd.Flags().StringP("fdb-cluster", "c", "", "Selects process groups from the provided cluster. "+
+		"Required if not passing cluster-label.")
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
+	cmd.SetIn(o.In)
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// updateConnectionStringCmd will update the connection string if the current connection string is outdated in the fdbv1beta2.FoundationDBCluster status.
+func updateConnectionStringCmd(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluster, connectionString string) error {
+	if cluster.Status.ConnectionString == connectionString {
+		cmd.Printf("cluster %s/%s already has connections string \"%s\" set\n", cluster.Namespace, cluster.Name, connectionString)
+		return nil
+	}
+
+	_, err := fdbv1beta2.ParseConnectionString(connectionString)
+	if err != nil {
+		return err
+	}
+
+	return updateConnectionString(cmd.Context(), kubeClient, cluster, connectionString)
+}

--- a/kubectl-fdb/cmd/update_connection_string_test.go
+++ b/kubectl-fdb/cmd/update_connection_string_test.go
@@ -1,0 +1,113 @@
+/*
+ * update_connection_string_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2018-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("[plugin] update connection string command", func() {
+	var outBuffer bytes.Buffer
+	var errBuffer bytes.Buffer
+	var inBuffer bytes.Buffer
+	var cmd *cobra.Command
+	var err error
+	var connectionString string
+	var initialConnectionString string
+
+	BeforeEach(func() {
+		// We use these buffers to check the input/output
+		outBuffer = bytes.Buffer{}
+		errBuffer = bytes.Buffer{}
+		inBuffer = bytes.Buffer{}
+		cmd = NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer}, &MockVersionChecker{})
+		initialConnectionString = cluster.Status.ConnectionString
+	})
+
+	JustBeforeEach(func() {
+		err = updateConnectionStringCmd(cmd, k8sClient, cluster, connectionString)
+	})
+
+	When("the connection string is already correct", func() {
+		BeforeEach(func() {
+			connectionString = cluster.Status.ConnectionString
+		})
+
+		It("should not return an error and keep the resource", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(outBuffer.String()).To(ContainSubstring("already has connections string"))
+			Expect(initialConnectionString).To(Equal(connectionString))
+		})
+	})
+
+	When("the connection string is different", func() {
+		When("the connection string is valid", func() {
+			BeforeEach(func() {
+				connectionString = "test:4321id@127.0.0.1:4500"
+				Expect(k8sClient.Create(context.Background(), &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-config", cluster.Name),
+						Namespace: cluster.Namespace,
+					},
+					Data: map[string]string{
+						fdbv1beta2.ClusterFileKey: cluster.Status.ConnectionString,
+					},
+				})).To(Succeed())
+			})
+
+			It("should not return an error and update resource", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(outBuffer.String()).To(BeEmpty())
+
+				fetchedCluster := &fdbv1beta2.FoundationDBCluster{}
+				Expect(k8sClient.Get(context.Background(), ctrlClient.ObjectKeyFromObject(cluster), fetchedCluster)).To(Succeed())
+
+				Expect(fetchedCluster.Status.ConnectionString).To(Equal(connectionString))
+				Expect(fetchedCluster.Status.ConnectionString).NotTo(Equal(initialConnectionString))
+
+				fetchedConfigMap := &corev1.ConfigMap{}
+				Expect(k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Namespace: cluster.Namespace, Name: fmt.Sprintf("%s-config", cluster.Name)}, fetchedConfigMap)).To(Succeed())
+				Expect(fetchedConfigMap.Data).To(HaveLen(1))
+				Expect(fetchedConfigMap.Data).To(HaveKeyWithValue(fdbv1beta2.ClusterFileKey, connectionString))
+			})
+		})
+
+		When("the connection string is invalid", func() {
+			BeforeEach(func() {
+				connectionString = "test-invalid@127.0.0.1:4500"
+			})
+
+			It("should return an error with the information that the connection string is invalid", func() {
+				Expect(err).To(MatchError(ContainSubstring("invalid connection string")))
+			})
+		})
+	})
+})

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -67,7 +67,8 @@ type AdminClient interface {
 	// ChangeCoordinators changes the coordinator set
 	ChangeCoordinators(addresses []fdbv1beta2.ProcessAddress) (string, error)
 
-	// GetConnectionString fetches the latest connection string.
+	// GetConnectionString fetches the latest connection string. This method will make use of fdbcli to ensure that the
+	// cluster file managed by the fdb client library is not changed.
 	GetConnectionString() (string, error)
 
 	// VersionSupported reports whether we can support a cluster with a given


### PR DESCRIPTION
# Description

Make use of dedicated cluster file for the fdb client lib and ensure to reuse it. The cli tooling will get a temp cluster file which will be deleted after the command was used.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

Ran e2e tests related to HA clusters.

I have to add another test in the e2e setup to see what happens when an operator is partitioned and all coordinators change (and no old coordinator is around) and how to resolve this case, in the previous setup a user could just update the `SeedConnectionString`.

## Documentation

Will be updated before merging.

## Follow-up

We should add a command in the kubectl plugin to update the connection string in the `FoundationDBCluster` status.
