### PR TITLE
Add workaround for cases where the operator gets stuck because of coordinator restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN set -eux && \
     fi; \
     curl --fail -L "${FDB_WEBSITE}/${FDB_VERSION}/foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm" -o foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm && \
     curl --fail -L "${FDB_WEBSITE}/${FDB_VERSION}/foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm.sha256" -o foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm.sha256 && \
-    microdnf install -y glibc pkg-config && \
+    microdnf install -y glibc pkg-config bind-utils && \
     microdnf clean all && \
     sha256sum -c foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm.sha256 && \
     rpm -i foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm --excludepath=/usr/bin --excludepath=/usr/lib/foundationdb/backup_agent && \

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -28,6 +28,9 @@ STORAGE_ENGINE?=
 DUMP_OPERATOR_STATE?=true
 SEAWEEDFS_IMAGE?=chrislusf/seaweedfs:3.73
 NODE_SELECTOR?=
+# DEFAULT_UNAVAILABLE_THRESHOLD defines the default unavailability threshold.
+# If the database is unavailable for a longer period the test will fail if unavailability checks are enabled.
+DEFAULT_UNAVAILABLE_THRESHOLD?=30s
 # Defines the cloud provider used for the underlying Kubernetes cluster. Currently only kind is support, other cloud providers
 # should still work but this test framework has no special cases for those.
 CLOUD_PROVIDER?=
@@ -194,6 +197,7 @@ endif
 	  --unified-fdb-image=$(UNIFIED_FDB_IMAGE) \
 	  --feature-server-side-apply=$(FEATURE_SERVER_SIDE_APPLY) \
 	  --feature-synchronization-mode=$(FEATURE_SYNCHRONIZATION_MODE) \
-	  --seaweedfs-image=$(SEAWEEDFS_IMAGE) $(FEATURE_LOCALITIES_FLAG) $(FEATURE_DNS) \
 	  --node-selector="$(NODE_SELECTOR)" \
+	  --default-unavailable-threshold=$(DEFAULT_UNAVAILABLE_THRESHOLD) \
+	  --seaweedfs-image=$(SEAWEEDFS_IMAGE) $(FEATURE_LOCALITIES_FLAG) $(FEATURE_DNS) \
 	  | grep -v 'constructing many client instances from the same exec auth config can cause performance problems during cert rotation' &> $(BASE_DIR)/../logs/$<.log

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -891,3 +891,9 @@ func (factory *Factory) GetSynchronizationMode() fdbv1beta2.SynchronizationMode 
 
 	return fdbv1beta2.SynchronizationMode(factory.options.synchronizationMode)
 }
+
+// GetDefaultUnavailableThreshold returns the default unavailable threshold. If the cluster is unavailable for a longer
+// period the test case will fail.
+func (factory *Factory) GetDefaultUnavailableThreshold() time.Duration {
+	return factory.options.defaultUnavailableThreshold
+}

--- a/e2e/fixtures/ha_fdb_cluster.go
+++ b/e2e/fixtures/ha_fdb_cluster.go
@@ -189,7 +189,7 @@ func (haFDBCluster *HaFdbCluster) WaitForReconciliation(
 	return g.Wait()
 }
 
