### PR TITLE
Ensure that pods are replaced if we change the Pod IP family

### DIFF
--- a/api/v1beta2/foundationdb_labels.go
+++ b/api/v1beta2/foundationdb_labels.go
@@ -40,6 +40,9 @@ const (
 	// gets its public IP from.
 	PublicIPSourceAnnotation = "foundationdb.org/public-ip-source"
 
+	// IPFamilyAnnotation is an annotation key that specifies the IP family of the pod.
+	IPFamilyAnnotation = "foundationdb.org/ip-family"
+
 	// PublicIPAnnotation is an annotation key that specifies the current public
 	// IP for a pod.
 	PublicIPAnnotation = "foundationdb.org/public-ip"

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -468,7 +468,7 @@ RoutingConfig allows configuring routing to our pods, and services that sit in f
 | ----- | ----------- | ------ | -------- |
 | headlessService | Headless determines whether we want to run a headless service for the cluster. | *bool | false |
 | publicIPSource | PublicIPSource specifies what source a process should use to get its public IPs.  This supports the values `pod` and `service`. | *[PublicIPSource](#publicipsource) | false |
-| podIPFamily | PodIPFamily tells the pod which family of IP addresses to use. You can use 4 to represent IPv4, and 6 to represent IPv6. This feature is only supported in FDB 7.0 or later, and requires dual-stack support in your Kubernetes environment. | *int | false |
+| podIPFamily | PodIPFamily tells the pod which family of IP addresses to use. You can use 4 to represent IPv4, and 6 to represent IPv6. This feature requires dual-stack support in your Kubernetes environment. | *int | false |
 | useDNSInClusterFile | UseDNSInClusterFile determines whether to use DNS names rather than IP addresses to identify coordinators in the cluster file. This requires FoundationDB 7.0+. | *bool | false |
 | defineDNSLocalityFields | DefineDNSLocalityFields determines whether to define pod DNS names on pod specs and provide them in the locality arguments to fdbserver.  This is ignored if UseDNSInCluster is true. | *bool | false |
 | dnsDomain | DNSDomain defines the cluster domain used in a DNS name generated for a service. The default is `cluster.local`. | *string | false |

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -36,6 +36,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -2735,6 +2736,41 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				Expect(initialExclusionTimestamp.Before(newExclusionTimestamp)).To(BeTrue())
 				Expect(initialExclusionTimestamp).NotTo(Equal(newExclusionTimestamp))
 			})
+		})
+	})
+
+	When("the pod IP family is changed", func() {
+		var testStartTime time.Time
+		// TODO (johscheuer): Make the IP family configurable in the future.
+		var podIPFamily = fdbv1beta2.PodIPFamilyIPv4
+
+		BeforeEach(func() {
+			testStartTime = time.Now()
+			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec.Routing.PodIPFamily = pointer.Int(podIPFamily)
+			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			Expect(fdbCluster.WaitForReconciliation()).To(Succeed())
+		})
+
+		AfterEach(func() {
+			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec.Routing.PodIPFamily = nil
+			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			Expect(fdbCluster.WaitForReconciliation(fixtures.SoftReconcileOption(true))).To(Succeed())
+		})
+
+		It("should replace all pods and configure them properly", func() {
+			pods := fdbCluster.GetPods()
+			podIPFamilyString := strconv.Itoa(podIPFamily)
+
+			for _, pod := range pods.Items {
+				if !pod.DeletionTimestamp.IsZero() {
+					continue
+				}
+
+				Expect(pod.CreationTimestamp.After(testStartTime)).To(BeTrue())
+				Expect(pod.Annotations).To(HaveKeyWithValue(fdbv1beta2.IPFamilyAnnotation, podIPFamilyString))
+			}
 		})
 	})
 })

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2768,6 +2768,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					continue
 				}
 
+				if pod.Status.Phase != corev1.PodRunning {
+					log.Println("ignoring pod:", pod.Name, "with pod phase", pod.Status.Phase, "message:", pod.Status.Message)
+					continue
+				}
+
 				Expect(pod.CreationTimestamp.After(testStartTime)).To(BeTrue())
 				Expect(pod.Annotations).To(HaveKeyWithValue(fdbv1beta2.IPFamilyAnnotation, podIPFamilyString))
 			}

