### PR TITLE
Fix a bug in the connection string parser when a cluster has a single letter as name

### DIFF
--- a/api/v1beta2/foundationdb_process_address.go
+++ b/api/v1beta2/foundationdb_process_address.go
@@ -156,6 +156,10 @@ func (address ProcessAddress) MarshalJSON() ([]byte, error) {
 // representation.
 func ParseProcessAddress(address string) (ProcessAddress, error) {
 	result := ProcessAddress{}
+	if address == "" {
+		return result, fmt.Errorf("cannot parse empty address")
+	}
+
 	if strings.HasSuffix(address, "(fromHostname)") {
 		address = strings.TrimSuffix(address, "(fromHostname)")
 		result.FromHostname = true

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1744,7 +1744,7 @@ func ParseConnectionString(str string) (ConnectionString, error) {
 	// The description is a logical description of the database using alphanumeric characters (a-z, A-Z, 0-9) and underscores.
 	description := firstSplit[0]
 	if !isAlphanumericWithUnderScore.MatchString(description) {
-		return ConnectionString{}, fmt.Errorf("invalid connection string: %s, only alphanumeric characters (a-z, A-Z, 0-9) and underscores are allowed", str)
+		return ConnectionString{}, fmt.Errorf("invalid connection string: %s, database description can only contain alphanumeric characters (a-z, A-Z, 0-9) and underscores", str)
 	}
 
 	secondSplit := strings.SplitN(firstSplit[1], "@", 2)
@@ -1755,20 +1755,15 @@ func ParseConnectionString(str string) (ConnectionString, error) {
 	// The ID is an arbitrary value containing alphanumeric characters (a-z, A-Z, 0-9).
 	generationID := secondSplit[0]
 	if !isAlphanumeric.MatchString(generationID) {
-		return ConnectionString{}, fmt.Errorf("invalid connection string: %s, only alphanumeric characters (a-z, A-Z, 0-9) are allowed", str)
+		return ConnectionString{}, fmt.Errorf("invalid connection string: %s, generation ID can only contain alphanumeric characters (a-z, A-Z, 0-9)", str)
 	}
 
 	coordinatorsStrings := strings.Split(secondSplit[1], ",")
 	coordinators := make([]string, 0, len(coordinatorsStrings))
 	for _, coordinatorsString := range coordinatorsStrings {
-		// Ignore empty strings
-		if coordinatorsString == "" {
-			continue
-		}
-
 		coordinatorAddress, err := ParseProcessAddress(coordinatorsString)
 		if err != nil {
-			return ConnectionString{}, err
+			return ConnectionString{}, fmt.Errorf("invalid connection string: %s, could not parse coordinator address: %s, got error: %w", str, coordinatorAddress, err)
 		}
 
 		coordinators = append(coordinators, coordinatorAddress.String())

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1713,10 +1713,6 @@ func (cluster *FoundationDBCluster) GetLogServersPerPod() int {
 // connection string.
 var alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
-// connectionStringPattern provides a regular expression for parsing the
-// connection string.
-var connectionStringPattern = regexp.MustCompile("(?m)^([^#][^:@]+):([^:@]+)@(.*)$")
-
 // ConnectionString models the contents of a cluster file in a structured way
 type ConnectionString struct {
 	// DatabaseName provides an identifier for the database which persists
@@ -1731,30 +1727,73 @@ type ConnectionString struct {
 	Coordinators []string `json:"coordinators,omitempty"`
 }
 
+// isAlphanumeric regex to validate: value containing alphanumeric characters (a-z, A-Z, 0-9).
+var isAlphanumeric = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
+
+// isAlphanumericWithUnderScore regex to validate: value containing alphanumeric characters (a-z, A-Z, 0-9) and underscores.
+var isAlphanumericWithUnderScore = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+
 // ParseConnectionString parses a connection string from its string
 // representation
 func ParseConnectionString(str string) (ConnectionString, error) {
-	components := connectionStringPattern.FindStringSubmatch(str)
-	if components == nil {
-		return ConnectionString{}, fmt.Errorf("invalid connection string %s", str)
+	firstSplit := strings.SplitN(str, ":", 2)
+	if len(firstSplit) != 2 {
+		return ConnectionString{}, fmt.Errorf("invalid connection string: %s, could not split string to get database description", str)
 	}
 
-	coordinatorsStrings := strings.Split(components[3], ",")
-	coordinators := make([]string, len(coordinatorsStrings))
-	for idx, coordinatorsString := range coordinatorsStrings {
+	// The description is a logical description of the database using alphanumeric characters (a-z, A-Z, 0-9) and underscores.
+	description := firstSplit[0]
+	if !isAlphanumericWithUnderScore.MatchString(description) {
+		return ConnectionString{}, fmt.Errorf("invalid connection string: %s, only alphanumeric characters (a-z, A-Z, 0-9) and underscores are allowed", str)
+	}
+
+	secondSplit := strings.SplitN(firstSplit[1], "@", 2)
+	if len(secondSplit) != 2 {
+		return ConnectionString{}, fmt.Errorf("invalid connection string: %s, could not split string to get generation ID", str)
+	}
+
+	// The ID is an arbitrary value containing alphanumeric characters (a-z, A-Z, 0-9).
+	generationID := secondSplit[0]
+	if !isAlphanumeric.MatchString(generationID) {
+		return ConnectionString{}, fmt.Errorf("invalid connection string: %s, only alphanumeric characters (a-z, A-Z, 0-9) are allowed", str)
+	}
+
+	coordinatorsStrings := strings.Split(secondSplit[1], ",")
+	coordinators := make([]string, 0, len(coordinatorsStrings))
+	for _, coordinatorsString := range coordinatorsStrings {
+		// Ignore empty strings
+		if coordinatorsString == "" {
+			continue
+		}
+
 		coordinatorAddress, err := ParseProcessAddress(coordinatorsString)
 		if err != nil {
 			return ConnectionString{}, err
 		}
 
-		coordinators[idx] = coordinatorAddress.String()
+		coordinators = append(coordinators, coordinatorAddress.String())
+	}
+
+	if len(coordinators) == 0 {
+		return ConnectionString{}, fmt.Errorf("invalid connection string: %s, connection string must contain at least one coordinator", str)
 	}
 
 	return ConnectionString{
-		components[1],
-		components[2],
+		description,
+		generationID,
 		coordinators,
 	}, nil
+}
+
+// SanitizeConnectionStringDescription will replace "-" to "_".
+func SanitizeConnectionStringDescription(str string) string {
+	return strings.ReplaceAll(str, "-", "_")
+}
+
+// Validate will return nil if the connection string is valid or an error if the connection string is not valid.
+func (str *ConnectionString) Validate() error {
+	_, err := ParseConnectionString(str.String())
+	return err
 }
 
 // String formats a connection string as a string

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -804,7 +804,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 		},
 	}
 
-	coordinatorsStr := []string{
+	coordinatorsList := []string{
 		"127.0.0.1:4500",
 		"127.0.0.2:4500",
 		"127.0.0.3:4500",
@@ -828,7 +828,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(str.DatabaseName).To(Equal("test"))
 				Expect(str.GenerationID).To(Equal("abcd"))
-				Expect(str.Coordinators).To(ConsistOf(coordinatorsStr))
+				Expect(str.Coordinators).To(ConsistOf(coordinatorsList))
 			})
 		})
 
@@ -838,7 +838,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			})
 
 			It("should return an error", func() {
-				Expect(err).To(MatchError(ContainSubstring("invalid connection string: test:abcd, could not split string to get generation ID")))
+				Expect(err).To(MatchError(Equal("invalid connection string: test:abcd, could not split string to get generation ID")))
 			})
 		})
 
@@ -848,7 +848,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			})
 
 			It("should return an error", func() {
-				Expect(err).To(MatchError(ContainSubstring("invalid connection string: te-st:abcd, only alphanumeric characters (a-z, A-Z, 0-9) and underscores are allowed")))
+				Expect(err).To(MatchError(Equal("invalid connection string: te-st:abcd, database description can only contain alphanumeric characters (a-z, A-Z, 0-9) and underscores")))
 			})
 		})
 