-func (factory Factory) createHaFdbClusterSpec(
+func (factory *Factory) createHaFdbClusterSpec(
 	config *ClusterConfig,
 	dcID string,
 	seedConnection string,

--- a/e2e/fixtures/options.go
+++ b/e2e/fixtures/options.go
@@ -25,6 +25,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 )
@@ -50,6 +51,7 @@ type FactoryOptions struct {
 	storageEngine                  string
 	fdbVersionTagMapping           string
 	synchronizationMode            string
+	nodeSelector                   string
 	enableChaosTests               bool
 	enableDataLoading              bool
 	cleanup                        bool
@@ -58,7 +60,7 @@ type FactoryOptions struct {
 	featureOperatorUnifiedImage    bool
 	featureOperatorServerSideApply bool
 	dumpOperatorState              bool
-	nodeSelector                   string
+	defaultUnavailableThreshold    time.Duration
 }
 
 // BindFlags binds the FactoryOptions flags to the provided FlagSet. This can be used to extend the current test setup
@@ -231,6 +233,10 @@ func (options *FactoryOptions) BindFlags(fs *flag.FlagSet) {
 		"local",
 		"defines the synchronization mode that should be used. Only applies for multi-region clusters.",
 	)
+	fs.DurationVar(&options.defaultUnavailableThreshold,
+		"default-unavailable-threshold",
+		30*time.Second,
+		"defines the default unavailability threshold. If the database is unavailable for a longer period the test will fail if unavailability checks are enabled.")
 }
 
 func (options *FactoryOptions) validateFlags() error {

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1764,18 +1764,6 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		It("should not replace the process group", func() {
-			Consistently(func() []*fdbv1beta2.ProcessGroupCondition {
-				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
-					if processGroup.ProcessGroupID != targetProcessGroup.ProcessGroupID {
-						continue
-					}
-
-					return processGroup.ProcessGroupConditions
-				}
-
-				return nil
-			}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(BeEmpty())
-
 			Consistently(func() bool {
 				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
 					if processGroup.ProcessGroupID != targetProcessGroup.ProcessGroupID {
@@ -2066,10 +2054,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			// See: https://github.com/apple/foundationdb/issues/11222
 			// We can remove this once 7.1 is the default version.
 			factory.DeleteChaosMeshExperimentSafe(scheduleInjectPodKill)
-			cluster := fdbCluster.GetCluster()
-
-			initialSetting = cluster.UseDNSInClusterFile()
-			if !cluster.UseDNSInClusterFile() {
+			initialSetting = fdbCluster.GetCluster().UseDNSInClusterFile()
+			if !initialSetting {
 				Expect(fdbCluster.SetUseDNSInClusterFile(true)).ToNot(HaveOccurred())
 			}
 		})

--- a/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
+++ b/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
@@ -28,7 +28,6 @@ Each test will create a new HA FoundationDB cluster which will be upgraded.
 
 import (
 	"log"
-	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	chaosmesh "github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/chaos-mesh/api/v1alpha1"
@@ -64,7 +63,7 @@ func clusterSetupWithHealthCheckOption(beforeVersion string, enableOperatorPodCh
 	)
 	if enableHealthCheck {
 		Expect(
-			fdbCluster.GetPrimary().InvariantClusterStatusAvailableWithThreshold(15 * time.Second),
+			fdbCluster.GetPrimary().InvariantClusterStatusAvailable(),
 		).ShouldNot(HaveOccurred())
 	}
 

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -83,7 +83,7 @@ func clusterSetupWithTestConfig(config testConfig) {
 
 	if config.enableHealthCheck {
 		Expect(
-			fdbCluster.GetPrimary().InvariantClusterStatusAvailableWithThreshold(15 * time.Second),
+			fdbCluster.GetPrimary().InvariantClusterStatusAvailable(),
 		).ShouldNot(HaveOccurred())
 	}
 

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -75,7 +75,7 @@ func clusterSetupWithConfig(beforeVersion string, availabilityCheck bool, config
 	}
 
 	Expect(
-		fdbCluster.InvariantClusterStatusAvailableWithThreshold(15 * time.Second),
+		fdbCluster.InvariantClusterStatusAvailable(),
 	).ShouldNot(HaveOccurred())
 }
 

--- a/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
+++ b/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
@@ -77,7 +77,7 @@ func clusterSetupWithConfig(config testConfig) *fixtures.FdbCluster {
 	}
 
 	Expect(
-		cluster.InvariantClusterStatusAvailableWithThreshold(15 * time.Second),
+		cluster.InvariantClusterStatusAvailable(),
 	).ShouldNot(HaveOccurred())
 
 	return cluster

--- a/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
@@ -66,7 +66,7 @@ func clusterSetup(beforeVersion string) {
 	)
 
 	Expect(
-		fdbCluster.InvariantClusterStatusAvailableWithThreshold(15 * time.Second),
+		fdbCluster.InvariantClusterStatusAvailable(),
 	).ShouldNot(HaveOccurred())
 }
 

--- a/e2e/test_operator_velocity/operator_velocity_test.go
+++ b/e2e/test_operator_velocity/operator_velocity_test.go
@@ -65,8 +65,7 @@ func CheckKnobRollout(
 	startTime := time.Now()
 	timeoutTime := startTime.Add(time.Duration(knobRolloutTimeoutSeconds) * time.Second)
 
-	Eventually(func(g Gomega) bool {
-		primary = fdbCluster.GetPrimary()
+	Eventually(func(g Gomega) {
 		status := primary.GetStatus()
 		commandLines := primary.GetCommandlineForProcessesPerClassWithStatus(status)
 		var generalProcessCounts, storageProcessCounts int
@@ -103,9 +102,7 @@ func CheckKnobRollout(
 
 		g.Expect(generalProcessCounts).To(BeNumerically("==", totalGeneralProcessCount))
 		g.Expect(storageProcessCounts).To(BeNumerically("==", totalStorageProcessCount))
-
-		return true
-	}).WithTimeout(time.Until(timeoutTime)).WithPolling(15 * time.Second).Should(BeTrue())
+	}).WithTimeout(time.Until(timeoutTime)).WithPolling(15 * time.Second).Should(Succeed())
 
 	rolloutDuration := time.Since(startTime)
 	finalGeneration := primary.GetStatus().Cluster.Generation


### PR DESCRIPTION
# Description

Related: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2311 (not really fixed, only a workaround is added).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

Interestingly the issue doesn't happen always but only sometimes.

## Testing

Ran the e2e test from the issue manually multiple times.

## Documentation

Added in code.

## Follow-up

Fix the actual underlying issue.