--- a/internal/pod_helper_test.go
+++ b/internal/pod_helper_test.go
@@ -1,0 +1,194 @@
+/*
+ * pod_helper_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2018-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import (
+	"errors"
+
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	monitorapi "github.com/apple/foundationdb/fdbkubernetesmonitor/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("pod_helper", func() {
+	DescribeTable("when getting the IP family from a pod", func(pod *corev1.Pod, expected *int, expectedErr error) {
+		result, err := GetIPFamily(pod)
+		if expectedErr != nil {
+			Expect(err).To(MatchError(expectedErr))
+		} else {
+			Expect(err).To(Succeed())
+		}
+		Expect(result).To(Equal(expected))
+	},
+		Entry("empty pod",
+			nil,
+			nil,
+			errors.New("failed to fetch IP family from nil Pod"),
+		),
+		Entry("pod has IP family annotation for IPv4",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.IPFamilyAnnotation: "4",
+					},
+				},
+			},
+			pointer.Int(fdbv1beta2.PodIPFamilyIPv4),
+			nil,
+		),
+		Entry("pod has IP family annotation for IPv6",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.IPFamilyAnnotation: "6",
+					},
+				},
+			},
+			pointer.Int(fdbv1beta2.PodIPFamilyIPv6),
+			nil,
+		),
+		Entry("pod has IP family annotation with invalid value",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.IPFamilyAnnotation: "1337",
+					},
+				},
+			},
+			nil,
+			errors.New("unsupported IP family 1337"),
+		),
+		Entry("pod has no IP family annotation and nothing specified in the pod spec",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			nil,
+			nil,
+		),
+		Entry("pod has no IP family annotation and uses IP family IPv4 with split image",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: fdbv1beta2.SidecarContainerName,
+							Args: []string{
+								"--public-ip-family",
+								"4",
+							},
+						},
+					},
+				},
+			},
+			pointer.Int(fdbv1beta2.PodIPFamilyIPv4),
+			nil,
+		),
+		Entry("pod has no IP family annotation and uses IP family IPv6 with split image",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: fdbv1beta2.SidecarContainerName,
+							Args: []string{
+								"--public-ip-family",
+								"6",
+							},
+						},
+					},
+				},
+			},
+			pointer.Int(fdbv1beta2.PodIPFamilyIPv6),
+			nil,
+		),
+		Entry("pod has no IP family annotation and uses unsupported IP family with split image",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: fdbv1beta2.SidecarContainerName,
+							Args: []string{
+								"--public-ip-family",
+								"1337",
+							},
+						},
+					},
+				},
+			},
+			nil,
+			errors.New("unsupported IP family 1337"),
+		),
+
+		Entry("pod has no IP family annotation and uses IP family IPv4 with unified image",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.ImageTypeAnnotation:            string(fdbv1beta2.ImageTypeUnified),
+						monitorapi.CurrentConfigurationAnnotation: "{\"arguments\": [{\"type\": \"IPList\", \"ipFamily\": 4}]}",
+					},
+				},
+			},
+			pointer.Int(fdbv1beta2.PodIPFamilyIPv4),
+			nil,
+		),
+		Entry("pod has no IP family annotation and uses IP family IPv6 with unified image",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.ImageTypeAnnotation:            string(fdbv1beta2.ImageTypeUnified),
+						monitorapi.CurrentConfigurationAnnotation: "{\"arguments\": [{\"type\": \"IPList\", \"ipFamily\": 6}]}",
+					},
+				},
+			},
+			pointer.Int(fdbv1beta2.PodIPFamilyIPv6),
+			nil,
+		),
+		Entry("pod has no IP family annotation and uses unsupported IP family with unified image",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fdbv1beta2.ImageTypeAnnotation:            string(fdbv1beta2.ImageTypeUnified),
+						monitorapi.CurrentConfigurationAnnotation: "{\"arguments\": [{\"type\": \"IPList\", \"ipFamily\": 1337}]}",
+					},
+				},
+			},
+			nil,
+			errors.New("unsupported IP family 1337"),
+		),
+	)
+})

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -1039,6 +1039,9 @@ func GetPodMetadata(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1b
 	metadata.Annotations[fdbv1beta2.LastSpecKey] = specHash
 	metadata.Annotations[fdbv1beta2.PublicIPSourceAnnotation] = string(cluster.GetPublicIPSource())
 	metadata.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(cluster.DesiredImageType())
+	if cluster.Spec.Routing.PodIPFamily != nil {
+		metadata.Annotations[fdbv1beta2.IPFamilyAnnotation] = strconv.Itoa(*cluster.Spec.Routing.PodIPFamily)
+	}
 
 	return metadata
 }

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -234,7 +234,7 @@ func processGroupNeedsRemovalForPod(cluster *fdbv1beta2.FoundationDBCluster, pod
 		return true, nil
 	}
 
-	podIPFamily, err := internal.GetIPFamilyFromPod(pod)
+	podIPFamily, err := internal.GetIPFamily(pod)
 	if err != nil {
 		return false, err
 	}

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -234,6 +234,21 @@ func processGroupNeedsRemovalForPod(cluster *fdbv1beta2.FoundationDBCluster, pod
 		return true, nil
 	}
 
+	podIPFamily, err := internal.GetIPFamilyFromPod(pod)
+	if err != nil {
+		return false, err
+	}
+
+	if !equality.Semantic.DeepEqual(cluster.Spec.Routing.PodIPFamily, podIPFamily) {
+		logger.Info("Replace process group",
+			"reason", "pod IP family has changed",
+			"currentPodIPFamily", podIPFamily,
+			"desiredPodIPFamily", cluster.Spec.Routing.PodIPFamily,
+		)
+
+		return true, nil
+	}
+
 	if cluster.NeedsReplacement(processGroup) {
 		jsonSpec, err := json.Marshal(spec)
 		if err != nil {

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,25 +22,23 @@ package replacements
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
-	"github.com/FoundationDB/fdb-kubernetes-operator/v2/pkg/podmanager"
-	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	"k8s.io/utils/pointer"
-
-	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
-	"github.com/go-logr/logr"
-
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
+	"github.com/FoundationDB/fdb-kubernetes-operator/v2/pkg/podmanager"
+	monitorapi "github.com/apple/foundationdb/fdbkubernetesmonitor/api"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var _ = Describe("replace_misconfigured_pods", func() {
@@ -529,6 +527,309 @@ var _ = Describe("replace_misconfigured_pods", func() {
 						It("should not need a removal (guard against server-side defaults)", func() {
 							Expect(needsRemoval).To(BeFalse())
 							Expect(err).NotTo(HaveOccurred())
+						})
+					})
+				})
+			})
+
+			When("the pod IP family is checked", func() {
+				When("the pod IP family matches", func() {
+					When("the pod ip family is nil", func() {
+						It("should *not* need a removal", func() {
+							Expect(needsRemoval).To(BeFalse())
+							Expect(err).NotTo(HaveOccurred())
+						})
+					})
+
+					When("the pod ip family is v4", func() {
+						BeforeEach(func() {
+							cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
+						})
+
+						When("the image type is split", func() {
+							BeforeEach(func() {
+								for idx, container := range pod.Spec.Containers {
+									if container.Name != fdbv1beta2.SidecarContainerName {
+										continue
+									}
+
+									pod.Spec.Containers[idx].Args = append(pod.Spec.Containers[idx].Args, "--public-ip-family", "4")
+								}
+							})
+
+							It("should *not* need a removal", func() {
+								Expect(needsRemoval).To(BeFalse())
+								Expect(err).NotTo(HaveOccurred())
+							})
+						})
+
+						When("the image type is unified", func() {
+							BeforeEach(func() {
+								unified := fdbv1beta2.ImageTypeUnified
+								cluster.Spec.ImageType = &unified
+								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(fdbv1beta2.ImageTypeUnified)
+
+								currentConfiguration := monitorapi.ProcessConfiguration{
+									Arguments: []monitorapi.Argument{
+										{
+											ArgumentType: monitorapi.IPListArgumentType,
+											IPFamily:     4,
+										},
+									},
+								}
+
+								currentConfig, err := json.Marshal(currentConfiguration)
+								Expect(err).NotTo(HaveOccurred())
+
+								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(currentConfig)
+							})
+
+							It("should *not* need a removal", func() {
+								Expect(needsRemoval).To(BeFalse())
+								Expect(err).NotTo(HaveOccurred())
+							})
+						})
+					})
+
+					When("the pod ip family is v6", func() {
+						BeforeEach(func() {
+							cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv6)
+						})
+
+						When("the image type is split", func() {
+							BeforeEach(func() {
+								for idx, container := range pod.Spec.Containers {
+									if container.Name != fdbv1beta2.SidecarContainerName {
+										continue
+									}
+
+									pod.Spec.Containers[idx].Args = append(pod.Spec.Containers[idx].Args, "--public-ip-family", "6")
+								}
+							})
+
+							It("should *not* need a removal", func() {
+								Expect(needsRemoval).To(BeFalse())
+								Expect(err).NotTo(HaveOccurred())
+							})
+						})
+
+						When("the image type is unified", func() {
+							BeforeEach(func() {
+								unified := fdbv1beta2.ImageTypeUnified
+								cluster.Spec.ImageType = &unified
+								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(fdbv1beta2.ImageTypeUnified)
+
+								currentConfiguration := monitorapi.ProcessConfiguration{
+									Arguments: []monitorapi.Argument{
+										{
+											ArgumentType: monitorapi.IPListArgumentType,
+											IPFamily:     6,
+										},
+									},
+								}
+
+								currentConfig, err := json.Marshal(currentConfiguration)
+								Expect(err).NotTo(HaveOccurred())
+
+								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(currentConfig)
+							})
+
+							It("should *not* need a removal", func() {
+								Expect(needsRemoval).To(BeFalse())
+								Expect(err).NotTo(HaveOccurred())
+							})
+						})
+					})
+				})
+
+				When("the pod IP family doesn't match", func() {
+					When("the pod ip family at the pod is nil", func() {
+						When("the pod ip family at cluster level is v4", func() {
+							BeforeEach(func() {
+								cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
+							})
+
+							It("should need a removal", func() {
+								Expect(needsRemoval).To(BeTrue())
+								Expect(err).NotTo(HaveOccurred())
+							})
+						})
+
+						When("the pod ip family at cluster level is v6", func() {
+							BeforeEach(func() {
+								cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
+							})
+
+							It("should need a removal", func() {
+								Expect(needsRemoval).To(BeTrue())
+								Expect(err).NotTo(HaveOccurred())
+							})
+						})
+					})
+
+					When("the pod ip family at the pod is v4", func() {
+						When("the image type is split", func() {
+							BeforeEach(func() {
+								for idx, container := range pod.Spec.Containers {
+									if container.Name != fdbv1beta2.SidecarContainerName {
+										continue
+									}
+
+									pod.Spec.Containers[idx].Args = append(pod.Spec.Containers[idx].Args, "--public-ip-family", "4")
+								}
+
+								pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = ""
+							})
+
+							When("the pod ip family at cluster level is nil", func() {
+								BeforeEach(func() {
+									cluster.Spec.Routing.PodIPFamily = nil
+								})
+
+								It("should need a removal", func() {
+									Expect(needsRemoval).To(BeTrue())
+									Expect(err).NotTo(HaveOccurred())
+								})
+							})
+
+							When("the pod ip family at cluster level is v6", func() {
+								BeforeEach(func() {
+									cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv6)
+								})
+
+								It("should need a removal", func() {
+									Expect(needsRemoval).To(BeTrue())
+									Expect(err).NotTo(HaveOccurred())
+								})
+							})
+						})
+
+						When("the image type is unified", func() {
+							BeforeEach(func() {
+								unified := fdbv1beta2.ImageTypeUnified
+								cluster.Spec.ImageType = &unified
+								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(fdbv1beta2.ImageTypeUnified)
+
+								currentConfiguration := monitorapi.ProcessConfiguration{
+									Arguments: []monitorapi.Argument{
+										{
+											ArgumentType: monitorapi.IPListArgumentType,
+											IPFamily:     4,
+										},
+									},
+								}
+
+								currentConfig, err := json.Marshal(currentConfiguration)
+								Expect(err).NotTo(HaveOccurred())
+
+								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(currentConfig)
+								pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = ""
+							})
+
+							When("the pod ip family at cluster level is nil", func() {
+								BeforeEach(func() {
+									cluster.Spec.Routing.PodIPFamily = nil
+								})
+
+								It("should need a removal", func() {
+									Expect(needsRemoval).To(BeTrue())
+									Expect(err).NotTo(HaveOccurred())
+								})
+							})
+
+							When("the pod ip family at cluster level is v6", func() {
+								BeforeEach(func() {
+									cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv6)
+								})
+
+								It("should need a removal", func() {
+									Expect(needsRemoval).To(BeTrue())
+									Expect(err).NotTo(HaveOccurred())
+								})
+							})
+						})
+					})
+
+					When("the pod ip family at the pod is v6", func() {
+						When("the image type is split", func() {
+							BeforeEach(func() {
+								for idx, container := range pod.Spec.Containers {
+									if container.Name != fdbv1beta2.SidecarContainerName {
+										continue
+									}
+
+									pod.Spec.Containers[idx].Args = append(pod.Spec.Containers[idx].Args, "--public-ip-family", "6")
+								}
+
+								pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = ""
+							})
+
+							When("the pod ip family at cluster level is nil", func() {
+								BeforeEach(func() {
+									cluster.Spec.Routing.PodIPFamily = nil
+								})
+
+								It("should need a removal", func() {
+									Expect(needsRemoval).To(BeTrue())
+									Expect(err).NotTo(HaveOccurred())
+								})
+							})
+
+							When("the pod ip family at cluster level is v4", func() {
+								BeforeEach(func() {
+									cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
+								})
+
+								It("should need a removal", func() {
+									Expect(needsRemoval).To(BeTrue())
+									Expect(err).NotTo(HaveOccurred())
+								})
+							})
+						})
+
+						When("the image type is unified", func() {
+							BeforeEach(func() {
+								unified := fdbv1beta2.ImageTypeUnified
+								cluster.Spec.ImageType = &unified
+								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(fdbv1beta2.ImageTypeUnified)
+
+								currentConfiguration := monitorapi.ProcessConfiguration{
+									Arguments: []monitorapi.Argument{
+										{
+											ArgumentType: monitorapi.IPListArgumentType,
+											IPFamily:     6,
+										},
+									},
+								}
+
+								currentConfig, err := json.Marshal(currentConfiguration)
+								Expect(err).NotTo(HaveOccurred())
+
+								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(currentConfig)
+								pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = ""
+							})
+
+							When("the pod ip family at cluster level is nil", func() {
+								BeforeEach(func() {
+									cluster.Spec.Routing.PodIPFamily = nil
+								})
+
+								It("should need a removal", func() {
+									Expect(needsRemoval).To(BeTrue())
+									Expect(err).NotTo(HaveOccurred())
+								})
+							})
+
+							When("the pod ip family at cluster level is v4", func() {
+								BeforeEach(func() {
+									cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
+								})
+
+								It("should need a removal", func() {
+									Expect(needsRemoval).To(BeTrue())
+									Expect(err).NotTo(HaveOccurred())
+								})
+							})
 						})
 					})
 				})


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2243

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

With the previous behaviour it could happen that the coordinators went unreachable because they were listening on the wrong IP family and then the operator would get stuck. This change prevents it by spinning up a new set of pods.

## Testing

Added a new e2e test to convert from `nil` family to `v4`. I run some tests in a dual-stack cluster.

## Documentation

-

## Follow-up

https://github.com/FoundationDB/fdb-kubernetes-operator/issues/834 the idea here would be to listen on both addresses for some time.
