### PR TITLE
Update typos and change the rollout strategy for the operator pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ dist/
 
 # Used for testing locally build FDB library
 libfdb_c.so
+fdb-kubernetes-operator

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -572,7 +572,6 @@ func (r *FoundationDBClusterReconciler) takeLock(logger logr.Logger, cluster *fd
 
 // releaseLock attempts to release a lock.
 func (r *FoundationDBClusterReconciler) releaseLock(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster) error {
-	logger.Info("Release lock on cluster")
 	lockClient, err := r.getLockClient(logger, cluster)
 	if err != nil {
 		return err

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -360,7 +360,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			log.Println("Restoring connectivity")
 			factory.DeleteChaosMeshExperimentSafe(partitionExperiment)
 
-			// Delete the operator Pods to ensure they pickup the work directly otherwise it could take a long time
+			// Delete the operator Pods to ensure they pick up the work directly otherwise it could take a long time
 			// until the operator tries to reconcile the cluster again. If the operator is not able to reconcile a
 			// cluster it will be put into a queue again, at some time the queue will delay the next reconcile attempt
 			// for a long time and since the network partition is not emitting any events for the operator this won't trigger

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			)
 
 			// Disable the feature that the operator restarts processes. This allows us to restart the coordinator
-			// once tall new binaries are present.
+			// once all new binaries are present.
 			fdbCluster.SetKillProcesses(false)
 
 			// Start the upgrade.

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -350,10 +350,12 @@ func (client *realLockClient) ReleaseLock() error {
 		}
 
 		ownerID := client.cluster.GetLockID()
+		startTime := time.Unix(currentLockStartTimestamp, 0)
 		logger := client.log.WithValues(
 			"currentLockOwnerID", currentLockOwnerID,
-			"startTime", time.Unix(currentLockStartTimestamp, 0),
-			"endTime", time.Unix(currentLockEndTimestamp, 0))
+			"startTime", startTime,
+			"endTime", time.Unix(currentLockEndTimestamp, 0),
+			"lockDuration", time.Since(startTime).String())
 
 		if currentLockOwnerID != ownerID {
 			logger.Info("cannot release lock from other owner")


### PR DESCRIPTION
# Description

Fixed a few typos and changed the way hoe the operator pods are recreated in the test suite. Instead of deleting them we add a new annotation in the template (similar to `kubectl rollout restart ..`). I also added a new log entry for the lock client when the lock is released to log how long the lock was held.

## Type of change

- Other

## Discussion

-

## Testing

Ran the e2e tests manually.

## Documentation

-

## Follow-up

-
