### PR TITLE
Allow to modify the default CPU and memory for pods

### DIFF
--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -23,7 +23,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-
 	"github.com/go-logr/logr"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal/locality"


### PR DESCRIPTION
# Description

Allow to modify the default CPU and memory for pods, e.g. to perform tests with different CPU/memory settings.

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

-

## Testing

Updated unit tests and CI will run e2e tests.

## Documentation

-

## Follow-up
-
