### PR TITLE
Ensure that the cordon command doesn't stop when a node doesn't host any pods

### DIFF
--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -109,7 +109,7 @@ var _ = Describe("[plugin] cordon command", func() {
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:       clusterName,
 					clusterLabel:      "",
-					wantErrorContains: "no pods were found that were running on node",
+					wantErrorContains: "",
 				}),
 			Entry("Cordon no node nodes without exclusion",
 				testCase{
@@ -119,7 +119,7 @@ var _ = Describe("[plugin] cordon command", func() {
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:       clusterName,
 					clusterLabel:      "",
-					wantErrorContains: "no pods were found that were running on node",
+					wantErrorContains: "",
 				}),
 			Entry("Cordon all nodes with exclusion",
 				testCase{
@@ -197,7 +197,7 @@ var _ = Describe("[plugin] cordon command", func() {
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:       "",
 					clusterLabel:      fdbv1beta2.FDBClusterLabel,
-					wantErrorContains: "no pods were found that were running on node",
+					wantErrorContains: "",
 				}),
 		)
 	})


### PR DESCRIPTION
# Description

The previous behaviour was bad in cases where a few hosts where not hosting any pods, in this case the whole command would be aborted. I think it's better to just print a warning instead of returning an error and stop everything. In some cases when enough nodes are selected (e.g. with a node selector) the chances that a single node not hosting any pods, is fairly high.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Adjusted unit tests and ran some manual tests.

## Documentation

-

## Follow-up

-