@@ -858,17 +858,17 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			})
 
 			It("should return an error", func() {
-				Expect(err).To(MatchError(ContainSubstring("invalid connection string: :abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500, only alphanumeric characters (a-z, A-Z, 0-9) and underscores are allowed")))
+				Expect(err).To(MatchError(Equal("invalid connection string: :abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500, database description can only contain alphanumeric characters (a-z, A-Z, 0-9) and underscores")))
 			})
 		})
 
-		When("the input has an generation description", func() {
+		When("the input has an empty generation ID", func() {
 			BeforeEach(func() {
 				input = "test:@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500"
 			})
 
 			It("should return an error", func() {
-				Expect(err).To(MatchError(ContainSubstring("invalid connection string: test:@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500, only alphanumeric characters (a-z, A-Z, 0-9) are allowed")))
+				Expect(err).To(MatchError(Equal("invalid connection string: test:@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500, generation ID can only contain alphanumeric characters (a-z, A-Z, 0-9)")))
 			})
 		})
 
@@ -878,7 +878,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			})
 
 			It("should return an error", func() {
-				Expect(err).To(MatchError(ContainSubstring("invalid connection string: test:abcd@, connection string must contain at least one coordinator")))
+				Expect(err).To(MatchError(Equal("invalid connection string: test:abcd@, could not parse coordinator address: <nil>, got error: cannot parse empty address")))
 			})
 		})
 
