### PR TITLE
Change the ordering of the coordinator change and the exclusion

### DIFF
--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -172,6 +172,8 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 	// data is moved and the processes are fully excluded. Using the no_wait flag here will reduce the timeout errors
 	// as those are hit most of the time if at least one storage process is included in the exclusion list.
 	err = adminClient.ExcludeProcessesWithNoWait(fdbProcessesToExclude, true)
+	// Reset the SecondsSinceLastRecovered since the operator just excluded some processes, which will cause a recovery.
+	status.Cluster.RecoveryState.SecondsSinceLastRecovered = 0.0
 	// If the exclusion failed, we don't want to change the coordinators and delay the coordinators change to a later time.
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
@@ -203,9 +205,6 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 			return &requeue{curError: err, delayedRequeue: true}
 		}
 	}
-
-	// Reset the SecondsSinceLastRecovered since the operator just excluded some processes, which will cause a recovery.
-	status.Cluster.RecoveryState.SecondsSinceLastRecovered = 0.0
 
 	return nil
 }

--- a/internal/locality/locality.go
+++ b/internal/locality/locality.go
@@ -384,7 +384,6 @@ func CheckCoordinatorValidity(logger logr.Logger, cluster *fdbv1beta2.Foundation
 			Flags:         ipAddress.Flags,
 		}
 		_, isCoordinatorWithDNS := coordinatorStatus[dnsAddress.String()]
-
 		if !isCoordinatorWithDNS {
 			dnsAddress = ipAddress
 			dnsAddress.FromHostname = true


### PR DESCRIPTION
# Description

Change the ordering of the coordinator change and the exclusion. It's better to first run the exclusion and then change the coordinators, this should ensure that the processes are excluded faster, e.g. in a case where the coordinator change causes a long recovery. We previously implemented with the coordinators change first because we waited for the exclusion to complete, since we use the `no_wait` option now per default, the exclude command shouldn't timeout, expect in cases where the FDB cluster is in a bad state. So doing the exclude first and then the coordinator change seems like the better choice to ensure that the processes are quickly excluded.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

I labeled this as a bug but arguably this is not a bug.

## Testing

CI will run e2e tests.

## Documentation

-

## Follow-up

-
