### PR TITLE
Remove the use-process-group-id flag and validate the process group ID

### DIFF
--- a/kubectl-fdb/cmd/buggify_crash_loop_test.go
+++ b/kubectl-fdb/cmd/buggify_crash_loop_test.go
@@ -192,8 +192,7 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							if crashLoopContainerObj.ContainerName != fdbv1beta2.MainContainerName {
 								continue
 							}
-							Expect(tc.ExpectedProcessGroupsInCrashLoop).To(ContainElements(crashLoopContainerObj.Targets))
-							Expect(tc.ExpectedProcessGroupsInCrashLoop).To(HaveLen(len(crashLoopContainerObj.Targets)))
+							Expect(tc.ExpectedProcessGroupsInCrashLoop).To(ConsistOf(crashLoopContainerObj.Targets))
 						}
 					},
 					Entry("Adding same process group.",
@@ -208,8 +207,8 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 						}),
 					Entry("Adding multiple process groups.",
 						testCase{
-							ProcessGroups:                    []string{"test-storage-1", "test-storage-2", "test-storage-3"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-storage-3"},
+							ProcessGroups:                    []string{"test-storage-1", "test-storage-2", "test-stateless-3"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-stateless-3"},
 						}),
 				)
 			})
@@ -251,8 +250,7 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							if crashLoopContainerObj.ContainerName != fdbv1beta2.MainContainerName {
 								continue
 							}
-							Expect(tc.ExpectedProcessGroupsInCrashLoop).To(ContainElements(crashLoopContainerObj.Targets))
-							Expect(tc.ExpectedProcessGroupsInCrashLoop).To(HaveLen(len(crashLoopContainerObj.Targets)))
+							Expect(tc.ExpectedProcessGroupsInCrashLoop).To(ConsistOf(crashLoopContainerObj.Targets))
 						}
 					},
 					Entry("Adding single process group.",
@@ -262,8 +260,8 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 						}),
 					Entry("Adding multiple process group.",
 						testCase{
-							ProcessGroups:                    []string{"test-storage-1", "test-storage-2", "test-storage-3"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-storage-3"},
+							ProcessGroups:                    []string{"test-storage-1", "test-storage-2", "test-stateless-3"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-stateless-3"},
 						}),
 				)
 
@@ -279,7 +277,7 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 			BeforeEach(func() {
 				crashLoopContainerObj := fdbv1beta2.CrashLoopContainerObject{
 					ContainerName: fdbv1beta2.MainContainerName,
-					Targets:       []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-storage-3"},
+					Targets:       []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-stateless-3"},
 				}
 				cluster.Spec.Buggify.CrashLoopContainers = append(cluster.Spec.Buggify.CrashLoopContainers, crashLoopContainerObj)
 			})
@@ -311,23 +309,22 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 						if crashLoopContainerObj.ContainerName != fdbv1beta2.MainContainerName {
 							continue
 						}
-						Expect(tc.ExpectedProcessGroupsInCrashLoop).To(ContainElements(crashLoopContainerObj.Targets))
-						Expect(tc.ExpectedProcessGroupsInCrashLoop).To(HaveLen(len(crashLoopContainerObj.Targets)))
+						Expect(tc.ExpectedProcessGroupsInCrashLoop).To(ConsistOf(crashLoopContainerObj.Targets))
 					}
 				},
 				Entry("Removing single process group.",
 					testCase{
 						ProcessGroups:                    []string{"test-storage-1"},
-						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-2", "test-storage-3"},
+						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-2", "test-stateless-3"},
 					}),
 				Entry("Removing multiple process groups.",
 					testCase{
 						ProcessGroups:                    []string{"test-storage-1", "test-storage-2"},
-						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-3"},
+						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-stateless-3"},
 					}),
 				Entry("Removing all process groups.",
 					testCase{
-						ProcessGroups:                    []string{"test-storage-1", "test-storage-2", "test-storage-3"},
+						ProcessGroups:                    []string{"test-storage-1", "test-storage-2", "test-stateless-3"},
 						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{},
 					}),
 			)

--- a/kubectl-fdb/cmd/buggify_no_schedule_test.go
+++ b/kubectl-fdb/cmd/buggify_no_schedule_test.go
@@ -163,8 +163,7 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 							Name:      clusterName,
 						}, &resCluster)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(tc.ExpectedInstancesInNoSchedule).To(ContainElements(resCluster.Spec.Buggify.NoSchedule))
