### PR TITLE
Fix crash in findFoundationDBClusterForNode when in global mode

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -339,17 +339,19 @@ func (r *FoundationDBClusterReconciler) findFoundationDBClusterForNode(node clie
 	podsOnNode := &corev1.PodList{}
 
 	labelSelector := client.HasLabels([]string{r.ClusterLabelKeyForNodeTrigger})
-	var namespaceOption client.ListOption
-	if r.Namespace != "" {
-		namespaceOption = client.InNamespace(r.Namespace)
-	}
 
-	err := r.List(context.Background(), podsOnNode,
+	listOpts := []client.ListOption{
 		client.MatchingFieldsSelector{
 			Selector: fields.OneTermEqualSelector("spec.nodeName", node.GetName()),
 		},
 		labelSelector,
-		namespaceOption)
+	}
+
+	if r.Namespace != "" {
+		listOpts = append(listOpts, client.InNamespace(r.Namespace))
+	}
+
+	err := r.List(context.Background(), podsOnNode, listOpts...)
 
 	if err != nil {
 		logger.Error(err, "Processing findFoundationDBClusterForNode could not fetch Pods on node")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -79,7 +79,11 @@ var _ = BeforeSuite(func() {
 
 var _ = BeforeEach(func() {
 	// +kubebuilder:scaffold:scheme
-	k8sClient = mockclient.NewMockClient(scheme.Scheme)
+	k8sClient = mockclient.NewMockClientWithHooksAndIndexes(
+		scheme.Scheme,
+		nil, /* create hooks */
+		nil, /* update hooks */
+		true /* enable indexing by nodeName */)
 
 	clusterReconciler = createTestClusterReconciler()
 	backupReconciler = &FoundationDBBackupReconciler{


### PR DESCRIPTION
# Description

When the operator is executed with `cluster-label-key-for-node-trigger` flag in global mode it goes to crash loop, because the namespace is empty and in `FoundationDBClusterReconciler.findFoundationDBClusterForNode` a null pointer is passed to k8s-client Lister. We fix this issue by passing the variable only if namespace is not empty.

## Type of change

*Please select one of the options below.*

X Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation
- Other

## Discussion

N/A

## Testing

We ran it in different environments. 

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No

## Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
