### PR TITLE
Use patch for pod updates

### DIFF
--- a/controllers/update_metadata.go
+++ b/controllers/update_metadata.go
@@ -95,13 +95,14 @@ func (updateMetadata) reconcile(ctx context.Context, r *FoundationDBClusterRecon
 
 func updatePodMetadata(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus) error {
 	pod, err := r.PodLifecycleManager.GetPod(ctx, r, cluster, processGroup.GetPodName(cluster))
+	originalPod := pod.DeepCopy()
 	if err != nil {
 		return err
 	}
 
 	desiredMetadata := internal.GetPodMetadata(cluster, processGroup.ProcessClass, processGroup.ProcessGroupID, "")
 	if !podMetadataCorrect(desiredMetadata, pod) {
-		return r.PodLifecycleManager.UpdateMetadata(ctx, r, cluster, pod)
+		return r.PodLifecycleManager.UpdateMetadata(ctx, r, cluster, pod, originalPod)
 	}
 
 	return nil

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -66,6 +66,7 @@ func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		}
 
 		pod, err := r.PodLifecycleManager.GetPod(ctx, r, cluster, processGroup.GetPodName(cluster))
+		originalPod := pod.DeepCopy()
 		// If a Pod is not found ignore it for now.
 		if err != nil {
 			logger.V(1).Info("Could not find Pod for process group ID")
@@ -124,7 +125,7 @@ func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReco
 			}
 
 			pod.ObjectMeta.Annotations[api.OutdatedConfigMapAnnotation] = strconv.FormatInt(time.Now().Unix(), 10)
-			err = r.PodLifecycleManager.UpdateMetadata(ctx, r, cluster, pod)
+			err = r.PodLifecycleManager.UpdateMetadata(ctx, r, cluster, pod, originalPod)
 			if err != nil {
 				allSynced = false
 				curLogger.Error(err, "Update Pod ConfigMap annotation")
@@ -137,7 +138,7 @@ func (updatePodConfig) reconcile(ctx context.Context, r *FoundationDBClusterReco
 		if pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey] != configMapHash {
 			pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey] = configMapHash
 			delete(pod.ObjectMeta.Annotations, api.OutdatedConfigMapAnnotation)
-			err = r.PodLifecycleManager.UpdateMetadata(ctx, r, cluster, pod)
+			err = r.PodLifecycleManager.UpdateMetadata(ctx, r, cluster, pod, originalPod)
 			if err != nil {
 				allSynced = false
 				curLogger.Error(err, "Update Pod metadata")

--- a/pkg/podmanager/pod_lifecycle_manager.go
+++ b/pkg/podmanager/pod_lifecycle_manager.go
@@ -168,7 +168,7 @@ func (manager StandardPodLifecycleManager) UpdateImageVersion(ctx context.Contex
 }
 
 // UpdateMetadata updates an Pod's metadata.
-func (manager StandardPodLifecycleManager) UpdateMetadata(ctx context.Context, r client.Client, _ *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod, *corev1.Pod) error {
+func (manager StandardPodLifecycleManager) UpdateMetadata(ctx context.Context, r client.Client, _ *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod, originalPod *corev1.Pod) error {
 	return r.Patch(ctx, pod, client.MergeFrom(originalPod))
 }
 

--- a/pkg/podmanager/pod_lifecycle_manager.go
+++ b/pkg/podmanager/pod_lifecycle_manager.go
@@ -58,7 +58,7 @@ type PodLifecycleManager interface {
 	UpdateImageVersion(context.Context, client.Client, *fdbv1beta2.FoundationDBCluster, *corev1.Pod, int, string) error
 
 	// UpdateMetadata updates a Pod's metadata.
-	UpdateMetadata(context.Context, client.Client, *fdbv1beta2.FoundationDBCluster, *corev1.Pod) error
+	UpdateMetadata(context.Context, client.Client, *fdbv1beta2.FoundationDBCluster, *corev1.Pod, *corev1.Pod) error
 
 	// PodIsUpdated determines whether a Pod is up to date.
 	//
@@ -162,13 +162,14 @@ func (manager StandardPodLifecycleManager) UpdatePods(ctx context.Context, r cli
 
 // UpdateImageVersion updates a Pod container's image.
 func (manager StandardPodLifecycleManager) UpdateImageVersion(ctx context.Context, r client.Client, _ *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod, containerIndex int, image string) error {
+	originalPod := pod.DeepCopy()
 	pod.Spec.Containers[containerIndex].Image = image
-	return r.Update(ctx, pod)
+	return r.Patch(ctx, pod, client.MergeFrom(originalPod))
 }
 
 // UpdateMetadata updates an Pod's metadata.
-func (manager StandardPodLifecycleManager) UpdateMetadata(ctx context.Context, r client.Client, _ *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod) error {
-	return r.Update(ctx, pod)
+func (manager StandardPodLifecycleManager) UpdateMetadata(ctx context.Context, r client.Client, _ *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod, *corev1.Pod) error {
+	return r.Patch(ctx, pod, client.MergeFrom(originalPod))
 }
 
 // PodIsUpdated determines whether a Pod is up to date.


### PR DESCRIPTION
# Description

In a Kubernetes environment with admission controllers that mutate pod specs (for example, to enforce a particular `appArmorProfile`), if the K8s client API versions used for pod spec ser/de in the operator are too old to include the fields that the admission controllers mutated (e.g. `appArmorProfile`), then the pod spec deserialized from `GetPod` will drop those unknown fields. 

If any of these fields are immutable, then all subsequent pod update attempts will fail because the full pod spec update will implicitly attempt to set those immutable unknown fields back to `nil`.

By using a patch instead of a full update, the operator will only attempt to update the fields it has explicitly changed, avoiding this class of issues resulting from desync between K8s client and server api versions.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

Alternatively, bumping the K8s client libraries to more recent versions that include `appArmorProfile` would likely resolve this particular occurrence of this issue. However, the same issue could plausibly reoccur in the future if the full update strategy continues to be used.

## Testing

## Documentation

## Follow-up