-						Expect(len(tc.ExpectedInstancesInNoSchedule)).To(BeNumerically("==", len(resCluster.Spec.Buggify.NoSchedule)))
+						Expect(tc.ExpectedInstancesInNoSchedule).To(ConsistOf(resCluster.Spec.Buggify.NoSchedule))
 					},
 					Entry("Adding the same instance.",
 						testCase{
@@ -178,8 +177,8 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 						}),
 					Entry("Adding multiple instances.",
 						testCase{
-							Instances:                     []string{"test-storage-2", "test-storage-3"},
-							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-storage-3"},
+							Instances:                     []string{"test-storage-2", "test-stateless-3"},
+							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-stateless-3"},
 						}),
 				)
 			})
@@ -187,7 +186,7 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 
 		When("removing process group from no-schedule list from a cluster", func() {
 			BeforeEach(func() {
-				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-storage-3"}
+				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-stateless-3"}
 			})
 
 			type testCase struct {
@@ -217,17 +216,16 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 						Name:      clusterName,
 					}, &resCluster)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(tc.ExpectedInstancesInNoSchedule).To(Equal(resCluster.Spec.Buggify.NoSchedule))
-					Expect(len(tc.ExpectedInstancesInNoSchedule)).To(BeNumerically("==", len(resCluster.Spec.Buggify.NoSchedule)))
+					Expect(tc.ExpectedInstancesInNoSchedule).To(ConsistOf(resCluster.Spec.Buggify.NoSchedule))
 				},
 				Entry("Removing single instance.",
 					testCase{
 						Instances:                     []string{"test-storage-1"},
-						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-2", "test-storage-3"},
+						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-2", "test-stateless-3"},
 					}),
 				Entry("Removing multiple instances.",
 					testCase{
-						Instances:                     []string{"test-storage-2", "test-storage-3"},
+						Instances:                     []string{"test-storage-2", "test-stateless-3"},
 						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
 					}),
 			)

