### PR TITLE
Add support for the operator to run on ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG TAG="latest"
 
 RUN set -eux && \
     if [ "$TARGETARCH" = "amd64" ]; then \
-         FDB_ARCH=x86_64; \
+         FDB_ARCH=amd64; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
          FDB_ARCH=aarch64; \
     else \


### PR DESCRIPTION
# Description

Add support for the operator to run on ARM.

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

Right now only 7.3 and newer is supported as the previous versions don't have the client packages for arm.

## Testing

Build and ran the image locally.

## Documentation

Added some notes to the Dockerfile.

## Follow-up

-
