### PR TITLE
Remove the 3DH setup from e2e pipeline to reduce required resources

### DIFF
--- a/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
+++ b/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
@@ -84,7 +84,8 @@ var _ = AfterSuite(func() {
 	factory.Shutdown()
 })
 
-var _ = Describe("Operator with three data hall", Label("e2e", "pr"), func() {
+// TODO (johscheuer): Add those tests later again to the e2e pipeline.
+var _ = Describe("Operator with three data hall", func() {
 	var availabilityCheck bool
 
 	AfterEach(func() {

--- a/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
+++ b/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
@@ -85,7 +85,7 @@ var _ = AfterSuite(func() {
 })
 
 // TODO (johscheuer): Add those tests later again to the e2e pipeline.
-var _ = Describe("Operator with three data hall", func() {
+var _ = Describe("Operator with three data hall", Label("e2e"), func() {
 	var availabilityCheck bool
 
 	AfterEach(func() {


### PR DESCRIPTION
# Description

Remove the 3DH setup from e2e pipeline to reduce required resources. The main idea is to reduce the required resources for our e2e test pipelines, we eventually enable those tests again. If someone changes things related to 3DH we can run those tests manually.

## Type of change

- Other

## Discussion

-

## Testing

-

## Documentation

-

## Follow-up

-
