### PR TITLE
Only pick running pods and pods with an empty deletion timestamp

### DIFF
--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -702,7 +702,10 @@ func (factory *Factory) GetOperatorPods(namespace string) *corev1.PodList {
 	pods := &corev1.PodList{}
 	gomega.Eventually(func() error {
 		return factory.GetControllerRuntimeClient().
-			List(ctx.TODO(), pods, client.InNamespace(namespace), client.MatchingLabels(map[string]string{"app": operatorDeploymentName}))
+			List(ctx.TODO(), pods,
+				client.InNamespace(namespace),
+				client.MatchingLabels(map[string]string{"app": operatorDeploymentName}),
+				client.MatchingFields(map[string]string{"status.phase": string(corev1.PodRunning)}))
 	}).WithTimeout(1 * time.Minute).WithPolling(1 * time.Second).ShouldNot(gomega.HaveOccurred())
 
 	return pods


### PR DESCRIPTION
# Description

This should reduce the cases where the e2e test framework picks a terminating pod randomly. We run enough e2e test cases that we sometimes hit this issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran a test suite manually.

## Documentation

-

## Follow-up

-
