### PR TITLE
Fix the operator plugin e2e test

### DIFF
--- a/e2e/test_operator_plugin/operator_plugin_test.go
+++ b/e2e/test_operator_plugin/operator_plugin_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 				stdout, stderr, err := factory.ExecuteCmdOnPod(context.Background(), &operatorPod, "manager", fmt.Sprintf("kubectl-fdb -n %s --version-check=false version", fdbCluster.GetPrimary().Namespace()), false)
 				g.Expect(err).NotTo(HaveOccurred(), stderr)
 				return stdout
-			}).WithTimeout(10 * time.Minute).WithPolling(2 * time.Second).Should(And(ContainSubstring("kubectl-fdb:"), ContainSubstring("foundationdb-operator:")))
+			}).WithTimeout(10 * time.Minute).WithPolling(2 * time.Second).Should(And(ContainSubstring("kubectl-fdb build information:"), ContainSubstring("foundationdb-operator:")))
 		})
 	})
 


### PR DESCRIPTION
# Description

We changed the output of the kubectl fdb plugin which causes the operator plugin e2e tests to fail (only run during nightlies):

```text
  [FAILED] Timed out after 600.000s.
  Expected
      <string>: foundationdb-operator: 585b2e00
      kubectl-fdb build information:
      
      version:      585b2e0037fb20d61103c7cd1f894e6449aa4367
      build date:   now
      build commit: none
      
  to contain substring
      <string>: kubectl-fdb:
  In [It] at: /codebuild/output/src2801943745/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator_plugin/operator_plugin_test.go:80 @
```

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran the test manually.

## Documentation

-

## Follow-up

-