### PR TITLE
Enable TLS conversion for e2e tests

### DIFF
--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -832,6 +832,7 @@ func (fdbCluster *FdbCluster) SetTLS(
 	enableMainContainerTLS bool,
 	enableSidecarContainerTLS bool,
 ) error {
+	log.Println("updating the TLS setting for main container:", enableMainContainerTLS, "for sidecar container:", enableSidecarContainerTLS)
 	fdbCluster.cluster.Spec.MainContainer.EnableTLS = enableMainContainerTLS
 	fdbCluster.cluster.Spec.SidecarContainer.EnableTLS = enableSidecarContainerTLS
 	fdbCluster.UpdateClusterSpec()


### PR DESCRIPTION
# Description

Enable TLS conversion for e2e tests to get a signal about the stability of the conversion.

## Type of change

- Other

## Discussion

I ran the test multiple times with the unified image and the split image (with the local client disabled) and it always passed (ran roughly 3/3).

## Testing

See above.

## Documentation

-

## Follow-up

-