--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -151,12 +151,11 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 		cmd.Println("Cordoning node:", node)
 		removedFromNode, err := replaceProcessGroups(cmd, kubeClient,
 			processGroupSelectionOptions{
-				ids:               podNames,
-				namespace:         namespace,
-				clusterName:       inputClusterName,
-				clusterLabel:      clusterLabel,
-				processClass:      "",
-				useProcessGroupID: false,
+				ids:          podNames,
+				namespace:    namespace,
+				clusterName:  inputClusterName,
+				clusterLabel: clusterLabel,
+				processClass: "",
 			},
 			replaceProcessGroupsOptions{
 				withExclusion:   withExclusion,

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -255,10 +255,13 @@ func getAllPodsFromClusterWithCondition(ctx context.Context, stdErr io.Writer, k
 }
 
 // getProcessGroupIDsFromPodName returns the process group IDs based on the cluster configuration.
-func getProcessGroupIDsFromPodName(cluster *fdbv1beta2.FoundationDBCluster, podNames []string) ([]fdbv1beta2.ProcessGroupID, error) {
+func getProcessGroupIDsFromPodName(out io.Writer, cluster *fdbv1beta2.FoundationDBCluster, podNames []string) ([]fdbv1beta2.ProcessGroupID, error) {
 	processGroupIDs := make([]fdbv1beta2.ProcessGroupID, 0, len(podNames))
+	currentProcessGroups := map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None{}
+	for _, processGroup := range cluster.Status.ProcessGroups {
+		currentProcessGroups[processGroup.ProcessGroupID] = fdbv1beta2.None{}
+	}
 
-	// TODO(johscheuer): We could validate if the provided process group is actually part of the cluster
 	for _, podName := range podNames {
 		if podName == "" {
 			continue
@@ -268,7 +271,14 @@ func getProcessGroupIDsFromPodName(cluster *fdbv1beta2.FoundationDBCluster, podN
 			return nil, fmt.Errorf("cluster name %s is not set as prefix for Pod name %s, please ensure the specified Pod is part of the cluster", cluster.Name, podName)
 		}
 
-		processGroupIDs = append(processGroupIDs, internal.GetProcessGroupIDFromPodName(cluster, podName))
+		processGroupID := internal.GetProcessGroupIDFromPodName(cluster, podName)
+		_, ok := currentProcessGroups[processGroupID]
+		if !ok {
+			_, _ = fmt.Fprintf(out, "Process Group: %s is not part of the cluster, will be ignored", processGroupID)
+			continue
+		}
+
+		processGroupIDs = append(processGroupIDs, processGroupID)
 	}
 
 	return processGroupIDs, nil
@@ -453,17 +463,14 @@ func fetchPodsOnNode(kubeClient client.Client, clusterName string, namespace str
 // getPodNamesByCluster returns a map of pod names (strings) by FDB cluster that match the criteria in the provided
 // processSelectionOptions.
 func getPodNamesByCluster(cmd *cobra.Command, kubeClient client.Client, opts processGroupSelectionOptions) (map[*fdbv1beta2.FoundationDBCluster][]string, error) {
-	if opts.useProcessGroupID {
-		return nil, errors.New("useProcessGroupID is not supported by getPodNamesByCluster")
-	}
 	// option compatibility checks
 	if opts.clusterName == "" && opts.clusterLabel == "" {
 		return nil, errors.New("podNames will not be selected without cluster specification")
 	}
 	if opts.clusterName == "" { // cli has a default for clusterLabel
-		if opts.useProcessGroupID || opts.processClass != "" || len(opts.conditions) > 0 || len(opts.matchLabels) > 0 {
+		if opts.processClass != "" || len(opts.conditions) > 0 || len(opts.matchLabels) > 0 {
 			return nil, errors.New("selection of pods / process groups by cluster-label (cross-cluster selection) is " +
-				"incompatible with use-process-group-id, process-class, process-condition, and match-labels options.  " +
+				"incompatible with process-class, process-condition, and match-labels options.  " +
 				"Please specify a cluster")
 		}
 	}
@@ -476,7 +483,7 @@ func getPodNamesByCluster(cmd *cobra.Command, kubeClient client.Client, opts pro
 	}
 
 	// cross-cluster logic: given a list of Pod names, we can look up the FDB clusters by pod label, and work across clusters
-	if !opts.useProcessGroupID && opts.clusterName == "" {
+	if opts.clusterName == "" {
 		return fetchPodNamesCrossCluster(kubeClient, opts.namespace, opts.clusterLabel, opts.ids...)
 	}
 
@@ -523,9 +530,9 @@ func getProcessGroupsByCluster(cmd *cobra.Command, kubeClient client.Client, opt
 		return nil, errors.New("processGroups will not be selected without cluster specification")
 	}
 	if opts.clusterName == "" { // cli has a default for clusterLabel
-		if opts.useProcessGroupID || opts.processClass != "" || len(opts.conditions) > 0 {
+		if opts.processClass != "" || len(opts.conditions) > 0 {
 			return nil, errors.New("selection of process groups by cluster-label (cross-cluster selection) is " +
-				"incompatible with use-process-group-id, process-class, process-condition, and match-labels options.  " +
+				"incompatible with process-class, process-condition, and match-labels options.  " +
 				"Please specify a cluster")
 		}
 	}
@@ -537,7 +544,7 @@ func getProcessGroupsByCluster(cmd *cobra.Command, kubeClient client.Client, opt
 	}
 
 	// cross-cluster logic: given a list of Pod names, we can look up the FDB clusters by pod label, and work across clusters
-	if !opts.useProcessGroupID && opts.clusterName == "" {
+	if opts.clusterName == "" {
 		return fetchProcessGroupsCrossCluster(kubeClient, opts.namespace, opts.clusterLabel, opts.ids...)
 	}
 
@@ -560,18 +567,22 @@ func getProcessGroupsByCluster(cmd *cobra.Command, kubeClient client.Client, opt
 		podNames, err = getPodsMatchingLabels(kubeClient, cluster, opts.namespace, opts.matchLabels)
 	} else if len(opts.conditions) > 0 {
 		podNames, err = getAllPodsFromClusterWithCondition(cmd.Context(), cmd.ErrOrStderr(), kubeClient, opts.clusterName, opts.namespace, opts.conditions)
-	} else if !opts.useProcessGroupID { // match by pod name
+	} else {
 		podNames = opts.ids
-	} else { // match by process group ID
-		for _, id := range opts.ids {
-			processGroupIDs = append(processGroupIDs, fdbv1beta2.ProcessGroupID(id))
-		}
 	}
+
+	//else if !opts.useProcessGroupID { // match by pod name
+	//	podNames = opts.ids
+	//} else { // match by process group ID
+	//	for _, id := range opts.ids {
+	//		processGroupIDs = append(processGroupIDs, fdbv1beta2.ProcessGroupID(id))
+	//	}
+	//}
 	if err != nil {
 		return nil, err
 	}
 	if len(podNames) > 0 {
-		processGroupIDs, err = getProcessGroupIDsFromPodName(cluster, podNames)
+		processGroupIDs, err = getProcessGroupIDsFromPodName(cmd.ErrOrStderr(), cluster, podNames)
 		if err != nil {
 			return nil, err
 		}

--- a/kubectl-fdb/cmd/remove.go
+++ b/kubectl-fdb/cmd/remove.go
@@ -42,10 +42,6 @@ kubectl fdb remove process-groups -c cluster pod-1 -i pod-2
 
 # Remove process groups for a cluster in the namespace default
 kubectl fdb -n default remove process-groups -c cluster pod-1 pod-2
-
-# Remove process groups for a cluster with the process group ID.
-# The process group ID of a Pod can be fetched with "kubectl get po -L foundationdb.org/fdb-process-group-id"
-kubectl fdb -n default remove process-groups --use-process-group-id -c cluster storage-1 storage-2
 `,
 	}
 	cmd.SetOut(o.Out)

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -81,10 +81,6 @@ kubectl fdb remove process-groups pod-1-cluster-A pod-2-cluster-B -l your-cluste
 # Remove process groups for a cluster in the namespace default
 kubectl fdb -n default remove process-groups -c cluster pod-1 pod-2
 
-# Remove process groups for a cluster with the process group ID.
-# The process group ID of a Pod can be fetched with "kubectl get po -L foundationdb.org/fdb-process-group-id"
-kubectl fdb -n default remove process-groups --use-process-group-id -c cluster storage-1 storage-2
-
 # Remove all failed process groups for a cluster (all process groups that have a missing process)
 kubectl fdb -n default remove process-groups -c cluster --remove-all-failed
 

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -66,12 +66,11 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
 					_, err := replaceProcessGroups(cmd, k8sClient,
 						processGroupSelectionOptions{
-							ids:               tc.Instances,
-							namespace:         namespace,
-							clusterName:       clusterName,
-							clusterLabel:      "",
-							processClass:      "",
-							useProcessGroupID: false,
+							ids:          tc.Instances,
+							namespace:    namespace,
+							clusterName:  clusterName,
+							clusterLabel: "",
+							processClass: "",
 						},
 						replaceProcessGroupsOptions{
 							withExclusion:   tc.WithExclusion,
@@ -137,12 +136,11 @@ var _ = Describe("[plugin] remove process groups command", func() {
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
 						_, err := replaceProcessGroups(cmd, k8sClient,
 							processGroupSelectionOptions{
-								ids:               removals,
-								namespace:         namespace,
-								clusterName:       clusterName,
-								clusterLabel:      "",
-								processClass:      "",
-								useProcessGroupID: false,
+								ids:          removals,
+								namespace:    namespace,
+								clusterName:  clusterName,
+								clusterLabel: "",
+								processClass: "",
 							},
 							replaceProcessGroupsOptions{
 								withExclusion:   false,
@@ -171,12 +169,11 @@ var _ = Describe("[plugin] remove process groups command", func() {
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
 						_, err := replaceProcessGroups(cmd, k8sClient,
 							processGroupSelectionOptions{
-								ids:               removals,
-								namespace:         namespace,
-								clusterName:       clusterName,
-								clusterLabel:      "",
-								processClass:      "",
-								useProcessGroupID: false,
+								ids:          removals,
+								namespace:    namespace,
+								clusterName:  clusterName,
+								clusterLabel: "",
+								processClass: "",
 							},
 							replaceProcessGroupsOptions{
 								withExclusion:   true,
@@ -230,12 +227,11 @@ var _ = Describe("[plugin] remove process groups command", func() {
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
 						_, err := replaceProcessGroups(cmd, k8sClient,
 							processGroupSelectionOptions{
-								ids:               tc.podNames,
-								namespace:         namespace,
-								clusterName:       tc.clusterNameFilter,
-								clusterLabel:      tc.clusterLabel,
-								processClass:      "",
-								useProcessGroupID: false,
+								ids:          tc.podNames,
+								namespace:    namespace,
+								clusterName:  tc.clusterNameFilter,
+								clusterLabel: tc.clusterLabel,
+								processClass: "",
 							},
 							replaceProcessGroupsOptions{
 								withExclusion:   true,
@@ -411,13 +407,12 @@ var _ = Describe("[plugin] remove process groups command", func() {
 						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
 						_, err := replaceProcessGroups(cmd, k8sClient,
 							processGroupSelectionOptions{
-								ids:               tc.ids,
-								namespace:         namespace,
-								clusterName:       tc.clusterName,
-								clusterLabel:      "",
-								processClass:      tc.processClass,
-								useProcessGroupID: false,
-								conditions:        tc.conditions,
+								ids:          tc.ids,
+								namespace:    namespace,
+								clusterName:  tc.clusterName,
+								clusterLabel: "",
+								processClass: tc.processClass,
+								conditions:   tc.conditions,
 							},
 							replaceProcessGroupsOptions{
 								withExclusion:   true,

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -174,14 +174,13 @@ func usingLatestPluginVersion(cmd *cobra.Command, pluginVersionChecker VersionCh
 }
 
 type processGroupSelectionOptions struct {
-	ids               []string
-	namespace         string
-	clusterName       string
-	clusterLabel      string
-	matchLabels       map[string]string
-	processClass      string
-	useProcessGroupID bool
-	conditions        []fdbv1beta2.ProcessGroupConditionType
+	ids          []string
+	namespace    string
+	clusterName  string
+	clusterLabel string
+	matchLabels  map[string]string
+	processClass string
+	conditions   []fdbv1beta2.ProcessGroupConditionType
 }
 
 func addProcessSelectionFlags(cmd *cobra.Command) {
@@ -189,8 +188,7 @@ func addProcessSelectionFlags(cmd *cobra.Command) {
 		"Required if not passing cluster-label.")
 	cmd.Flags().String("process-class", "", "Selects process groups matching the provided value in the provided cluster.  Using this option ignores provided ids.")
 	cmd.Flags().StringP("cluster-label", "l", fdbv1beta2.FDBClusterLabel, "cluster label used to identify the cluster for a requested pod. "+
-		"It is incompatible with use-process-group-id, process-class, and process-condition.")
-	cmd.Flags().Bool("use-process-group-id", false, "Selects process groups by process-group ID instead of the Pod name.")
+		"It is incompatible with process-class, and process-condition.")
 	cmd.Flags().StringArray("process-condition", []string{}, "Selects process groups that are in any of the given FDB process group conditions.")
 	cmd.Flags().StringToString("match-labels", map[string]string{}, "Selects process groups running on pods matching the given labels and are in the provided cluster.  Using this option ignores provided ids.")
 }
@@ -221,22 +219,17 @@ func getProcessSelectionOptsFromFlags(cmd *cobra.Command, o *fdbBOptions, ids []
 	if err != nil {
 		return opts, err
 	}
-	useProcessGroupID, err := cmd.Flags().GetBool("use-process-group-id")
-	if err != nil {
-		return opts, err
-	}
 	namespace, err := getNamespace(*o.configFlags.Namespace)
 	if err != nil {
 		return opts, err
 	}
 	return processGroupSelectionOptions{
-		ids:               ids,
-		namespace:         namespace,
-		clusterName:       cluster,
-		matchLabels:       matchLabels,
-		clusterLabel:      clusterLabel,
-		processClass:      processClass,
-		useProcessGroupID: useProcessGroupID,
-		conditions:        conditions,
+		ids:          ids,
+		namespace:    namespace,
+		clusterName:  cluster,
+		matchLabels:  matchLabels,
+		clusterLabel: clusterLabel,
+		processClass: processClass,
+		conditions:   conditions,
 	}, nil
 }


### PR DESCRIPTION
# Description

Remove the use-process-group-id flag and validate the process group ID. The validation of process groups should make it easier to detect typos in the input.

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1296

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

Initially we added the `use-process-group-id` as the only option. based on our experience we never use this option, so we could drop it.

## Testing

Updated the unit tests.

## Documentation

-

## Follow-up

-
