### PR TITLE
Remove maintenance information if process group doesn't exist

### DIFF
--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -69,7 +69,7 @@ func (c maintenanceModeChecker) reconcile(_ context.Context, r *FoundationDBClus
 	}
 
 	// Get all the maintenance information from the FDB cluster.
-	finishedMaintenance, staleMaintenanceInformation, processesToUpdate := maintenance.GetMaintenanceInformation(logger, status, processesUnderMaintenance, r.MaintenanceListStaleDuration, r.MaintenanceListWaitDuration)
+	finishedMaintenance, staleMaintenanceInformation, processesToUpdate := maintenance.GetMaintenanceInformation(logger, cluster, status, processesUnderMaintenance, r.MaintenanceListStaleDuration, r.MaintenanceListWaitDuration)
 	logger.Info("maintenance information", "finishedMaintenance", finishedMaintenance, "staleMaintenanceInformation", staleMaintenanceInformation, "processesToUpdate", processesToUpdate)
 
 	// We can remove the information for all the finished maintenance and the stale entries.

--- a/internal/maintenance/maintenance_test.go
+++ b/internal/maintenance/maintenance_test.go
@@ -31,6 +31,7 @@ import (
 
 var _ = Describe("maintenance", func() {
 	type maintenanceTest struct {
+		cluster                     *fdbv1beta2.FoundationDBCluster
 		status                      *fdbv1beta2.FoundationDBStatus
 		processesUnderMaintenance   map[fdbv1beta2.ProcessGroupID]int64
 		staleDuration               time.Duration
@@ -41,13 +42,14 @@ var _ = Describe("maintenance", func() {
 	}
 
 	DescribeTable("when getting the maintenance information", func(input maintenanceTest) {
-		finishedMaintenance, staleMaintenanceInformation, processesToUpdate := GetMaintenanceInformation(logr.Discard(), input.status, input.processesUnderMaintenance, input.staleDuration, input.differentZoneWaitDuration)
+		finishedMaintenance, staleMaintenanceInformation, processesToUpdate := GetMaintenanceInformation(logr.Discard(), input.cluster, input.status, input.processesUnderMaintenance, input.staleDuration, input.differentZoneWaitDuration)
 		Expect(finishedMaintenance).To(ConsistOf(input.finishedMaintenance))
 		Expect(staleMaintenanceInformation).To(ConsistOf(input.staleMaintenanceInformation))
 		Expect(processesToUpdate).To(ConsistOf(input.processesToUpdate))
 	},
 		Entry("when no process are under maintenance",
 			maintenanceTest{
+				cluster:                     &fdbv1beta2.FoundationDBCluster{},
 				status:                      &fdbv1beta2.FoundationDBStatus{},
 				processesUnderMaintenance:   nil,
 				staleDuration:               1 * time.Hour,
@@ -58,6 +60,16 @@ var _ = Describe("maintenance", func() {
 		),
 		Entry("when one process is done with the maintenance",
 			maintenanceTest{
+				cluster: &fdbv1beta2.FoundationDBCluster{
+					Status: fdbv1beta2.FoundationDBClusterStatus{
+						ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
+							{
+								ProcessGroupID: "storage-1",
+								ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							},
+						},
+					},
+				},
 				status: &fdbv1beta2.FoundationDBStatus{
 					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 						MaintenanceZone: "rack-1",
@@ -84,6 +96,20 @@ var _ = Describe("maintenance", func() {
 		),
 		Entry("when one process is done with the maintenance but another one is pending",
 			maintenanceTest{
+				cluster: &fdbv1beta2.FoundationDBCluster{
+					Status: fdbv1beta2.FoundationDBClusterStatus{
+						ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
+							{
+								ProcessGroupID: "storage-1",
+								ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							},
+							{
+								ProcessGroupID: "storage-2",
+								ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							},
+						},
+					},
+				},
 				status: &fdbv1beta2.FoundationDBStatus{
 					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 						MaintenanceZone: "rack-1",
@@ -119,6 +145,20 @@ var _ = Describe("maintenance", func() {
 		),
 		Entry("when one process is done with the maintenance but another one is missing in the status",
 			maintenanceTest{
+				cluster: &fdbv1beta2.FoundationDBCluster{
+					Status: fdbv1beta2.FoundationDBClusterStatus{
+						ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
+							{
+								ProcessGroupID: "storage-1",
+								ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							},
+							{
+								ProcessGroupID: "storage-2",
+								ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							},
+						},
+					},
+				},
 				status: &fdbv1beta2.FoundationDBStatus{
 					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 						MaintenanceZone: "rack-1",
@@ -144,8 +184,59 @@ var _ = Describe("maintenance", func() {
 				processesToUpdate:           []fdbv1beta2.ProcessGroupID{"storage-2"},
 			},
 		),
+		Entry("when one process is done with the maintenance but another one is missing in the status and is removed from the process group list",
+			maintenanceTest{
+				cluster: &fdbv1beta2.FoundationDBCluster{
+					Status: fdbv1beta2.FoundationDBClusterStatus{
+						ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
+							{
+								ProcessGroupID: "storage-1",
+								ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							},
+						},
+					},
+				},
+				status: &fdbv1beta2.FoundationDBStatus{
+					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+						MaintenanceZone: "rack-1",
+						Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+							"storage-1": {
+								ProcessClass: fdbv1beta2.ProcessClassStorage,
+								Locality: map[string]string{
+									fdbv1beta2.FDBLocalityInstanceIDKey: "storage-1",
+									fdbv1beta2.FDBLocalityZoneIDKey:     "rack-1",
+								},
+								UptimeSeconds: 15.0,
+							},
+						},
+					},
+				},
+				processesUnderMaintenance: map[fdbv1beta2.ProcessGroupID]int64{
+					"storage-1": time.Now().Add(-1 * time.Minute).Unix(),
+					"storage-2": time.Now().Add(-1 * time.Minute).Unix(),
+				},
+				staleDuration:               1 * time.Hour,
+				finishedMaintenance:         []fdbv1beta2.ProcessGroupID{"storage-1"},
+				staleMaintenanceInformation: []fdbv1beta2.ProcessGroupID{"storage-2"},
+				processesToUpdate:           nil,
+			},
+		),
 		Entry("when one process is done with the maintenance and another one from a different fault domain is present",
 			maintenanceTest{
+				cluster: &fdbv1beta2.FoundationDBCluster{
+					Status: fdbv1beta2.FoundationDBClusterStatus{
+						ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
+							{
+								ProcessGroupID: "storage-1",
+								ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							},
+							{
+								ProcessGroupID: "storage-2",
+								ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							},
+						},
+					},
+				},
 				status: &fdbv1beta2.FoundationDBStatus{
 					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 						MaintenanceZone: "rack-1",
@@ -181,6 +272,20 @@ var _ = Describe("maintenance", func() {
 		),
 		Entry("when one process is done with the maintenance and another one from a different fault domain is present with an old entry",
 			maintenanceTest{
+				cluster: &fdbv1beta2.FoundationDBCluster{
+					Status: fdbv1beta2.FoundationDBClusterStatus{
+						ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
+							{
+								ProcessGroupID: "storage-1",
+								ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							},
+							{
+								ProcessGroupID: "storage-2",
+								ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							},
+						},
+					},
+				},
 				status: &fdbv1beta2.FoundationDBStatus{
 					Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 						MaintenanceZone: "rack-1",


### PR DESCRIPTION
# Description

If the operator finds maintenance information for a process group that doesn't exist, the operator should mark this information as stale. Otherwise the operator has to wait until the information is marked as stale (exists for more than 4h).

## Type of change

- Other

## Discussion

-

## Testing

Updated the unit tests.

## Documentation

-

## Follow-up

-
