### PR TITLE
Set logger in e2e tests to remove the stack trace

### DIFF
--- a/e2e/fixtures/test_runner.go
+++ b/e2e/fixtures/test_runner.go
@@ -28,6 +28,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	"github.com/onsi/ginkgo/v2/types"
 
 	"github.com/onsi/ginkgo/v2"
@@ -44,6 +47,9 @@ func RunGinkgoTests(t *testing.T, name string) {
 	// Setup logging
 	log.SetFlags(log.LstdFlags)
 	log.SetOutput(ginkgo.GinkgoWriter)
+	// Do not output the logs from the controller-runtime. We only use it as a client.
+	// Without this call we get a stack trace.
+	ctrl.SetLogger(logr.Discard())
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	_, inCI := os.LookupEnv("CODEBUILD_SRC_DIR")
 	if inCI {

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -731,7 +731,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		BeforeEach(func() {
 			podToDelete = factory.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
 			log.Printf("deleting storage pod %s/%s", podToDelete.Namespace, podToDelete.Name)
-			deleteTime = time.Now()
+			// Add some buffer here to reduce the risk of a race condition.
+			deleteTime = time.Now().Add(-15 * time.Second)
 			factory.DeletePod(&podToDelete)
 		})
 


### PR DESCRIPTION
# Description

Without this change we get the following stack trace (which is not an error but confusing):

```text
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 62 [running]:
	>  runtime/debug.Stack()
	>  	/codebuild/output/src3086599534/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.linux-amd64/src/runtime/debug/stack.go:26 +0x5e
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/codebuild/output/src3086599534/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/log/log.go:60 +0xcd
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithValues(0xc000314840, {0x0, 0x0, 0x0})
	>  	/codebuild/output/src3086599534/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/log/deleg.go:168 +0x49
	>  github.com/go-logr/logr.Logger.WithValues(...)
	>  	/codebuild/output/src3086599534/pkg/mod/github.com/go-logr/logr@v1.4.3/logr.go:332
	>  sigs.k8s.io/controller-runtime/pkg/log.FromContext({0x3332748?, 0x4678c40?}, {0x0?, 0x0?, 0x0?})
	>  	/codebuild/output/src3086599534/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/log/log.go:98 +0xba
	>  sigs.k8s.io/controller-runtime/pkg/log.(*KubeAPIWarningLogger).HandleWarningHeaderWithContext(0xc0001496b0, {0x3332748?, 0x4678c40?}, 0x12b, {0xb?, 0x2e2e47f?}, {0xc00055e000, 0x4d})
	>  	/codebuild/output/src3086599534/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/log/warning_handler.go:49 +0x65
	>  k8s.io/client-go/rest.handleWarnings({0x3332748, 0x4678c40}, 0x10?, {0x3311820?, 0xc0001496b0?})
	>  	/codebuild/output/src3086599534/pkg/mod/k8s.io/client-go@v0.33.0/rest/warnings.go:187 +0x11e
	>  k8s.io/client-go/rest.(*Request).transformResponse(0xc000a7e780, {0x3332748, 0x4678c40}, 0xc00055b680, 0xc00074b040)
	>  	/codebuild/output/src3086599534/pkg/mod/k8s.io/client-go@v0.33.0/rest/request.go:1427 +0x3ab
	>  k8s.io/client-go/rest.(*Request).Do.func1(0xc00014b280?, 0xc00090acf0?)
	>  	/codebuild/output/src3086599534/pkg/mod/k8s.io/client-go@v0.33.0/rest/request.go:1301 +0x3f
	>  k8s.io/client-go/rest.(*Request).request.func3.1(...)
	>  	/codebuild/output/src3086599534/pkg/mod/k8s.io/client-go@v0.33.0/rest/request.go:1271
	>  k8s.io/client-go/rest.(*Request).request.func3(0xc00055b680, 0xc000958eb0, {0x3332cf0?, 0xc00014b280?}, 0x0?, 0x0?, 0xc00074b040, {0x0?, 0x0?}, 0x30f1ae0)
	>  	/codebuild/output/src3086599534/pkg/mod/k8s.io/client-go@v0.33.0/rest/request.go:1278 +0xcd
	>  k8s.io/client-go/rest.(*Request).request(0xc000a7e780, {0x3332748, 0x4678c40}, 0xc000958eb0)
	>  	/codebuild/output/src3086599534/pkg/mod/k8s.io/client-go@v0.33.0/rest/request.go:1280 +0x587
	>  k8s.io/client-go/rest.(*Request).Do(0xc000a7e780, {0x3332748, 0x4678c40})
	>  	/codebuild/output/src3086599534/pkg/mod/k8s.io/client-go@v0.33.0/rest/request.go:1300 +0x127
	>  sigs.k8s.io/controller-runtime/pkg/client.(*typedClient).Create(0xc000155440, {0x3332748, 0x4678c40}, {0x334e528, 0xc000421508}, {0x0, 0x0, 0xc0009590c0?})
	>  	/codebuild/output/src3086599534/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/client/typed_client.go:48 +0x350
	>  sigs.k8s.io/controller-runtime/pkg/client.(*client).Create(0xc000155440?, {0x3332748?, 0x4678c40?}, {0x334e528?, 0xc000421508?}, {0x0?, 0x0?, 0x0?})
	>  	/codebuild/output/src3086599534/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/client/client.go:278 +0x85
	>  github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/fixtures.(*FdbCluster).Create(0xc0001b0990?)
	>  	/codebuild/output/src3086599534/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures/fdb_cluster.go:129 +0x48
	>  github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/fixtures.(*Factory).ensureFdbClusterExists(0xc00064e0f0, 0xc000421508, 0xc000959e50)
	>  	/codebuild/output/src3086599534/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures/fdb_operator_fixtures.go:50 +0x21b
	>  github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/fixtures.(*Factory).startFDBFromClusterSpec(0xc00064e0f0, 0xc000470008?, 0xc000959e50, {0xc000681eb8, 0x1, 0x0?})
	>  	/codebuild/output/src3086599534/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures/factory.go:380 +0xff
	>  github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/fixtures.(*Factory).CreateFdbClusterFromSpec(0xc00064e0f0, 0xc000470008, 0xc000959e50, {0xc000681eb8, 0x1, 0x1})
	>  	/codebuild/output/src3086599534/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures/factory.go:186 +0x16c
	>  github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/fixtures.(*Factory).CreateFdbCluster(0xc00064e0f0, 0xc000959e50, {0xc000681eb8, 0x1, 0x1})
	>  	/codebuild/output/src3086599534/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures/factory.go:172 +0x4d
	>  github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/test_operator.init.func1()
	>  	/codebuild/output/src3086599534/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator/operator_test.go:84 +0x194
	>  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3({0x0?, 0x0?})
	>  	/codebuild/output/src3086599534/pkg/mod/github.com/onsi/ginkgo/v2@v2.23.4/internal/node.go:475 +0x13
	>  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
	>  	/codebuild/output/src3086599534/pkg/mod/github.com/onsi/ginkgo/v2@v2.23.4/internal/suite.go:894 +0x7b
	>  created by github.com/onsi/ginkgo/v2/internal.(*Suite).runNode in goroutine 60
	>  	/codebuild/output/src3086599534/pkg/mod/github.com/onsi/ginkgo/v2@v2.23.4/internal/suite.go:881 +0xd7b
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

I also increased the delete timestamp to reduce the risk of a race condition.

## Testing

Ran tests locally.

## Documentation

-

## Follow-up

-