@@ -891,11 +891,11 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(str.DatabaseName).To(Equal("s"))
 				Expect(str.GenerationID).To(Equal("abcd"))
-				Expect(str.Coordinators).To(ConsistOf(coordinatorsStr))
+				Expect(str.Coordinators).To(ConsistOf(coordinatorsList))
 			})
 		})
 
-		When("the input is valid with amultiple underscores", func() {
+		When("the input is valid with multiple underscores", func() {
 			BeforeEach(func() {
 				input = "fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@100.82.81.253:4500:tls,100.82.71.5:4500:tls,100.82.119.151:4500:tls,100.82.122.125:4500:tls,100.82.76.240:4500:tls"
 			})
@@ -904,7 +904,66 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(str.DatabaseName).To(Equal("fdb_cluster_52v1bpr8"))
 				Expect(str.GenerationID).To(Equal("rhUbBjrtyweZBQO1U3Td81zyP9d46yEh"))
-				Expect(str.Coordinators).To(HaveLen(5))
+				Expect(str.Coordinators).To(ConsistOf([]string{
+					"100.82.81.253:4500:tls",
+					"100.82.71.5:4500:tls",
+					"100.82.119.151:4500:tls",
+					"100.82.122.125:4500:tls",
+					"100.82.76.240:4500:tls",
+				}))
+			})
+		})
+
+		When("the input is valid with DNS entries", func() {
+			BeforeEach(func() {
+				input = "fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@coordinator1.test.svc.cluster.local:4500:tls,coordinator2.test.svc.cluster.local:4500:tls,coordinator2.test.svc.cluster.local:4500:tls"
+			})
+
+			It("should be parsed correctly", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(str.DatabaseName).To(Equal("fdb_cluster_52v1bpr8"))
+				Expect(str.GenerationID).To(Equal("rhUbBjrtyweZBQO1U3Td81zyP9d46yEh"))
+				Expect(str.Coordinators).To(ConsistOf([]string{
+					"coordinator1.test.svc.cluster.local:4500:tls",
+					"coordinator2.test.svc.cluster.local:4500:tls",
+					"coordinator2.test.svc.cluster.local:4500:tls",
+				}))
+			})
+		})
+
+		When("the input is valid with IPv6 entries", func() {
+			BeforeEach(func() {
+				input = "fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@[0100::2]:4500:tls,[0100::3]:4500:tls,[0100::4]:4500:tls"
+			})
+
+			It("should be parsed correctly", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(str.DatabaseName).To(Equal("fdb_cluster_52v1bpr8"))
+				Expect(str.GenerationID).To(Equal("rhUbBjrtyweZBQO1U3Td81zyP9d46yEh"))
+				Expect(str.Coordinators).To(ConsistOf([]string{
+					"[100::2]:4500:tls",
+					"[100::3]:4500:tls",
+					"[100::4]:4500:tls",
+				}))
+			})
+		})
+
+		When("the input is valid with IPv6 and IPv4 entries", func() {
+			BeforeEach(func() {
+				input = "fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@100.82.81.253:4500:tls,100.82.71.5:4500:tls,100.82.119.151:4500:tls,[0100::3]:4500:tls,[0100::4]:4500:tls"
+			})
+
+			It("should be parsed correctly", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(str.DatabaseName).To(Equal("fdb_cluster_52v1bpr8"))
+				Expect(str.GenerationID).To(Equal("rhUbBjrtyweZBQO1U3Td81zyP9d46yEh"))
+				Expect(str.Coordinators).To(ConsistOf([]string{
+					"100.82.81.253:4500:tls",
+					"100.82.71.5:4500:tls",
+					"100.82.119.151:4500:tls",
+					"[100::3]:4500:tls",
+					"[100::4]:4500:tls",
+				}))
 			})
 		})
 	})
@@ -921,7 +980,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			str := ConnectionString{
 				DatabaseName: "test",
 				GenerationID: "abcd",
-				Coordinators: coordinatorsStr,
+				Coordinators: coordinatorsList,
 			}
 			Expect(str.String()).To(Equal("test:abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500"))
 		})
@@ -932,7 +991,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			str := ConnectionString{
 				DatabaseName: "test",
 				GenerationID: "abcd",
-				Coordinators: coordinatorsStr,
+				Coordinators: coordinatorsList,
 			}
 			err := str.GenerateNewGenerationID()
 			Expect(err).NotTo(HaveOccurred())
