### PR TITLE
Run the addPods reconciler before connecting to FDB in case we use DNS entries in the cluster file

### DIFF
--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -114,7 +114,7 @@ func (a addPods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler
 				return &requeue{curError: err, delayedRequeue: true}
 			}
 
-			return &requeue{curError: err}
+			return &requeue{curError: err, delayedRequeue: true}
 		}
 	}
 

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -208,7 +208,7 @@ func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request c
 	// the FoundationDB cluster.
 	if cluster.UseDNSInClusterFile() {
 		req := runClusterSubReconciler(ctx, clusterLog, addPodsReconciler, r, cluster, nil)
-		if req != nil {
+		if req != nil && !req.delayedRequeue {
 			return processRequeue(req, addPodsReconciler, cluster, r.Recorder, clusterLog)
 		}
 	}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -60,7 +60,7 @@ import (
 // addPodsReconciler is the reconciler for addPods.
 var addPodsReconciler = addPods{}
 
-// subReconcilers has the orded list of all subreconcilers that should be used by the cluster controller.
+// subReconcilers has the ordered list of all reconcilers that should be used by the cluster controller.
 var subReconcilers = []clusterSubReconciler{
 	updateStatus{},
 	updateLockConfiguration{},

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -166,7 +166,8 @@ func (c updateStatus) reconcile(ctx context.Context, r *FoundationDBClusterRecon
 
 	if clusterStatus.ConnectionString == "" {
 		connectionString, ok := existingConfigMap.Data[fdbv1beta2.ClusterFileKey]
-		if ok {
+		// Only update the connection string if the connection string value is not empty.
+		if ok && connectionString != "" {
 			clusterStatus.ConnectionString = connectionString
 		} else {
 			clusterStatus.ConnectionString = cluster.Spec.SeedConnectionString

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -2076,13 +2076,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				// Make sure the operator is not taking any action to prevent any race condition.
 				fdbCluster.SetSkipReconciliation(true)
 
-				// Delete all Pods
-				pods := fdbCluster.GetPods()
-				initialPodsCnt = len(pods.Items)
-				for _, pod := range pods.Items {
-					podToDelete := &pod
-					factory.Delete(podToDelete)
-				}
+				// Delete all Pods, including the operator pods.
+				Expect(factory.GetControllerRuntimeClient().DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.InNamespace(fdbCluster.Namespace()))).To(Succeed())
 
 				// Make sure the Pods are all deleted.
 				Eventually(func() []corev1.Pod {


### PR DESCRIPTION
# Description

Otherwise this could lead to the operator crashing with:

```text
  Error determining public address.
  SIGSEGV: segmentation violation
  PC=0x7fc6699c41fa m=16 sigcode=1 addr=0x40
  signal arrived during cgo execution
```

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2286 (seems like a bug caused by the previous behaviour).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Updated the e2e test + an it locally.

## Documentation

-

## Follow-up

-