### PR TITLE
Improve the pod spec change handling during version incompatible upgrades

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -977,6 +977,10 @@ const (
 	ProcessIsMarkedAsExcluded ProcessGroupConditionType = "ProcessIsMarkedAsExcluded"
 	// ProcessHasIOError represents a process group that has an I/O error.
 	ProcessHasIOError ProcessGroupConditionType = "ProcessHasIOError"
+	// IncorrectSidecarImage represents a process group where the sidecar image has not the desired image.
+	// This condition can occur during the migration of the image type, the change of the image configuration
+	// for the sidecar or during version incompatible upgrades until the sidecar is updated to the new desired version.
+	IncorrectSidecarImage ProcessGroupConditionType = "IncorrectSidecarImage"
 )
 
 // AllProcessGroupConditionTypes returns all ProcessGroupConditionType
@@ -998,6 +1002,7 @@ func AllProcessGroupConditionTypes() []ProcessGroupConditionType {
 		NodeTaintReplacing,
 		ProcessIsMarkedAsExcluded,
 		ProcessHasIOError,
+		IncorrectSidecarImage,
 	}
 }
 
@@ -1038,6 +1043,8 @@ func GetProcessGroupConditionType(processGroupConditionType string) (ProcessGrou
 		return ProcessIsMarkedAsExcluded, nil
 	case "ProcessHasIOError":
 		return ProcessHasIOError, nil
+	case "IncorrectSidecarImage":
+		return IncorrectSidecarImage, nil
 	}
 
 	return "", fmt.Errorf("unknown process group condition type: %s", processGroupConditionType)

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -977,7 +977,7 @@ const (
 	ProcessIsMarkedAsExcluded ProcessGroupConditionType = "ProcessIsMarkedAsExcluded"
 	// ProcessHasIOError represents a process group that has an I/O error.
 	ProcessHasIOError ProcessGroupConditionType = "ProcessHasIOError"
-	// IncorrectSidecarImage represents a process group where the sidecar image has not the desired image.
+	// IncorrectSidecarImage represents a process group where the sidecar image does not have the desired image.
 	// This condition can occur during the migration of the image type, the change of the image configuration
 	// for the sidecar or during version incompatible upgrades until the sidecar is updated to the new desired version.
 	IncorrectSidecarImage ProcessGroupConditionType = "IncorrectSidecarImage"

--- a/controllers/replace_misconfigured_process_groups_test.go
+++ b/controllers/replace_misconfigured_process_groups_test.go
@@ -1,0 +1,57 @@
+/*
+ * replace_misconfigured_process_groups_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import (
+	"context"
+	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("replace_misconfigured_process_groups", func() {
+	When("a version incompatible upgrade is ongoing", func() {
+		var cluster *fdbv1beta2.FoundationDBCluster
+
+		BeforeEach(func() {
+			cluster = internal.CreateDefaultCluster()
+			Expect(k8sClient.Create(context.TODO(), cluster)).NotTo(HaveOccurred())
+			result, err := reconcileCluster(cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(k8sClient.Get(context.TODO(), ctrlClient.ObjectKeyFromObject(cluster), cluster)).NotTo(HaveOccurred())
+
+			version, err := fdbv1beta2.ParseFdbVersion(cluster.Spec.Version)
+			Expect(err).NotTo(HaveOccurred())
+			cluster.Spec.Version = version.NextMinorVersion().String()
+		})
+
+		It("should not perform any replacements and requeue", func() {
+			result := replaceMisconfiguredProcessGroups{}.reconcile(context.Background(), clusterReconciler, cluster, nil, testLogger)
+			Expect(result).NotTo(BeNil())
+			Expect(result.delayedRequeue).To(BeTrue())
+			Expect(result.message).To(Equal("Replacements because of misconfiguration are skipped because of an ongoing version incompatible upgrade"))
+		})
+	})
+})

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -68,12 +68,7 @@ func (updateSidecarVersions) reconcile(ctx context.Context, r *FoundationDBClust
 			continue
 		}
 
-		processClass, err := podmanager.GetProcessClass(cluster, pod)
-		if err != nil {
-			return &requeue{curError: err}
-		}
-
-		image, err := internal.GetSidecarImage(cluster, processClass)
+		image, err := internal.GetSidecarImage(cluster, processGroup.ProcessClass)
 		if err != nil {
 			return &requeue{curError: err}
 		}
@@ -86,6 +81,7 @@ func (updateSidecarVersions) reconcile(ctx context.Context, r *FoundationDBClust
 					return &requeue{curError: err}
 				}
 				upgraded++
+				break
 			}
 		}
 	}

--- a/docs/manual/warnings.md
+++ b/docs/manual/warnings.md
@@ -54,6 +54,13 @@ The operator doesn't support to use custom ports for FDB.
 Per default a FDB cluster without TLS will use the ports `4501` and a FDB cluster using TLS will be using `4500`.
 If more than one process should be running per Pod, e.g. when using the `storageServersPerPod` setting, the additional processes will get the `standard port + 2*processNumber`, e.g. for the second process in a TLS cluster that would be `4502`.
 
+## FDB version upgrades
+
+It's not recommended to perform additional changes during an FDB version upgrade.
+This can cause side effects that might cause some downtime or will interfere with the upgrade process.
+You should ensure that the cluster is fully reconciled before starting the upgrade, and you should make sure that the Pod spec is not changed during an upgrade.
+Once the cluster is fully reconciled after the upgrade you can change the pod configuration again.
+
 ## Next
 
 You can continue on to the [next section](resources.md) or go back to the [table of contents](index.md).

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -1020,7 +1020,7 @@ func (fdbCluster *FdbCluster) UpgradeCluster(version string, waitForReconciliati
 
 	log.Printf(
 		"Upgrading cluster from version %s to version %s",
-		fdbCluster.cluster.Spec.Version,
+		fdbCluster.cluster.GetRunningVersion(),
 		version,
 	)
 

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -56,14 +56,13 @@ func ReplaceMisconfiguredProcessGroups(ctx context.Context, podManager podmanage
 			continue
 		}
 
-		needsRemoval, err := ProcessGroupNeedsRemoval(ctx, podManager, ctrlClient, log, cluster, processGroup, replaceOnSecurityContextChange)
-
+		needsReplacement, err := ProcessGroupNeedsReplacements(ctx, podManager, ctrlClient, log, cluster, processGroup, replaceOnSecurityContextChange)
 		// Do not mark for removal if there is an error
 		if err != nil {
 			continue
 		}
 
-		if needsRemoval {
+		if needsReplacement {
 			processGroup.MarkForRemoval()
 			hasReplacements = true
 			maxReplacements--
@@ -73,8 +72,8 @@ func ReplaceMisconfiguredProcessGroups(ctx context.Context, podManager podmanage
 	return hasReplacements, nil
 }
 
-// ProcessGroupNeedsRemoval checks if a process group needs to be removed.
-func ProcessGroupNeedsRemoval(ctx context.Context, podManager podmanager.PodLifecycleManager, ctrlClient client.Client, log logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus, replaceOnSecurityContextChange bool) (bool, error) {
+// ProcessGroupNeedsReplacements checks if a process group needs to be replaced.
+func ProcessGroupNeedsReplacements(ctx context.Context, podManager podmanager.PodLifecycleManager, ctrlClient client.Client, log logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus, replaceOnSecurityContextChange bool) (bool, error) {
 	pod, podErr := podManager.GetPod(ctx, ctrlClient, cluster, processGroup.GetPodName(cluster))
 	if processGroup.ProcessClass.IsStateful() {
 		pvc := &corev1.PersistentVolumeClaim{}

--- a/internal/restarts/restarts.go
+++ b/internal/restarts/restarts.go
@@ -40,13 +40,12 @@ func GetFilterConditions(cluster *fdbv1beta2.FoundationDBCluster) map[fdbv1beta2
 		}
 	}
 
-	// If we perform an upgrade we have to wait until all processes are
-	// ready to be restarted. Therefore we can't ignore process groups with the SidecarUnreachable condition.
-	// We could be less restrictive here in cases where we perform a version compatible upgrade.m
+	// If we perform a version incompatible upgrade, we have to wait until all processes are ready to be restarted.
+	// This means that all the sidecar images are updated to the new desired image that contains the new version.
 	return map[fdbv1beta2.ProcessGroupConditionType]bool{
-		fdbv1beta2.IncorrectCommandLine: true,
-		fdbv1beta2.IncorrectPodSpec:     false,
-		fdbv1beta2.IncorrectConfigMap:   false,
+		fdbv1beta2.IncorrectCommandLine:  true,
+		fdbv1beta2.IncorrectSidecarImage: false,
+		fdbv1beta2.IncorrectConfigMap:    false,
 	}
 }
 

--- a/internal/restarts/restarts_test.go
+++ b/internal/restarts/restarts_test.go
@@ -57,7 +57,7 @@ var _ = Describe("restarts", func() {
 				fdbv1beta2.SidecarUnreachable:   false,
 				fdbv1beta2.IncorrectConfigMap:   false,
 			}),
-		Entry("when an upgrade is performed",
+		Entry("when a version incompatible upgrade is performed",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
 					Version: "7.1.25",
@@ -67,9 +67,9 @@ var _ = Describe("restarts", func() {
 				},
 			},
 			map[fdbv1beta2.ProcessGroupConditionType]bool{
-				fdbv1beta2.IncorrectCommandLine: true,
-				fdbv1beta2.IncorrectPodSpec:     false,
-				fdbv1beta2.IncorrectConfigMap:   false,
+				fdbv1beta2.IncorrectCommandLine:  true,
+				fdbv1beta2.IncorrectSidecarImage: false,
+				fdbv1beta2.IncorrectConfigMap:    false,
 			}),
 	)
 })


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2292

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

The issue in the reported GitHub issue was, that the upgrade was triggered with a change to the Pod spec, which caused the operator to replace some pods. Those new pods came up with the new version and caused issues (as the older pods should be removed). I changed the operator logic to wait with Pod spec related changes until all processes are running on the new version (this doesn't wait for the rolling recreation/bounce phase).

## Testing

I added a new e2e test case for this.

## Documentation

Added a note in our `warnings.md` that doing an upgrade and Pod spec changes is something that brings some risk and should be prevented if possible.

## Follow-up

-