@@ -945,7 +1004,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			str := ConnectionString{
 				DatabaseName: "test",
 				GenerationID: "abcd",
-				Coordinators: coordinatorsStr,
+				Coordinators: coordinatorsList,
 			}
 			Expect(str.HasCoordinators(coordinators)).To(BeTrue())
 			// We have to copy the slice to prevent to modify the original slice

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -811,18 +811,110 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	}
 
 	When("parsing the connection string", func() {
-		It("should be parsed correctly", func() {
-			str, err := ParseConnectionString("test:abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(str.DatabaseName).To(Equal("test"))
-			Expect(str.GenerationID).To(Equal("abcd"))
-			Expect(str.Coordinators).To(Equal(coordinatorsStr))
+		var str ConnectionString
+		var err error
+		var input string
 
-			str, err = ParseConnectionString("test:abcd")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("invalid connection string test:abcd"))
+		JustBeforeEach(func() {
+			str, err = ParseConnectionString(input)
+		})
+
+		When("the input is valid", func() {
+			BeforeEach(func() {
+				input = "test:abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500"
+			})
+
+			It("should be parsed correctly", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(str.DatabaseName).To(Equal("test"))
+				Expect(str.GenerationID).To(Equal("abcd"))
+				Expect(str.Coordinators).To(ConsistOf(coordinatorsStr))
+			})
+		})
+
+		When("the input is invalid", func() {
+			BeforeEach(func() {
+				input = "test:abcd"
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(MatchError(ContainSubstring("invalid connection string: test:abcd, could not split string to get generation ID")))
+			})
+		})
+
+		When("the input has an invalid char", func() {
+			BeforeEach(func() {
+				input = "te-st:abcd"
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(MatchError(ContainSubstring("invalid connection string: te-st:abcd, only alphanumeric characters (a-z, A-Z, 0-9) and underscores are allowed")))
+			})
+		})
+
+		When("the input has an empty description", func() {
+			BeforeEach(func() {
+				input = ":abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500"
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(MatchError(ContainSubstring("invalid connection string: :abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500, only alphanumeric characters (a-z, A-Z, 0-9) and underscores are allowed")))
+			})
+		})
+
+		When("the input has an generation description", func() {
+			BeforeEach(func() {
+				input = "test:@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500"
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(MatchError(ContainSubstring("invalid connection string: test:@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500, only alphanumeric characters (a-z, A-Z, 0-9) are allowed")))
+			})
+		})
+
+		When("the input has no coordinators", func() {
+			BeforeEach(func() {
+				input = "test:abcd@"
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(MatchError(ContainSubstring("invalid connection string: test:abcd@, connection string must contain at least one coordinator")))
+			})
+		})
+
+		When("the input is valid with a single char description", func() {
+			BeforeEach(func() {
+				input = "s:abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500"
+			})
+
+			It("should be parsed correctly", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(str.DatabaseName).To(Equal("s"))
+				Expect(str.GenerationID).To(Equal("abcd"))
+				Expect(str.Coordinators).To(ConsistOf(coordinatorsStr))
+			})
+		})
+
+		When("the input is valid with amultiple underscores", func() {
+			BeforeEach(func() {
+				input = "fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@100.82.81.253:4500:tls,100.82.71.5:4500:tls,100.82.119.151:4500:tls,100.82.122.125:4500:tls,100.82.76.240:4500:tls"
+			})
+
+			It("should be parsed correctly", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(str.DatabaseName).To(Equal("fdb_cluster_52v1bpr8"))
+				Expect(str.GenerationID).To(Equal("rhUbBjrtyweZBQO1U3Td81zyP9d46yEh"))
+				Expect(str.Coordinators).To(HaveLen(5))
+			})
 		})
 	})
+
+	DescribeTable("sanitize connection string description", func(input string, expected string) {
+		Expect(SanitizeConnectionStringDescription(input)).To(Equal(expected))
+	},
+		Entry("without hyphen", "test", "test"),
+		Entry("with hyphen", "test-string", "test_string"),
+	)
 
 	When("formatting the connection string", func() {
 		It("should be formatted correctly", func() {

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -489,8 +488,6 @@ func (r *FoundationDBClusterReconciler) releaseLock(logger logr.Logger, cluster 
 
 	return lockClient.ReleaseLock()
 }
-
-var connectionStringNameRegex, _ = regexp.Compile("[^A-Za-z0-9_]")
 
 // clusterSubReconciler describes a class that does part of the work of
 // reconciliation for a cluster.


### PR DESCRIPTION
# Description

Fix a bug in the connection string parser when a cluster has a single letter as name. Before that the `ParseConnectionString` method would return an error. In addition we will validate the initial cluster file before creating it.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Added unit tests and CI will run e2e tests.

## Documentation

-

## Follow-up

-
