### PR TITLE
Fix test case for Pod IP family change

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2740,12 +2740,15 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	})
 
 	When("the pod IP family is changed", func() {
-		var testStartTime time.Time
-		// TODO (johscheuer): Make the IP family configurable in the future.
+		var initialPods []string
 		var podIPFamily = fdbv1beta2.PodIPFamilyIPv4
 
 		BeforeEach(func() {
-			testStartTime = time.Now()
+			pods := fdbCluster.GetPods()
+			for _, pod := range pods.Items {
+				initialPods = append(initialPods, pod.Name)
+			}
+
 			spec := fdbCluster.GetCluster().Spec.DeepCopy()
 			spec.Routing.PodIPFamily = pointer.Int(podIPFamily)
 			fdbCluster.UpdateClusterSpecWithSpec(spec)
@@ -2763,6 +2766,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			pods := fdbCluster.GetPods()
 			podIPFamilyString := strconv.Itoa(podIPFamily)
 
+			newPods := make([]string, 0, len(pods.Items))
 			for _, pod := range pods.Items {
 				if !pod.DeletionTimestamp.IsZero() {
 					continue
@@ -2773,9 +2777,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					continue
 				}
 
-				Expect(pod.CreationTimestamp.After(testStartTime)).To(BeTrue())
+				newPods = append(newPods, pod.Name)
 				Expect(pod.Annotations).To(HaveKeyWithValue(fdbv1beta2.IPFamilyAnnotation, podIPFamilyString))
 			}
+
+			Expect(newPods).NotTo(ContainElements(initialPods))
 		})
 	})
 })


### PR DESCRIPTION
# Description

Fix to make the replacement for pod IP family e2e test more robust.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran test manually.

## Documentation

-

## Follow-up

-
