### PR TITLE
Enable additional linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,6 @@ bin/kubectl-fdb: ${GO_SRC} $(GORELEASER)
 	$(GORELEASER) build --single-target --skip validate --clean
 	@mkdir -p bin
 	@touch $@
-# TODO test here that the tag is set properly
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate manifests
@@ -161,10 +160,10 @@ ${MANIFESTS}: ${CONTROLLER_GEN} ${GO_SRC}
 fmt: bin/fmt_check
 
 bin/fmt_check: ${GO_ALL}
-	$(GO_LINES) -w $(GO_SRC)
+	@$(GO_LINES) -w $(GO_SRC)
 	@go fmt $$(go list ./...)
-	$(GO_IMPORTS) -w $(GO_SRC)
-	$(GOLANGCI_LINT) run --fix
+	@$(GO_IMPORTS) -w $(GO_SRC)
+	@$(GOLANGCI_LINT) run --fix
 	@mkdir -p bin
 	@touch $@
 
@@ -172,7 +171,7 @@ bin/fmt_check: ${GO_ALL}
 vet: bin/vet_check
 
 bin/vet_check: ${GO_ALL}
-	go vet ./...
+	@go vet ./...
 	@mkdir -p bin
 	@touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ GOLANGCI_LINT_PKG=github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 GOLANGCI_LINT=$(GOBIN)/golangci-lint
 GORELEASER_PKG=github.com/goreleaser/goreleaser/v2@v2.10.2
 GORELEASER=$(GOBIN)/goreleaser
-GO_LINES_PKG=github.com/segmentio/golines@v0.11.0
+GO_LINES_PKG=github.com/segmentio/golines@v0.12.2
 GO_LINES=$(GOBIN)/golines
-GO_IMPORTS_PKG=golang.org/x/tools/cmd/goimports@v0.20.0
+GO_IMPORTS_PKG=golang.org/x/tools/cmd/goimports@v0.34.0
 GO_IMPORTS=$(GOBIN)/goimports
 
 BUILD_DEPS?=
@@ -160,12 +160,11 @@ ${MANIFESTS}: ${CONTROLLER_GEN} ${GO_SRC}
 # Run go fmt against code
 fmt: bin/fmt_check
 
-# TODO johscheuer: enable those new command in a new PR.
 bin/fmt_check: ${GO_ALL}
-	# $(GO_LINES) -w .
+	$(GO_LINES) -w $(GO_SRC)
 	@go fmt $$(go list ./...)
-	#$(GO_IMPORTS) -w $(GO_SRC)
-	#$(GOLANGCI_LINT) run --fix
+	$(GO_IMPORTS) -w $(GO_SRC)
+	$(GOLANGCI_LINT) run --fix
 	@mkdir -p bin
 	@touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,8 @@ ${MANIFESTS}: ${CONTROLLER_GEN} ${GO_SRC}
 fmt: bin/fmt_check
 
 bin/fmt_check: ${GO_ALL}
-	@$(GO_LINES) -w $(GO_SRC)
-	@go fmt $$(go list ./...)
+	# We make use of gofmt with golines because of: https://github.com/segmentio/golines/issues/155
+	@$(GO_LINES) -w --base-formatter=gofmt --ignored-dirs=./e2e/chaos-mesh --ignore-generated $(GO_SRC)
 	@$(GO_IMPORTS) -w $(GO_SRC)
 	@$(GOLANGCI_LINT) run --fix
 	@mkdir -p bin

--- a/api/v1beta2/foundationdb_custom_parameter.go
+++ b/api/v1beta2/foundationdb_custom_parameter.go
@@ -82,16 +82,31 @@ func (customParameters FoundationDBCustomParameters) ValidateCustomParameters() 
 		}
 
 		if _, ok := protectedParameters[parameterName]; ok {
-			violations = append(violations, fmt.Sprintf("found protected customParameter: %s, please remove this parameter from the customParameters list", parameterName))
+			violations = append(
+				violations,
+				fmt.Sprintf(
+					"found protected customParameter: %s, please remove this parameter from the customParameters list",
+					parameterName,
+				),
+			)
 		}
 
 		if _, ok := fdbMonitorGeneralParameters[parameterName]; ok {
-			violations = append(violations, fmt.Sprintf("found general or fdbmonitor customParameter: %s, please remove this parameter from the customParameters list as they are not supported", parameterName))
+			violations = append(
+				violations,
+				fmt.Sprintf(
+					"found general or fdbmonitor customParameter: %s, please remove this parameter from the customParameters list as they are not supported",
+					parameterName,
+				),
+			)
 		}
 	}
 
 	if len(violations) > 0 {
-		return fmt.Errorf("found the following customParameters violations:\n%s", strings.Join(violations, "\n"))
+		return fmt.Errorf(
+			"found the following customParameters violations:\n%s",
+			strings.Join(violations, "\n"),
+		)
 	}
 
 	return nil

--- a/api/v1beta2/foundationdb_custom_parameter_test.go
+++ b/api/v1beta2/foundationdb_custom_parameter_test.go
@@ -67,32 +67,44 @@ var _ = Describe("FoundationDBCustomParameters", func() {
 					"test=test",
 				},
 				nil),
-			Entry("custom parameters that sets protected knob",
+			Entry(
+				"custom parameters that sets protected knob",
 				FoundationDBCustomParameters{
 					"datadir=test",
 				},
-				errors.New("found the following customParameters violations:\nfound protected customParameter: datadir, please remove this parameter from the customParameters list"),
+				errors.New(
+					"found the following customParameters violations:\nfound protected customParameter: datadir, please remove this parameter from the customParameters list",
+				),
 			),
-			Entry("duplicate custom parameters",
+			Entry(
+				"duplicate custom parameters",
 				FoundationDBCustomParameters{
 					"test=test",
 					"test=test",
 				},
-				errors.New("found the following customParameters violations:\nfound duplicated customParameter: test"),
+				errors.New(
+					"found the following customParameters violations:\nfound duplicated customParameter: test",
+				),
 			),
-			Entry("duplicate custom parameters",
+			Entry(
+				"duplicate custom parameters",
 				FoundationDBCustomParameters{
 					"test=test",
 					"datadir=test",
 					"test=test",
 				},
-				errors.New("found the following customParameters violations:\nfound protected customParameter: datadir, please remove this parameter from the customParameters list\nfound duplicated customParameter: test"),
+				errors.New(
+					"found the following customParameters violations:\nfound protected customParameter: datadir, please remove this parameter from the customParameters list\nfound duplicated customParameter: test",
+				),
 			),
-			Entry("custom parameters that sets general knob",
+			Entry(
+				"custom parameters that sets general knob",
 				FoundationDBCustomParameters{
 					"restart-delay",
 				},
-				errors.New("found the following customParameters violations:\nfound general or fdbmonitor customParameter: restart-delay, please remove this parameter from the customParameters list as they are not supported"),
+				errors.New(
+					"found the following customParameters violations:\nfound general or fdbmonitor customParameter: restart-delay, please remove this parameter from the customParameters list as they are not supported",
+				),
 			),
 		)
 	})

--- a/api/v1beta2/foundationdb_database_configuration.go
+++ b/api/v1beta2/foundationdb_database_configuration.go
@@ -188,7 +188,9 @@ func (configuration *DatabaseConfiguration) FailOver() DatabaseConfiguration {
 //
 // This will fill in defaults of -1 for some fields that have a default of 0,
 // and will ensure that the region configuration is ordered consistently.
-func (configuration DatabaseConfiguration) NormalizeConfiguration(cluster *FoundationDBCluster) DatabaseConfiguration {
+func (configuration DatabaseConfiguration) NormalizeConfiguration(
+	cluster *FoundationDBCluster,
+) DatabaseConfiguration {
 	result := configuration.DeepCopy()
 
 	if result.RemoteLogs == 0 {
@@ -273,7 +275,10 @@ func (configuration DatabaseConfiguration) getRegion(id string, priority int) Re
 	}
 
 	if len(matchingRegion.DataCenters) == 0 {
-		matchingRegion.DataCenters = append(matchingRegion.DataCenters, DataCenter{ID: id, Priority: priority})
+		matchingRegion.DataCenters = append(
+			matchingRegion.DataCenters,
+			DataCenter{ID: id, Priority: priority},
+		)
 	}
 
 	return matchingRegion
@@ -298,7 +303,9 @@ func (configuration DatabaseConfiguration) getRegion(id string, priority int) Re
 // The default LogRouters value will be equal to 3 times the Logs value when
 // the UsableRegions is greater than 1. It will be equal to -1 when the
 // UsableRegions is less than or equal to 1.
-func (configuration *DatabaseConfiguration) GetRoleCountsWithDefaults(faultTolerance int) RoleCounts {
+func (configuration *DatabaseConfiguration) GetRoleCountsWithDefaults(
+	faultTolerance int,
+) RoleCounts {
 	counts := configuration.RoleCounts.DeepCopy()
 	if counts.Storage == 0 {
 		counts.Storage = 2*faultTolerance + 1
@@ -356,7 +363,9 @@ func (configuration *DatabaseConfiguration) GetRoleCountsWithDefaults(faultToler
 // converge on the final configuration.
 //
 // See: https://apple.github.io/foundationdb/configuration.html#migrating-a-database-to-use-a-region-configuration
-func (configuration DatabaseConfiguration) GetNextConfigurationChange(finalConfiguration DatabaseConfiguration) DatabaseConfiguration {
+func (configuration DatabaseConfiguration) GetNextConfigurationChange(
+	finalConfiguration DatabaseConfiguration,
+) DatabaseConfiguration {
 	if !reflect.DeepEqual(configuration.Regions, finalConfiguration.Regions) {
 		result := configuration.DeepCopy()
 		currentPriorities := configuration.getRegionPriorities()
@@ -368,7 +377,10 @@ func (configuration DatabaseConfiguration) GetNextConfigurationChange(finalConfi
 		for regionIndex, region := range result.Regions {
 			for _, dataCenter := range region.DataCenters {
 				if dataCenter.Satellite == 0 {
-					result.Regions[regionIndex] = finalConfiguration.getRegion(dataCenter.ID, dataCenter.Priority)
+					result.Regions[regionIndex] = finalConfiguration.getRegion(
+						dataCenter.ID,
+						dataCenter.Priority,
+					)
 					break
 				}
 			}
@@ -397,7 +409,10 @@ func (configuration DatabaseConfiguration) GetNextConfigurationChange(finalConfi
 				if len(result.Regions) == 0 {
 					priority = 1
 				}
-				result.Regions = append(result.Regions, finalConfiguration.getRegion(regionToAdd, priority))
+				result.Regions = append(
+					result.Regions,
+					finalConfiguration.getRegion(regionToAdd, priority),
+				)
 				currentPriorities[regionToAdd] = priority
 			}
 		}
@@ -653,9 +668,15 @@ func (configuration DatabaseConfiguration) AreSeparatedProxiesConfigured() bool 
 // string "commit_proxies=%d grv_proxies=%d", otherwise just
 // "proxies=%d" using the correct counts of the configuration object.
 func (configuration DatabaseConfiguration) GetProxiesString() string {
-	counts := configuration.GetRoleCountsWithDefaults(DesiredFaultTolerance(configuration.RedundancyMode))
+	counts := configuration.GetRoleCountsWithDefaults(
+		DesiredFaultTolerance(configuration.RedundancyMode),
+	)
 	if configuration.AreSeparatedProxiesConfigured() {
-		return fmt.Sprintf(" commit_proxies=%d grv_proxies=%d", counts.CommitProxies, counts.GrvProxies)
+		return fmt.Sprintf(
+			" commit_proxies=%d grv_proxies=%d",
+			counts.CommitProxies,
+			counts.GrvProxies,
+		)
 	}
 
 	return fmt.Sprintf(" proxies=%d", counts.Proxies)
@@ -757,7 +778,9 @@ func (configuration DatabaseConfiguration) GetConfigurationString() (string, err
 //
 // Deprecated: Use ClearMissingVersionFlags instead on the live configuration
 // instead.
-func (configuration *DatabaseConfiguration) FillInDefaultVersionFlags(liveConfiguration DatabaseConfiguration) {
+func (configuration *DatabaseConfiguration) FillInDefaultVersionFlags(
+	liveConfiguration DatabaseConfiguration,
+) {
 	if configuration.LogSpill == 0 {
 		configuration.LogSpill = liveConfiguration.LogSpill
 	}

--- a/api/v1beta2/foundationdb_database_configuration_test.go
+++ b/api/v1beta2/foundationdb_database_configuration_test.go
@@ -58,7 +58,9 @@ var _ = Describe("DatabaseConfiguration", func() {
 
 		When("the configuration string is calculated", func() {
 			It("should print the correct configuration string", func() {
-				Expect(config.GetConfigurationString()).To(Equal("triple ssd usable_regions=1 logs=3 resolvers=1 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\",\\\"priority\\\":1}]}]"))
+				Expect(
+					config.GetConfigurationString(),
+				).To(Equal("triple ssd usable_regions=1 logs=3 resolvers=1 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\",\\\"priority\\\":1}]}]"))
 			})
 		})
 
@@ -66,7 +68,9 @@ var _ = Describe("DatabaseConfiguration", func() {
 			It("should not change the config and print the correct configuration string", func() {
 				newConfig := config.FailOver()
 				Expect(newConfig).To(Equal(*config))
-				Expect(newConfig.GetConfigurationString()).To(Equal("triple ssd usable_regions=1 logs=3 resolvers=1 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\",\\\"priority\\\":1}]}]"))
+				Expect(
+					newConfig.GetConfigurationString(),
+				).To(Equal("triple ssd usable_regions=1 logs=3 resolvers=1 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\",\\\"priority\\\":1}]}]"))
 			})
 		})
 	})
@@ -124,37 +128,48 @@ var _ = Describe("DatabaseConfiguration", func() {
 
 		When("the configuration string is calculated", func() {
 			It("should print the correct configuration string", func() {
-				Expect(config.GetConfigurationString()).To(Equal("triple ssd usable_regions=1 logs=3 resolvers=1 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_single\\\"},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\"},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_double\\\"}]"))
+				Expect(
+					config.GetConfigurationString(),
+				).To(Equal("triple ssd usable_regions=1 logs=3 resolvers=1 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_single\\\"},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\"},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_double\\\"}]"))
 			})
 		})
 
 		When("the configuration string is calculated with fail over", func() {
-			It("should change the priority of the primary and the remote DC and print the new configuration string", func() {
-				newConfig := config.FailOver()
-				Expect(newConfig).NotTo(Equal(*config))
+			It(
+				"should change the priority of the primary and the remote DC and print the new configuration string",
+				func() {
+					newConfig := config.FailOver()
+					Expect(newConfig).NotTo(Equal(*config))
 
-				Expect(len(newConfig.Regions)).To(BeNumerically("==", 2))
-				Expect(newConfig.Regions[0].SatelliteLogs).To(Equal(3))
-				Expect(newConfig.Regions[0].SatelliteRedundancyMode).To(Equal(RedundancyModeOneSatelliteSingle))
-				Expect(len(newConfig.Regions[0].DataCenters)).To(BeNumerically("==", 2))
-				Expect(newConfig.Regions[0].DataCenters[0].Priority).To(Equal(0))
-				Expect(newConfig.Regions[0].DataCenters[0].ID).To(Equal("primary"))
-				Expect(newConfig.Regions[0].DataCenters[0].Satellite).To(Equal(0))
-				Expect(newConfig.Regions[0].DataCenters[1].Priority).To(Equal(1))
-				Expect(newConfig.Regions[0].DataCenters[1].ID).To(Equal("primary-sat"))
-				Expect(newConfig.Regions[0].DataCenters[1].Satellite).To(Equal(1))
+					Expect(len(newConfig.Regions)).To(BeNumerically("==", 2))
+					Expect(newConfig.Regions[0].SatelliteLogs).To(Equal(3))
+					Expect(
+						newConfig.Regions[0].SatelliteRedundancyMode,
+					).To(Equal(RedundancyModeOneSatelliteSingle))
+					Expect(len(newConfig.Regions[0].DataCenters)).To(BeNumerically("==", 2))
+					Expect(newConfig.Regions[0].DataCenters[0].Priority).To(Equal(0))
+					Expect(newConfig.Regions[0].DataCenters[0].ID).To(Equal("primary"))
+					Expect(newConfig.Regions[0].DataCenters[0].Satellite).To(Equal(0))
+					Expect(newConfig.Regions[0].DataCenters[1].Priority).To(Equal(1))
+					Expect(newConfig.Regions[0].DataCenters[1].ID).To(Equal("primary-sat"))
+					Expect(newConfig.Regions[0].DataCenters[1].Satellite).To(Equal(1))
 
-				Expect(len(newConfig.Regions[1].DataCenters)).To(BeNumerically("==", 2))
-				Expect(newConfig.Regions[1].SatelliteLogs).To(Equal(3))
-				Expect(newConfig.Regions[1].SatelliteRedundancyMode).To(Equal(RedundancyModeOneSatelliteDouble))
-				Expect(newConfig.Regions[1].DataCenters[0].Priority).To(Equal(1))
-				Expect(newConfig.Regions[1].DataCenters[0].ID).To(Equal("remote"))
-				Expect(newConfig.Regions[1].DataCenters[1].Priority).To(Equal(1))
-				Expect(newConfig.Regions[1].DataCenters[1].ID).To(Equal("remote-sat"))
-				Expect(newConfig.Regions[1].DataCenters[1].Satellite).To(Equal(1))
+					Expect(len(newConfig.Regions[1].DataCenters)).To(BeNumerically("==", 2))
+					Expect(newConfig.Regions[1].SatelliteLogs).To(Equal(3))
+					Expect(
+						newConfig.Regions[1].SatelliteRedundancyMode,
+					).To(Equal(RedundancyModeOneSatelliteDouble))
+					Expect(newConfig.Regions[1].DataCenters[0].Priority).To(Equal(1))
+					Expect(newConfig.Regions[1].DataCenters[0].ID).To(Equal("remote"))
+					Expect(newConfig.Regions[1].DataCenters[1].Priority).To(Equal(1))
+					Expect(newConfig.Regions[1].DataCenters[1].ID).To(Equal("remote-sat"))
+					Expect(newConfig.Regions[1].DataCenters[1].Satellite).To(Equal(1))
 
-				Expect(newConfig.GetConfigurationString()).To(Equal("triple ssd usable_regions=1 logs=3 resolvers=1 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\"},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_single\\\"},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_double\\\"}]"))
-			})
+					Expect(
+						newConfig.GetConfigurationString(),
+					).To(Equal("triple ssd usable_regions=1 logs=3 resolvers=1 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\"},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_single\\\"},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_double\\\"}]"))
+				},
+			)
 		})
 	})
 

--- a/api/v1beta2/foundationdb_process_address.go
+++ b/api/v1beta2/foundationdb_process_address.go
@@ -40,7 +40,12 @@ type ProcessAddress struct {
 
 // NewProcessAddress creates a new ProcessAddress if the provided string address is a valid IP address it will be set as
 // IPAddress.
-func NewProcessAddress(address net.IP, stringAddress string, port int, flags map[string]bool) ProcessAddress {
+func NewProcessAddress(
+	address net.IP,
+	stringAddress string,
+	port int,
+	flags map[string]bool,
+) ProcessAddress {
 	pAddr := ProcessAddress{
 		IPAddress:     address,
 		StringAddress: stringAddress,
@@ -313,7 +318,13 @@ func GetProcessPort(processNumber int, tls bool) int {
 // If a process needs multiple addresses, this will include all of them,
 // separated by commas. If you pass false for primaryOnly, this will return only
 // the primary address.
-func GetFullAddressList(address string, primaryOnly bool, processNumber int, requireTLS bool, requireNonTLS bool) []ProcessAddress {
+func GetFullAddressList(
+	address string,
+	primaryOnly bool,
+	processNumber int,
+	requireTLS bool,
+	requireNonTLS bool,
+) []ProcessAddress {
 	addrs := make([]ProcessAddress, 0, 2)
 
 	// If the address is already enclosed in brackets, remove them since they
@@ -323,7 +334,12 @@ func GetFullAddressList(address string, primaryOnly bool, processNumber int, req
 	// When a TLS address is provided the TLS address will always be the primary address
 	// see: https://github.com/apple/foundationdb/blob/master/fdbrpc/FlowTransport.h#L49-L56
 	if requireTLS {
-		pAddr := NewProcessAddress(nil, address, GetProcessPort(processNumber, true), map[string]bool{"tls": true})
+		pAddr := NewProcessAddress(
+			nil,
+			address,
+			GetProcessPort(processNumber, true),
+			map[string]bool{"tls": true},
+		)
 		addrs = append(addrs, pAddr)
 
 		if primaryOnly {

--- a/api/v1beta2/foundationdb_process_class.go
+++ b/api/v1beta2/foundationdb_process_class.go
@@ -54,7 +54,8 @@ const (
 
 // IsStateful determines whether a process class should store data.
 func (pClass ProcessClass) IsStateful() bool {
-	return pClass == ProcessClassStorage || pClass.IsLogProcess() || pClass == ProcessClassCoordinator
+	return pClass == ProcessClassStorage || pClass.IsLogProcess() ||
+		pClass == ProcessClassCoordinator
 }
 
 // IsTransaction determines whether a process class could be part of the transaction system.

--- a/api/v1beta2/foundationdb_status_test.go
+++ b/api/v1beta2/foundationdb_status_test.go
@@ -46,12 +46,21 @@ var _ = Describe("FoundationDBStatus", func() {
 			IncompatibleConnections: []string{},
 			ConnectionString:        "test_cluster:aHeD9ocNXOUxi0dyzU3k7Bhg53SpyrBV@10.1.18.253:4501,10.1.18.254:4501,10.1.19.0:4501",
 			DatabaseConfiguration: DatabaseConfiguration{
-				RedundancyMode:                 "double",
-				StorageEngine:                  StorageEngineSSD2,
-				UsableRegions:                  1,
-				Regions:                        nil,
-				ExcludedServers:                make([]ExcludedServers, 0),
-				RoleCounts:                     RoleCounts{Storage: 0, Logs: 3, Proxies: 3, CommitProxies: 2, GrvProxies: 1, Resolvers: 1, LogRouters: -1, RemoteLogs: -1},
+				RedundancyMode:  "double",
+				StorageEngine:   StorageEngineSSD2,
+				UsableRegions:   1,
+				Regions:         nil,
+				ExcludedServers: make([]ExcludedServers, 0),
+				RoleCounts: RoleCounts{
+					Storage:       0,
+					Logs:          3,
+					Proxies:       3,
+					CommitProxies: 2,
+					GrvProxies:    1,
+					Resolvers:     1,
+					LogRouters:    -1,
+					RemoteLogs:    -1,
+				},
 				VersionFlags:                   VersionFlags{LogSpill: 2, LogVersion: 0},
 				StorageMigrationType:           &migrationType,
 				PerpetualStorageWiggle:         pointer.Int(0),
@@ -80,8 +89,16 @@ var _ = Describe("FoundationDBStatus", func() {
 							Role: string(ProcessRoleGrvProxy),
 							ID:   "0de7f5c5e549cad1",
 							GRVLatencyStatistics: FoundationDBStatusGRVStatistics{
-								Batch:   FoundationDBStatusPerfStatistics{Count: pointer.Int(6), Median: pointer.Float64(0.000531435), P99: pointer.Float64(0.00130677)},
-								Default: FoundationDBStatusPerfStatistics{Count: pointer.Int(225), Median: pointer.Float64(0.00062561), P99: pointer.Float64(0.010715200000000001)},
+								Batch: FoundationDBStatusPerfStatistics{
+									Count:  pointer.Int(6),
+									Median: pointer.Float64(0.000531435),
+									P99:    pointer.Float64(0.00130677),
+								},
+								Default: FoundationDBStatusPerfStatistics{
+									Count:  pointer.Int(225),
+									Median: pointer.Float64(0.00062561),
+									P99:    pointer.Float64(0.010715200000000001),
+								},
 							},
 						},
 						{
@@ -95,7 +112,11 @@ var _ = Describe("FoundationDBStatus", func() {
 							KVStoreTotalBytes:     pointer.Int64(135012552704),
 							KVStoreFreeBytes:      pointer.Int64(84178223104),
 							KVStoreAvailableBytes: pointer.Int64(84178223104),
-							ReadLatencyStatistics: FoundationDBStatusPerfStatistics{Count: pointer.Int(297), Median: pointer.Float64(0.000116825), P99: pointer.Float64(0.000711441)},
+							ReadLatencyStatistics: FoundationDBStatusPerfStatistics{
+								Count:  pointer.Int(297),
+								Median: pointer.Float64(0.000116825),
+								P99:    pointer.Float64(0.000711441),
+							},
 						},
 					},
 					Messages: []FoundationDBStatusProcessMessage{},
@@ -119,14 +140,21 @@ var _ = Describe("FoundationDBStatus", func() {
 					Roles: []FoundationDBStatusProcessRoleInfo{
 						{Role: string(ProcessRoleCoordinator)},
 						{
-							Role:                  string(ProcessClassStorage),
-							ID:                    "389c23d59a646e52",
-							DataLag:               FoundationDBStatusLagInfo{Seconds: 2.1227, Versions: 2122697},
+							Role: string(ProcessClassStorage),
+							ID:   "389c23d59a646e52",
+							DataLag: FoundationDBStatusLagInfo{
+								Seconds:  2.1227,
+								Versions: 2122697,
+							},
 							KVStoreUsedBytes:      pointer.Int64(104878232),
 							KVStoreTotalBytes:     pointer.Int64(135012552704),
 							KVStoreFreeBytes:      pointer.Int64(84178239488),
 							KVStoreAvailableBytes: pointer.Int64(84178239488),
-							ReadLatencyStatistics: FoundationDBStatusPerfStatistics{Count: pointer.Int(334), Median: pointer.Float64(0.000102282), P99: pointer.Float64(0.000386477)},
+							ReadLatencyStatistics: FoundationDBStatusPerfStatistics{
+								Count:  pointer.Int(334),
+								Median: pointer.Float64(0.000102282),
+								P99:    pointer.Float64(0.000386477),
+							},
 						},
 						{
 							Role: string(ProcessRoleResolver),
@@ -173,7 +201,11 @@ var _ = Describe("FoundationDBStatus", func() {
 							KVStoreTotalBytes:     pointer.Int64(135012552704),
 							KVStoreFreeBytes:      pointer.Int64(84178112512),
 							KVStoreAvailableBytes: pointer.Int64(84178112512),
-							ReadLatencyStatistics: FoundationDBStatusPerfStatistics{Count: pointer.Int(0), Median: pointer.Float64(0), P99: pointer.Float64(0)},
+							ReadLatencyStatistics: FoundationDBStatusPerfStatistics{
+								Count:  pointer.Int(0),
+								Median: pointer.Float64(0),
+								P99:    pointer.Float64(0),
+							},
 						},
 					},
 					Messages: []FoundationDBStatusProcessMessage{},
@@ -320,13 +352,27 @@ var _ = Describe("FoundationDBStatus", func() {
 				},
 			},
 			Data: FoundationDBStatusDataStatistics{
-				KVBytes:    0,
-				MovingData: FoundationDBStatusMovingData{HighestPriority: 0, InFlightBytes: 0, InQueueBytes: 0},
-				State:      FoundationDBStatusDataState{Description: "", Healthy: true, Name: "healthy", MinReplicasRemaining: 2},
+				KVBytes: 0,
+				MovingData: FoundationDBStatusMovingData{
+					HighestPriority: 0,
+					InFlightBytes:   0,
+					InQueueBytes:    0,
+				},
+				State: FoundationDBStatusDataState{
+					Description:          "",
+					Healthy:              true,
+					Name:                 "healthy",
+					MinReplicasRemaining: 2,
+				},
 				TeamTrackers: []FoundationDBStatusTeamTracker{
 					{
-						Primary:          true,
-						State:            FoundationDBStatusDataState{Description: "", Healthy: true, Name: "healthy", MinReplicasRemaining: 2},
+						Primary: true,
+						State: FoundationDBStatusDataState{
+							Description:          "",
+							Healthy:              true,
+							Name:                 "healthy",
+							MinReplicasRemaining: 2,
+						},
 						UnhealthyServers: pointer.Int64(0),
 					},
 				},
@@ -504,7 +550,11 @@ var _ = Describe("FoundationDBStatus", func() {
 		}
 
 		It("should parse all values correctly", func() {
-			statusFile, err := os.OpenFile(filepath.Join("testdata", "fdb_status_7_1_rc1.json"), os.O_RDONLY, os.ModePerm)
+			statusFile, err := os.OpenFile(
+				filepath.Join("testdata", "fdb_status_7_1_rc1.json"),
+				os.O_RDONLY,
+				os.ModePerm,
+			)
 			Expect(err).NotTo(HaveOccurred())
 			defer statusFile.Close()
 			statusDecoder := json.NewDecoder(statusFile)
@@ -515,20 +565,28 @@ var _ = Describe("FoundationDBStatus", func() {
 			// Gomega needs some prodding to effectively format diffs between these status objects, so we compare
 			// the fields one by one.
 			clusterInfoParsed := statusParsed.Cluster
-			Expect(clusterInfoParsed.DatabaseConfiguration).To(Equal(clusterInfo.DatabaseConfiguration))
-			Expect(clusterInfoParsed.Processes).To(ConsistOf(slices.Collect(maps.Values(clusterInfo.Processes))))
+			Expect(
+				clusterInfoParsed.DatabaseConfiguration,
+			).To(Equal(clusterInfo.DatabaseConfiguration))
+			Expect(
+				clusterInfoParsed.Processes,
+			).To(ConsistOf(slices.Collect(maps.Values(clusterInfo.Processes))))
 			Expect(clusterInfoParsed.Data).To(Equal(clusterInfo.Data))
 			Expect(clusterInfoParsed.FullReplication).To(Equal(clusterInfo.FullReplication))
 			Expect(clusterInfoParsed.Generation).To(Equal(clusterInfo.Generation))
 			Expect(clusterInfoParsed.MaintenanceZone).To(Equal(clusterInfo.MaintenanceZone))
 			Expect(clusterInfoParsed.Clients.Count).To(Equal(clusterInfo.Clients.Count))
-			Expect(clusterInfoParsed.Clients.SupportedVersions).To(HaveExactElements(clusterInfoParsed.Clients.SupportedVersions))
+			Expect(
+				clusterInfoParsed.Clients.SupportedVersions,
+			).To(HaveExactElements(clusterInfoParsed.Clients.SupportedVersions))
 			Expect(clusterInfoParsed.Layers).To(Equal(clusterInfo.Layers))
 			Expect(clusterInfoParsed.Logs).To(HaveExactElements(clusterInfo.Logs))
 			Expect(clusterInfoParsed.Qos).To(Equal(clusterInfo.Qos))
 			Expect(clusterInfoParsed.FaultTolerance).To(Equal(clusterInfo.FaultTolerance))
 			Expect(clusterInfoParsed.MaintenanceZone).To(Equal(clusterInfo.MaintenanceZone))
-			Expect(clusterInfoParsed.IncompatibleConnections).To(HaveExactElements(clusterInfo.IncompatibleConnections))
+			Expect(
+				clusterInfoParsed.IncompatibleConnections,
+			).To(HaveExactElements(clusterInfo.IncompatibleConnections))
 			Expect(clusterInfoParsed.BounceImpact).To(Equal(clusterInfo.BounceImpact))
 			Expect(clusterInfoParsed.DatabaseAvailable).To(Equal(clusterInfo.DatabaseAvailable))
 			Expect(clusterInfoParsed.ActivePrimaryDC).To(Equal(clusterInfo.ActivePrimaryDC))
@@ -536,20 +594,29 @@ var _ = Describe("FoundationDBStatus", func() {
 		})
 	})
 
-	When("parsing a machine-readable status that contains the unreachable processes message", func() {
-		It("should parse the cluster messages correct", func() {
-			statusFile, err := os.OpenFile(filepath.Join("testdata", "unreachable_test_processes.json"), os.O_RDONLY, os.ModePerm)
-			Expect(err).NotTo(HaveOccurred())
-			defer statusFile.Close()
-			statusDecoder := json.NewDecoder(statusFile)
-			statusParsed := FoundationDBStatus{}
-			Expect(statusDecoder.Decode(&statusParsed)).NotTo(HaveOccurred())
-			Expect(statusParsed.Cluster.Messages).To(HaveLen(2))
-			Expect(statusParsed.Cluster.Messages[0].UnreachableProcesses).To(HaveLen(1))
-			Expect(statusParsed.Cluster.Messages[0].Name).To(Equal("unreachable_processes"))
-			Expect(statusParsed.Cluster.Messages[0].UnreachableProcesses[0].Address).To(Equal("100.82.115.41:4500:tls"))
-			Expect(statusParsed.Cluster.Messages[1].UnreachableProcesses).To(HaveLen(0))
-			Expect(statusParsed.Cluster.Messages[1].Name).To(Equal("status_incomplete"))
-		})
-	})
+	When(
+		"parsing a machine-readable status that contains the unreachable processes message",
+		func() {
+			It("should parse the cluster messages correct", func() {
+				statusFile, err := os.OpenFile(
+					filepath.Join("testdata", "unreachable_test_processes.json"),
+					os.O_RDONLY,
+					os.ModePerm,
+				)
+				Expect(err).NotTo(HaveOccurred())
+				defer statusFile.Close()
+				statusDecoder := json.NewDecoder(statusFile)
+				statusParsed := FoundationDBStatus{}
+				Expect(statusDecoder.Decode(&statusParsed)).NotTo(HaveOccurred())
+				Expect(statusParsed.Cluster.Messages).To(HaveLen(2))
+				Expect(statusParsed.Cluster.Messages[0].UnreachableProcesses).To(HaveLen(1))
+				Expect(statusParsed.Cluster.Messages[0].Name).To(Equal("unreachable_processes"))
+				Expect(
+					statusParsed.Cluster.Messages[0].UnreachableProcesses[0].Address,
+				).To(Equal("100.82.115.41:4500:tls"))
+				Expect(statusParsed.Cluster.Messages[1].UnreachableProcesses).To(HaveLen(0))
+				Expect(statusParsed.Cluster.Messages[1].Name).To(Equal("status_incomplete"))
+			})
+		},
+	)
 })

--- a/api/v1beta2/foundationdb_version_test.go
+++ b/api/v1beta2/foundationdb_version_test.go
@@ -93,9 +93,15 @@ var _ = Describe("[api] FDBVersion", func() {
 	When("getting the next version of the current FDBVersion", func() {
 		It("should return the correct next version", func() {
 			version := Versions.Default
-			Expect(version.NextMajorVersion()).To(Equal(Version{api.Version{Major: 8, Minor: 0, Patch: 0}}))
-			Expect(version.NextMinorVersion()).To(Equal(Version{api.Version{Major: version.Major, Minor: 2, Patch: 0}}))
-			Expect(version.NextPatchVersion()).To(Equal(Version{api.Version{Major: version.Major, Minor: version.Minor, Patch: 58}}))
+			Expect(
+				version.NextMajorVersion(),
+			).To(Equal(Version{api.Version{Major: 8, Minor: 0, Patch: 0}}))
+			Expect(
+				version.NextMinorVersion(),
+			).To(Equal(Version{api.Version{Major: version.Major, Minor: 2, Patch: 0}}))
+			Expect(
+				version.NextPatchVersion(),
+			).To(Equal(Version{api.Version{Major: version.Major, Minor: version.Minor, Patch: 58}}))
 		})
 	})
 
@@ -111,18 +117,34 @@ var _ = Describe("[api] FDBVersion", func() {
 
 		It("should return correct result for IsAtleast", func() {
 			version := Version{api.Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 2}}
-			Expect(version.IsAtLeast(Version{api.Version{Major: 7, Minor: 1, Patch: 0}})).To(BeFalse())
-			Expect(version.IsAtLeast(Version{api.Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 1}})).To(BeTrue())
-			Expect(version.IsAtLeast(Version{api.Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 3}})).To(BeFalse())
+			Expect(
+				version.IsAtLeast(Version{api.Version{Major: 7, Minor: 1, Patch: 0}}),
+			).To(BeFalse())
+			Expect(
+				version.IsAtLeast(
+					Version{api.Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 1}},
+				),
+			).To(BeTrue())
+			Expect(
+				version.IsAtLeast(
+					Version{api.Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 3}},
+				),
+			).To(BeFalse())
 
 			version = Version{api.Version{Major: 7, Minor: 1, Patch: 0}}
-			Expect(version.IsAtLeast(Version{api.Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 1}})).To(BeTrue())
+			Expect(
+				version.IsAtLeast(
+					Version{api.Version{Major: 7, Minor: 1, Patch: 0, ReleaseCandidate: 1}},
+				),
+			).To(BeTrue())
 		})
 	})
 
-	DescribeTable("validating in a version check is allowed", func(version Version, targetVersion Version, expected bool) {
-		Expect(version.SupportsVersionChange(targetVersion)).To(Equal(expected))
-	},
+	DescribeTable(
+		"validating in a version check is allowed",
+		func(version Version, targetVersion Version, expected bool) {
+			Expect(version.SupportsVersionChange(targetVersion)).To(Equal(expected))
+		},
 		Entry("Same version",
 			Version{api.Version{
 				Major: 7,
@@ -216,9 +238,11 @@ var _ = Describe("[api] FDBVersion", func() {
 		),
 	)
 
-	DescribeTable("validating if the provided version supports locality based exclusions", func(version Version, expected bool) {
-		Expect(version.SupportsLocalityBasedExclusions()).To(Equal(expected))
-	},
+	DescribeTable(
+		"validating if the provided version supports locality based exclusions",
+		func(version Version, expected bool) {
+			Expect(version.SupportsLocalityBasedExclusions()).To(Equal(expected))
+		},
 		Entry(
 			"Version is 6.3",
 			Version{api.Version{
@@ -266,9 +290,11 @@ var _ = Describe("[api] FDBVersion", func() {
 		),
 	)
 
-	DescribeTable("validating if the provided version automatically removes dead tester processes", func(version Version, expected bool) {
-		Expect(version.AutomaticallyRemovesDeadTesterProcesses()).To(Equal(expected))
-	},
+	DescribeTable(
+		"validating if the provided version automatically removes dead tester processes",
+		func(version Version, expected bool) {
+			Expect(version.AutomaticallyRemovesDeadTesterProcesses()).To(Equal(expected))
+		},
 		Entry(
 			"Version is 6.3",
 			Version{api.Version{

--- a/api/v1beta2/foundationdbbackup_types.go
+++ b/api/v1beta2/foundationdbbackup_types.go
@@ -48,8 +48,8 @@ type FoundationDBBackup struct {
 
 // FoundationDBBackupList contains a list of FoundationDBBackup objects
 type FoundationDBBackupList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `                     json:",inline"`
+	metav1.ListMeta `                     json:"metadata,omitempty"`
 	Items           []FoundationDBBackup `json:"items"`
 }
 
@@ -218,7 +218,8 @@ type BlobStoreConfiguration struct {
 
 // ShouldRun determines whether a backup should be running.
 func (backup *FoundationDBBackup) ShouldRun() bool {
-	return backup.Spec.BackupState == "" || backup.Spec.BackupState == BackupStateRunning || backup.Spec.BackupState == BackupStatePaused
+	return backup.Spec.BackupState == "" || backup.Spec.BackupState == BackupStateRunning ||
+		backup.Spec.BackupState == BackupStatePaused
 }
 
 // ShouldBePaused determines whether the backups should be paused.
@@ -314,7 +315,8 @@ func (backup *FoundationDBBackup) CheckReconciliation() (bool, error) {
 		reconciled = false
 	}
 
-	if isRunning && backup.SnapshotPeriodSeconds() != backup.Status.BackupDetails.SnapshotPeriodSeconds {
+	if isRunning &&
+		backup.SnapshotPeriodSeconds() != backup.Status.BackupDetails.SnapshotPeriodSeconds {
 		backup.Status.Generations.NeedsBackupReconfiguration = backup.Generation
 		reconciled = false
 	}
@@ -374,7 +376,14 @@ func (configuration *BlobStoreConfiguration) getURL(backup string, bucket string
 		}
 	}
 
-	return fmt.Sprintf("blobstore://%s%s/%s?bucket=%s%s", configuration.AccountName, defaultPort, backup, bucket, sb.String())
+	return fmt.Sprintf(
+		"blobstore://%s%s/%s?bucket=%s%s",
+		configuration.AccountName,
+		defaultPort,
+		backup,
+		bucket,
+		sb.String(),
+	)
 }
 
 // BucketName gets the bucket this backup will use.

--- a/api/v1beta2/foundationdbbackup_types_test.go
+++ b/api/v1beta2/foundationdbbackup_types_test.go
@@ -225,7 +225,8 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 	})
 
 	When("getting the backup URL", func() {
-		DescribeTable("should generate the correct backup URL",
+		DescribeTable(
+			"should generate the correct backup URL",
 			func(backup FoundationDBBackup, expected string) {
 				Expect(backup.BackupURL()).To(Equal(expected))
 			},
@@ -269,7 +270,8 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 					},
 				},
 				"blobstore://account@account:443/test?bucket=my-bucket"),
-			Entry("A Backup with a blobstore config with a bucket and backup name and a defined port",
+			Entry(
+				"A Backup with a blobstore config with a bucket and backup name and a defined port",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mybackup",
@@ -282,8 +284,10 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@account:931/test?bucket=my-bucket"),
-			Entry("A Backup with a blobstore config with a bucket and backup name and HTTPS parameters",
+				"blobstore://account@account:931/test?bucket=my-bucket",
+			),
+			Entry(
+				"A Backup with a blobstore config with a bucket and backup name and HTTPS parameters",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mybackup",
@@ -299,8 +303,10 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@account:443/test?bucket=my-bucket&secure_connection=1"),
-			Entry("A Backup with a blobstore config with a bucket and backup name and HTTPS parameters (shorthand)",
+				"blobstore://account@account:443/test?bucket=my-bucket&secure_connection=1",
+			),
+			Entry(
+				"A Backup with a blobstore config with a bucket and backup name and HTTPS parameters (shorthand)",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mybackup",
@@ -316,8 +322,10 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@account:443/test?bucket=my-bucket&sc=1"),
-			Entry("A Backup with a blobstore config with HTTP parameters and backup and bucket name",
+				"blobstore://account@account:443/test?bucket=my-bucket&sc=1",
+			),
+			Entry(
+				"A Backup with a blobstore config with HTTP parameters and backup and bucket name",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mybackup",
@@ -333,7 +341,8 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@account:80/test?bucket=my-bucket&secure_connection=0"),
+				"blobstore://account@account:80/test?bucket=my-bucket&secure_connection=0",
+			),
 			Entry("A Backup with a blobstore config with HTTP parameters",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
@@ -364,7 +373,8 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 					},
 				},
 				"blobstore://account@account:8453/mybackup?bucket=fdb-backups&secure_connection=0"),
-			Entry("A Backup with a blobstore config with HTTP parameters (shorthand) and a defined port",
+			Entry(
+				"A Backup with a blobstore config with HTTP parameters (shorthand) and a defined port",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mybackup",
@@ -378,7 +388,8 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@account:8453/mybackup?bucket=fdb-backups&sc=0"),
+				"blobstore://account@account:8453/mybackup?bucket=fdb-backups&sc=0",
+			),
 			Entry("A Backup with a blobstore config with invalid HTTP parameters",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
@@ -394,7 +405,8 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 					},
 				},
 				"blobstore://account@account:443/mybackup?bucket=fdb-backups&secure_con=0"),
-			Entry("A Backup with a blobstore config with invalid HTTP parameters and a defined port",
+			Entry(
+				"A Backup with a blobstore config with invalid HTTP parameters and a defined port",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mybackup",
@@ -408,8 +420,10 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@account:633/mybackup?bucket=fdb-backups&secure_con=0"),
-			Entry("A Backup with a blobstore config with IPv6 and a defined port",
+				"blobstore://account@account:633/mybackup?bucket=fdb-backups&secure_con=0",
+			),
+			Entry(
+				"A Backup with a blobstore config with IPv6 and a defined port",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mybackup",
@@ -420,8 +434,10 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:633/mybackup?bucket=fdb-backups"),
-			Entry("A Backup with a blobstore config with IPv6 and no defined port",
+				"blobstore://account@[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:633/mybackup?bucket=fdb-backups",
+			),
+			Entry(
+				"A Backup with a blobstore config with IPv6 and no defined port",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mybackup",
@@ -432,8 +448,10 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443/mybackup?bucket=fdb-backups"),
-			Entry("A Backup with a blobstore config with IPv6 and no defined port (sc=0)",
+				"blobstore://account@[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443/mybackup?bucket=fdb-backups",
+			),
+			Entry(
+				"A Backup with a blobstore config with IPv6 and no defined port (sc=0)",
 				FoundationDBBackup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mybackup",
@@ -447,7 +465,8 @@ var _ = Describe("[api] FoundationDBBackup", func() {
 						},
 					},
 				},
-				"blobstore://account@[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:80/mybackup?bucket=fdb-backups&sc=0"),
+				"blobstore://account@[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:80/mybackup?bucket=fdb-backups&sc=0",
+			),
 		)
 	})
 })

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -286,59 +286,68 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 			})
 
-			It("should return the correct counts when only proxies are unconfigured and grv_proxies/commit_proxies are configured", func() {
-				cluster.Spec.DatabaseConfiguration.RoleCounts = RoleCounts{
-					Proxies:       0,
-					CommitProxies: 9,
-					GrvProxies:    4,
-				}
-				Expect(cluster.GetRoleCountsWithDefaults()).To(Equal(RoleCounts{
-					Storage:       3,
-					Logs:          3,
-					Proxies:       0,
-					GrvProxies:    4,
-					CommitProxies: 9,
-					Resolvers:     1,
-					RemoteLogs:    -1,
-					LogRouters:    -1,
-				}))
-			})
+			It(
+				"should return the correct counts when only proxies are unconfigured and grv_proxies/commit_proxies are configured",
+				func() {
+					cluster.Spec.DatabaseConfiguration.RoleCounts = RoleCounts{
+						Proxies:       0,
+						CommitProxies: 9,
+						GrvProxies:    4,
+					}
+					Expect(cluster.GetRoleCountsWithDefaults()).To(Equal(RoleCounts{
+						Storage:       3,
+						Logs:          3,
+						Proxies:       0,
+						GrvProxies:    4,
+						CommitProxies: 9,
+						Resolvers:     1,
+						RemoteLogs:    -1,
+						LogRouters:    -1,
+					}))
+				},
+			)
 
-			It("should return the correct counts when proxies, grv_proxies are unconfigured and commit_proxies configured", func() {
-				cluster.Spec.DatabaseConfiguration.RoleCounts = RoleCounts{
-					Proxies:       0,
-					CommitProxies: 3,
-					GrvProxies:    0,
-				}
-				Expect(cluster.GetRoleCountsWithDefaults()).To(Equal(RoleCounts{
-					Storage:       3,
-					Logs:          3,
-					Proxies:       0,
-					GrvProxies:    1,
-					CommitProxies: 3,
-					Resolvers:     1,
-					RemoteLogs:    -1,
-					LogRouters:    -1,
-				}))
-			})
+			It(
+				"should return the correct counts when proxies, grv_proxies are unconfigured and commit_proxies configured",
+				func() {
+					cluster.Spec.DatabaseConfiguration.RoleCounts = RoleCounts{
+						Proxies:       0,
+						CommitProxies: 3,
+						GrvProxies:    0,
+					}
+					Expect(cluster.GetRoleCountsWithDefaults()).To(Equal(RoleCounts{
+						Storage:       3,
+						Logs:          3,
+						Proxies:       0,
+						GrvProxies:    1,
+						CommitProxies: 3,
+						Resolvers:     1,
+						RemoteLogs:    -1,
+						LogRouters:    -1,
+					}))
+				},
+			)
 
-			It("should return the correct counts when proxies, commit_proxies are unconfigured and grv_proxies configured", func() {
-				cluster.Spec.DatabaseConfiguration.RoleCounts = RoleCounts{
-					Proxies:       0,
-					CommitProxies: 0,
-					GrvProxies:    5,
-				}
-				Expect(cluster.GetRoleCountsWithDefaults()).To(Equal(RoleCounts{
-					Storage:       3,
-					Logs:          3,
-					Proxies:       0,
-					GrvProxies:    5,
-					CommitProxies: 2,
-					Resolvers:     1,
-					RemoteLogs:    -1,
-					LogRouters:    -1,
-				}))
-			})
+			It(
+				"should return the correct counts when proxies, commit_proxies are unconfigured and grv_proxies configured",
+				func() {
+					cluster.Spec.DatabaseConfiguration.RoleCounts = RoleCounts{
+						Proxies:       0,
+						CommitProxies: 0,
+						GrvProxies:    5,
+					}
+					Expect(cluster.GetRoleCountsWithDefaults()).To(Equal(RoleCounts{
+						Storage:       3,
+						Logs:          3,
+						Proxies:       0,
+						GrvProxies:    5,
+						CommitProxies: 2,
+						Resolvers:     1,
+						RemoteLogs:    -1,
+						LogRouters:    -1,
+					}))
+				},
+			)
 
 		})
 	})
@@ -674,14 +683,25 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 					Expect(configuration.StorageMigrationType).To(BeNil())
 				})
 
-				It("should set the all storage migration related values to the empty defaults", func() {
-					configurationString, err := configuration.GetConfigurationString()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(configurationString).NotTo(ContainSubstring("storage_migration_type=disabled"))
-					Expect(configurationString).NotTo(ContainSubstring("perpetual_storage_wiggle"))
-					Expect(configurationString).NotTo(ContainSubstring("perpetual_storage_wiggle_locality"))
-					Expect(configurationString).NotTo(ContainSubstring("perpetual_storage_wiggle_engine"))
-				})
+				It(
+					"should set the all storage migration related values to the empty defaults",
+					func() {
+						configurationString, err := configuration.GetConfigurationString()
+						Expect(err).NotTo(HaveOccurred())
+						Expect(
+							configurationString,
+						).NotTo(ContainSubstring("storage_migration_type=disabled"))
+						Expect(
+							configurationString,
+						).NotTo(ContainSubstring("perpetual_storage_wiggle"))
+						Expect(
+							configurationString,
+						).NotTo(ContainSubstring("perpetual_storage_wiggle_locality"))
+						Expect(
+							configurationString,
+						).NotTo(ContainSubstring("perpetual_storage_wiggle_engine"))
+					},
+				)
 			})
 
 			When("storage migration settings are set", func() {
@@ -710,18 +730,31 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 					Expect(configuration.PerpetualStorageWiggle).NotTo(BeNil())
 					Expect(*configuration.PerpetualStorageWiggle).To(Equal(1))
 					Expect(configuration.StorageMigrationType).NotTo(BeNil())
-					Expect(*configuration.StorageMigrationType).To(Equal(StorageMigrationTypeGradual))
+					Expect(
+						*configuration.StorageMigrationType,
+					).To(Equal(StorageMigrationTypeGradual))
 					Expect(configuration.PerpetualStorageWiggleEngine).To(BeNil())
 				})
 
-				It("should set the all storage migration related values to the empty defaults", func() {
-					configurationString, err := configuration.GetConfigurationString()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(configurationString).To(ContainSubstring("storage_migration_type=gradual"))
-					Expect(configurationString).To(ContainSubstring("perpetual_storage_wiggle=1"))
-					Expect(configurationString).NotTo(ContainSubstring("perpetual_storage_wiggle_locality"))
-					Expect(configurationString).NotTo(ContainSubstring("perpetual_storage_wiggle_engine"))
-				})
+				It(
+					"should set the all storage migration related values to the empty defaults",
+					func() {
+						configurationString, err := configuration.GetConfigurationString()
+						Expect(err).NotTo(HaveOccurred())
+						Expect(
+							configurationString,
+						).To(ContainSubstring("storage_migration_type=gradual"))
+						Expect(
+							configurationString,
+						).To(ContainSubstring("perpetual_storage_wiggle=1"))
+						Expect(
+							configurationString,
+						).NotTo(ContainSubstring("perpetual_storage_wiggle_locality"))
+						Expect(
+							configurationString,
+						).NotTo(ContainSubstring("perpetual_storage_wiggle_engine"))
+					},
+				)
 			})
 
 			When("storage migration settings with perpetual storage engine set", func() {
@@ -753,26 +786,45 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 					Expect(configuration.PerpetualStorageWiggle).NotTo(BeNil())
 					Expect(*configuration.PerpetualStorageWiggle).To(Equal(1))
 					Expect(configuration.StorageMigrationType).NotTo(BeNil())
-					Expect(*configuration.StorageMigrationType).To(Equal(StorageMigrationTypeGradual))
+					Expect(
+						*configuration.StorageMigrationType,
+					).To(Equal(StorageMigrationTypeGradual))
 					Expect(configuration.PerpetualStorageWiggleEngine).NotTo(BeNil())
-					Expect(*configuration.PerpetualStorageWiggleEngine).To(Equal(StorageEngineRocksDbV1))
+					Expect(
+						*configuration.PerpetualStorageWiggleEngine,
+					).To(Equal(StorageEngineRocksDbV1))
 				})
 
-				It("should set the all storage migration related values to the empty defaults", func() {
-					configurationString, err := configuration.GetConfigurationString()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(configurationString).To(ContainSubstring("storage_migration_type=gradual"))
-					Expect(configurationString).To(ContainSubstring("perpetual_storage_wiggle=1"))
-					Expect(configurationString).To(ContainSubstring("perpetual_storage_wiggle_locality=dcid:remote"))
-					Expect(configurationString).To(ContainSubstring("perpetual_storage_wiggle_engine=ssd-rocksdb-v1"))
-				})
+				It(
+					"should set the all storage migration related values to the empty defaults",
+					func() {
+						configurationString, err := configuration.GetConfigurationString()
+						Expect(err).NotTo(HaveOccurred())
+						Expect(
+							configurationString,
+						).To(ContainSubstring("storage_migration_type=gradual"))
+						Expect(
+							configurationString,
+						).To(ContainSubstring("perpetual_storage_wiggle=1"))
+						Expect(
+							configurationString,
+						).To(ContainSubstring("perpetual_storage_wiggle_locality=dcid:remote"))
+						Expect(
+							configurationString,
+						).To(ContainSubstring("perpetual_storage_wiggle_engine=ssd-rocksdb-v1"))
+					},
+				)
 			})
 		})
 	})
 
 	When("parsing the backup status for 6.2", func() {
 		It("should be parsed correctly", func() {
-			statusFile, err := os.OpenFile(filepath.Join("testdata", "fdbbackup_status_6_2.json"), os.O_RDONLY, os.ModePerm)
+			statusFile, err := os.OpenFile(
+				filepath.Join("testdata", "fdbbackup_status_6_2.json"),
+				os.O_RDONLY,
+				os.ModePerm,
+			)
 			Expect(err).NotTo(HaveOccurred())
 			defer statusFile.Close()
 			statusDecoder := json.NewDecoder(statusFile)
@@ -838,7 +890,9 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			})
 
 			It("should return an error", func() {
-				Expect(err).To(MatchError(Equal("invalid connection string: test:abcd, could not split string to get generation ID")))
+				Expect(
+					err,
+				).To(MatchError(Equal("invalid connection string: test:abcd, could not split string to get generation ID")))
 			})
 		})
 
@@ -848,7 +902,9 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			})
 
 			It("should return an error", func() {
-				Expect(err).To(MatchError(Equal("invalid connection string: te-st:abcd, database description can only contain alphanumeric characters (a-z, A-Z, 0-9) and underscores")))
+				Expect(
+					err,
+				).To(MatchError(Equal("invalid connection string: te-st:abcd, database description can only contain alphanumeric characters (a-z, A-Z, 0-9) and underscores")))
 			})
 		})
 
@@ -858,7 +914,9 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			})
 
 			It("should return an error", func() {
-				Expect(err).To(MatchError(Equal("invalid connection string: :abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500, database description can only contain alphanumeric characters (a-z, A-Z, 0-9) and underscores")))
+				Expect(
+					err,
+				).To(MatchError(Equal("invalid connection string: :abcd@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500, database description can only contain alphanumeric characters (a-z, A-Z, 0-9) and underscores")))
 			})
 		})
 
@@ -868,7 +926,9 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			})
 
 			It("should return an error", func() {
-				Expect(err).To(MatchError(Equal("invalid connection string: test:@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500, generation ID can only contain alphanumeric characters (a-z, A-Z, 0-9)")))
+				Expect(
+					err,
+				).To(MatchError(Equal("invalid connection string: test:@127.0.0.1:4500,127.0.0.2:4500,127.0.0.3:4500, generation ID can only contain alphanumeric characters (a-z, A-Z, 0-9)")))
 			})
 		})
 
@@ -878,7 +938,9 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			})
 
 			It("should return an error", func() {
-				Expect(err).To(MatchError(Equal("invalid connection string: test:abcd@, could not parse coordinator address: <nil>, got error: cannot parse empty address")))
+				Expect(
+					err,
+				).To(MatchError(Equal("invalid connection string: test:abcd@, could not parse coordinator address: <nil>, got error: cannot parse empty address")))
 			})
 		})
 
@@ -1017,11 +1079,17 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			Expect(str.HasCoordinators(newCoord)).To(BeTrue())
 			newCoord = make([]ProcessAddress, len(coordinators))
 			copy(newCoord, coordinators)
-			newCoord = append(newCoord, ProcessAddress{IPAddress: net.ParseIP("127.0.0.4"), Port: 4500})
+			newCoord = append(
+				newCoord,
+				ProcessAddress{IPAddress: net.ParseIP("127.0.0.4"), Port: 4500},
+			)
 			Expect(str.HasCoordinators(newCoord)).To(BeFalse())
 			newCoord = make([]ProcessAddress, len(coordinators))
 			copy(newCoord, coordinators)
-			newCoord = append(newCoord[:2], ProcessAddress{IPAddress: net.ParseIP("127.0.0.4"), Port: 4500})
+			newCoord = append(
+				newCoord[:2],
+				ProcessAddress{IPAddress: net.ParseIP("127.0.0.4"), Port: 4500},
+			)
 			Expect(str.HasCoordinators(newCoord)).To(BeFalse())
 			Expect(str.HasCoordinators(newCoord[:2])).To(BeFalse())
 		})
@@ -1164,25 +1232,28 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 			})
 
-			It("should be parsed correctly when both grv_proxies/commit_proxies and proxies are set", func() {
-				cluster.Spec.DatabaseConfiguration.Proxies = 12
-				cluster.Spec.DatabaseConfiguration.CommitProxies = 4
-				cluster.Spec.DatabaseConfiguration.GrvProxies = 4
-				Expect(cluster.DesiredDatabaseConfiguration()).To(Equal(DatabaseConfiguration{
-					RedundancyMode: RedundancyModeDouble,
-					StorageEngine:  StorageEngineSSD2,
-					UsableRegions:  1,
-					RoleCounts: RoleCounts{
-						Logs:          4,
-						Proxies:       0,
-						CommitProxies: 4,
-						GrvProxies:    4,
-						Resolvers:     1,
-						LogRouters:    -1,
-						RemoteLogs:    -1,
-					},
-				}))
-			})
+			It(
+				"should be parsed correctly when both grv_proxies/commit_proxies and proxies are set",
+				func() {
+					cluster.Spec.DatabaseConfiguration.Proxies = 12
+					cluster.Spec.DatabaseConfiguration.CommitProxies = 4
+					cluster.Spec.DatabaseConfiguration.GrvProxies = 4
+					Expect(cluster.DesiredDatabaseConfiguration()).To(Equal(DatabaseConfiguration{
+						RedundancyMode: RedundancyModeDouble,
+						StorageEngine:  StorageEngineSSD2,
+						UsableRegions:  1,
+						RoleCounts: RoleCounts{
+							Logs:          4,
+							Proxies:       0,
+							CommitProxies: 4,
+							GrvProxies:    4,
+							Resolvers:     1,
+							LogRouters:    -1,
+							RemoteLogs:    -1,
+						},
+					}))
+				},
+			)
 		})
 	})
 
@@ -1201,7 +1272,9 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			}
 			// This check is not version dependent
 			Expect(configuration.AreSeparatedProxiesConfigured()).To(BeTrue())
-			Expect(configuration.GetConfigurationString()).To(Equal("double ssd usable_regions=1 logs=5 resolvers=0 log_routers=0 remote_logs=0 commit_proxies=4 grv_proxies=2 regions=[]"))
+			Expect(
+				configuration.GetConfigurationString(),
+			).To(Equal("double ssd usable_regions=1 logs=5 resolvers=0 log_routers=0 remote_logs=0 commit_proxies=4 grv_proxies=2 regions=[]"))
 
 			configuration.Regions = []Region{{
 				DataCenters: []DataCenter{{
@@ -1211,10 +1284,14 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}},
 				SatelliteLogs: 2,
 			}}
-			Expect(configuration.GetConfigurationString()).To(Equal("double ssd usable_regions=1 logs=5 resolvers=0 log_routers=0 remote_logs=0 commit_proxies=4 grv_proxies=2 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"iad\\\",\\\"priority\\\":1}],\\\"satellite_logs\\\":2}]"))
+			Expect(
+				configuration.GetConfigurationString(),
+			).To(Equal("double ssd usable_regions=1 logs=5 resolvers=0 log_routers=0 remote_logs=0 commit_proxies=4 grv_proxies=2 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"iad\\\",\\\"priority\\\":1}],\\\"satellite_logs\\\":2}]"))
 			configuration.Regions = nil
 			configuration.LogSpill = 3
-			Expect(configuration.GetConfigurationString()).To(Equal("double ssd usable_regions=1 logs=5 resolvers=0 log_routers=0 remote_logs=0 commit_proxies=4 grv_proxies=2 log_spill:=3 regions=[]"))
+			Expect(
+				configuration.GetConfigurationString(),
+			).To(Equal("double ssd usable_regions=1 logs=5 resolvers=0 log_routers=0 remote_logs=0 commit_proxies=4 grv_proxies=2 log_spill:=3 regions=[]"))
 		})
 
 		When("CommitProxies and GrvProxies are not configured", func() {
@@ -1228,7 +1305,9 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				},
 			}
 			It("should be parsed correctly", func() {
-				Expect(configuration.GetConfigurationString()).To(Equal("double ssd usable_regions=1 logs=5 resolvers=0 log_routers=0 remote_logs=0 proxies=1 regions=[]"))
+				Expect(
+					configuration.GetConfigurationString(),
+				).To(Equal("double ssd usable_regions=1 logs=5 resolvers=0 log_routers=0 remote_logs=0 proxies=1 regions=[]"))
 			})
 
 			It("should have no proxies configured", func() {
@@ -1251,8 +1330,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			It("should have separated proxies configured with FDB > 7.0.0", func() {
 				Expect(configuration.AreSeparatedProxiesConfigured()).To(BeTrue())
-				Expect(configuration.GetProxiesString()).To(Equal(" commit_proxies=2 grv_proxies=1"))
-				Expect(configuration.GetConfigurationString()).To(Equal("double ssd usable_regions=1 logs=5 resolvers=0 log_routers=0 remote_logs=0 commit_proxies=2 grv_proxies=1 regions=[]"))
+				Expect(
+					configuration.GetProxiesString(),
+				).To(Equal(" commit_proxies=2 grv_proxies=1"))
+				Expect(
+					configuration.GetConfigurationString(),
+				).To(Equal("double ssd usable_regions=1 logs=5 resolvers=0 log_routers=0 remote_logs=0 commit_proxies=2 grv_proxies=1 regions=[]"))
 			})
 		})
 	})
@@ -3181,7 +3264,10 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 
 				cluster = createCluster()
-				cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, &ProcessGroupStatus{ProcessGroupID: "storage-5", ProcessClass: "storage"})
+				cluster.Status.ProcessGroups = append(
+					cluster.Status.ProcessGroups,
+					&ProcessGroupStatus{ProcessGroupID: "storage-5", ProcessClass: "storage"},
+				)
 				result, err = cluster.CheckReconciliation(log)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeFalse())
@@ -3309,7 +3395,10 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 
 				cluster = createCluster()
-				cluster.Spec.LockOptions.DenyList = append(cluster.Spec.LockOptions.DenyList, LockDenyListEntry{ID: "dc1"})
+				cluster.Spec.LockOptions.DenyList = append(
+					cluster.Spec.LockOptions.DenyList,
+					LockDenyListEntry{ID: "dc1"},
+				)
 				result, err = cluster.CheckReconciliation(log)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeFalse())
@@ -3319,7 +3408,10 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 
 				cluster = createCluster()
-				cluster.Spec.LockOptions.DenyList = append(cluster.Spec.LockOptions.DenyList, LockDenyListEntry{ID: "dc1"})
+				cluster.Spec.LockOptions.DenyList = append(
+					cluster.Spec.LockOptions.DenyList,
+					LockDenyListEntry{ID: "dc1"},
+				)
 				cluster.Status.Locks.DenyList = []string{"dc1", "dc2"}
 				result, err = cluster.CheckReconciliation(log)
 				Expect(err).NotTo(HaveOccurred())
@@ -3329,7 +3421,10 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 
 				cluster = createCluster()
-				cluster.Spec.LockOptions.DenyList = append(cluster.Spec.LockOptions.DenyList, LockDenyListEntry{ID: "dc1", Allow: true})
+				cluster.Spec.LockOptions.DenyList = append(
+					cluster.Spec.LockOptions.DenyList,
+					LockDenyListEntry{ID: "dc1", Allow: true},
+				)
 				cluster.Status.Locks.DenyList = []string{"dc1", "dc2"}
 				result, err = cluster.CheckReconciliation(log)
 				Expect(err).NotTo(HaveOccurred())
@@ -3340,7 +3435,10 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 
 				cluster = createCluster()
-				cluster.Spec.LockOptions.DenyList = append(cluster.Spec.LockOptions.DenyList, LockDenyListEntry{ID: "dc1", Allow: true})
+				cluster.Spec.LockOptions.DenyList = append(
+					cluster.Spec.LockOptions.DenyList,
+					LockDenyListEntry{ID: "dc1", Allow: true},
+				)
 				result, err = cluster.CheckReconciliation(log)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeTrue())
@@ -3433,7 +3531,10 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 
 				cluster = createCluster()
-				cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, &ProcessGroupStatus{ProcessGroupID: "storage-5", ProcessClass: "storage"})
+				cluster.Status.ProcessGroups = append(
+					cluster.Status.ProcessGroups,
+					&ProcessGroupStatus{ProcessGroupID: "storage-5", ProcessClass: "storage"},
+				)
 				result, err = cluster.CheckReconciliation(log)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeFalse())
@@ -3561,7 +3662,10 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 
 				cluster = createCluster()
-				cluster.Spec.LockOptions.DenyList = append(cluster.Spec.LockOptions.DenyList, LockDenyListEntry{ID: "dc1"})
+				cluster.Spec.LockOptions.DenyList = append(
+					cluster.Spec.LockOptions.DenyList,
+					LockDenyListEntry{ID: "dc1"},
+				)
 				result, err = cluster.CheckReconciliation(log)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeFalse())
@@ -3571,7 +3675,10 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 
 				cluster = createCluster()
-				cluster.Spec.LockOptions.DenyList = append(cluster.Spec.LockOptions.DenyList, LockDenyListEntry{ID: "dc1"})
+				cluster.Spec.LockOptions.DenyList = append(
+					cluster.Spec.LockOptions.DenyList,
+					LockDenyListEntry{ID: "dc1"},
+				)
 				cluster.Status.Locks.DenyList = []string{"dc1", "dc2"}
 				result, err = cluster.CheckReconciliation(log)
 				Expect(err).NotTo(HaveOccurred())
@@ -3581,7 +3688,10 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 
 				cluster = createCluster()
-				cluster.Spec.LockOptions.DenyList = append(cluster.Spec.LockOptions.DenyList, LockDenyListEntry{ID: "dc1", Allow: true})
+				cluster.Spec.LockOptions.DenyList = append(
+					cluster.Spec.LockOptions.DenyList,
+					LockDenyListEntry{ID: "dc1", Allow: true},
+				)
 				cluster.Status.Locks.DenyList = []string{"dc1", "dc2"}
 				result, err = cluster.CheckReconciliation(log)
 				Expect(err).NotTo(HaveOccurred())
@@ -3592,7 +3702,10 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}))
 
 				cluster = createCluster()
-				cluster.Spec.LockOptions.DenyList = append(cluster.Spec.LockOptions.DenyList, LockDenyListEntry{ID: "dc1", Allow: true})
+				cluster.Spec.LockOptions.DenyList = append(
+					cluster.Spec.LockOptions.DenyList,
+					LockDenyListEntry{ID: "dc1", Allow: true},
+				)
 				result, err = cluster.CheckReconciliation(log)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeTrue())
@@ -3635,8 +3748,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				},
 			}
 			settings := cluster.GetProcessSettings(ProcessClassStorage)
-			Expect(settings.PodTemplate.ObjectMeta.Labels).To(Equal(map[string]string{"test-label": "label2"}))
-			Expect(settings.CustomParameters).To(Equal(FoundationDBCustomParameters{"test_knob=value1"}))
+			Expect(
+				settings.PodTemplate.ObjectMeta.Labels,
+			).To(Equal(map[string]string{"test-label": "label2"}))
+			Expect(
+				settings.CustomParameters,
+			).To(Equal(FoundationDBCustomParameters{"test_knob=value1"}))
 		})
 	})
 
@@ -3644,7 +3761,9 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 		It("should return the correct lock options", func() {
 			cluster := &FoundationDBCluster{}
 
-			Expect(cluster.GetLockPrefix()).To(Equal("\xff\x02/org.foundationdb.kubernetes-operator"))
+			Expect(
+				cluster.GetLockPrefix(),
+			).To(Equal("\xff\x02/org.foundationdb.kubernetes-operator"))
 			Expect(cluster.GetLockDuration()).To(Equal(10 * time.Minute))
 
 			var disabled = true
@@ -3689,7 +3808,13 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			status := &ProcessGroupStatus{}
 
 			timestamp := time.Now().Unix()
-			status.ProcessGroupConditions = append(status.ProcessGroupConditions, &ProcessGroupCondition{ProcessGroupConditionType: MissingProcesses, Timestamp: timestamp})
+			status.ProcessGroupConditions = append(
+				status.ProcessGroupConditions,
+				&ProcessGroupCondition{
+					ProcessGroupConditionType: MissingProcesses,
+					Timestamp:                 timestamp,
+				},
+			)
 
 			result := status.GetConditionTime(MissingProcesses)
 			Expect(result).NotTo(BeNil())
@@ -3706,21 +3831,30 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				ProcessGroupID: "storage-1",
 			})
 			status = append(status, &ProcessGroupStatus{
-				ProcessGroupID:         "storage-2",
-				ProcessGroupConditions: []*ProcessGroupCondition{NewProcessGroupCondition(IncorrectCommandLine)},
+				ProcessGroupID: "storage-2",
+				ProcessGroupConditions: []*ProcessGroupCondition{
+					NewProcessGroupCondition(IncorrectCommandLine),
+				},
 			})
 			status = append(status, &ProcessGroupStatus{
-				ProcessGroupID:         "storage-3",
-				ProcessGroupConditions: []*ProcessGroupCondition{NewProcessGroupCondition(IncorrectPodSpec)},
+				ProcessGroupID: "storage-3",
+				ProcessGroupConditions: []*ProcessGroupCondition{
+					NewProcessGroupCondition(IncorrectPodSpec),
+				},
 			})
 			status = append(status, &ProcessGroupStatus{
-				ProcessGroupID:         "storage-4",
-				ProcessGroupConditions: []*ProcessGroupCondition{NewProcessGroupCondition(IncorrectCommandLine), NewProcessGroupCondition(IncorrectPodSpec)},
+				ProcessGroupID: "storage-4",
+				ProcessGroupConditions: []*ProcessGroupCondition{
+					NewProcessGroupCondition(IncorrectCommandLine),
+					NewProcessGroupCondition(IncorrectPodSpec),
+				},
 			})
 			status = append(status, &ProcessGroupStatus{
-				ProcessGroupID:         "storage-5",
-				ProcessGroupConditions: []*ProcessGroupCondition{NewProcessGroupCondition(IncorrectCommandLine)},
-				RemovalTimestamp:       &metav1.Time{Time: time.Now()},
+				ProcessGroupID: "storage-5",
+				ProcessGroupConditions: []*ProcessGroupCondition{
+					NewProcessGroupCondition(IncorrectCommandLine),
+				},
+				RemovalTimestamp: &metav1.Time{Time: time.Now()},
 			})
 		})
 
@@ -3740,7 +3874,14 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 		Context("with a mix of required and forbidden conditions", func() {
 			It("should return the process groups that match all rules", func() {
-				groups := FilterByConditions(status, map[ProcessGroupConditionType]bool{IncorrectCommandLine: true, IncorrectPodSpec: false}, false)
+				groups := FilterByConditions(
+					status,
+					map[ProcessGroupConditionType]bool{
+						IncorrectCommandLine: true,
+						IncorrectPodSpec:     false,
+					},
+					false,
+				)
 				Expect(groups).To(Equal([]ProcessGroupID{"storage-2", "storage-5"}))
 			})
 		})
@@ -4178,7 +4319,8 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			expected bool
 		}
 
-		DescribeTable("should return the expected result",
+		DescribeTable(
+			"should return the expected result",
 			func(tc testCase) {
 				Expect(tc.cluster.SkipProcessGroup(tc.pStatus)).To(Equal(tc.expected))
 			},
@@ -4207,7 +4349,8 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 					},
 					expected: false,
 				}),
-			Entry("process group with a pending condition for only a few seconds should not be skipped",
+			Entry(
+				"process group with a pending condition for only a few seconds should not be skipped",
 				testCase{
 					cluster: &FoundationDBCluster{},
 					pStatus: &ProcessGroupStatus{
@@ -4219,7 +4362,8 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 						},
 					},
 					expected: false,
-				}),
+				},
+			),
 			Entry("process group with a pending condition for multiple minutes should be skipped",
 				testCase{
 					cluster: &FoundationDBCluster{},
@@ -4854,11 +4998,16 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			When("a process group is already included in the list", func() {
 				BeforeEach(func() {
-					cluster.Spec.ProcessGroupsToRemove = append(cluster.Spec.ProcessGroupsToRemove, "test1")
+					cluster.Spec.ProcessGroupsToRemove = append(
+						cluster.Spec.ProcessGroupsToRemove,
+						"test1",
+					)
 				})
 
 				It("should only add the missing process groups", func() {
-					Expect(cluster.Spec.ProcessGroupsToRemove).To(ContainElements(ProcessGroupID("test1")))
+					Expect(
+						cluster.Spec.ProcessGroupsToRemove,
+					).To(ContainElements(ProcessGroupID("test1")))
 					removals := []ProcessGroupID{"test1", "test2"}
 					cluster.AddProcessGroupsToRemovalList(removals)
 					Expect(cluster.Spec.ProcessGroupsToRemove).To(ContainElements(removals))
@@ -4873,39 +5022,61 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				It("should add the process group to the removal list", func() {
 					removals := []ProcessGroupID{"test1"}
 					cluster.AddProcessGroupsToRemovalWithoutExclusionList(removals)
-					Expect(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion).To(ContainElements(removals))
-					Expect(len(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion)).To(Equal(len(removals)))
+					Expect(
+						cluster.Spec.ProcessGroupsToRemoveWithoutExclusion,
+					).To(ContainElements(removals))
+					Expect(
+						len(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion),
+					).To(Equal(len(removals)))
 					Expect(len(cluster.Spec.ProcessGroupsToRemove)).To(Equal(0))
 				})
 			})
 
 			When("a process group is already included in the list", func() {
 				BeforeEach(func() {
-					cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = append(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion, "test1")
-					Expect(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion).To(ContainElements(ProcessGroupID("test1")))
+					cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = append(
+						cluster.Spec.ProcessGroupsToRemoveWithoutExclusion,
+						"test1",
+					)
+					Expect(
+						cluster.Spec.ProcessGroupsToRemoveWithoutExclusion,
+					).To(ContainElements(ProcessGroupID("test1")))
 				})
 
 				It("should only add the missing process groups", func() {
 					removals := []ProcessGroupID{"test1", "test2"}
 					cluster.AddProcessGroupsToRemovalWithoutExclusionList(removals)
-					Expect(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion).To(ContainElements(removals))
-					Expect(len(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion)).To(Equal(len(removals)))
+					Expect(
+						cluster.Spec.ProcessGroupsToRemoveWithoutExclusion,
+					).To(ContainElements(removals))
+					Expect(
+						len(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion),
+					).To(Equal(len(removals)))
 					Expect(len(cluster.Spec.ProcessGroupsToRemove)).To(Equal(0))
 				})
 			})
 
 			When("a process group is already included in the with exclusion list", func() {
 				BeforeEach(func() {
-					cluster.Spec.ProcessGroupsToRemove = append(cluster.Spec.ProcessGroupsToRemove, "test1")
-					Expect(cluster.Spec.ProcessGroupsToRemove).To(ContainElements(ProcessGroupID("test1")))
+					cluster.Spec.ProcessGroupsToRemove = append(
+						cluster.Spec.ProcessGroupsToRemove,
+						"test1",
+					)
+					Expect(
+						cluster.Spec.ProcessGroupsToRemove,
+					).To(ContainElements(ProcessGroupID("test1")))
 					Expect(len(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion)).To(Equal(0))
 				})
 
 				It("should only add the missing process groups", func() {
 					removals := []ProcessGroupID{"test1", "test2"}
 					cluster.AddProcessGroupsToRemovalWithoutExclusionList(removals)
-					Expect(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion).To(ContainElements(removals))
-					Expect(len(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion)).To(Equal(len(removals)))
+					Expect(
+						cluster.Spec.ProcessGroupsToRemoveWithoutExclusion,
+					).To(ContainElements(removals))
+					Expect(
+						len(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion),
+					).To(Equal(len(removals)))
 					Expect(len(cluster.Spec.ProcessGroupsToRemove)).To(Equal(1))
 				})
 			})
@@ -4996,7 +5167,8 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				},
 				fmt.Errorf("stateless is not a valid process class for coordinators"),
 			),
-			Entry("multiple validations",
+			Entry(
+				"multiple validations",
 				&FoundationDBCluster{
 					Spec: FoundationDBClusterSpec{
 						Version: Versions.Default.String(),
@@ -5010,7 +5182,9 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 						},
 					},
 				},
-				fmt.Errorf("storage engine ssd-sharded-rocksdb is not supported on version 7.1.57, stateless is not a valid process class for coordinators"),
+				fmt.Errorf(
+					"storage engine ssd-sharded-rocksdb is not supported on version 7.1.57, stateless is not a valid process class for coordinators",
+				),
 			),
 			Entry("using invalid version for sharded rocksdb",
 				&FoundationDBCluster{
@@ -5064,8 +5238,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			DescribeTable("should add all targeted processes to the no-schedule list",
 				func(tc testCase) {
 					cluster.AddProcessGroupsToNoScheduleList(tc.Instances)
-					Expect(cluster.Spec.Buggify.NoSchedule).To(ContainElements(tc.ExpectedInstancesInNoSchedule))
-					Expect(len(cluster.Spec.Buggify.NoSchedule)).To(Equal(len(tc.ExpectedInstancesInNoSchedule)))
+					Expect(
+						cluster.Spec.Buggify.NoSchedule,
+					).To(ContainElements(tc.ExpectedInstancesInNoSchedule))
+					Expect(
+						len(cluster.Spec.Buggify.NoSchedule),
+					).To(Equal(len(tc.ExpectedInstancesInNoSchedule)))
 				},
 				Entry("Adding single instance",
 					testCase{
@@ -5093,8 +5271,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			DescribeTable("should add all targeted processes to no-schedule list",
 				func(tc testCase) {
 					cluster.AddProcessGroupsToNoScheduleList(tc.Instances)
-					Expect(cluster.Spec.Buggify.NoSchedule).To(ContainElements(tc.ExpectedInstancesInNoSchedule))
-					Expect(len(cluster.Spec.Buggify.NoSchedule)).To(Equal(len(tc.ExpectedInstancesInNoSchedule)))
+					Expect(
+						cluster.Spec.Buggify.NoSchedule,
+					).To(ContainElements(tc.ExpectedInstancesInNoSchedule))
+					Expect(
+						len(cluster.Spec.Buggify.NoSchedule),
+					).To(Equal(len(tc.ExpectedInstancesInNoSchedule)))
 				},
 				Entry("Adding single instance",
 					testCase{
@@ -5103,8 +5285,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 					}),
 				Entry("Adding multiple instances",
 					testCase{
-						Instances:                     []ProcessGroupID{"instance-2", "instance-3"},
-						ExpectedInstancesInNoSchedule: []ProcessGroupID{"instance-1", "instance-2", "instance-3"},
+						Instances: []ProcessGroupID{"instance-2", "instance-3"},
+						ExpectedInstancesInNoSchedule: []ProcessGroupID{
+							"instance-1",
+							"instance-2",
+							"instance-3",
+						},
 					}),
 			)
 		})
@@ -5132,8 +5318,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 		DescribeTable("should remove all targeted processes from the no-schedule list",
 			func(tc testCase) {
 				cluster.RemoveProcessGroupsFromNoScheduleList(tc.Instances)
-				Expect(cluster.Spec.Buggify.NoSchedule).To(ContainElements(tc.ExpectedInstancesInNoScheduleList))
-				Expect(len(cluster.Spec.Buggify.NoSchedule)).To(Equal(len(tc.ExpectedInstancesInNoScheduleList)))
+				Expect(
+					cluster.Spec.Buggify.NoSchedule,
+				).To(ContainElements(tc.ExpectedInstancesInNoScheduleList))
+				Expect(
+					len(cluster.Spec.Buggify.NoSchedule),
+				).To(Equal(len(tc.ExpectedInstancesInNoScheduleList)))
 			},
 			Entry("Removing single instance",
 				testCase{
@@ -5165,8 +5355,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			DescribeTable("should add all targeted processes to the crash-loop list",
 				func(tc testCase) {
 					cluster.AddProcessGroupsToCrashLoopList(tc.Instances)
-					Expect(cluster.Spec.Buggify.CrashLoop).To(ContainElements(tc.ExpectedInstancesInCrashLoop))
-					Expect(len(cluster.Spec.Buggify.CrashLoop)).To(Equal(len(tc.ExpectedInstancesInCrashLoop)))
+					Expect(
+						cluster.Spec.Buggify.CrashLoop,
+					).To(ContainElements(tc.ExpectedInstancesInCrashLoop))
+					Expect(
+						len(cluster.Spec.Buggify.CrashLoop),
+					).To(Equal(len(tc.ExpectedInstancesInCrashLoop)))
 				},
 				Entry("Adding single instance",
 					testCase{
@@ -5199,8 +5393,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			DescribeTable("should add all targeted processes to crash-loop list",
 				func(tc testCase) {
 					cluster.AddProcessGroupsToCrashLoopList(tc.Instances)
-					Expect(cluster.Spec.Buggify.CrashLoop).To(ContainElements(tc.ExpectedInstancesInCrashLoop))
-					Expect(len(cluster.Spec.Buggify.CrashLoop)).To(Equal(len(tc.ExpectedInstancesInCrashLoop)))
+					Expect(
+						cluster.Spec.Buggify.CrashLoop,
+					).To(ContainElements(tc.ExpectedInstancesInCrashLoop))
+					Expect(
+						len(cluster.Spec.Buggify.CrashLoop),
+					).To(Equal(len(tc.ExpectedInstancesInCrashLoop)))
 				},
 				Entry("Adding single instance",
 					testCase{
@@ -5209,8 +5407,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 					}),
 				Entry("Adding multiple instances",
 					testCase{
-						Instances:                    []ProcessGroupID{"instance-2", "instance-3"},
-						ExpectedInstancesInCrashLoop: []ProcessGroupID{"instance-1", "instance-2", "instance-3"},
+						Instances: []ProcessGroupID{"instance-2", "instance-3"},
+						ExpectedInstancesInCrashLoop: []ProcessGroupID{
+							"instance-1",
+							"instance-2",
+							"instance-3",
+						},
 					}),
 				Entry("Adding all instances",
 					testCase{
@@ -5233,8 +5435,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			DescribeTable("should add all targeted processes to crash-loop list",
 				func(tc testCase) {
 					cluster.AddProcessGroupsToCrashLoopList(tc.Instances)
-					Expect(cluster.Spec.Buggify.CrashLoop).To(ContainElements(tc.ExpectedInstancesInCrashLoop))
-					Expect(len(cluster.Spec.Buggify.CrashLoop)).To(Equal(len(tc.ExpectedInstancesInCrashLoop)))
+					Expect(
+						cluster.Spec.Buggify.CrashLoop,
+					).To(ContainElements(tc.ExpectedInstancesInCrashLoop))
+					Expect(
+						len(cluster.Spec.Buggify.CrashLoop),
+					).To(Equal(len(tc.ExpectedInstancesInCrashLoop)))
 				},
 				Entry("Adding single instance",
 					testCase{
@@ -5243,8 +5449,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 					}),
 				Entry("Adding multiple instances",
 					testCase{
-						Instances:                    []ProcessGroupID{"instance-2", "instance-3"},
-						ExpectedInstancesInCrashLoop: []ProcessGroupID{"*", "instance-2", "instance-3"},
+						Instances: []ProcessGroupID{"instance-2", "instance-3"},
+						ExpectedInstancesInCrashLoop: []ProcessGroupID{
+							"*",
+							"instance-2",
+							"instance-3",
+						},
 					}),
 				Entry("Adding all instances",
 					testCase{
@@ -5278,8 +5488,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			DescribeTable("should remove all targeted processes from the crash-loop list",
 				func(tc testCase) {
 					cluster.RemoveProcessGroupsFromCrashLoopList(tc.Instances)
-					Expect(cluster.Spec.Buggify.CrashLoop).To(ContainElements(tc.ExpectedInstancesInCrashLoop))
-					Expect(len(cluster.Spec.Buggify.CrashLoop)).To(Equal(len(tc.ExpectedInstancesInCrashLoop)))
+					Expect(
+						cluster.Spec.Buggify.CrashLoop,
+					).To(ContainElements(tc.ExpectedInstancesInCrashLoop))
+					Expect(
+						len(cluster.Spec.Buggify.CrashLoop),
+					).To(Equal(len(tc.ExpectedInstancesInCrashLoop)))
 				},
 				Entry("Removing single instance",
 					testCase{
@@ -5299,7 +5513,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				cluster = &FoundationDBCluster{
 					Spec: FoundationDBClusterSpec{
 						Buggify: BuggifyConfig{
-							CrashLoop: []ProcessGroupID{"*", "instance-1", "instance-2", "instance-3"},
+							CrashLoop: []ProcessGroupID{
+								"*",
+								"instance-1",
+								"instance-2",
+								"instance-3",
+							},
 						},
 					},
 				}
@@ -5313,13 +5532,21 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			DescribeTable("should remove all targeted processes from the crash-loop list",
 				func(tc testCase) {
 					cluster.RemoveProcessGroupsFromCrashLoopList(tc.Instances)
-					Expect(cluster.Spec.Buggify.CrashLoop).To(ContainElements(tc.ExpectedInstancesInCrashLoop))
-					Expect(len(cluster.Spec.Buggify.CrashLoop)).To(Equal(len(tc.ExpectedInstancesInCrashLoop)))
+					Expect(
+						cluster.Spec.Buggify.CrashLoop,
+					).To(ContainElements(tc.ExpectedInstancesInCrashLoop))
+					Expect(
+						len(cluster.Spec.Buggify.CrashLoop),
+					).To(Equal(len(tc.ExpectedInstancesInCrashLoop)))
 				},
 				Entry("Removing single instance",
 					testCase{
-						Instances:                    []ProcessGroupID{"instance-1"},
-						ExpectedInstancesInCrashLoop: []ProcessGroupID{"*", "instance-2", "instance-3"},
+						Instances: []ProcessGroupID{"instance-1"},
+						ExpectedInstancesInCrashLoop: []ProcessGroupID{
+							"*",
+							"instance-2",
+							"instance-3",
+						},
 					}),
 				Entry("Removing multiple instances",
 					testCase{
@@ -5328,31 +5555,40 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 					}),
 				Entry("Removing *",
 					testCase{
-						Instances:                    []ProcessGroupID{"*"},
-						ExpectedInstancesInCrashLoop: []ProcessGroupID{"instance-1", "instance-2", "instance-3"},
+						Instances: []ProcessGroupID{"*"},
+						ExpectedInstancesInCrashLoop: []ProcessGroupID{
+							"instance-1",
+							"instance-2",
+							"instance-3",
+						},
 					}),
 			)
 		})
 	})
 
-	DescribeTable("when checking if the cluster is being upgraded", func(cluster *FoundationDBCluster, isUpgraded bool, isCompatibleUpgrade bool) {
-		Expect(cluster.IsBeingUpgraded()).To(Equal(isUpgraded))
+	DescribeTable(
+		"when checking if the cluster is being upgraded",
+		func(cluster *FoundationDBCluster, isUpgraded bool, isCompatibleUpgrade bool) {
+			Expect(cluster.IsBeingUpgraded()).To(Equal(isUpgraded))
 
-		if !isUpgraded {
-			return
-		}
+			if !isUpgraded {
+				return
+			}
 
-		Expect(cluster.VersionCompatibleUpgradeInProgress()).To(Equal(isCompatibleUpgrade))
-		Expect(cluster.IsBeingUpgradedWithVersionIncompatibleVersion()).To(Equal(!isCompatibleUpgrade))
-	}, Entry("no upgrade in progress",
-		&FoundationDBCluster{
-			Spec: FoundationDBClusterSpec{
-				Version: "7.1.27",
-			},
-			Status: FoundationDBClusterStatus{
-				RunningVersion: "7.1.27",
-			},
-		}, false, false),
+			Expect(cluster.VersionCompatibleUpgradeInProgress()).To(Equal(isCompatibleUpgrade))
+			Expect(
+				cluster.IsBeingUpgradedWithVersionIncompatibleVersion(),
+			).To(Equal(!isCompatibleUpgrade))
+		},
+		Entry("no upgrade in progress",
+			&FoundationDBCluster{
+				Spec: FoundationDBClusterSpec{
+					Version: "7.1.27",
+				},
+				Status: FoundationDBClusterStatus{
+					RunningVersion: "7.1.27",
+				},
+			}, false, false),
 		Entry("patch upgrade",
 			&FoundationDBCluster{
 				Spec: FoundationDBClusterSpec{
@@ -5382,19 +5618,22 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			}, true, false),
 	)
 
-	DescribeTable("when getting the Pod name for a Process group", func(cluster *FoundationDBCluster, processGroup *ProcessGroupStatus, expected string) {
-		Expect(processGroup.GetPodName(cluster)).To(Equal(expected))
-	}, Entry("when the process group has no prefix",
-		&FoundationDBCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "testing-cluster",
+	DescribeTable(
+		"when getting the Pod name for a Process group",
+		func(cluster *FoundationDBCluster, processGroup *ProcessGroupStatus, expected string) {
+			Expect(processGroup.GetPodName(cluster)).To(Equal(expected))
+		},
+		Entry("when the process group has no prefix",
+			&FoundationDBCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testing-cluster",
+				},
 			},
-		},
-		&ProcessGroupStatus{
-			ProcessGroupID: "storage-1",
-			ProcessClass:   ProcessClassStorage,
-		},
-		"testing-cluster-storage-1"),
+			&ProcessGroupStatus{
+				ProcessGroupID: "storage-1",
+				ProcessClass:   ProcessClassStorage,
+			},
+			"testing-cluster-storage-1"),
 		Entry("when the process group has a prefix",
 			&FoundationDBCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -5430,25 +5669,30 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			"testing-cluster-cluster-controller-1"),
 	)
 
-	DescribeTable("when adding a condition to a process group", func(processGroup *ProcessGroupStatus, condition ProcessGroupConditionType, expectedConditions []*ProcessGroupCondition) {
-		processGroup.addCondition(condition)
+	DescribeTable(
+		"when adding a condition to a process group",
+		func(processGroup *ProcessGroupStatus, condition ProcessGroupConditionType, expectedConditions []*ProcessGroupCondition) {
+			processGroup.addCondition(condition)
 
-		Expect(processGroup.ProcessGroupConditions).To(HaveLen(len(expectedConditions)))
-		for _, expectedCondition := range expectedConditions {
-			timestamp := processGroup.GetConditionTime(expectedCondition.ProcessGroupConditionType)
-			Expect(timestamp).NotTo(BeNil())
-			if expectedCondition.Timestamp > 0 {
-				Expect(*timestamp).To(BeNumerically("==", expectedCondition.Timestamp))
+			Expect(processGroup.ProcessGroupConditions).To(HaveLen(len(expectedConditions)))
+			for _, expectedCondition := range expectedConditions {
+				timestamp := processGroup.GetConditionTime(
+					expectedCondition.ProcessGroupConditionType,
+				)
+				Expect(timestamp).NotTo(BeNil())
+				if expectedCondition.Timestamp > 0 {
+					Expect(*timestamp).To(BeNumerically("==", expectedCondition.Timestamp))
+				}
 			}
-		}
-	}, Entry("no conditions are present",
-		&ProcessGroupStatus{},
-		PodPending,
-		[]*ProcessGroupCondition{
-			{
-				ProcessGroupConditionType: PodPending,
-			},
-		}),
+		},
+		Entry("no conditions are present",
+			&ProcessGroupStatus{},
+			PodPending,
+			[]*ProcessGroupCondition{
+				{
+					ProcessGroupConditionType: PodPending,
+				},
+			}),
 		Entry("adding a duplicate condition",
 			&ProcessGroupStatus{
 				ProcessGroupConditions: []*ProcessGroupCondition{
@@ -5482,7 +5726,8 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 					ProcessGroupConditionType: PodFailing,
 				},
 			}),
-		Entry("adding the resource terminating condition to process group marked as removed and excluded",
+		Entry(
+			"adding the resource terminating condition to process group marked as removed and excluded",
 			&ProcessGroupStatus{
 				RemovalTimestamp: &metav1.Time{
 					Time: time.Now(),
@@ -5494,7 +5739,8 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				{
 					ProcessGroupConditionType: ResourcesTerminating,
 				},
-			}),
+			},
+		),
 		Entry("adding another condition to process group marked as removed and excluded",
 			&ProcessGroupStatus{
 				RemovalTimestamp: &metav1.Time{
@@ -5506,13 +5752,16 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			[]*ProcessGroupCondition{}),
 	)
 
-	DescribeTable("when marking a process group as excluded", func(processGroup *ProcessGroupStatus) {
-		processGroup.SetExclude()
+	DescribeTable(
+		"when marking a process group as excluded",
+		func(processGroup *ProcessGroupStatus) {
+			processGroup.SetExclude()
 
-		Expect(processGroup.ProcessGroupConditions).To(HaveLen(0))
-		Expect(processGroup.ExclusionTimestamp.IsZero()).To(BeFalse())
-	}, Entry("no conditions are present",
-		&ProcessGroupStatus{}),
+			Expect(processGroup.ProcessGroupConditions).To(HaveLen(0))
+			Expect(processGroup.ExclusionTimestamp.IsZero()).To(BeFalse())
+		},
+		Entry("no conditions are present",
+			&ProcessGroupStatus{}),
 		Entry("one condition is present",
 			&ProcessGroupStatus{
 				ProcessGroupConditions: []*ProcessGroupCondition{
@@ -5584,9 +5833,11 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 		})
 	})
 
-	DescribeTable("getting the process class from the process group ID", func(input ProcessGroupID, expected ProcessClass) {
-		Expect(input.GetProcessClass()).To(Equal(expected))
-	},
+	DescribeTable(
+		"getting the process class from the process group ID",
+		func(input ProcessGroupID, expected ProcessClass) {
+			Expect(input.GetProcessClass()).To(Equal(expected))
+		},
 		Entry("storage ID",
 			ProcessGroupID("storage-12"),
 			ProcessClassStorage,
@@ -5601,22 +5852,27 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 		),
 	)
 
-	DescribeTable("when checking if all addresses are excluded for a process group", func(processGroupStatus *ProcessGroupStatus, remainingMap map[string]bool, expected bool, expectedErr error) {
-		excluded, err := processGroupStatus.AllAddressesExcluded(log, remainingMap)
-		Expect(excluded).To(Equal(expected))
+	DescribeTable(
+		"when checking if all addresses are excluded for a process group",
+		func(processGroupStatus *ProcessGroupStatus, remainingMap map[string]bool, expected bool, expectedErr error) {
+			excluded, err := processGroupStatus.AllAddressesExcluded(log, remainingMap)
+			Expect(excluded).To(Equal(expected))
 
-		if expectedErr != nil {
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(expectedErr))
-		} else {
-			Expect(err).NotTo(HaveOccurred())
-		}
-	},
-		Entry("process group has no addresses",
+			if expectedErr != nil {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(expectedErr))
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		Entry(
+			"process group has no addresses",
 			&ProcessGroupStatus{},
 			nil,
 			false,
-			fmt.Errorf("process has no addresses, cannot safely determine if process can be removed"),
+			fmt.Errorf(
+				"process has no addresses, cannot safely determine if process can be removed",
+			),
 		),
 		Entry("process group is excluded",
 			&ProcessGroupStatus{
@@ -5695,7 +5951,8 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			false,
 			fmt.Errorf("process has missing address in exclusion results: 192.168.0.2"),
 		),
-		Entry("process group is excluded using locality and it is present in the remaining map as excluded",
+		Entry(
+			"process group is excluded using locality and it is present in the remaining map as excluded",
 			&ProcessGroupStatus{
 				ProcessGroupID: "storage-1",
 			},
@@ -5705,7 +5962,8 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			true,
 			nil,
 		),
-		Entry("process group is excluded using locality and it is present in the remaining map as not excluded",
+		Entry(
+			"process group is excluded using locality and it is present in the remaining map as not excluded",
 			&ProcessGroupStatus{
 				ProcessGroupID: "storage-1",
 			},
@@ -5713,13 +5971,18 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				fmt.Sprintf("%s:storage-1", FDBLocalityExclusionPrefix): true,
 			},
 			false,
-			fmt.Errorf("process has missing exclusion string in exclusion results: %s", fmt.Sprintf("%s:storage-1", FDBLocalityExclusionPrefix)),
+			fmt.Errorf(
+				"process has missing exclusion string in exclusion results: %s",
+				fmt.Sprintf("%s:storage-1", FDBLocalityExclusionPrefix),
+			),
 		),
 	)
 
-	DescribeTable("when getting the removal mode", func(cluster *FoundationDBCluster, expected PodUpdateMode) {
-		Expect(cluster.GetRemovalMode()).To(Equal(expected))
-	},
+	DescribeTable(
+		"when getting the removal mode",
+		func(cluster *FoundationDBCluster, expected PodUpdateMode) {
+			Expect(cluster.GetRemovalMode()).To(Equal(expected))
+		},
 		Entry("no removal mode defined",
 			&FoundationDBCluster{
 				Spec: FoundationDBClusterSpec{

--- a/api/v1beta2/foundationdbrestore_types.go
+++ b/api/v1beta2/foundationdbrestore_types.go
@@ -41,8 +41,8 @@ type FoundationDBRestore struct {
 
 // FoundationDBRestoreList contains a list of FoundationDBRestore objects
 type FoundationDBRestoreList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `                      json:",inline"`
+	metav1.ListMeta `                      json:"metadata,omitempty"`
 	Items           []FoundationDBRestore `json:"items"`
 }
 
@@ -115,7 +115,8 @@ type FoundationDBKeyRange struct {
 // BackupName gets the name of the backup for the source backup.
 // This will fill in a default value if the backup name in the spec is empty.
 func (restore *FoundationDBRestore) BackupName() string {
-	if restore.Spec.BlobStoreConfiguration == nil || restore.Spec.BlobStoreConfiguration.BackupName == "" {
+	if restore.Spec.BlobStoreConfiguration == nil ||
+		restore.Spec.BlobStoreConfiguration.BackupName == "" {
 		return restore.Name
 	}
 
@@ -124,7 +125,10 @@ func (restore *FoundationDBRestore) BackupName() string {
 
 // BackupURL gets the destination url of the backup.
 func (restore *FoundationDBRestore) BackupURL() string {
-	return restore.Spec.BlobStoreConfiguration.getURL(restore.BackupName(), restore.Spec.BlobStoreConfiguration.BucketName())
+	return restore.Spec.BlobStoreConfiguration.getURL(
+		restore.BackupName(),
+		restore.Spec.BlobStoreConfiguration.BucketName(),
+	)
 }
 
 func init() {

--- a/api/v1beta2/foundationdbrestore_types_test.go
+++ b/api/v1beta2/foundationdbrestore_types_test.go
@@ -28,7 +28,8 @@ import (
 
 var _ = Describe("[api] FoundationDBRestore", func() {
 	When("getting the backup URL", func() {
-		DescribeTable("should generate the correct backup URL",
+		DescribeTable(
+			"should generate the correct backup URL",
 			func(restore FoundationDBRestore, expected string) {
 				Expect(restore.BackupURL()).To(Equal(expected))
 			},
@@ -84,7 +85,8 @@ var _ = Describe("[api] FoundationDBRestore", func() {
 					},
 				},
 				"blobstore://account@account:443/test?bucket=my-bucket"),
-			Entry("A restore with a blobstore config with HTTP parameters and backup and bucket name",
+			Entry(
+				"A restore with a blobstore config with HTTP parameters and backup and bucket name",
 				FoundationDBRestore{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mybackup",
@@ -100,7 +102,8 @@ var _ = Describe("[api] FoundationDBRestore", func() {
 						},
 					},
 				},
-				"blobstore://account@account:80/test?bucket=my-bucket&secure_connection=0"),
+				"blobstore://account@account:80/test?bucket=my-bucket&secure_connection=0",
+			),
 			Entry("A restore with a blobstore config with HTTP parameters",
 				FoundationDBRestore{
 					ObjectMeta: metav1.ObjectMeta{

--- a/api/v1beta2/image_config_test.go
+++ b/api/v1beta2/image_config_test.go
@@ -64,7 +64,9 @@ var _ = Describe("[api] ImageConfig", func() {
 				TagSuffix: "-2",
 			}
 			image := config.Image()
-			Expect(image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-2", Versions.Default)))
+			Expect(
+				image,
+			).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-2", Versions.Default)))
 		})
 
 		It("uses the tag to override the version and tag suffix", func() {

--- a/cmd/po-docgen/api.go
+++ b/cmd/po-docgen/api.go
@@ -232,7 +232,9 @@ func wrapInLink(text, link string) string {
 func fieldName(field *ast.Field) string {
 	jsonTag := ""
 	if field.Tag != nil {
-		jsonTag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
+		jsonTag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).
+			Get("json")
+			// Delete first and last quotation
 		if strings.Contains(jsonTag, "inline") {
 			return "-"
 		}
@@ -252,7 +254,9 @@ func fieldName(field *ast.Field) string {
 func fieldRequired(field *ast.Field) bool {
 	jsonTag := ""
 	if field.Tag != nil {
-		jsonTag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
+		jsonTag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).
+			Get("json")
+			// Delete first and last quotation
 		return !strings.Contains(jsonTag, "omitempty")
 	}
 

--- a/controllers/add_pods_test.go
+++ b/controllers/add_pods_test.go
@@ -61,7 +61,13 @@ var _ = Describe("add_pods", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = addPods{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+		requeue = addPods{}.reconcile(
+			context.TODO(),
+			clusterReconciler,
+			cluster,
+			nil,
+			globalControllerLogger,
+		)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())
@@ -90,17 +96,27 @@ var _ = Describe("add_pods", func() {
 		BeforeEach(func() {
 			for i := 1; i < 100; i++ {
 				_, processGroupID := cluster.GetProcessGroupID(fdbv1beta2.ProcessClassStorage, i)
-				processGroup := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, processGroupID)
+				processGroup := fdbv1beta2.FindProcessGroupByID(
+					cluster.Status.ProcessGroups,
+					processGroupID,
+				)
 				// If that process group ID is already in use pick another one.
 				if processGroup != nil {
 					continue
 				}
 
-				processGroupWithoutPod = fdbv1beta2.NewProcessGroupStatus(processGroupID, fdbv1beta2.ProcessClassStorage, []string{"100.101.102.103"})
+				processGroupWithoutPod = fdbv1beta2.NewProcessGroupStatus(
+					processGroupID,
+					fdbv1beta2.ProcessClassStorage,
+					[]string{"100.101.102.103"},
+				)
 				newProcessGroupID = processGroupID
 			}
 
-			cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, processGroupWithoutPod)
+			cluster.Status.ProcessGroups = append(
+				cluster.Status.ProcessGroups,
+				processGroupWithoutPod,
+			)
 		})
 
 		It("should not requeue", func() {
@@ -146,7 +162,12 @@ var _ = Describe("add_pods", func() {
 	})
 })
 
-func expectNewPodToHaveBeenCreated(initialPods *corev1.PodList, newPods *corev1.PodList, cluster *fdbv1beta2.FoundationDBCluster, newProcessGroup fdbv1beta2.ProcessGroupID) {
+func expectNewPodToHaveBeenCreated(
+	initialPods *corev1.PodList,
+	newPods *corev1.PodList,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	newProcessGroup fdbv1beta2.ProcessGroupID,
+) {
 	Expect(newPods.Items).To(HaveLen(len(initialPods.Items) + 1))
 	var podHaveBeenChecked bool
 
@@ -158,8 +179,12 @@ func expectNewPodToHaveBeenCreated(initialPods *corev1.PodList, newPods *corev1.
 
 		Expect(pod.Name).To(Equal(expectedPodName))
 		Expect(pod.Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal(string(newProcessGroup)))
-		Expect(pod.Labels[fdbv1beta2.FDBProcessClassLabel]).To(Equal(string(fdbv1beta2.ProcessClassStorage)))
-		Expect(pod.OwnerReferences).To(Equal(internal.BuildOwnerReference(cluster.TypeMeta, cluster.ObjectMeta)))
+		Expect(
+			pod.Labels[fdbv1beta2.FDBProcessClassLabel],
+		).To(Equal(string(fdbv1beta2.ProcessClassStorage)))
+		Expect(
+			pod.OwnerReferences,
+		).To(Equal(internal.BuildOwnerReference(cluster.TypeMeta, cluster.ObjectMeta)))
 		podHaveBeenChecked = true
 		break
 	}

--- a/controllers/add_pvcs.go
+++ b/controllers/add_pvcs.go
@@ -37,7 +37,13 @@ import (
 type addPVCs struct{}
 
 // reconcile runs the reconciler's work.
-func (a addPVCs) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (a addPVCs) reconcile(
+	ctx context.Context,
+	r *FoundationDBClusterReconciler,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	_ *fdbv1beta2.FoundationDBStatus,
+	logger logr.Logger,
+) *requeue {
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.IsMarkedForRemoval() && processGroup.IsExcluded() {
 			continue

--- a/controllers/add_pvcs_test.go
+++ b/controllers/add_pvcs_test.go
@@ -41,7 +41,9 @@ var _ = Describe("add_pvcs", func() {
 
 	BeforeEach(func() {
 		cluster = internal.CreateDefaultCluster()
-		Expect(internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})).NotTo(HaveOccurred())
+		Expect(
+			internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{}),
+		).NotTo(HaveOccurred())
 		Expect(k8sClient.Create(context.TODO(), cluster)).NotTo(HaveOccurred())
 
 		result, err := reconcileCluster(cluster)
@@ -57,7 +59,13 @@ var _ = Describe("add_pvcs", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = addPVCs{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+		requeue = addPVCs{}.reconcile(
+			context.TODO(),
+			clusterReconciler,
+			cluster,
+			nil,
+			globalControllerLogger,
+		)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())
@@ -86,8 +94,15 @@ var _ = Describe("add_pvcs", func() {
 		BeforeEach(func() {
 			_, processGroupIDs, err := cluster.GetCurrentProcessGroupsAndProcessCounts()
 			Expect(err).NotTo(HaveOccurred())
-			newProcessGroupID = cluster.GetNextRandomProcessGroupID(fdbv1beta2.ProcessClassStorage, processGroupIDs[fdbv1beta2.ProcessClassStorage])
-			pickedProcessGroup = fdbv1beta2.NewProcessGroupStatus(newProcessGroupID, fdbv1beta2.ProcessClassStorage, nil)
+			newProcessGroupID = cluster.GetNextRandomProcessGroupID(
+				fdbv1beta2.ProcessClassStorage,
+				processGroupIDs[fdbv1beta2.ProcessClassStorage],
+			)
+			pickedProcessGroup = fdbv1beta2.NewProcessGroupStatus(
+				newProcessGroupID,
+				fdbv1beta2.ProcessClassStorage,
+				nil,
+			)
 			cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, pickedProcessGroup)
 		})
 
@@ -103,9 +118,15 @@ var _ = Describe("add_pvcs", func() {
 					continue
 				}
 
-				Expect(pvc.Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal(string(newProcessGroupID)))
-				Expect(pvc.Labels[fdbv1beta2.FDBProcessClassLabel]).To(Equal(string(fdbv1beta2.ProcessClassStorage)))
-				Expect(pvc.OwnerReferences).To(Equal(internal.BuildOwnerReference(cluster.TypeMeta, cluster.ObjectMeta)))
+				Expect(
+					pvc.Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+				).To(Equal(string(newProcessGroupID)))
+				Expect(
+					pvc.Labels[fdbv1beta2.FDBProcessClassLabel],
+				).To(Equal(string(fdbv1beta2.ProcessClassStorage)))
+				Expect(
+					pvc.OwnerReferences,
+				).To(Equal(internal.BuildOwnerReference(cluster.TypeMeta, cluster.ObjectMeta)))
 				checked = true
 			}
 
@@ -147,8 +168,18 @@ var _ = Describe("add_pvcs", func() {
 		BeforeEach(func() {
 			_, processGroupIDs, err := cluster.GetCurrentProcessGroupsAndProcessCounts()
 			Expect(err).NotTo(HaveOccurred())
-			newProcessGroupID := cluster.GetNextRandomProcessGroupID(fdbv1beta2.ProcessClassStateless, processGroupIDs[fdbv1beta2.ProcessClassStateless])
-			cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(newProcessGroupID, fdbv1beta2.ProcessClassStateless, nil))
+			newProcessGroupID := cluster.GetNextRandomProcessGroupID(
+				fdbv1beta2.ProcessClassStateless,
+				processGroupIDs[fdbv1beta2.ProcessClassStateless],
+			)
+			cluster.Status.ProcessGroups = append(
+				cluster.Status.ProcessGroups,
+				fdbv1beta2.NewProcessGroupStatus(
+					newProcessGroupID,
+					fdbv1beta2.ProcessClassStateless,
+					nil,
+				),
+			)
 		})
 
 		It("should not requeue", func() {

--- a/controllers/add_services_test.go
+++ b/controllers/add_services_test.go
@@ -60,11 +60,19 @@ var _ = Describe("add_services", func() {
 		initialServices = &corev1.ServiceList{}
 		Expect(k8sClient.List(context.TODO(), initialServices)).NotTo(HaveOccurred())
 
-		Expect(internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})).NotTo(HaveOccurred())
+		Expect(
+			internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{}),
+		).NotTo(HaveOccurred())
 	})
 
 	JustBeforeEach(func() {
-		requeue = addServices{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+		requeue = addServices{}.reconcile(
+			context.TODO(),
+			clusterReconciler,
+			cluster,
+			nil,
+			globalControllerLogger,
+		)
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -124,8 +132,15 @@ var _ = Describe("add_services", func() {
 		BeforeEach(func() {
 			_, processGroupIDs, err := cluster.GetCurrentProcessGroupsAndProcessCounts()
 			Expect(err).NotTo(HaveOccurred())
-			newProcessGroupID = cluster.GetNextRandomProcessGroupID(fdbv1beta2.ProcessClassStorage, processGroupIDs[fdbv1beta2.ProcessClassStorage])
-			pickedProcessGroup = fdbv1beta2.NewProcessGroupStatus(newProcessGroupID, fdbv1beta2.ProcessClassStorage, nil)
+			newProcessGroupID = cluster.GetNextRandomProcessGroupID(
+				fdbv1beta2.ProcessClassStorage,
+				processGroupIDs[fdbv1beta2.ProcessClassStorage],
+			)
+			pickedProcessGroup = fdbv1beta2.NewProcessGroupStatus(
+				newProcessGroupID,
+				fdbv1beta2.ProcessClassStorage,
+				nil,
+			)
 			cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, pickedProcessGroup)
 		})
 
@@ -143,9 +158,15 @@ var _ = Describe("add_services", func() {
 					continue
 				}
 
-				Expect(svc.Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal(string(newProcessGroupID)))
-				Expect(svc.Labels[fdbv1beta2.FDBProcessClassLabel]).To(Equal(string(fdbv1beta2.ProcessClassStorage)))
-				Expect(svc.OwnerReferences).To(Equal(internal.BuildOwnerReference(cluster.TypeMeta, cluster.ObjectMeta)))
+				Expect(
+					svc.Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+				).To(Equal(string(newProcessGroupID)))
+				Expect(
+					svc.Labels[fdbv1beta2.FDBProcessClassLabel],
+				).To(Equal(string(fdbv1beta2.ProcessClassStorage)))
+				Expect(
+					svc.OwnerReferences,
+				).To(Equal(internal.BuildOwnerReference(cluster.TypeMeta, cluster.ObjectMeta)))
 				Expect(svc.Spec.ClusterIP).NotTo(Equal("None"))
 				checked = true
 			}
@@ -200,7 +221,13 @@ var _ = Describe("add_services", func() {
 	Context("with no headless service", func() {
 		BeforeEach(func() {
 			service := &corev1.Service{}
-			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, service)).NotTo(HaveOccurred())
+			Expect(
+				k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name},
+					service,
+				),
+			).NotTo(HaveOccurred())
 			Expect(k8sClient.Delete(context.TODO(), service)).NotTo(HaveOccurred())
 		})
 

--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -68,7 +68,9 @@ var _ = Describe("admin_client_test", func() {
 				It("should generate the status", func() {
 					noneEngine := fdbv1beta2.StorageEngineNone
 					migrationTypeDisabled := fdbv1beta2.StorageMigrationTypeDisabled
-					Expect(status.Cluster.DatabaseConfiguration).To(Equal(fdbv1beta2.DatabaseConfiguration{
+					Expect(
+						status.Cluster.DatabaseConfiguration,
+					).To(Equal(fdbv1beta2.DatabaseConfiguration{
 						RedundancyMode: fdbv1beta2.RedundancyModeDouble,
 						StorageEngine:  fdbv1beta2.StorageEngineSSD2,
 						UsableRegions:  1,
@@ -93,14 +95,23 @@ var _ = Describe("admin_client_test", func() {
 					pickedProcessGroup := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
 					address := pickedProcessGroup.Addresses[0]
 					zoneID := cluster.Name + "-" + string(pickedProcessGroup.ProcessGroupID)
-					Expect(status.Cluster.Processes[fdbv1beta2.ProcessGroupID(zoneID+"-1")]).To(Equal(fdbv1beta2.FoundationDBStatusProcessInfo{
+					Expect(
+						status.Cluster.Processes[fdbv1beta2.ProcessGroupID(zoneID+"-1")],
+					).To(Equal(fdbv1beta2.FoundationDBStatusProcessInfo{
 						Address: fdbv1beta2.ProcessAddress{
 							IPAddress: net.ParseIP(address),
 							Port:      4501,
 						},
 						ProcessClass: fdbv1beta2.ProcessClassStorage,
-						CommandLine:  fmt.Sprintf("/usr/bin/fdbserver --class=storage --cluster_file=/var/fdb/data/fdb.cluster --datadir=/var/fdb/data --listen_address=%s:4501 --locality_instance_id=%s --locality_machineid=%s --locality_zoneid=%s --logdir=/var/log/fdb-trace-logs --loggroup=operator-test-1 --public_address=%s:4501 --seed_cluster_file=/var/dynamic-conf/fdb.cluster", address, pickedProcessGroup.ProcessGroupID, zoneID, zoneID, address),
-						Excluded:     false,
+						CommandLine: fmt.Sprintf(
+							"/usr/bin/fdbserver --class=storage --cluster_file=/var/fdb/data/fdb.cluster --datadir=/var/fdb/data --listen_address=%s:4501 --locality_instance_id=%s --locality_machineid=%s --locality_zoneid=%s --logdir=/var/log/fdb-trace-logs --loggroup=operator-test-1 --public_address=%s:4501 --seed_cluster_file=/var/dynamic-conf/fdb.cluster",
+							address,
+							pickedProcessGroup.ProcessGroupID,
+							zoneID,
+							zoneID,
+							address,
+						),
+						Excluded: false,
 						Locality: map[string]string{
 							"instance_id": string(pickedProcessGroup.ProcessGroupID),
 							"zoneid":      zoneID,
@@ -141,7 +152,9 @@ var _ = Describe("admin_client_test", func() {
 
 				It("should have DNS names in the locality", func() {
 					locality := status.Cluster.Processes[fdbv1beta2.ProcessGroupID(processID)].Locality
-					Expect(locality[fdbv1beta2.FDBLocalityDNSNameKey]).To(Equal(internal.GetPodDNSName(cluster, podName)))
+					Expect(
+						locality[fdbv1beta2.FDBLocalityDNSNameKey],
+					).To(Equal(internal.GetPodDNSName(cluster, podName)))
 				})
 			})
 		})
@@ -157,7 +170,9 @@ var _ = Describe("admin_client_test", func() {
 
 			It("puts the additional processes in the status", func() {
 				Expect(status.Cluster.Processes).To(HaveLen(len(cluster.Status.ProcessGroups) + 1))
-				Expect(status.Cluster.Processes["dc2-storage-1"]).To(Equal(fdbv1beta2.FoundationDBStatusProcessInfo{
+				Expect(
+					status.Cluster.Processes["dc2-storage-1"],
+				).To(Equal(fdbv1beta2.FoundationDBStatusProcessInfo{
 					Address: fdbv1beta2.ProcessAddress{
 						IPAddress: net.ParseIP("1.2.3.4"),
 						Port:      4501,
@@ -175,13 +190,19 @@ var _ = Describe("admin_client_test", func() {
 
 		Context("with a backup running", func() {
 			BeforeEach(func() {
-				err = mockAdminClient.StartBackup("blobstore://test@test-service/test-backup", 10, "")
+				err = mockAdminClient.StartBackup(
+					"blobstore://test@test-service/test-backup",
+					10,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should put the backup in the layer status", func() {
 				Expect(status.Cluster.Layers.Backup.Paused).To(BeFalse())
-				Expect(status.Cluster.Layers.Backup.Tags).To(Equal(map[string]fdbv1beta2.FoundationDBStatusBackupTag{
+				Expect(
+					status.Cluster.Layers.Backup.Tags,
+				).To(Equal(map[string]fdbv1beta2.FoundationDBStatusBackupTag{
 					"default": {
 						CurrentContainer: "blobstore://test@test-service/test-backup",
 						RunningBackup:    pointer.Bool(true),
@@ -221,7 +242,9 @@ var _ = Describe("admin_client_test", func() {
 				})
 
 				It("should mark the backup as stopped", func() {
-					Expect(status.Cluster.Layers.Backup.Tags).To(Equal(map[string]fdbv1beta2.FoundationDBStatusBackupTag{
+					Expect(
+						status.Cluster.Layers.Backup.Tags,
+					).To(Equal(map[string]fdbv1beta2.FoundationDBStatusBackupTag{
 						"default": {
 							CurrentContainer: "blobstore://test@test-service/test-backup",
 							RunningBackup:    pointer.Bool(false),
@@ -250,7 +273,11 @@ var _ = Describe("admin_client_test", func() {
 
 		Context("with a backup running", func() {
 			BeforeEach(func() {
-				err = mockAdminClient.StartBackup("blobstore://test@test-service/test-backup", 10, "")
+				err = mockAdminClient.StartBackup(
+					"blobstore://test@test-service/test-backup",
+					10,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -325,14 +352,22 @@ var _ = Describe("admin_client_test", func() {
 
 		Context("with a restore running", func() {
 			BeforeEach(func() {
-				Expect(mockAdminClient.StartRestore("blobstore://test@test-service/test-backup", nil, "")).To(Succeed())
+				Expect(
+					mockAdminClient.StartRestore(
+						"blobstore://test@test-service/test-backup",
+						nil,
+						"",
+					),
+				).To(Succeed())
 
 				restoreStatus, err = mockAdminClient.GetRestoreStatus()
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should contain the backup URL", func() {
-				Expect(restoreStatus).To(ContainSubstring("blobstore://test@test-service/test-backup"))
+				Expect(
+					restoreStatus,
+				).To(ContainSubstring("blobstore://test@test-service/test-backup"))
 			})
 		})
 	})

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -46,8 +46,14 @@ func reloadBackup(backup *fdbv1beta2.FoundationDBBackup) (int64, error) {
 	return generations.Reconciled, err
 }
 
-func reloadBackupGenerations(backup *fdbv1beta2.FoundationDBBackup) (fdbv1beta2.BackupGenerationStatus, error) {
-	err := k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: backup.Namespace, Name: backup.Name}, backup)
+func reloadBackupGenerations(
+	backup *fdbv1beta2.FoundationDBBackup,
+) (fdbv1beta2.BackupGenerationStatus, error) {
+	err := k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{Namespace: backup.Namespace, Name: backup.Name},
+		backup,
+	)
 	if err != nil {
 		return fdbv1beta2.BackupGenerationStatus{}, err
 	}
@@ -82,7 +88,13 @@ var _ = Describe("backup_controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(generation).NotTo(Equal(int64(0)))
 
-			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, cluster)).To(Succeed())
+			Expect(
+				k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name},
+					cluster,
+				),
+			).To(Succeed())
 
 			Expect(k8sClient.Create(context.TODO(), backup)).To(Succeed())
 
@@ -93,7 +105,13 @@ var _ = Describe("backup_controller", func() {
 			generation, err = reloadBackup(backup)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(generation).NotTo(Equal(int64(0)))
-			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, cluster)).To(Succeed())
+			Expect(
+				k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name},
+					cluster,
+				),
+			).To(Succeed())
 
 			originalVersion = backup.ObjectMeta.Generation
 			generationGap = 1
@@ -107,7 +125,11 @@ var _ = Describe("backup_controller", func() {
 			generation, err := reloadBackup(backup)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(generation).To(Equal(originalVersion + generationGap))
-			err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: backup.Namespace, Name: backup.Name}, cluster)
+			err = k8sClient.Get(
+				context.TODO(),
+				types.NamespacedName{Namespace: backup.Namespace, Name: backup.Name},
+				cluster,
+			)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -120,10 +142,16 @@ var _ = Describe("backup_controller", func() {
 				deployment := &appsv1.Deployment{}
 				deploymentName := fmt.Sprintf("%s-backup-agents", cluster.Name)
 
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: deploymentName}, deployment)
+				err := k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{Namespace: cluster.Namespace, Name: deploymentName},
+					deployment,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(*deployment.Spec.Replicas).To(Equal(int32(3)))
-				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
+				Expect(
+					deployment.Spec.Template.Spec.Containers[0].Image,
+				).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
 			})
 
 			It("should update the status on the resource", func() {
@@ -144,7 +172,9 @@ var _ = Describe("backup_controller", func() {
 			It("should start a backup", func() {
 				status, err := adminClient.GetBackupStatus()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(status.DestinationURL).To(Equal("blobstore://test@test-service:443/test-backup?bucket=fdb-backups"))
+				Expect(
+					status.DestinationURL,
+				).To(Equal("blobstore://test@test-service:443/test-backup?bucket=fdb-backups"))
 				Expect(status.Status.Running).To(BeTrue())
 				Expect(status.BackupAgentsPaused).To(BeFalse())
 			})

--- a/controllers/bounce_processes_test.go
+++ b/controllers/bounce_processes_test.go
@@ -57,7 +57,13 @@ var _ = Describe("bounceProcesses", func() {
 		})
 
 		JustBeforeEach(func() {
-			requeue = bounceProcesses{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+			requeue = bounceProcesses{}.reconcile(
+				context.TODO(),
+				clusterReconciler,
+				cluster,
+				nil,
+				globalControllerLogger,
+			)
 		})
 
 		When("the cluster is reconciled", func() {
@@ -75,7 +81,11 @@ var _ = Describe("bounceProcesses", func() {
 			var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
 
 			BeforeEach(func() {
-				pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
+				pickedProcessGroups = internal.PickProcessGroups(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					2,
+				)
 
 				for _, processGroup := range pickedProcessGroups {
 					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
@@ -119,7 +129,9 @@ var _ = Describe("bounceProcesses", func() {
 			When("one process was manually excluded", func() {
 				BeforeEach(func() {
 					for _, address := range pickedProcessGroups[0].Addresses {
-						err := adminClient.ExcludeProcesses([]fdbv1beta2.ProcessAddress{{StringAddress: address, Port: 4501}})
+						err := adminClient.ExcludeProcesses(
+							[]fdbv1beta2.ProcessAddress{{StringAddress: address, Port: 4501}},
+						)
 						Expect(err).To(BeNil())
 					}
 				})
@@ -144,7 +156,11 @@ var _ = Describe("bounceProcesses", func() {
 			var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
 
 			BeforeEach(func() {
-				pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)
+				pickedProcessGroups = internal.PickProcessGroups(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+				)
 
 				for _, processGroup := range pickedProcessGroups {
 					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
@@ -170,16 +186,23 @@ var _ = Describe("bounceProcesses", func() {
 			var pickedProcessGroups []*fdbv1beta2.ProcessGroupStatus
 
 			BeforeEach(func() {
-				pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
+				pickedProcessGroups = internal.PickProcessGroups(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					2,
+				)
 
 				for _, processGroup := range pickedProcessGroups {
 					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
 				}
 
-				pickedProcessGroups[0].ProcessGroupConditions = append(pickedProcessGroups[0].ProcessGroupConditions, &fdbv1beta2.ProcessGroupCondition{
-					ProcessGroupConditionType: fdbv1beta2.MissingProcesses,
-					Timestamp:                 time.Now().Add(-2 * time.Minute).Unix(),
-				})
+				pickedProcessGroups[0].ProcessGroupConditions = append(
+					pickedProcessGroups[0].ProcessGroupConditions,
+					&fdbv1beta2.ProcessGroupCondition{
+						ProcessGroupConditionType: fdbv1beta2.MissingProcesses,
+						Timestamp:                 time.Now().Add(-2 * time.Minute).Unix(),
+					},
+				)
 			})
 
 			It("should not requeue", func() {
@@ -207,7 +230,11 @@ var _ = Describe("bounceProcesses", func() {
 				_, err = reloadCluster(cluster)
 				Expect(err).NotTo(HaveOccurred())
 
-				pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
+				pickedProcessGroups = internal.PickProcessGroups(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					2,
+				)
 				for _, processGroup := range pickedProcessGroups {
 					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
 				}
@@ -242,7 +269,10 @@ var _ = Describe("bounceProcesses", func() {
 					})
 
 					It("should kill all the processes", func() {
-						addresses := make(map[string]fdbv1beta2.None, len(cluster.Status.ProcessGroups))
+						addresses := make(
+							map[string]fdbv1beta2.None,
+							len(cluster.Status.ProcessGroups),
+						)
 						for _, processGroup := range cluster.Status.ProcessGroups {
 							for _, address := range processGroup.Addresses {
 								addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
@@ -257,15 +287,22 @@ var _ = Describe("bounceProcesses", func() {
 					It("should update the running version in the status", func() {
 						_, err = reloadCluster(cluster)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(cluster.Status.RunningVersion).To(Equal(fdbv1beta2.Versions.NextMajorVersion.String()))
+						Expect(
+							cluster.Status.RunningVersion,
+						).To(Equal(fdbv1beta2.Versions.NextMajorVersion.String()))
 					})
 
 					It("should submit pending upgrade information for all the processes", func() {
-						expectedUpgrades := make(map[fdbv1beta2.ProcessGroupID]bool, len(cluster.Status.ProcessGroups))
+						expectedUpgrades := make(
+							map[fdbv1beta2.ProcessGroupID]bool,
+							len(cluster.Status.ProcessGroups),
+						)
 						for _, processGroup := range cluster.Status.ProcessGroups {
 							expectedUpgrades[processGroup.ProcessGroupID] = true
 						}
-						pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+						pendingUpgrades, err := lockClient.GetPendingUpgrades(
+							fdbv1beta2.Versions.NextMajorVersion,
+						)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(pendingUpgrades).To(Equal(expectedUpgrades))
 					})
@@ -284,8 +321,13 @@ var _ = Describe("bounceProcesses", func() {
 							break
 						}
 
-						Expect(missingProcessGroup.ProcessClass).To(Equal(fdbv1beta2.ProcessClassStorage))
-						adminClient.MockMissingProcessGroup(missingProcessGroup.ProcessGroupID, true)
+						Expect(
+							missingProcessGroup.ProcessClass,
+						).To(Equal(fdbv1beta2.ProcessClassStorage))
+						adminClient.MockMissingProcessGroup(
+							missingProcessGroup.ProcessGroupID,
+							true,
+						)
 						missingProcessGroup.UpdateCondition(fdbv1beta2.MissingProcesses, true)
 					})
 
@@ -296,7 +338,9 @@ var _ = Describe("bounceProcesses", func() {
 
 						It("should requeue", func() {
 							Expect(requeue).NotTo(BeNil())
-							Expect(requeue.message).To(Equal(fmt.Sprintf("could not find address for processes: %s", []fdbv1beta2.ProcessGroupID{missingProcessGroup.ProcessGroupID})))
+							Expect(
+								requeue.message,
+							).To(Equal(fmt.Sprintf("could not find address for processes: %s", []fdbv1beta2.ProcessGroupID{missingProcessGroup.ProcessGroupID})))
 						})
 
 						It("shouldn't kill any processes", func() {
@@ -304,7 +348,9 @@ var _ = Describe("bounceProcesses", func() {
 						})
 
 						It("should not submit pending upgrade information", func() {
-							pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+							pendingUpgrades, err := lockClient.GetPendingUpgrades(
+								fdbv1beta2.Versions.NextMajorVersion,
+							)
 							Expect(err).NotTo(HaveOccurred())
 							Expect(pendingUpgrades).To(BeEmpty())
 						})
@@ -315,7 +361,9 @@ var _ = Describe("bounceProcesses", func() {
 							missingProcessGroup.ProcessGroupConditions = []*fdbv1beta2.ProcessGroupCondition{
 								{
 									ProcessGroupConditionType: fdbv1beta2.MissingProcesses,
-									Timestamp:                 time.Now().Add(-5 * time.Minute).Unix(),
+									Timestamp: time.Now().
+										Add(-5 * time.Minute).
+										Unix(),
 								},
 							}
 						})
@@ -327,11 +375,15 @@ var _ = Describe("bounceProcesses", func() {
 
 						It("should kill the processes except the missing process", func() {
 							Expect(adminClient.KilledAddresses).NotTo(BeEmpty())
-							Expect(adminClient.KilledAddresses).NotTo(ContainElement(missingProcessGroup.Addresses))
+							Expect(
+								adminClient.KilledAddresses,
+							).NotTo(ContainElement(missingProcessGroup.Addresses))
 						})
 
 						It("should not submit pending upgrade information", func() {
-							pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+							pendingUpgrades, err := lockClient.GetPendingUpgrades(
+								fdbv1beta2.Versions.NextMajorVersion,
+							)
 							Expect(err).NotTo(HaveOccurred())
 							Expect(pendingUpgrades).NotTo(BeEmpty())
 						})
@@ -352,7 +404,11 @@ var _ = Describe("bounceProcesses", func() {
 				_, err = reloadCluster(cluster)
 				Expect(err).NotTo(HaveOccurred())
 
-				pickedProcessGroups = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassLog, 2)
+				pickedProcessGroups = internal.PickProcessGroups(
+					cluster,
+					fdbv1beta2.ProcessClassLog,
+					2,
+				)
 				for _, processGroup := range pickedProcessGroups {
 					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
 				}
@@ -401,15 +457,22 @@ var _ = Describe("bounceProcesses", func() {
 				It("should update the running version in the status", func() {
 					_, err = reloadCluster(cluster)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(cluster.Status.RunningVersion).To(Equal(fdbv1beta2.Versions.NextMajorVersion.String()))
+					Expect(
+						cluster.Status.RunningVersion,
+					).To(Equal(fdbv1beta2.Versions.NextMajorVersion.String()))
 				})
 
 				It("should submit pending upgrade information for all the processes", func() {
-					expectedUpgrades := make(map[fdbv1beta2.ProcessGroupID]bool, len(cluster.Status.ProcessGroups))
+					expectedUpgrades := make(
+						map[fdbv1beta2.ProcessGroupID]bool,
+						len(cluster.Status.ProcessGroups),
+					)
 					for _, processGroup := range cluster.Status.ProcessGroups {
 						expectedUpgrades[processGroup.ProcessGroupID] = true
 					}
-					pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+					pendingUpgrades, err := lockClient.GetPendingUpgrades(
+						fdbv1beta2.Versions.NextMajorVersion,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pendingUpgrades).To(Equal(expectedUpgrades))
 				})
@@ -441,15 +504,22 @@ var _ = Describe("bounceProcesses", func() {
 			It("should update the running version in the status", func() {
 				_, err = reloadCluster(cluster)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cluster.Status.RunningVersion).To(Equal(fdbv1beta2.Versions.NextMajorVersion.String()))
+				Expect(
+					cluster.Status.RunningVersion,
+				).To(Equal(fdbv1beta2.Versions.NextMajorVersion.String()))
 			})
 
 			It("should submit pending upgrade information for all the processes", func() {
-				expectedUpgrades := make(map[fdbv1beta2.ProcessGroupID]bool, len(cluster.Status.ProcessGroups))
+				expectedUpgrades := make(
+					map[fdbv1beta2.ProcessGroupID]bool,
+					len(cluster.Status.ProcessGroups),
+				)
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					expectedUpgrades[processGroup.ProcessGroupID] = true
 				}
-				pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+				pendingUpgrades, err := lockClient.GetPendingUpgrades(
+					fdbv1beta2.Versions.NextMajorVersion,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pendingUpgrades).To(Equal(expectedUpgrades))
 			})
@@ -465,7 +535,9 @@ var _ = Describe("bounceProcesses", func() {
 
 				It("should requeue", func() {
 					Expect(requeue).NotTo(BeNil())
-					Expect(requeue.message).To(Equal("Waiting for processes to be updated: [dc2-storage-1]"))
+					Expect(
+						requeue.message,
+					).To(Equal("Waiting for processes to be updated: [dc2-storage-1]"))
 				})
 
 				It("should not kill any processes", func() {
@@ -475,22 +547,34 @@ var _ = Describe("bounceProcesses", func() {
 				It("should not update the running version in the status", func() {
 					_, err = reloadCluster(cluster)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(cluster.Status.RunningVersion).To(Equal(fdbv1beta2.Versions.Default.String()))
+					Expect(
+						cluster.Status.RunningVersion,
+					).To(Equal(fdbv1beta2.Versions.Default.String()))
 				})
 
 				It("should submit pending upgrade information for all the processes", func() {
-					expectedUpgrades := make(map[fdbv1beta2.ProcessGroupID]bool, len(cluster.Status.ProcessGroups))
+					expectedUpgrades := make(
+						map[fdbv1beta2.ProcessGroupID]bool,
+						len(cluster.Status.ProcessGroups),
+					)
 					for _, processGroup := range cluster.Status.ProcessGroups {
 						expectedUpgrades[processGroup.ProcessGroupID] = true
 					}
-					pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+					pendingUpgrades, err := lockClient.GetPendingUpgrades(
+						fdbv1beta2.Versions.NextMajorVersion,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pendingUpgrades).To(Equal(expectedUpgrades))
 				})
 
 				Context("with a pending upgrade for the unknown process", func() {
 					BeforeEach(func() {
-						Expect(lockClient.AddPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion, []fdbv1beta2.ProcessGroupID{"dc2-storage-1"})).NotTo(HaveOccurred())
+						Expect(
+							lockClient.AddPendingUpgrades(
+								fdbv1beta2.Versions.NextMajorVersion,
+								[]fdbv1beta2.ProcessGroupID{"dc2-storage-1"},
+							),
+						).NotTo(HaveOccurred())
 					})
 
 					It("should requeue", func() {
@@ -498,7 +582,10 @@ var _ = Describe("bounceProcesses", func() {
 					})
 
 					It("should kill all the processes", func() {
-						addresses := make(map[string]fdbv1beta2.None, len(cluster.Status.ProcessGroups)+1)
+						addresses := make(
+							map[string]fdbv1beta2.None,
+							len(cluster.Status.ProcessGroups)+1,
+						)
 						for _, processGroup := range cluster.Status.ProcessGroups {
 							for _, address := range processGroup.Addresses {
 								addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
@@ -511,13 +598,18 @@ var _ = Describe("bounceProcesses", func() {
 
 				Context("with a pending upgrade to an older version", func() {
 					BeforeEach(func() {
-						err = lockClient.AddPendingUpgrades(fdbv1beta2.Versions.NextPatchVersion, []fdbv1beta2.ProcessGroupID{"dc2-storage-1"})
+						err = lockClient.AddPendingUpgrades(
+							fdbv1beta2.Versions.NextPatchVersion,
+							[]fdbv1beta2.ProcessGroupID{"dc2-storage-1"},
+						)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
 					It("should requeue", func() {
 						Expect(requeue).NotTo(BeNil())
-						Expect(requeue.message).To(Equal("Waiting for processes to be updated: [dc2-storage-1]"))
+						Expect(
+							requeue.message,
+						).To(Equal("Waiting for processes to be updated: [dc2-storage-1]"))
 					})
 
 					It("should not kill any processes", func() {
@@ -535,7 +627,10 @@ var _ = Describe("bounceProcesses", func() {
 					})
 
 					It("should kill all the processes", func() {
-						addresses := make(map[string]fdbv1beta2.None, len(cluster.Status.ProcessGroups))
+						addresses := make(
+							map[string]fdbv1beta2.None,
+							len(cluster.Status.ProcessGroups),
+						)
 						for _, processGroup := range cluster.Status.ProcessGroups {
 							for _, address := range processGroup.Addresses {
 								addresses[fmt.Sprintf("%s:4501", address)] = fdbv1beta2.None{}
@@ -545,7 +640,9 @@ var _ = Describe("bounceProcesses", func() {
 					})
 
 					It("should not submit pending upgrade information", func() {
-						pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+						pendingUpgrades, err := lockClient.GetPendingUpgrades(
+							fdbv1beta2.Versions.NextMajorVersion,
+						)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(pendingUpgrades).To(BeEmpty())
 					})
@@ -563,7 +660,9 @@ var _ = Describe("bounceProcesses", func() {
 
 				It("should requeue", func() {
 					Expect(requeue).NotTo(BeNil())
-					Expect(requeue.message).To(Equal(fmt.Sprintf("could not find address for processes: %s", []fdbv1beta2.ProcessGroupID{missingProcessGroup.ProcessGroupID})))
+					Expect(
+						requeue.message,
+					).To(Equal(fmt.Sprintf("could not find address for processes: %s", []fdbv1beta2.ProcessGroupID{missingProcessGroup.ProcessGroupID})))
 				})
 
 				It("shouldn't kill any processes", func() {
@@ -571,7 +670,9 @@ var _ = Describe("bounceProcesses", func() {
 				})
 
 				It("should not submit pending upgrade information", func() {
-					pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+					pendingUpgrades, err := lockClient.GetPendingUpgrades(
+						fdbv1beta2.Versions.NextMajorVersion,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pendingUpgrades).To(BeEmpty())
 				})
@@ -598,11 +699,15 @@ var _ = Describe("bounceProcesses", func() {
 
 				It("should kill the processes except the missing process", func() {
 					Expect(adminClient.KilledAddresses).NotTo(BeEmpty())
-					Expect(adminClient.KilledAddresses).NotTo(ContainElement(missingProcessGroup.Addresses))
+					Expect(
+						adminClient.KilledAddresses,
+					).NotTo(ContainElement(missingProcessGroup.Addresses))
 				})
 
 				It("should not submit pending upgrade information", func() {
-					pendingUpgrades, err := lockClient.GetPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion)
+					pendingUpgrades, err := lockClient.GetPendingUpgrades(
+						fdbv1beta2.Versions.NextMajorVersion,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pendingUpgrades).NotTo(BeEmpty())
 				})
@@ -614,7 +719,9 @@ var _ = Describe("bounceProcesses", func() {
 
 			BeforeEach(func() {
 				ignoredProcessGroup = cluster.Status.ProcessGroups[0]
-				cluster.Spec.Buggify.IgnoreDuringRestart = []fdbv1beta2.ProcessGroupID{ignoredProcessGroup.ProcessGroupID}
+				cluster.Spec.Buggify.IgnoreDuringRestart = []fdbv1beta2.ProcessGroupID{
+					ignoredProcessGroup.ProcessGroupID,
+				}
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
 				}
@@ -632,7 +739,9 @@ var _ = Describe("bounceProcesses", func() {
 					Expect(address).NotTo(HavePrefix(ignoredAddress))
 				}
 
-				Expect(adminClient.KilledAddresses).To(HaveLen(len(cluster.Status.ProcessGroups) - 1))
+				Expect(
+					adminClient.KilledAddresses,
+				).To(HaveLen(len(cluster.Status.ProcessGroups) - 1))
 			})
 
 			When("filtering process groups for buggify", func() {
@@ -642,57 +751,83 @@ var _ = Describe("bounceProcesses", func() {
 				BeforeEach(func() {
 					status, err := adminClient.GetStatus()
 					Expect(err).NotTo(HaveOccurred())
-					processAddresses := make([]fdbv1beta2.ProcessAddress, 0, len(cluster.Status.ProcessGroups))
+					processAddresses := make(
+						[]fdbv1beta2.ProcessAddress,
+						0,
+						len(cluster.Status.ProcessGroups),
+					)
 					for _, process := range status.Cluster.Processes {
 						processAddresses = append(processAddresses, process.Address)
 					}
 
-					filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(cluster, processAddresses, status)
+					filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(
+						cluster,
+						processAddresses,
+						status,
+					)
 				})
 
 				It("should filter the ignored address", func() {
 					Expect(removed).To(BeTrue())
-					Expect(len(filteredAddresses)).To(BeNumerically("==", len(cluster.Status.ProcessGroups)-1))
+					Expect(
+						len(filteredAddresses),
+					).To(BeNumerically("==", len(cluster.Status.ProcessGroups)-1))
 				})
 			})
 
-			When("buggify ignore processes is set and only this process has the IncorrectCommandLine condition", func() {
-				var filteredAddresses []fdbv1beta2.ProcessAddress
-				var removed bool
+			When(
+				"buggify ignore processes is set and only this process has the IncorrectCommandLine condition",
+				func() {
+					var filteredAddresses []fdbv1beta2.ProcessAddress
+					var removed bool
 
-				BeforeEach(func() {
-					for _, processGroup := range cluster.Status.ProcessGroups {
-						processGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, processGroup.ProcessGroupID == ignoredProcessGroup.ProcessGroupID)
-					}
-
-					status, err := adminClient.GetStatus()
-					Expect(err).NotTo(HaveOccurred())
-					processAddresses := make([]fdbv1beta2.ProcessAddress, 0, len(cluster.Status.ProcessGroups))
-					for _, process := range status.Cluster.Processes {
-						if fdbv1beta2.ProcessGroupID(process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]) != ignoredProcessGroup.ProcessGroupID {
-							continue
+					BeforeEach(func() {
+						for _, processGroup := range cluster.Status.ProcessGroups {
+							processGroup.UpdateCondition(
+								fdbv1beta2.IncorrectCommandLine,
+								processGroup.ProcessGroupID == ignoredProcessGroup.ProcessGroupID,
+							)
 						}
 
-						processAddresses = append(processAddresses, process.Address)
-					}
+						status, err := adminClient.GetStatus()
+						Expect(err).NotTo(HaveOccurred())
+						processAddresses := make(
+							[]fdbv1beta2.ProcessAddress,
+							0,
+							len(cluster.Status.ProcessGroups),
+						)
+						for _, process := range status.Cluster.Processes {
+							if fdbv1beta2.ProcessGroupID(
+								process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey],
+							) != ignoredProcessGroup.ProcessGroupID {
+								continue
+							}
 
-					filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(cluster, processAddresses, status)
-				})
+							processAddresses = append(processAddresses, process.Address)
+						}
 
-				It("should filter the ignored address", func() {
-					Expect(removed).To(BeTrue())
-					Expect(filteredAddresses).To(BeEmpty())
-				})
+						filteredAddresses, removed = buggify.FilterIgnoredProcessGroups(
+							cluster,
+							processAddresses,
+							status,
+						)
+					})
 
-				It("should not requeue", func() {
-					Expect(err).NotTo(HaveOccurred())
-					Expect(requeue).To(BeNil())
-				})
+					It("should filter the ignored address", func() {
+						Expect(removed).To(BeTrue())
+						Expect(filteredAddresses).To(BeEmpty())
+					})
 
-				It("should not kill any processes", func() {
-					Expect(adminClient.KilledAddresses).To(BeEmpty())
-				})
-			})
+					It("should not requeue", func() {
+						Expect(err).NotTo(HaveOccurred())
+						Expect(requeue).To(BeNil())
+					})
+
+					It("should not kill any processes", func() {
+						Expect(adminClient.KilledAddresses).To(BeEmpty())
+					})
+				},
+			)
 		})
 
 		When("when there are unreachable processes", func() {
@@ -726,7 +861,9 @@ var _ = Describe("bounceProcesses", func() {
 							Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 								"1": {
 									ProcessClass: fdbv1beta2.ProcessClassStateless,
-									Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+									Address: fdbv1beta2.ProcessAddress{
+										StringAddress: "192.168.0.2:4500:tls",
+									},
 									Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
 										{
 											Role: string(fdbv1beta2.ProcessRoleClusterController),
@@ -738,8 +875,10 @@ var _ = Describe("bounceProcesses", func() {
 									},
 								},
 								"2": {
-									ProcessClass:  fdbv1beta2.ProcessClassTest,
-									Address:       fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.1:4500:tls"},
+									ProcessClass: fdbv1beta2.ProcessClassTest,
+									Address: fdbv1beta2.ProcessAddress{
+										StringAddress: "192.168.0.1:4500:tls",
+									},
 									UptimeSeconds: 61.0,
 									Locality: map[string]string{
 										fdbv1beta2.FDBLocalityInstanceIDKey: "2",
@@ -826,7 +965,9 @@ var _ = Describe("bounceProcesses", func() {
 							Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 								"1": {
 									ProcessClass: fdbv1beta2.ProcessClassStateless,
-									Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+									Address: fdbv1beta2.ProcessAddress{
+										StringAddress: "192.168.0.2:4500:tls",
+									},
 									Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
 										{
 											Role: string(fdbv1beta2.ProcessRoleClusterController),
@@ -835,7 +976,9 @@ var _ = Describe("bounceProcesses", func() {
 								},
 								"2": {
 									ProcessClass: fdbv1beta2.ProcessClassStorage,
-									Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.1:4500:tls"},
+									Address: fdbv1beta2.ProcessAddress{
+										StringAddress: "192.168.0.1:4500:tls",
+									},
 								},
 							},
 						},
@@ -872,7 +1015,9 @@ var _ = Describe("bounceProcesses", func() {
 							Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 								"1": {
 									ProcessClass: fdbv1beta2.ProcessClassStateless,
-									Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+									Address: fdbv1beta2.ProcessAddress{
+										StringAddress: "192.168.0.2:4500:tls",
+									},
 									Roles: []fdbv1beta2.FoundationDBStatusProcessRoleInfo{
 										{
 											Role: string(fdbv1beta2.ProcessRoleClusterController),
@@ -881,7 +1026,9 @@ var _ = Describe("bounceProcesses", func() {
 								},
 								"2": {
 									ProcessClass: fdbv1beta2.ProcessClassTest,
-									Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.1:4500:tls"},
+									Address: fdbv1beta2.ProcessAddress{
+										StringAddress: "192.168.0.1:4500:tls",
+									},
 								},
 							},
 						},
@@ -901,7 +1048,9 @@ var _ = Describe("bounceProcesses", func() {
 
 		When("using the global synchronization mode", func() {
 			BeforeEach(func() {
-				cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeGlobal))
+				cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+					string(fdbv1beta2.SynchronizationModeGlobal),
+				)
 				adminClient.MockAdditionTimeForGlobalCoordination = time.Now().Add(-1 * time.Minute)
 			})
 
@@ -917,7 +1066,11 @@ var _ = Describe("bounceProcesses", func() {
 				var pickedProcessGroup *fdbv1beta2.ProcessGroupStatus
 
 				BeforeEach(func() {
-					pickedProcessGroups := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)
+					pickedProcessGroups := internal.PickProcessGroups(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						1,
+					)
 					Expect(pickedProcessGroups).To(HaveLen(1))
 					pickedProcessGroup = pickedProcessGroups[0]
 					pickedProcessGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
@@ -929,7 +1082,9 @@ var _ = Describe("bounceProcesses", func() {
 							Expect(requeue).To(BeNil())
 							Expect(adminClient.KilledAddresses).To(HaveLen(1))
 							for _, address := range pickedProcessGroup.Addresses {
-								Expect(adminClient.KilledAddresses).To(HaveKey(fmt.Sprintf("%s:4501", address)))
+								Expect(
+									adminClient.KilledAddresses,
+								).To(HaveKey(fmt.Sprintf("%s:4501", address)))
 							}
 
 							pendingForRestart, err := adminClient.GetPendingForRestart("")
@@ -966,16 +1121,22 @@ var _ = Describe("bounceProcesses", func() {
 
 				When("the process is part of the pending to restart set", func() {
 					BeforeEach(func() {
-						Expect(adminClient.UpdatePendingForRestart(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-							pickedProcessGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
-						})).To(Succeed())
+						Expect(
+							adminClient.UpdatePendingForRestart(
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+									pickedProcessGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
+								},
+							),
+						).To(Succeed())
 					})
 
 					It("should kill the process", func() {
 						Expect(requeue).To(BeNil())
 						Expect(adminClient.KilledAddresses).To(HaveLen(1))
 						for _, address := range pickedProcessGroup.Addresses {
-							Expect(adminClient.KilledAddresses).To(HaveKey(fmt.Sprintf("%s:4501", address)))
+							Expect(
+								adminClient.KilledAddresses,
+							).To(HaveKey(fmt.Sprintf("%s:4501", address)))
 						}
 
 						pendingForRestart, err := adminClient.GetPendingForRestart("")
@@ -992,11 +1153,18 @@ var _ = Describe("bounceProcesses", func() {
 		})
 	})
 
-	DescribeTable("when getting all the addresses to upgrade from the current status", func(inputStatus *fdbv1beta2.FoundationDBStatus, pendingUpgrades map[fdbv1beta2.ProcessGroupID]bool, version string, expectedAddresses []fdbv1beta2.ProcessAddress, expectedNotReady []string) {
-		addresses, notReady := getUpgradeAddressesFromStatus(GinkgoLogr, inputStatus, pendingUpgrades, version)
-		Expect(addresses).To(ConsistOf(expectedAddresses))
-		Expect(notReady).To(ConsistOf(expectedNotReady))
-	},
+	DescribeTable(
+		"when getting all the addresses to upgrade from the current status",
+		func(inputStatus *fdbv1beta2.FoundationDBStatus, pendingUpgrades map[fdbv1beta2.ProcessGroupID]bool, version string, expectedAddresses []fdbv1beta2.ProcessAddress, expectedNotReady []string) {
+			addresses, notReady := getUpgradeAddressesFromStatus(
+				GinkgoLogr,
+				inputStatus,
+				pendingUpgrades,
+				version,
+			)
+			Expect(addresses).To(ConsistOf(expectedAddresses))
+			Expect(notReady).To(ConsistOf(expectedNotReady))
+		},
 		Entry("no tester processes are present",
 			&fdbv1beta2.FoundationDBStatus{
 				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
@@ -1007,7 +1175,9 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "1",
 							},
 							Version: "6.3.43",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.2:4500:tls",
+							},
 						},
 					},
 				},
@@ -1029,7 +1199,9 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "1",
 							},
 							Version: "6.3.43",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.2:4500:tls",
+							},
 						},
 						"2": {
 							ProcessClass: fdbv1beta2.ProcessClassTest,
@@ -1037,7 +1209,9 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "2",
 							},
 							Version: "6.3.43",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.3:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.3:4500:tls",
+							},
 						},
 					},
 				},
@@ -1059,7 +1233,9 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "1",
 							},
 							Version: "6.3.43",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.2:4500:tls",
+							},
 						},
 						"2": {
 							ProcessClass: fdbv1beta2.ProcessClassTest,
@@ -1067,13 +1243,17 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "2",
 							},
 							Version: "6.3.43",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.3:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.3:4500:tls",
+							},
 						},
 						"3": {
 							ProcessClass: fdbv1beta2.ProcessClassStorage,
 							Locality:     map[string]string{},
 							Version:      "6.3.43",
-							Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.4:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.4:4500:tls",
+							},
 						},
 					},
 				},
@@ -1095,7 +1275,9 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "1",
 							},
 							Version: "6.3.43",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.2:4500:tls",
+							},
 						},
 						"2": {
 							ProcessClass: fdbv1beta2.ProcessClassTest,
@@ -1103,13 +1285,17 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "2",
 							},
 							Version: "6.3.43",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.3:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.3:4500:tls",
+							},
 						},
 						"3": {
 							ProcessClass: fdbv1beta2.ProcessClassStorage,
 							Locality:     map[string]string{},
 							Version:      "6.3.43",
-							Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.4:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.4:4500:tls",
+							},
 						},
 						"4": {
 							ProcessClass: fdbv1beta2.ProcessClassStorage,
@@ -1117,7 +1303,9 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "4",
 							},
 							Version: "7.1.56",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.5:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.5:4500:tls",
+							},
 						},
 					},
 				},
@@ -1139,7 +1327,9 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "1",
 							},
 							Version: "6.3.43",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.2:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.2:4500:tls",
+							},
 						},
 						"2": {
 							ProcessClass: fdbv1beta2.ProcessClassTest,
@@ -1147,13 +1337,17 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "2",
 							},
 							Version: "6.3.43",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.3:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.3:4500:tls",
+							},
 						},
 						"3": {
 							ProcessClass: fdbv1beta2.ProcessClassStorage,
 							Locality:     map[string]string{},
 							Version:      "6.3.43",
-							Address:      fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.4:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.4:4500:tls",
+							},
 						},
 						"4": {
 							ProcessClass: fdbv1beta2.ProcessClassStorage,
@@ -1161,7 +1355,9 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "4",
 							},
 							Version: "7.1.56",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.5:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.5:4500:tls",
+							},
 						},
 						"5": {
 							ProcessClass: fdbv1beta2.ProcessClassStorage,
@@ -1169,7 +1365,9 @@ var _ = Describe("bounceProcesses", func() {
 								fdbv1beta2.FDBLocalityInstanceIDKey: "5",
 							},
 							Version: "6.3.43",
-							Address: fdbv1beta2.ProcessAddress{StringAddress: "192.168.0.6:4500:tls"},
+							Address: fdbv1beta2.ProcessAddress{
+								StringAddress: "192.168.0.6:4500:tls",
+							},
 						},
 					},
 				},

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -37,7 +37,13 @@ import (
 type changeCoordinators struct{}
 
 // reconcile runs the reconciler's work.
-func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (c changeCoordinators) reconcile(
+	ctx context.Context,
+	r *FoundationDBClusterReconciler,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	status *fdbv1beta2.FoundationDBStatus,
+	logger logr.Logger,
+) *requeue {
 	if !cluster.Status.Configured {
 		return nil
 	}
@@ -63,7 +69,12 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 		coordinatorStatus[coord.Address.String()] = false
 	}
 
-	hasValidCoordinators, allAddressesValid, err := locality.CheckCoordinatorValidity(logger, cluster, status, coordinatorStatus)
+	hasValidCoordinators, allAddressesValid, err := locality.CheckCoordinatorValidity(
+		logger,
+		cluster,
+		status,
+		coordinatorStatus,
+	)
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true}
 	}
@@ -74,7 +85,12 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 
 	if !allAddressesValid {
 		logger.Info("Deferring coordinator change")
-		r.Recorder.Event(cluster, corev1.EventTypeNormal, "DeferringCoordinatorChange", "Deferring coordinator change until all processes have consistent address TLS settings")
+		r.Recorder.Event(
+			cluster,
+			corev1.EventTypeNormal,
+			"DeferringCoordinatorChange",
+			"Deferring coordinator change until all processes have consistent address TLS settings",
+		)
 		return nil
 	}
 
@@ -84,7 +100,12 @@ func (c changeCoordinators) reconcile(ctx context.Context, r *FoundationDBCluste
 	}
 
 	logger.Info("Changing coordinators")
-	r.Recorder.Event(cluster, corev1.EventTypeNormal, "ChangingCoordinators", "Choosing new coordinators")
+	r.Recorder.Event(
+		cluster,
+		corev1.EventTypeNormal,
+		"ChangingCoordinators",
+		"Choosing new coordinators",
+	)
 
 	err = coordinator.ChangeCoordinators(logger, adminClient, cluster, status)
 	if err != nil {

--- a/controllers/change_coordinators_test.go
+++ b/controllers/change_coordinators_test.go
@@ -65,7 +65,13 @@ var _ = Describe("Change coordinators", func() {
 		})
 
 		JustBeforeEach(func() {
-			requeue = changeCoordinators{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+			requeue = changeCoordinators{}.reconcile(
+				context.TODO(),
+				clusterReconciler,
+				cluster,
+				nil,
+				globalControllerLogger,
+			)
 		})
 
 		When("the cluster is healthy", func() {
@@ -96,7 +102,13 @@ var _ = Describe("Change coordinators", func() {
 
 				for _, pod := range pods.Items {
 					container := pod.Spec.Containers[1]
-					container.Env = append(container.Env, corev1.EnvVar{Name: fdbv1beta2.EnvNameDNSName, Value: internal.GetPodDNSName(cluster, pod.Name)})
+					container.Env = append(
+						container.Env,
+						corev1.EnvVar{
+							Name:  fdbv1beta2.EnvNameDNSName,
+							Value: internal.GetPodDNSName(cluster, pod.Name),
+						},
+					)
 					pod.Spec.Containers[1] = container
 					Expect(k8sClient.Update(context.TODO(), &pod)).NotTo(HaveOccurred())
 				}
@@ -108,7 +120,9 @@ var _ = Describe("Change coordinators", func() {
 
 			It("should change the cluster file", func() {
 				Expect(cluster.Status.ConnectionString).NotTo(Equal(originalConnectionString))
-				Expect(cluster.Status.ConnectionString).NotTo(ContainSubstring("my-ns.svc.cluster.local"))
+				Expect(
+					cluster.Status.ConnectionString,
+				).NotTo(ContainSubstring("my-ns.svc.cluster.local"))
 			})
 		})
 
@@ -132,13 +146,23 @@ var _ = Describe("Change coordinators", func() {
 					}
 				}
 
-				adminClient.MockMissingLocalities(fdbv1beta2.ProcessGroupID(badCoordinator.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]), true)
+				adminClient.MockMissingLocalities(
+					fdbv1beta2.ProcessGroupID(
+						badCoordinator.Locality[fdbv1beta2.FDBLocalityInstanceIDKey],
+					),
+					true,
+				)
 			})
 
-			It("should change the coordinators to not include the coordinator with the missing localities", func() {
-				Expect(cluster.Status.ConnectionString).NotTo(Equal(originalConnectionString))
-				Expect(cluster.Status.ConnectionString).NotTo(ContainSubstring(badCoordinator.Address.IPAddress.String()))
-			})
+			It(
+				"should change the coordinators to not include the coordinator with the missing localities",
+				func() {
+					Expect(cluster.Status.ConnectionString).NotTo(Equal(originalConnectionString))
+					Expect(
+						cluster.Status.ConnectionString,
+					).NotTo(ContainSubstring(badCoordinator.Address.IPAddress.String()))
+				},
+			)
 		})
 	})
 })

--- a/controllers/check_client_compatibility.go
+++ b/controllers/check_client_compatibility.go
@@ -38,7 +38,13 @@ import (
 type checkClientCompatibility struct{}
 
 // reconcile runs the reconciler's work.
-func (c checkClientCompatibility) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (c checkClientCompatibility) reconcile(
+	_ context.Context,
+	r *FoundationDBClusterReconciler,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	status *fdbv1beta2.FoundationDBStatus,
+	logger logr.Logger,
+) *requeue {
 	if !cluster.Status.Configured && !cluster.IsBeingUpgraded() {
 		return nil
 	}
@@ -58,7 +64,13 @@ func (c checkClientCompatibility) reconcile(_ context.Context, r *FoundationDBCl
 	}
 
 	if !runningVersion.SupportsVersionChange(version) {
-		return &requeue{message: fmt.Sprintf("cluster version change from version %s to version %s is not supported", runningVersion, version)}
+		return &requeue{
+			message: fmt.Sprintf(
+				"cluster version change from version %s to version %s is not supported",
+				runningVersion,
+				version,
+			),
+		}
 	}
 
 	if version.IsProtocolCompatible(runningVersion) {
@@ -105,7 +117,11 @@ func (c checkClientCompatibility) reconcile(_ context.Context, r *FoundationDBCl
 	return nil
 }
 
-func getUnsupportedClients(status *fdbv1beta2.FoundationDBStatus, protocolVersion string, ignoredLogGroups map[fdbv1beta2.LogGroup]fdbv1beta2.None) []string {
+func getUnsupportedClients(
+	status *fdbv1beta2.FoundationDBStatus,
+	protocolVersion string,
+	ignoredLogGroups map[fdbv1beta2.LogGroup]fdbv1beta2.None,
+) []string {
 	var unsupportedClients []string
 
 	processAddresses := map[string]fdbv1beta2.None{}

--- a/controllers/check_client_compatibility_test.go
+++ b/controllers/check_client_compatibility_test.go
@@ -276,7 +276,9 @@ var _ = Describe("check client compatibility", func() {
 
 		When("the fdb-kubernetes-operator log group should be ignored", func() {
 			BeforeEach(func() {
-				ignoredLogGroups = map[fdbv1beta2.LogGroup]fdbv1beta2.None{"fdb-kubernetes-operator": {}}
+				ignoredLogGroups = map[fdbv1beta2.LogGroup]fdbv1beta2.None{
+					"fdb-kubernetes-operator": {},
+				}
 			})
 
 			It("should show all clients as unsupported", func() {
@@ -326,7 +328,9 @@ var _ = Describe("check client compatibility", func() {
 
 				When("the fdb-kubernetes-operator log group should be ignored", func() {
 					BeforeEach(func() {
-						ignoredLogGroups = map[fdbv1beta2.LogGroup]fdbv1beta2.None{"fdb-kubernetes-operator": {}}
+						ignoredLogGroups = map[fdbv1beta2.LogGroup]fdbv1beta2.None{
+							"fdb-kubernetes-operator": {},
+						}
 					})
 
 					It("should show all clients as unsupported", func() {

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -56,7 +56,13 @@ var _ = Describe("choose_removals", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = chooseRemovals{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+		requeue = chooseRemovals{}.reconcile(
+			context.TODO(),
+			clusterReconciler,
+			cluster,
+			nil,
+			globalControllerLogger,
+		)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reloadCluster(cluster)
 		Expect(err).NotTo(HaveOccurred())
@@ -100,7 +106,9 @@ var _ = Describe("choose_removals", func() {
 			BeforeEach(func() {
 				processGroup := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
 				processGroup.MarkForRemoval()
-				Expect(clusterReconciler.updateOrApply(context.TODO(), cluster)).NotTo(HaveOccurred())
+				Expect(
+					clusterReconciler.updateOrApply(context.TODO(), cluster),
+				).NotTo(HaveOccurred())
 				processGroupID = processGroup.ProcessGroupID
 			})
 
@@ -117,11 +125,24 @@ var _ = Describe("choose_removals", func() {
 			var processGroupIDs []fdbv1beta2.ProcessGroupID
 
 			BeforeEach(func() {
-				processGroups := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2)
-				adminClient.MockLocalityInfo(processGroups[0].ProcessGroupID, map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "r1"})
-				adminClient.MockLocalityInfo(processGroups[1].ProcessGroupID, map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "r1"})
+				processGroups := internal.PickProcessGroups(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					2,
+				)
+				adminClient.MockLocalityInfo(
+					processGroups[0].ProcessGroupID,
+					map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "r1"},
+				)
+				adminClient.MockLocalityInfo(
+					processGroups[1].ProcessGroupID,
+					map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "r1"},
+				)
 
-				processGroupIDs = []fdbv1beta2.ProcessGroupID{processGroups[0].ProcessGroupID, processGroups[1].ProcessGroupID}
+				processGroupIDs = []fdbv1beta2.ProcessGroupID{
+					processGroups[0].ProcessGroupID,
+					processGroups[1].ProcessGroupID,
+				}
 			})
 
 			It("should not requeue", func() {

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -63,7 +63,9 @@ func reloadCluster(cluster *fdbv1beta2.FoundationDBCluster) (int64, error) {
 	return generations.Reconciled, err
 }
 
-func reloadClusterGenerations(cluster *fdbv1beta2.FoundationDBCluster) (fdbv1beta2.ClusterGenerationStatus, error) {
+func reloadClusterGenerations(
+	cluster *fdbv1beta2.FoundationDBCluster,
+) (fdbv1beta2.ClusterGenerationStatus, error) {
 	key := client.ObjectKeyFromObject(cluster)
 	*cluster = fdbv1beta2.FoundationDBCluster{}
 	err := k8sClient.Get(context.TODO(), key, cluster)
@@ -153,25 +155,45 @@ var _ = Describe("cluster_controller", func() {
 				sortPodsByName(pods)
 
 				Expect(pods.Items[0].Name).To(HavePrefix("operator-test-1-cluster-controller-"))
-				Expect(pods.Items[0].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("cluster_controller-"))
-				Expect(pods.Items[0].Labels[fdbv1beta2.FDBProcessClassLabel]).To(Equal(string(fdbv1beta2.ProcessClassClusterController)))
-				Expect(pods.Items[0].Annotations[fdbv1beta2.PublicIPSourceAnnotation]).To(Equal("pod"))
+				Expect(
+					pods.Items[0].Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+				).To(HavePrefix("cluster_controller-"))
+				Expect(
+					pods.Items[0].Labels[fdbv1beta2.FDBProcessClassLabel],
+				).To(Equal(string(fdbv1beta2.ProcessClassClusterController)))
+				Expect(
+					pods.Items[0].Annotations[fdbv1beta2.PublicIPSourceAnnotation],
+				).To(Equal("pod"))
 				Expect(pods.Items[0].Annotations[fdbv1beta2.PublicIPAnnotation]).To(Equal(""))
 
 				Expect(pods.Items[1].Name).To(HavePrefix("operator-test-1-log-"))
-				Expect(pods.Items[1].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("log-"))
+				Expect(
+					pods.Items[1].Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+				).To(HavePrefix("log-"))
 				Expect(pods.Items[4].Name).To(HavePrefix("operator-test-1-log-"))
-				Expect(pods.Items[4].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("log-"))
+				Expect(
+					pods.Items[4].Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+				).To(HavePrefix("log-"))
 				Expect(pods.Items[5].Name).To(HavePrefix("operator-test-1-stateless-"))
-				Expect(pods.Items[5].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("stateless-"))
+				Expect(
+					pods.Items[5].Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+				).To(HavePrefix("stateless-"))
 				Expect(pods.Items[12].Name).To(HavePrefix("operator-test-1-stateless-"))
-				Expect(pods.Items[12].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("stateless-"))
+				Expect(
+					pods.Items[12].Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+				).To(HavePrefix("stateless-"))
 				Expect(pods.Items[13].Name).To(HavePrefix("operator-test-1-storage-"))
-				Expect(pods.Items[13].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("storage-"))
+				Expect(
+					pods.Items[13].Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+				).To(HavePrefix("storage-"))
 				Expect(pods.Items[16].Name).To(HavePrefix("operator-test-1-storage-"))
-				Expect(pods.Items[16].Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(HavePrefix("storage-"))
+				Expect(
+					pods.Items[16].Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+				).To(HavePrefix("storage-"))
 
-				Expect(getProcessClassMap(cluster, pods.Items)).To(Equal(map[fdbv1beta2.ProcessClass]int{
+				Expect(
+					getProcessClassMap(cluster, pods.Items),
+				).To(Equal(map[fdbv1beta2.ProcessClass]int{
 					fdbv1beta2.ProcessClassStorage:           4,
 					fdbv1beta2.ProcessClassLog:               4,
 					fdbv1beta2.ProcessClassStateless:         8,
@@ -179,27 +201,42 @@ var _ = Describe("cluster_controller", func() {
 				}))
 
 				pod := &pods.Items[0]
-				configMapHash, err := getConfigMapHash(cluster, internal.GetProcessClassFromMeta(cluster, pod.ObjectMeta), pod)
+				configMapHash, err := getConfigMapHash(
+					cluster,
+					internal.GetProcessClassFromMeta(cluster, pod.ObjectMeta),
+					pod,
+				)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey]).To(Equal(configMapHash))
+				Expect(
+					pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey],
+				).To(Equal(configMapHash))
 				Expect(len(cluster.Status.ProcessGroups)).To(Equal(len(pods.Items)))
 			})
 
 			It("should create an headless service", func() {
 				services := &corev1.ServiceList{}
-				Expect(k8sClient.List(context.TODO(), services, getListOptions(cluster)...)).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.List(context.TODO(), services, getListOptions(cluster)...),
+				).NotTo(HaveOccurred())
 				Expect(services.Items).To(HaveLen(1))
 			})
 
 			It("should fill in the required fields in the configuration", func() {
-				Expect(cluster.Status.DatabaseConfiguration.RedundancyMode).To(Equal(fdbv1beta2.RedundancyModeDouble))
-				Expect(cluster.Status.DatabaseConfiguration.StorageEngine).To(Equal(fdbv1beta2.StorageEngineSSD2))
+				Expect(
+					cluster.Status.DatabaseConfiguration.RedundancyMode,
+				).To(Equal(fdbv1beta2.RedundancyModeDouble))
+				Expect(
+					cluster.Status.DatabaseConfiguration.StorageEngine,
+				).To(Equal(fdbv1beta2.StorageEngineSSD2))
 				Expect(cluster.Status.ConnectionString).NotTo(Equal(""))
 			})
 
 			It("should create a config map for the cluster", func() {
 				configMap := &corev1.ConfigMap{}
-				configMapName := types.NamespacedName{Namespace: "my-ns", Name: fmt.Sprintf("%s-config", cluster.Name)}
+				configMapName := types.NamespacedName{
+					Namespace: "my-ns",
+					Name:      fmt.Sprintf("%s-config", cluster.Name),
+				}
 				err = k8sClient.Get(context.TODO(), configMapName, configMap)
 				Expect(err).NotTo(HaveOccurred())
 				expectedConfigMap, _ := internal.GetConfigMap(cluster)
@@ -210,8 +247,12 @@ var _ = Describe("cluster_controller", func() {
 				adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(adminClient).NotTo(BeNil())
-				Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal(fdbv1beta2.RedundancyModeDouble))
-				Expect(adminClient.DatabaseConfiguration.StorageEngine).To(Equal(fdbv1beta2.StorageEngineSSD2))
+				Expect(
+					adminClient.DatabaseConfiguration.RedundancyMode,
+				).To(Equal(fdbv1beta2.RedundancyModeDouble))
+				Expect(
+					adminClient.DatabaseConfiguration.StorageEngine,
+				).To(Equal(fdbv1beta2.StorageEngineSSD2))
 				Expect(adminClient.DatabaseConfiguration.RoleCounts).To(Equal(fdbv1beta2.RoleCounts{
 					Logs:          3,
 					Proxies:       3,
@@ -227,8 +268,12 @@ var _ = Describe("cluster_controller", func() {
 				adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(adminClient).NotTo(BeNil())
-				Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal(fdbv1beta2.RedundancyModeDouble))
-				Expect(adminClient.DatabaseConfiguration.StorageEngine).To(Equal(fdbv1beta2.StorageEngineSSD2))
+				Expect(
+					adminClient.DatabaseConfiguration.RedundancyMode,
+				).To(Equal(fdbv1beta2.RedundancyModeDouble))
+				Expect(
+					adminClient.DatabaseConfiguration.StorageEngine,
+				).To(Equal(fdbv1beta2.StorageEngineSSD2))
 				Expect(adminClient.DatabaseConfiguration.RoleCounts).To(Equal(fdbv1beta2.RoleCounts{
 					Logs:       3,
 					Proxies:    3,
@@ -244,7 +289,10 @@ var _ = Describe("cluster_controller", func() {
 
 				Expect(cluster.Status.Generations.Reconciled).To(Equal(int64(1)))
 
-				processCounts := fdbv1beta2.CreateProcessCountsFromProcessGroupStatus(cluster.Status.ProcessGroups, true)
+				processCounts := fdbv1beta2.CreateProcessCountsFromProcessGroupStatus(
+					cluster.Status.ProcessGroups,
+					true,
+				)
 				Expect(processCounts).To(Equal(fdbv1beta2.ProcessCounts{
 					Storage:           4,
 					Log:               4,
@@ -255,8 +303,20 @@ var _ = Describe("cluster_controller", func() {
 				desiredCounts, err := cluster.GetProcessCountsWithDefaults()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(processCounts).To(Equal(desiredCounts))
-				Expect(fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectCommandLine, false)).To(HaveLen(0))
-				Expect(fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.MissingProcesses, false)).To(HaveLen(0))
+				Expect(
+					fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.IncorrectCommandLine,
+						false,
+					),
+				).To(HaveLen(0))
+				Expect(
+					fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.MissingProcesses,
+						false,
+					),
+				).To(HaveLen(0))
 
 				status, err := adminClient.GetStatus()
 				Expect(err).NotTo(HaveOccurred())
@@ -295,9 +355,13 @@ var _ = Describe("cluster_controller", func() {
 
 				for _, pod := range pods.Items {
 					Expect(pod.Spec.Containers[0].Name).To(Equal(fdbv1beta2.MainContainerName))
-					Expect(pod.Spec.Containers[0].Image).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(fdbv1beta2.Versions.Default.String())))
+					Expect(
+						pod.Spec.Containers[0].Image,
+					).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(fdbv1beta2.Versions.Default.String())))
 					Expect(pod.Spec.Containers[1].Name).To(Equal(fdbv1beta2.SidecarContainerName))
-					Expect(pod.Spec.Containers[1].Image).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(fdbv1beta2.Versions.Default.String())))
+					Expect(
+						pod.Spec.Containers[1].Image,
+					).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(fdbv1beta2.Versions.Default.String())))
 				}
 
 				Expect(cluster.Status.ImageTypes).To(Equal([]fdbv1beta2.ImageType{"unified"}))
@@ -312,7 +376,9 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should disable DNS names for the pods", func() {
 				pods := &corev1.PodList{}
-				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+				).NotTo(HaveOccurred())
 				for _, pod := range pods.Items {
 					env := make(map[string]string)
 					for _, envVar := range pod.Spec.InitContainers[0].Env {
@@ -339,7 +405,9 @@ var _ = Describe("cluster_controller", func() {
 				sortPodsByName(pods)
 
 				pod := pods.Items[firstStorageIndex]
-				Expect(pod.ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal(string(processGroupID)))
+				Expect(
+					pod.ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+				).To(Equal(string(processGroupID)))
 
 				mainContainer := pod.Spec.Containers[0]
 				Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
@@ -394,7 +462,9 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should remove the pods", func() {
 				pods := &corev1.PodList{}
-				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).To(Succeed())
+				Expect(
+					k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+				).To(Succeed())
 				Expect(pods.Items).To(HaveLen(len(originalPods.Items) - 1))
 				sortPodsByName(pods)
 
@@ -402,7 +472,9 @@ var _ = Describe("cluster_controller", func() {
 				Expect(pods.Items[1].Name).To(Equal(originalPods.Items[1].Name))
 				Expect(pods.Items[2].Name).To(Equal(originalPods.Items[2].Name))
 
-				Expect(getProcessClassMap(cluster, pods.Items)).To(Equal(map[fdbv1beta2.ProcessClass]int{
+				Expect(
+					getProcessClassMap(cluster, pods.Items),
+				).To(Equal(map[fdbv1beta2.ProcessClass]int{
 					fdbv1beta2.ProcessClassStorage:           3,
 					fdbv1beta2.ProcessClassLog:               4,
 					fdbv1beta2.ProcessClassStateless:         8,
@@ -417,7 +489,11 @@ var _ = Describe("cluster_controller", func() {
 				Expect(adminClient.ExcludedAddresses).To(BeEmpty())
 
 				removedItem := originalPods.Items[16]
-				exclusionString := fmt.Sprintf("%s:%s", fdbv1beta2.FDBLocalityExclusionPrefix, removedItem.ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel])
+				exclusionString := fmt.Sprintf(
+					"%s:%s",
+					fdbv1beta2.FDBLocalityExclusionPrefix,
+					removedItem.ObjectMeta.Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+				)
 				Expect(adminClient.ReincludedAddresses).To(Equal(map[string]bool{
 					exclusionString: true,
 				}))
@@ -436,7 +512,9 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(pods.Items)).To(Equal(len(originalPods.Items) + 1))
 
-				Expect(getProcessClassMap(cluster, pods.Items)).To(Equal(map[fdbv1beta2.ProcessClass]int{
+				Expect(
+					getProcessClassMap(cluster, pods.Items),
+				).To(Equal(map[fdbv1beta2.ProcessClass]int{
 					fdbv1beta2.ProcessClassStorage:           5,
 					fdbv1beta2.ProcessClassLog:               4,
 					fdbv1beta2.ProcessClassStateless:         8,
@@ -446,7 +524,10 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should update the config map", func() {
 				configMap := &corev1.ConfigMap{}
-				configMapName := types.NamespacedName{Namespace: "my-ns", Name: fmt.Sprintf("%s-config", cluster.Name)}
+				configMapName := types.NamespacedName{
+					Namespace: "my-ns",
+					Name:      fmt.Sprintf("%s-config", cluster.Name),
+				}
 				err = k8sClient.Get(context.TODO(), configMapName, configMap)
 				Expect(err).NotTo(HaveOccurred())
 				expectedConfigMap, _ := internal.GetConfigMap(cluster)
@@ -467,7 +548,9 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(pods.Items)).To(Equal(18))
 
-				Expect(getProcessClassMap(cluster, pods.Items)).To(Equal(map[fdbv1beta2.ProcessClass]int{
+				Expect(
+					getProcessClassMap(cluster, pods.Items),
+				).To(Equal(map[fdbv1beta2.ProcessClass]int{
 					fdbv1beta2.ProcessClassStorage:           4,
 					fdbv1beta2.ProcessClassLog:               4,
 					fdbv1beta2.ProcessClassStateless:         9,
@@ -477,7 +560,10 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should update the config map", func() {
 				configMap := &corev1.ConfigMap{}
-				configMapName := types.NamespacedName{Namespace: "my-ns", Name: fmt.Sprintf("%s-config", cluster.Name)}
+				configMapName := types.NamespacedName{
+					Namespace: "my-ns",
+					Name:      fmt.Sprintf("%s-config", cluster.Name),
+				}
 				err = k8sClient.Get(context.TODO(), configMapName, configMap)
 				Expect(err).NotTo(HaveOccurred())
 				expectedConfigMap, _ := internal.GetConfigMap(cluster)
@@ -499,7 +585,9 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(pods.Items)).To(Equal(18))
 
-				Expect(getProcessClassMap(cluster, pods.Items)).To(Equal(map[fdbv1beta2.ProcessClass]int{
+				Expect(
+					getProcessClassMap(cluster, pods.Items),
+				).To(Equal(map[fdbv1beta2.ProcessClass]int{
 					fdbv1beta2.ProcessClassStorage:           4,
 					fdbv1beta2.ProcessClassLog:               4,
 					fdbv1beta2.ProcessClassStateless:         9,
@@ -521,7 +609,9 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(pods.Items)).To(Equal(9))
 
-				Expect(getProcessClassMap(cluster, pods.Items)).To(Equal(map[fdbv1beta2.ProcessClass]int{
+				Expect(
+					getProcessClassMap(cluster, pods.Items),
+				).To(Equal(map[fdbv1beta2.ProcessClass]int{
 					fdbv1beta2.ProcessClassStorage:           4,
 					fdbv1beta2.ProcessClassLog:               4,
 					fdbv1beta2.ProcessClassClusterController: 1,
@@ -563,17 +653,23 @@ var _ = Describe("cluster_controller", func() {
 				}
 
 				Expect(replacedProcessGroup).NotTo(BeNil())
-				cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{replacedProcessGroup.ProcessGroupID}
+				cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{
+					replacedProcessGroup.ProcessGroupID,
+				}
 				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 			})
 
 			When("the pod is in a healthy state", func() {
 				It("should replace the targeted Pod and update the cluster status", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 					Expect(pods.Items).To(HaveLen(17))
 
-					Expect(getProcessClassMap(cluster, pods.Items)).To(Equal(map[fdbv1beta2.ProcessClass]int{
+					Expect(
+						getProcessClassMap(cluster, pods.Items),
+					).To(Equal(map[fdbv1beta2.ProcessClass]int{
 						fdbv1beta2.ProcessClassStorage:           4,
 						fdbv1beta2.ProcessClassLog:               4,
 						fdbv1beta2.ProcessClassStateless:         8,
@@ -584,20 +680,29 @@ var _ = Describe("cluster_controller", func() {
 					for idx, pod := range pods.Items {
 						processGroupIDs[idx] = pod.Labels[fdbv1beta2.FDBProcessGroupIDLabel]
 					}
-					Expect(processGroupIDs).NotTo(ContainElements(string(replacedProcessGroup.ProcessGroupID)))
+					Expect(
+						processGroupIDs,
+					).NotTo(ContainElements(string(replacedProcessGroup.ProcessGroupID)))
 
 					// Should change the connection string
 					Expect(cluster.Status.ConnectionString).NotTo(Equal(originalConnectionString))
 
 					// Should remove the process group
-					Expect(fdbv1beta2.ContainsProcessGroupID(cluster.Status.ProcessGroups, replacedProcessGroup.ProcessGroupID)).To(BeFalse())
+					Expect(
+						fdbv1beta2.ContainsProcessGroupID(
+							cluster.Status.ProcessGroups,
+							replacedProcessGroup.ProcessGroupID,
+						),
+					).To(BeFalse())
 
 					// Should exclude and re-include the process
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(adminClient).NotTo(BeNil())
 					Expect(adminClient.ExcludedAddresses).To(BeEmpty())
-					Expect(adminClient.ReincludedAddresses).To(HaveKeyWithValue(replacedProcessGroup.Addresses[0], true))
+					Expect(
+						adminClient.ReincludedAddresses,
+					).To(HaveKeyWithValue(replacedProcessGroup.Addresses[0], true))
 				})
 			})
 
@@ -607,30 +712,44 @@ var _ = Describe("cluster_controller", func() {
 					Expect(k8sClient.Status().Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 
 					pod := &corev1.Pod{}
-					Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: replacedProcessGroup.GetPodName(cluster), Namespace: cluster.Namespace}, pod)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.Get(
+							context.Background(),
+							client.ObjectKey{
+								Name:      replacedProcessGroup.GetPodName(cluster),
+								Namespace: cluster.Namespace,
+							},
+							pod,
+						),
+					).NotTo(HaveOccurred())
 					Expect(k8sClient.MockStuckTermination(pod, true)).NotTo(HaveOccurred())
 					// The returned generation in the test case will be 0 since we have 2 pending removals
 					// which is expected.
 					generationGap = -1
 				})
 
-				It("should set the generation to both reconciled and pending removal and exclude the process", func() {
-					_, err = reloadCluster(cluster)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(cluster.Status.Generations).To(Equal(fdbv1beta2.ClusterGenerationStatus{
-						Reconciled:        2,
-						HasPendingRemoval: 2,
-					}))
+				It(
+					"should set the generation to both reconciled and pending removal and exclude the process",
+					func() {
+						_, err = reloadCluster(cluster)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(
+							cluster.Status.Generations,
+						).To(Equal(fdbv1beta2.ClusterGenerationStatus{
+							Reconciled:        2,
+							HasPendingRemoval: 2,
+						}))
 
-					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(adminClient).NotTo(BeNil())
-					Expect(adminClient.ReincludedAddresses).To(HaveLen(0))
-					Expect(adminClient.ExcludedAddresses).To(HaveLen(2))
-					Expect(adminClient.ExcludedAddresses).To(HaveKey(
-						replacedProcessGroup.Addresses[0],
-					))
-				})
+						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(adminClient).NotTo(BeNil())
+						Expect(adminClient.ReincludedAddresses).To(HaveLen(0))
+						Expect(adminClient.ExcludedAddresses).To(HaveLen(2))
+						Expect(adminClient.ExcludedAddresses).To(HaveKey(
+							replacedProcessGroup.Addresses[0],
+						))
+					},
+				)
 			})
 
 			When("a PVC is stuck in terminating", func() {
@@ -651,23 +770,28 @@ var _ = Describe("cluster_controller", func() {
 					generationGap = -1
 				})
 
-				It("should set the generation to both reconciled and pending removal and exclude the process", func() {
-					_, err = reloadCluster(cluster)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(cluster.Status.Generations).To(Equal(fdbv1beta2.ClusterGenerationStatus{
-						Reconciled:        2,
-						HasPendingRemoval: 2,
-					}))
+				It(
+					"should set the generation to both reconciled and pending removal and exclude the process",
+					func() {
+						_, err = reloadCluster(cluster)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(
+							cluster.Status.Generations,
+						).To(Equal(fdbv1beta2.ClusterGenerationStatus{
+							Reconciled:        2,
+							HasPendingRemoval: 2,
+						}))
 
-					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(adminClient).NotTo(BeNil())
-					Expect(adminClient.ReincludedAddresses).To(HaveLen(0))
-					Expect(adminClient.ExcludedAddresses).To(HaveLen(2))
-					Expect(adminClient.ExcludedAddresses).To(HaveKey(
-						replacedProcessGroup.Addresses[0],
-					))
-				})
+						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(adminClient).NotTo(BeNil())
+						Expect(adminClient.ReincludedAddresses).To(HaveLen(0))
+						Expect(adminClient.ExcludedAddresses).To(HaveLen(2))
+						Expect(adminClient.ExcludedAddresses).To(HaveKey(
+							replacedProcessGroup.Addresses[0],
+						))
+					},
+				)
 			})
 
 			When("the cluster skip setting is enabled", func() {
@@ -679,7 +803,9 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should not replace the pod", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 					Expect(pods.Items).To(HaveLen(17))
 
 					sortPodsByName(pods)
@@ -695,21 +821,34 @@ var _ = Describe("cluster_controller", func() {
 
 				BeforeEach(func() {
 					pod := &corev1.Pod{}
-					Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: replacedProcessGroup.GetPodName(cluster), Namespace: cluster.Namespace}, pod))
+					Expect(
+						k8sClient.Get(
+							context.Background(),
+							client.ObjectKey{
+								Name:      replacedProcessGroup.GetPodName(cluster),
+								Namespace: cluster.Namespace,
+							},
+							pod,
+						),
+					)
 					podIP = pod.Status.PodIP
 					Expect(k8sClient.RemovePodIP(pod)).NotTo(HaveOccurred())
 				})
 
 				It("should replace the pod and exclude and include it", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 					Expect(pods.Items).To(HaveLen(17))
 
 					processGroupIDs := make([]string, 17)
 					for idx, pod := range pods.Items {
 						processGroupIDs[idx] = pod.Labels[fdbv1beta2.FDBProcessGroupIDLabel]
 					}
-					Expect(processGroupIDs).NotTo(ContainElements(string(replacedProcessGroup.ProcessGroupID)))
+					Expect(
+						processGroupIDs,
+					).NotTo(ContainElements(string(replacedProcessGroup.ProcessGroupID)))
 
 					// Check for the exclusion and inclusion
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
@@ -723,23 +862,38 @@ var _ = Describe("cluster_controller", func() {
 			When("the pod should be removed without an exclusion", func() {
 				BeforeEach(func() {
 					pod := &corev1.Pod{}
-					Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: replacedProcessGroup.GetPodName(cluster), Namespace: cluster.Namespace}, pod))
+					Expect(
+						k8sClient.Get(
+							context.Background(),
+							client.ObjectKey{
+								Name:      replacedProcessGroup.GetPodName(cluster),
+								Namespace: cluster.Namespace,
+							},
+							pod,
+						),
+					)
 					Expect(k8sClient.RemovePodIP(pod)).NotTo(HaveOccurred())
-					cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = []fdbv1beta2.ProcessGroupID{replacedProcessGroup.ProcessGroupID}
+					cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = []fdbv1beta2.ProcessGroupID{
+						replacedProcessGroup.ProcessGroupID,
+					}
 					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 					generationGap++
 				})
 
 				It("should replace the pod", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 					Expect(pods.Items).To(HaveLen(17))
 
 					processGroupIDs := make([]string, 17)
 					for idx, pod := range pods.Items {
 						processGroupIDs[idx] = pod.Labels[fdbv1beta2.FDBProcessGroupIDLabel]
 					}
-					Expect(processGroupIDs).NotTo(ContainElements(string(replacedProcessGroup.ProcessGroupID)))
+					Expect(
+						processGroupIDs,
+					).NotTo(ContainElements(string(replacedProcessGroup.ProcessGroupID)))
 
 					// Check for the exclusion and inclusion
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
@@ -773,10 +927,15 @@ var _ = Describe("cluster_controller", func() {
 				// Tweak the time on the missing process to make it eligible for replacement.
 				_, err = reloadCluster(cluster)
 				Expect(err).NotTo(HaveOccurred())
-				processGroup := fdbv1beta2.FindProcessGroupByID(cluster.Status.ProcessGroups, processGroupID)
+				processGroup := fdbv1beta2.FindProcessGroupByID(
+					cluster.Status.ProcessGroups,
+					processGroupID,
+				)
 				Expect(processGroup).NotTo(BeNil())
 				Expect(len(processGroup.ProcessGroupConditions)).To(Equal(1))
-				Expect(processGroup.ProcessGroupConditions[0].ProcessGroupConditionType).To(Equal(fdbv1beta2.MissingProcesses))
+				Expect(
+					processGroup.ProcessGroupConditions[0].ProcessGroupConditionType,
+				).To(Equal(fdbv1beta2.MissingProcesses))
 				Expect(processGroup.ProcessGroupConditions[0].Timestamp).NotTo(Equal(0))
 				processGroup.ProcessGroupConditions[0].Timestamp -= 3600
 				Expect(k8sClient.Status().Update(context.TODO(), cluster)).NotTo(HaveOccurred())
@@ -786,12 +945,18 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should replace the pod", func() {
 				pod := &corev1.Pod{}
-				err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: podName, Namespace: cluster.Namespace}, pod)
+				err := k8sClient.Get(
+					context.TODO(),
+					client.ObjectKey{Name: podName, Namespace: cluster.Namespace},
+					pod,
+				)
 				Expect(err).To(HaveOccurred())
 				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 
 				pods := &corev1.PodList{}
-				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+				).NotTo(HaveOccurred())
 				Expect(pods.Items).To(HaveLen(17))
 			})
 		})
@@ -807,17 +972,26 @@ var _ = Describe("cluster_controller", func() {
 				}
 				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 
-				replacedPods = []string{picked[0].GetPodName(cluster), picked[1].GetPodName(cluster)}
+				replacedPods = []string{
+					picked[0].GetPodName(cluster),
+					picked[1].GetPodName(cluster),
+				}
 			})
 
 			It("should replace the pods", func() {
 				pods := &corev1.PodList{}
-				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+				).NotTo(HaveOccurred())
 				Expect(pods.Items).To(HaveLen(17))
 
 				for _, podName := range replacedPods {
 					pod := &corev1.Pod{}
-					err := k8sClient.Get(context.TODO(), client.ObjectKey{Name: podName, Namespace: cluster.Namespace}, pod)
+					err := k8sClient.Get(
+						context.TODO(),
+						client.ObjectKey{Name: podName, Namespace: cluster.Namespace},
+						pod,
+					)
 					Expect(err).To(HaveOccurred())
 					Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 				}
@@ -832,13 +1006,28 @@ var _ = Describe("cluster_controller", func() {
 
 				picked := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
 				pod = &corev1.Pod{}
-				Expect(k8sClient.Get(context.TODO(), client.ObjectKey{Name: picked.GetPodName(cluster), Namespace: cluster.Namespace}, pod)).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.Get(
+						context.TODO(),
+						client.ObjectKey{
+							Name:      picked.GetPodName(cluster),
+							Namespace: cluster.Namespace,
+						},
+						pod,
+					),
+				).NotTo(HaveOccurred())
 				Expect(k8sClient.Delete(context.TODO(), pod)).NotTo(HaveOccurred())
 			})
 
 			It("should replace the pod", func() {
 				newPod := &corev1.Pod{}
-				Expect(k8sClient.Get(context.TODO(), client.ObjectKey{Name: pod.Name, Namespace: cluster.Namespace}, newPod)).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.Get(
+						context.TODO(),
+						client.ObjectKey{Name: pod.Name, Namespace: cluster.Namespace},
+						newPod,
+					),
+				).NotTo(HaveOccurred())
 				Expect(pod.UID).NotTo(Equal(newPod.UID))
 				Expect(pod.Name).To(Equal(newPod.Name))
 			})
@@ -852,7 +1041,13 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 				err = adminClient.FreezeStatus()
 				Expect(err).NotTo(HaveOccurred())
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{"knob_disable_posix_kernel_aio=1"}}}
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {
+						CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+							"knob_disable_posix_kernel_aio=1",
+						},
+					},
+				}
 			})
 
 			Context("with bounces enabled", func() {
@@ -871,7 +1066,10 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should update the config map", func() {
 					configMap := &corev1.ConfigMap{}
-					configMapName := types.NamespacedName{Namespace: "my-ns", Name: fmt.Sprintf("%s-config", cluster.Name)}
+					configMapName := types.NamespacedName{
+						Namespace: "my-ns",
+						Name:      fmt.Sprintf("%s-config", cluster.Name),
+					}
 					err = k8sClient.Get(context.TODO(), configMapName, configMap)
 					Expect(err).NotTo(HaveOccurred())
 					expectedConfigMap, _ := internal.GetConfigMap(cluster)
@@ -882,7 +1080,9 @@ var _ = Describe("cluster_controller", func() {
 			Context("with a substitution variable", func() {
 				BeforeEach(func() {
 					settings := cluster.Spec.Processes["general"]
-					settings.CustomParameters = []fdbv1beta2.FoundationDBCustomParameter{"locality_disk_id=$FDB_INSTANCE_ID"}
+					settings.CustomParameters = []fdbv1beta2.FoundationDBCustomParameter{
+						"locality_disk_id=$FDB_INSTANCE_ID",
+					}
 					cluster.Spec.Processes["general"] = settings
 
 					err = k8sClient.Update(context.TODO(), cluster)
@@ -924,7 +1124,10 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should update the config map", func() {
 					configMap := &corev1.ConfigMap{}
-					configMapName := types.NamespacedName{Namespace: "my-ns", Name: fmt.Sprintf("%s-config", cluster.Name)}
+					configMapName := types.NamespacedName{
+						Namespace: "my-ns",
+						Name:      fmt.Sprintf("%s-config", cluster.Name),
+					}
 					err = k8sClient.Get(context.TODO(), configMapName, configMap)
 					Expect(err).NotTo(HaveOccurred())
 					expectedConfigMap, _ := internal.GetConfigMap(cluster)
@@ -934,7 +1137,11 @@ var _ = Describe("cluster_controller", func() {
 
 			Context("with multiple storage servers per pod", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{}}}
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{},
+						},
+					}
 					cluster.Spec.StorageServersPerPod = 2
 					adminClient.UnfreezeStatus()
 					Expect(err).NotTo(HaveOccurred())
@@ -959,7 +1166,13 @@ var _ = Describe("cluster_controller", func() {
 					err = adminClient.FreezeStatus()
 					Expect(err).NotTo(HaveOccurred())
 
-					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{"knob_disable_posix_kernel_aio=1"}}}
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_disable_posix_kernel_aio=1",
+							},
+						},
+					}
 					err = k8sClient.Update(context.TODO(), cluster)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -968,7 +1181,10 @@ var _ = Describe("cluster_controller", func() {
 					addresses := make(map[string]fdbv1beta2.None, len(originalPods.Items))
 					for _, pod := range originalPods.Items {
 						addresses[cluster.GetFullAddress(pod.Status.PodIP, 1).String()] = fdbv1beta2.None{}
-						if internal.ProcessClassFromLabels(cluster, pod.ObjectMeta.Labels) == fdbv1beta2.ProcessClassStorage {
+						if internal.ProcessClassFromLabels(
+							cluster,
+							pod.ObjectMeta.Labels,
+						) == fdbv1beta2.ProcessClassStorage {
 							addresses[cluster.GetFullAddress(pod.Status.PodIP, 2).String()] = fdbv1beta2.None{}
 						}
 					}
@@ -979,7 +1195,11 @@ var _ = Describe("cluster_controller", func() {
 
 			Context("with multiple log servers per pod", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{}}}
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{},
+						},
+					}
 					cluster.Spec.LogServersPerPod = 2
 					adminClient.UnfreezeStatus()
 					Expect(err).NotTo(HaveOccurred())
@@ -1004,7 +1224,13 @@ var _ = Describe("cluster_controller", func() {
 					err = adminClient.FreezeStatus()
 					Expect(err).NotTo(HaveOccurred())
 
-					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{"knob_disable_posix_kernel_aio=1"}}}
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_disable_posix_kernel_aio=1",
+							},
+						},
+					}
 					err = k8sClient.Update(context.TODO(), cluster)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1013,7 +1239,10 @@ var _ = Describe("cluster_controller", func() {
 					addresses := make(map[string]fdbv1beta2.None, len(originalPods.Items))
 					for _, pod := range originalPods.Items {
 						addresses[cluster.GetFullAddress(pod.Status.PodIP, 1).String()] = fdbv1beta2.None{}
-						if internal.ProcessClassFromLabels(cluster, pod.ObjectMeta.Labels) == fdbv1beta2.ProcessClassLog {
+						if internal.ProcessClassFromLabels(
+							cluster,
+							pod.ObjectMeta.Labels,
+						) == fdbv1beta2.ProcessClassLog {
 							addresses[cluster.GetFullAddress(pod.Status.PodIP, 2).String()] = fdbv1beta2.None{}
 						}
 					}
@@ -1025,16 +1254,18 @@ var _ = Describe("cluster_controller", func() {
 
 		Context("with a change to pod labels", func() {
 			BeforeEach(func() {
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							"fdb-label": "value3",
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"fdb-label": "value3",
+							},
 						},
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{},
-					},
-				}}}
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{},
+						},
+					}},
+				}
 				err := k8sClient.Update(context.TODO(), cluster)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1072,36 +1303,52 @@ var _ = Describe("cluster_controller", func() {
 				picked := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
 				pickedPod = picked.GetPodName(cluster)
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: pickedPod}, pod)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{Namespace: cluster.Namespace, Name: pickedPod},
+					pod,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				pod.Annotations["foundationdb.org/existing-annotation"] = "test-value"
 				Expect(k8sClient.Update(context.TODO(), pod)).NotTo(HaveOccurred())
 
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							"fdb-annotation": "value1",
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"fdb-annotation": "value1",
+							},
 						},
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{},
-					},
-				}}}
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{},
+						},
+					}},
+				}
 				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 			})
 
 			It("should set the annotations on the pod", func() {
-				Expect(internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})).To(Succeed())
+				Expect(
+					internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{}),
+				).To(Succeed())
 				pods := &corev1.PodList{}
-				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+				).NotTo(HaveOccurred())
 				for _, pod := range pods.Items {
 					hash, err := internal.GetPodSpecHash(cluster, &fdbv1beta2.ProcessGroupStatus{
-						ProcessGroupID: fdbv1beta2.ProcessGroupID(pod.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-						ProcessClass:   internal.ProcessClassFromLabels(cluster, pod.Labels),
+						ProcessGroupID: fdbv1beta2.ProcessGroupID(
+							pod.Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+						),
+						ProcessClass: internal.ProcessClassFromLabels(cluster, pod.Labels),
 					}, nil)
 					Expect(err).NotTo(HaveOccurred())
 
-					configMapHash, err := getConfigMapHash(cluster, internal.GetProcessClassFromMeta(cluster, pod.ObjectMeta), &pod)
+					configMapHash, err := getConfigMapHash(
+						cluster,
+						internal.GetProcessClassFromMeta(cluster, pod.ObjectMeta),
+						&pod,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					if pod.Name == pickedPod {
 						Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
@@ -1111,8 +1358,12 @@ var _ = Describe("cluster_controller", func() {
 							"foundationdb.org/existing-annotation": "test-value",
 							"fdb-annotation":                       "value1",
 							fdbv1beta2.NodeAnnotation:              pod.Spec.NodeName,
-							fdbv1beta2.ImageTypeAnnotation:         string(fdbv1beta2.ImageTypeSplit),
-							fdbv1beta2.IPFamilyAnnotation:          strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+							fdbv1beta2.ImageTypeAnnotation: string(
+								fdbv1beta2.ImageTypeSplit,
+							),
+							fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+								fdbv1beta2.PodIPFamilyUnset,
+							),
 						}))
 						continue
 					}
@@ -1124,7 +1375,9 @@ var _ = Describe("cluster_controller", func() {
 						"fdb-annotation":                    "value1",
 						fdbv1beta2.NodeAnnotation:           pod.Spec.NodeName,
 						fdbv1beta2.ImageTypeAnnotation:      string(fdbv1beta2.ImageTypeSplit),
-						fdbv1beta2.IPFamilyAnnotation:       strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+						fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+							fdbv1beta2.PodIPFamilyUnset,
+						),
 					}))
 				}
 			})
@@ -1151,13 +1404,17 @@ var _ = Describe("cluster_controller", func() {
 		Context("with a change to the PVC labels", func() {
 			Context("with the fields from the processes", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								"fdb-label": "value3",
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {
+							VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{
+										"fdb-label": "value3",
+									},
+								},
 							},
 						},
-					}}}
+					}
 					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
@@ -1197,18 +1454,28 @@ var _ = Describe("cluster_controller", func() {
 					picked := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
 					pickedPvc = picked.GetPodName(cluster) + "-data"
 					pvc := &corev1.PersistentVolumeClaim{}
-					Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: pickedPvc}, pvc)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.Get(
+							context.TODO(),
+							types.NamespacedName{Namespace: cluster.Namespace, Name: pickedPvc},
+							pvc,
+						),
+					).NotTo(HaveOccurred())
 					pvc.Annotations["foundationdb.org/existing-annotation"] = "test-value"
 					err = k8sClient.Update(context.TODO(), pvc)
 					Expect(err).NotTo(HaveOccurred())
 
-					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{
-								"fdb-annotation": "value1",
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {
+							VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"fdb-annotation": "value1",
+									},
+								},
 							},
 						},
-					}}}
+					}
 					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
@@ -1234,17 +1501,31 @@ var _ = Describe("cluster_controller", func() {
 				})
 
 				It("should not update the annotations on other resources", func() {
-					Expect(internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})).To(Succeed())
+					Expect(
+						internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{}),
+					).To(Succeed())
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).To(Succeed())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).To(Succeed())
 					for _, item := range pods.Items {
-						hash, err := internal.GetPodSpecHash(cluster, &fdbv1beta2.ProcessGroupStatus{
-							ProcessGroupID: fdbv1beta2.ProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-							ProcessClass:   internal.ProcessClassFromLabels(cluster, item.Labels),
-						}, nil)
+						hash, err := internal.GetPodSpecHash(
+							cluster,
+							&fdbv1beta2.ProcessGroupStatus{
+								ProcessGroupID: fdbv1beta2.ProcessGroupID(
+									item.Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+								),
+								ProcessClass: internal.ProcessClassFromLabels(cluster, item.Labels),
+							},
+							nil,
+						)
 						Expect(err).NotTo(HaveOccurred())
 
-						configMapHash, err := getConfigMapHash(cluster, internal.GetProcessClassFromMeta(cluster, item.ObjectMeta), &item)
+						configMapHash, err := getConfigMapHash(
+							cluster,
+							internal.GetProcessClassFromMeta(cluster, item.ObjectMeta),
+							&item,
+						)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
 							fdbv1beta2.LastConfigMapKey:         configMapHash,
@@ -1252,7 +1533,9 @@ var _ = Describe("cluster_controller", func() {
 							fdbv1beta2.PublicIPSourceAnnotation: "pod",
 							fdbv1beta2.NodeAnnotation:           item.Spec.NodeName,
 							fdbv1beta2.ImageTypeAnnotation:      string(fdbv1beta2.ImageTypeSplit),
-							fdbv1beta2.IPFamilyAnnotation:       strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+							fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+								fdbv1beta2.PodIPFamilyUnset,
+							),
 						}))
 					}
 
@@ -1308,7 +1591,14 @@ var _ = Describe("cluster_controller", func() {
 		Context("with a change to config map annotations", func() {
 			BeforeEach(func() {
 				configMap := &corev1.ConfigMap{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: "operator-test-1-config"}, configMap)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      "operator-test-1-config",
+					},
+					configMap,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				configMap.Annotations = make(map[string]string)
 				configMap.Annotations["foundationdb.org/existing-annotation"] = "test-value"
@@ -1348,12 +1638,18 @@ var _ = Describe("cluster_controller", func() {
 
 				for _, item := range pods.Items {
 					hash, err := internal.GetPodSpecHash(cluster, &fdbv1beta2.ProcessGroupStatus{
-						ProcessGroupID: fdbv1beta2.ProcessGroupID(item.Labels[fdbv1beta2.FDBProcessGroupIDLabel]),
-						ProcessClass:   internal.ProcessClassFromLabels(cluster, item.Labels),
+						ProcessGroupID: fdbv1beta2.ProcessGroupID(
+							item.Labels[fdbv1beta2.FDBProcessGroupIDLabel],
+						),
+						ProcessClass: internal.ProcessClassFromLabels(cluster, item.Labels),
 					}, nil)
 					Expect(err).NotTo(HaveOccurred())
 
-					configMapHash, err := getConfigMapHash(cluster, internal.GetProcessClassFromMeta(cluster, item.ObjectMeta), &item)
+					configMapHash, err := getConfigMapHash(
+						cluster,
+						internal.GetProcessClassFromMeta(cluster, item.ObjectMeta),
+						&item,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(item.ObjectMeta.Annotations).To(Equal(map[string]string{
 						fdbv1beta2.LastConfigMapKey:         configMapHash,
@@ -1361,7 +1657,9 @@ var _ = Describe("cluster_controller", func() {
 						fdbv1beta2.PublicIPSourceAnnotation: "pod",
 						fdbv1beta2.NodeAnnotation:           item.Spec.NodeName,
 						fdbv1beta2.ImageTypeAnnotation:      string(fdbv1beta2.ImageTypeSplit),
-						fdbv1beta2.IPFamilyAnnotation:       strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+						fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+							fdbv1beta2.PodIPFamilyUnset,
+						),
 					}))
 				}
 
@@ -1378,21 +1676,23 @@ var _ = Describe("cluster_controller", func() {
 
 		Context("with a change to environment variables", func() {
 			BeforeEach(func() {
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name: fdbv1beta2.MainContainerName,
-								Env: []corev1.EnvVar{
-									{
-										Name:  "TEST_CHANGE",
-										Value: "1",
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: fdbv1beta2.MainContainerName,
+									Env: []corev1.EnvVar{
+										{
+											Name:  "TEST_CHANGE",
+											Value: "1",
+										},
 									},
 								},
 							},
 						},
-					},
-				}}}
+					}},
+				}
 			})
 
 			Context("with deletion enabled", func() {
@@ -1441,7 +1741,9 @@ var _ = Describe("cluster_controller", func() {
 
 					for _, pod := range pods.Items {
 						Expect(len(pod.Spec.Containers[0].Env)).To(Equal(1))
-						Expect(pod.Spec.Containers[0].Env[0].Name).To(Equal(fdbv1beta2.EnvNameClusterFile))
+						Expect(
+							pod.Spec.Containers[0].Env[0].Name,
+						).To(Equal(fdbv1beta2.EnvNameClusterFile))
 					}
 				})
 			})
@@ -1473,7 +1775,9 @@ var _ = Describe("cluster_controller", func() {
 
 					for _, pod := range pods.Items {
 						Expect(len(pod.Spec.Containers[0].Env)).To(Equal(1))
-						Expect(pod.Spec.Containers[0].Env[0].Name).To(Equal(fdbv1beta2.EnvNameClusterFile))
+						Expect(
+							pod.Spec.Containers[0].Env[0].Name,
+						).To(Equal(fdbv1beta2.EnvNameClusterFile))
 					}
 				})
 			})
@@ -1493,15 +1797,23 @@ var _ = Describe("cluster_controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, pod := range pods.Items {
-					Expect(pod.Annotations[fdbv1beta2.PublicIPSourceAnnotation]).To(Equal("service"))
+					Expect(
+						pod.Annotations[fdbv1beta2.PublicIPSourceAnnotation],
+					).To(Equal("service"))
 				}
 
 				pod := pods.Items[0]
 				service := &corev1.Service{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, service)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
+					service,
+				)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(pod.Annotations[fdbv1beta2.PublicIPAnnotation]).To(Equal(service.Spec.ClusterIP))
+				Expect(
+					pod.Annotations[fdbv1beta2.PublicIPAnnotation],
+				).To(Equal(service.Spec.ClusterIP))
 				Expect(pod.Annotations[fdbv1beta2.PublicIPAnnotation]).NotTo(Equal(""))
 				Expect(len(service.Spec.Ports)).To(Equal(cluster.GetStorageServersPerPod() * 2))
 			})
@@ -1518,7 +1830,13 @@ var _ = Describe("cluster_controller", func() {
 
 				service := &corev1.Service{}
 				pod := pods.Items[0]
-				Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, service)).To(Succeed())
+				Expect(
+					k8sClient.Get(
+						context.TODO(),
+						types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
+						service,
+					),
+				).To(Succeed())
 				Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 				Expect(len(service.Spec.Ports)).To(Equal(cluster.GetStorageServersPerPod() * 2))
 			})
@@ -1582,105 +1900,138 @@ var _ = Describe("cluster_controller", func() {
 			})
 		})
 
-		Context("with a change to the public IP source and multiple storage servers per Pod", func() {
-			BeforeEach(func() {
-				source := fdbv1beta2.PublicIPSourceService
-				cluster.Spec.Routing.PublicIPSource = &source
-				cluster.Spec.StorageServersPerPod = 2
-				err = k8sClient.Update(context.TODO(), cluster)
-			})
+		Context(
+			"with a change to the public IP source and multiple storage servers per Pod",
+			func() {
+				BeforeEach(func() {
+					source := fdbv1beta2.PublicIPSourceService
+					cluster.Spec.Routing.PublicIPSource = &source
+					cluster.Spec.StorageServersPerPod = 2
+					err = k8sClient.Update(context.TODO(), cluster)
+				})
 
-			It("should set the public IP annotations", func() {
-				pods := &corev1.PodList{}
-				ContainOriginalPod := func(idx int) gomegatypes.GomegaMatcher {
-					return ContainElement(WithTransform(func(pod corev1.Pod) string {
-						return pod.Name
-					}, Equal(originalPods.Items[idx].Name)))
-				}
-				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-				Expect(err).NotTo(HaveOccurred())
-				sortPodsByName(pods)
-				Expect(pods.Items).To(HaveLen(len(originalPods.Items)))
-
-				Expect(pods.Items).NotTo(ContainOriginalPod(13))
-				Expect(pods.Items).NotTo(ContainOriginalPod(14))
-				Expect(pods.Items).NotTo(ContainOriginalPod(15))
-				Expect(pods.Items).NotTo(ContainOriginalPod(16))
-
-				var storagePod corev1.Pod
-				for _, pod := range pods.Items {
-					Expect(pod.Annotations[fdbv1beta2.PublicIPSourceAnnotation]).To(Equal("service"))
-
-					if internal.ProcessClassFromLabels(cluster, pod.Labels) == fdbv1beta2.ProcessClassStorage && storagePod.Name == "" {
-						storagePod = pod
+				It("should set the public IP annotations", func() {
+					pods := &corev1.PodList{}
+					ContainOriginalPod := func(idx int) gomegatypes.GomegaMatcher {
+						return ContainElement(WithTransform(func(pod corev1.Pod) string {
+							return pod.Name
+						}, Equal(originalPods.Items[idx].Name)))
 					}
-				}
+					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
+					Expect(err).NotTo(HaveOccurred())
+					sortPodsByName(pods)
+					Expect(pods.Items).To(HaveLen(len(originalPods.Items)))
 
-				service := &corev1.Service{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: storagePod.Namespace, Name: storagePod.Name}, service)
-				Expect(err).NotTo(HaveOccurred())
+					Expect(pods.Items).NotTo(ContainOriginalPod(13))
+					Expect(pods.Items).NotTo(ContainOriginalPod(14))
+					Expect(pods.Items).NotTo(ContainOriginalPod(15))
+					Expect(pods.Items).NotTo(ContainOriginalPod(16))
 
-				Expect(storagePod.Annotations[fdbv1beta2.PublicIPAnnotation]).To(Equal(service.Spec.ClusterIP))
-				Expect(storagePod.Annotations[fdbv1beta2.PublicIPAnnotation]).NotTo(Equal(""))
-				Expect(len(service.Spec.Ports)).To(Equal(cluster.GetStorageServersPerPod() * 2))
-			})
+					var storagePod corev1.Pod
+					for _, pod := range pods.Items {
+						Expect(
+							pod.Annotations[fdbv1beta2.PublicIPSourceAnnotation],
+						).To(Equal("service"))
 
-			It("should create services for the pods", func() {
-				pods := &corev1.PodList{}
-				ContainOriginalPod := func(idx int) gomegatypes.GomegaMatcher {
-					return ContainElement(WithTransform(func(pod corev1.Pod) string {
-						return pod.Name
-					}, Equal(originalPods.Items[idx].Name)))
-				}
-				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).To(Succeed())
-				sortPodsByName(pods)
-
-				// Exactly as many pods as we started with
-				Expect(pods.Items).To(HaveLen(len(originalPods.Items)))
-				// But the original storage pods should all be replaced
-				// with newly named storage pods
-				Expect(pods.Items).NotTo(ContainOriginalPod(13))
-				Expect(pods.Items).NotTo(ContainOriginalPod(14))
-				Expect(pods.Items).NotTo(ContainOriginalPod(15))
-				Expect(pods.Items).NotTo(ContainOriginalPod(16))
-
-				services := &corev1.ServiceList{}
-				Expect(k8sClient.List(context.TODO(), services, getListOptions(cluster)...)).To(Succeed())
-				Expect(services.Items).To(HaveLen(len(pods.Items) + 1))
-
-				var storagePod corev1.Pod
-				for _, pod := range pods.Items {
-					if internal.ProcessClassFromLabels(cluster, pod.Labels) == fdbv1beta2.ProcessClassStorage && storagePod.Name == "" {
-						storagePod = pod
-						break
+						if internal.ProcessClassFromLabels(
+							cluster,
+							pod.Labels,
+						) == fdbv1beta2.ProcessClassStorage &&
+							storagePod.Name == "" {
+							storagePod = pod
+						}
 					}
-				}
 
-				service := &corev1.Service{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: storagePod.Namespace, Name: storagePod.Name}, service)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
-				Expect(len(service.Spec.Ports)).To(Equal(cluster.GetStorageServersPerPod() * 2))
-			})
+					service := &corev1.Service{}
+					err = k8sClient.Get(
+						context.TODO(),
+						types.NamespacedName{
+							Namespace: storagePod.Namespace,
+							Name:      storagePod.Name,
+						},
+						service,
+					)
+					Expect(err).NotTo(HaveOccurred())
 
-			It("should replace the old processes", func() {
-				pods := &corev1.PodList{}
-				err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-				Expect(err).NotTo(HaveOccurred())
+					Expect(
+						storagePod.Annotations[fdbv1beta2.PublicIPAnnotation],
+					).To(Equal(service.Spec.ClusterIP))
+					Expect(storagePod.Annotations[fdbv1beta2.PublicIPAnnotation]).NotTo(Equal(""))
+					Expect(len(service.Spec.Ports)).To(Equal(cluster.GetStorageServersPerPod() * 2))
+				})
 
-				originalNames := make([]string, 0, len(originalPods.Items))
-				for _, pod := range originalPods.Items {
-					originalNames = append(originalNames, pod.Name)
-				}
+				It("should create services for the pods", func() {
+					pods := &corev1.PodList{}
+					ContainOriginalPod := func(idx int) gomegatypes.GomegaMatcher {
+						return ContainElement(WithTransform(func(pod corev1.Pod) string {
+							return pod.Name
+						}, Equal(originalPods.Items[idx].Name)))
+					}
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).To(Succeed())
+					sortPodsByName(pods)
 
-				currentNames := make([]string, 0, len(originalPods.Items))
-				for _, pod := range pods.Items {
-					currentNames = append(currentNames, pod.Name)
-				}
+					// Exactly as many pods as we started with
+					Expect(pods.Items).To(HaveLen(len(originalPods.Items)))
+					// But the original storage pods should all be replaced
+					// with newly named storage pods
+					Expect(pods.Items).NotTo(ContainOriginalPod(13))
+					Expect(pods.Items).NotTo(ContainOriginalPod(14))
+					Expect(pods.Items).NotTo(ContainOriginalPod(15))
+					Expect(pods.Items).NotTo(ContainOriginalPod(16))
 
-				Expect(currentNames).NotTo(ContainElements(originalNames))
-			})
-		})
+					services := &corev1.ServiceList{}
+					Expect(
+						k8sClient.List(context.TODO(), services, getListOptions(cluster)...),
+					).To(Succeed())
+					Expect(services.Items).To(HaveLen(len(pods.Items) + 1))
+
+					var storagePod corev1.Pod
+					for _, pod := range pods.Items {
+						if internal.ProcessClassFromLabels(
+							cluster,
+							pod.Labels,
+						) == fdbv1beta2.ProcessClassStorage &&
+							storagePod.Name == "" {
+							storagePod = pod
+							break
+						}
+					}
+
+					service := &corev1.Service{}
+					err = k8sClient.Get(
+						context.TODO(),
+						types.NamespacedName{
+							Namespace: storagePod.Namespace,
+							Name:      storagePod.Name,
+						},
+						service,
+					)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+					Expect(len(service.Spec.Ports)).To(Equal(cluster.GetStorageServersPerPod() * 2))
+				})
+
+				It("should replace the old processes", func() {
+					pods := &corev1.PodList{}
+					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
+					Expect(err).NotTo(HaveOccurred())
+
+					originalNames := make([]string, 0, len(originalPods.Items))
+					for _, pod := range originalPods.Items {
+						originalNames = append(originalNames, pod.Name)
+					}
+
+					currentNames := make([]string, 0, len(originalPods.Items))
+					for _, pod := range pods.Items {
+						currentNames = append(currentNames, pod.Name)
+					}
+
+					Expect(currentNames).NotTo(ContainElements(originalNames))
+				})
+			},
+		)
 
 		Context("with a change to TLS settings", func() {
 			BeforeEach(func() {
@@ -1701,7 +2052,9 @@ var _ = Describe("cluster_controller", func() {
 			})
 
 			It("should change the coordinators to use TLS", func() {
-				connectionString, err := fdbv1beta2.ParseConnectionString(cluster.Status.ConnectionString)
+				connectionString, err := fdbv1beta2.ParseConnectionString(
+					cluster.Status.ConnectionString,
+				)
 
 				Expect(err).NotTo(HaveOccurred())
 				for _, coordinator := range connectionString.Coordinators {
@@ -1751,7 +2104,9 @@ var _ = Describe("cluster_controller", func() {
 				originalVersion = cluster.ObjectMeta.Generation
 
 				originalPods = &corev1.PodList{}
-				Expect(k8sClient.List(context.TODO(), originalPods, getListOptions(cluster)...)).To(Succeed())
+				Expect(
+					k8sClient.List(context.TODO(), originalPods, getListOptions(cluster)...),
+				).To(Succeed())
 				Expect(originalPods.Items).To(HaveLen(17))
 
 				sortPodsByName(originalPods)
@@ -1849,7 +2204,9 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should downgrade the cluster", func() {
 					Expect(cluster.Status.Generations.Reconciled).To(Equal(originalVersion + 1))
-					Expect(cluster.Status.RunningVersion).To(Equal(fdbv1beta2.Versions.PreviousPatchVersion.String()))
+					Expect(
+						cluster.Status.RunningVersion,
+					).To(Equal(fdbv1beta2.Versions.PreviousPatchVersion.String()))
 				})
 			})
 
@@ -1862,7 +2219,9 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should not downgrade the cluster", func() {
 					Expect(cluster.Status.Generations.Reconciled).To(Equal(originalVersion))
-					Expect(cluster.Status.RunningVersion).To(Equal(fdbv1beta2.Versions.Default.String()))
+					Expect(
+						cluster.Status.RunningVersion,
+					).To(Equal(fdbv1beta2.Versions.Default.String()))
 				})
 			})
 		})
@@ -1890,10 +2249,14 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should set the image on the pods", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 
 					for _, pod := range pods.Items {
-						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextPatchVersion.String())))
+						Expect(
+							pod.Spec.Containers[0].Image,
+						).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextPatchVersion.String())))
 					}
 				})
 
@@ -1918,7 +2281,9 @@ var _ = Describe("cluster_controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					for _, pod := range pods.Items {
-						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextPatchVersion.String())))
+						Expect(
+							pod.Spec.Containers[0].Image,
+						).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextPatchVersion.String())))
 					}
 				})
 
@@ -1995,16 +2360,22 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should set the image on the pods", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 
 					for _, pod := range pods.Items {
-						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextPatchVersion.String())))
+						Expect(
+							pod.Spec.Containers[0].Image,
+						).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextPatchVersion.String())))
 					}
 				})
 
 				It("should replace the process group", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 
 					originalNames := make([]string, 0, len(originalPods.Items))
 					for _, pod := range originalPods.Items {
@@ -2046,10 +2417,14 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should set the image on the pods", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 
 					for _, pod := range pods.Items {
-						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
+						Expect(
+							pod.Spec.Containers[0].Image,
+						).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
 					}
 				})
 
@@ -2074,10 +2449,14 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should set the image on the pods", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 
 					for _, pod := range pods.Items {
-						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
+						Expect(
+							pod.Spec.Containers[0].Image,
+						).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
 					}
 				})
 
@@ -2087,7 +2466,9 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should replace the transaction system Pods", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 
 					originalNames := make([]string, 0, len(originalPods.Items))
 					for _, pod := range originalPods.Items {
@@ -2114,7 +2495,9 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should not replace the storage Pods", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 
 					originalNames := make([]string, 0, len(originalPods.Items))
 					for _, pod := range originalPods.Items {
@@ -2156,16 +2539,22 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should set the image on the pods", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 
 					for _, pod := range pods.Items {
-						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
+						Expect(
+							pod.Spec.Containers[0].Image,
+						).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
 					}
 				})
 
 				It("should replace the process group", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 
 					originalNames := make([]string, 0, len(originalPods.Items))
 					for _, pod := range originalPods.Items {
@@ -2183,7 +2572,10 @@ var _ = Describe("cluster_controller", func() {
 
 			Context("with all upgradable clients", func() {
 				BeforeEach(func() {
-					adminClient.MockClientVersion(fdbv1beta2.Versions.NextMajorVersion.String(), []string{"127.0.0.2:3687"})
+					adminClient.MockClientVersion(
+						fdbv1beta2.Versions.NextMajorVersion.String(),
+						[]string{"127.0.0.2:3687"},
+					)
 					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
@@ -2192,7 +2584,8 @@ var _ = Describe("cluster_controller", func() {
 					Expect(k8sClient.List(context.TODO(), events)).NotTo(HaveOccurred())
 					var matchingEvents []corev1.Event
 					for _, event := range events.Items {
-						if event.InvolvedObject.UID == cluster.ObjectMeta.UID && event.Reason == "UnsupportedClient" {
+						if event.InvolvedObject.UID == cluster.ObjectMeta.UID &&
+							event.Reason == "UnsupportedClient" {
 							matchingEvents = append(matchingEvents, event)
 						}
 					}
@@ -2206,8 +2599,14 @@ var _ = Describe("cluster_controller", func() {
 
 			Context("with a non-upgradable client", func() {
 				BeforeEach(func() {
-					adminClient.MockClientVersion(fdbv1beta2.Versions.NextMajorVersion.String(), []string{"127.0.0.2:3687"})
-					adminClient.MockClientVersion(fdbv1beta2.Versions.Default.String(), []string{"127.0.0.3:85891"})
+					adminClient.MockClientVersion(
+						fdbv1beta2.Versions.NextMajorVersion.String(),
+						[]string{"127.0.0.2:3687"},
+					)
+					adminClient.MockClientVersion(
+						fdbv1beta2.Versions.Default.String(),
+						[]string{"127.0.0.3:85891"},
+					)
 				})
 
 				Context("with the check enabled", func() {
@@ -2222,14 +2621,19 @@ var _ = Describe("cluster_controller", func() {
 						Expect(k8sClient.List(context.TODO(), events)).NotTo(HaveOccurred())
 
 						for _, event := range events.Items {
-							if event.InvolvedObject.UID == cluster.ObjectMeta.UID && event.Reason == "UnsupportedClient" {
+							if event.InvolvedObject.UID == cluster.ObjectMeta.UID &&
+								event.Reason == "UnsupportedClient" {
 								matchingEvents = append(matchingEvents, event)
 							}
 						}
 						Expect(len(matchingEvents)).NotTo(Equal(0))
 
 						Expect(matchingEvents[0].Message).To(Equal(
-							fmt.Sprintf("1 clients do not support version %s: 127.0.0.3:85891 (%s)", fdbv1beta2.Versions.NextMajorVersion, cluster.Name),
+							fmt.Sprintf(
+								"1 clients do not support version %s: 127.0.0.3:85891 (%s)",
+								fdbv1beta2.Versions.NextMajorVersion,
+								cluster.Name,
+							),
 						))
 					})
 				})
@@ -2246,7 +2650,8 @@ var _ = Describe("cluster_controller", func() {
 
 						var matchingEvents []corev1.Event
 						for _, event := range events.Items {
-							if event.InvolvedObject.UID == cluster.ObjectMeta.UID && event.Reason == "UnsupportedClient" {
+							if event.InvolvedObject.UID == cluster.ObjectMeta.UID &&
+								event.Reason == "UnsupportedClient" {
 								matchingEvents = append(matchingEvents, event)
 							}
 						}
@@ -2261,7 +2666,12 @@ var _ = Describe("cluster_controller", func() {
 
 			When("one processes is missing the localities", func() {
 				BeforeEach(func() {
-					adminClient.MockMissingLocalities(fdbv1beta2.ProcessGroupID(originalPods.Items[0].Labels[cluster.GetProcessClassLabel()]), true)
+					adminClient.MockMissingLocalities(
+						fdbv1beta2.ProcessGroupID(
+							originalPods.Items[0].Labels[cluster.GetProcessClassLabel()],
+						),
+						true,
+					)
 					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
 
@@ -2275,10 +2685,14 @@ var _ = Describe("cluster_controller", func() {
 
 				It("should set the image on the pods", func() {
 					pods := &corev1.PodList{}
-					Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+					).NotTo(HaveOccurred())
 
 					for _, pod := range pods.Items {
-						Expect(pod.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
+						Expect(
+							pod.Spec.Containers[0].Image,
+						).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", fdbv1beta2.Versions.NextMajorVersion.String())))
 					}
 				})
 
@@ -2291,15 +2705,19 @@ var _ = Describe("cluster_controller", func() {
 		Context("with a change to the volume size", func() {
 			Context("with the fields from the processes", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
-						Spec: corev1.PersistentVolumeClaimSpec{
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("32Gi"),
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {
+							VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									Resources: corev1.VolumeResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceStorage: resource.MustParse("32Gi"),
+										},
+									},
 								},
 							},
 						},
-					}}}
+					}
 
 					err = k8sClient.Update(context.TODO(), cluster)
 					Expect(err).NotTo(HaveOccurred())
@@ -2337,7 +2755,9 @@ var _ = Describe("cluster_controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					for _, pvc := range pvcs.Items {
-						Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("32Gi")))
+						Expect(
+							pvc.Spec.Resources.Requests[corev1.ResourceStorage],
+						).To(Equal(resource.MustParse("32Gi")))
 					}
 				})
 			})
@@ -2351,7 +2771,9 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should replace the process groups", func() {
 				pods := &corev1.PodList{}
-				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+				).NotTo(HaveOccurred())
 
 				originalNames := make([]string, 0, len(originalPods.Items))
 				for _, pod := range originalPods.Items {
@@ -2379,7 +2801,11 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should create a service", func() {
 				service := &corev1.Service{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, service)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name},
+					service,
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(service.Spec.ClusterIP).To(Equal("None"))
@@ -2407,7 +2833,11 @@ var _ = Describe("cluster_controller", func() {
 
 			It("should remove a service", func() {
 				service := &corev1.Service{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, service)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name},
+					service,
+				)
 				Expect(err).To(HaveOccurred())
 				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 			})
@@ -2415,7 +2845,10 @@ var _ = Describe("cluster_controller", func() {
 
 		Context("with a lock deny list", func() {
 			BeforeEach(func() {
-				cluster.Spec.LockOptions.DenyList = append(cluster.Spec.LockOptions.DenyList, fdbv1beta2.LockDenyListEntry{ID: "dc2"})
+				cluster.Spec.LockOptions.DenyList = append(
+					cluster.Spec.LockOptions.DenyList,
+					fdbv1beta2.LockDenyListEntry{ID: "dc2"},
+				)
 				cluster.Spec.LockOptions.DisableLocks = pointer.Bool(false)
 				err = k8sClient.Update(context.TODO(), cluster)
 				Expect(err).NotTo(HaveOccurred())
@@ -2453,9 +2886,24 @@ var _ = Describe("cluster_controller", func() {
 						Expect(err).NotTo(HaveOccurred())
 					}
 				}
-				healthMetricOutput := fmt.Sprintf(`\nfdb_operator_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`, cluster.Name, cluster.Namespace, "health")
-				availMetricOutput := fmt.Sprintf(`\nfdb_operator_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`, cluster.Name, cluster.Namespace, "available")
-				replMetricOutput := fmt.Sprintf(`\nfdb_operator_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`, cluster.Name, cluster.Namespace, "replication")
+				healthMetricOutput := fmt.Sprintf(
+					`\nfdb_operator_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`,
+					cluster.Name,
+					cluster.Namespace,
+					"health",
+				)
+				availMetricOutput := fmt.Sprintf(
+					`\nfdb_operator_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`,
+					cluster.Name,
+					cluster.Namespace,
+					"available",
+				)
+				replMetricOutput := fmt.Sprintf(
+					`\nfdb_operator_cluster_status{name="%s",namespace="%s",status_type="%s"} 1`,
+					cluster.Name,
+					cluster.Namespace,
+					"replication",
+				)
 				for _, re := range []*regexp.Regexp{
 					regexp.MustCompile(healthMetricOutput),
 					regexp.MustCompile(availMetricOutput),
@@ -2471,16 +2919,29 @@ var _ = Describe("cluster_controller", func() {
 
 			BeforeEach(func() {
 				pods := &corev1.PodList{}
-				Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+				).NotTo(HaveOccurred())
 
 				recreatedPod = pods.Items[0]
-				Expect(k8sClient.SetPodIntoFailed(context.Background(), &recreatedPod, "NodeAffinity")).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.SetPodIntoFailed(context.Background(), &recreatedPod, "NodeAffinity"),
+				).NotTo(HaveOccurred())
 				generationGap = 0
 			})
 
 			It("should recreate the Pod", func() {
 				pod := &corev1.Pod{}
-				Expect(k8sClient.Get(context.TODO(), client.ObjectKey{Namespace: recreatedPod.Namespace, Name: recreatedPod.Name}, pod)).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.Get(
+						context.TODO(),
+						client.ObjectKey{
+							Namespace: recreatedPod.Namespace,
+							Name:      recreatedPod.Name,
+						},
+						pod,
+					),
+				).NotTo(HaveOccurred())
 				Expect(pod.UID).NotTo(Equal(recreatedPod.UID))
 			})
 		})
@@ -2499,7 +2960,9 @@ var _ = Describe("cluster_controller", func() {
 			Context("minor upgrade from 7.1 to 7.2 with non empty ignoreLogGroups", func() {
 				BeforeEach(func() {
 					cluster.Spec.Version = "7.2.0"
-					cluster.Spec.AutomationOptions.IgnoreLogGroupsForUpgrade = []fdbv1beta2.LogGroup{fdbv1beta2.LogGroup(cluster.Name)}
+					cluster.Spec.AutomationOptions.IgnoreLogGroupsForUpgrade = []fdbv1beta2.LogGroup{
+						fdbv1beta2.LogGroup(cluster.Name),
+					}
 					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 					generationGap = 2
 				})
@@ -2510,7 +2973,9 @@ var _ = Describe("cluster_controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					for _, pod := range pods.Items {
-						Expect(pod.Spec.Containers[0].Image).To(Equal("foundationdb/foundationdb:7.2.0"))
+						Expect(
+							pod.Spec.Containers[0].Image,
+						).To(Equal("foundationdb/foundationdb:7.2.0"))
 					}
 				})
 
@@ -2534,14 +2999,18 @@ var _ = Describe("cluster_controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					for _, event := range events.Items {
-						if event.InvolvedObject.UID == cluster.ObjectMeta.UID && event.Reason == "UnsupportedClient" {
+						if event.InvolvedObject.UID == cluster.ObjectMeta.UID &&
+							event.Reason == "UnsupportedClient" {
 							matchingEvents = append(matchingEvents, event)
 						}
 					}
 					Expect(len(matchingEvents)).NotTo(Equal(0))
 
 					Expect(matchingEvents[0].Message).To(Equal(
-						fmt.Sprintf("1 clients do not support version 7.2.0: 127.0.0.2:3687 (%s)", cluster.Name),
+						fmt.Sprintf(
+							"1 clients do not support version 7.2.0: 127.0.0.2:3687 (%s)",
+							cluster.Name,
+						),
 					))
 				})
 			})
@@ -2659,8 +3128,14 @@ var _ = Describe("cluster_controller", func() {
 				// We have to reload the cluster because we don't reach the Reconcile state
 				_, err = reloadClusterGenerations(cluster)
 				Expect(err).NotTo(HaveOccurred())
-				incorrectProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectCommandLine, false)
-				Expect(incorrectProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{first.ProcessGroupID}))
+				incorrectProcesses := fdbv1beta2.FilterByCondition(
+					cluster.Status.ProcessGroups,
+					fdbv1beta2.IncorrectCommandLine,
+					false,
+				)
+				Expect(
+					incorrectProcesses,
+				).To(Equal([]fdbv1beta2.ProcessGroupID{first.ProcessGroupID}))
 			})
 
 			When("When an additional process have an incorrect commandline", func() {
@@ -2674,8 +3149,14 @@ var _ = Describe("cluster_controller", func() {
 					// We have to reload the cluster because we don't reach the Reconcile state
 					_, err = reloadClusterGenerations(cluster)
 					Expect(err).NotTo(HaveOccurred())
-					incorrectProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectCommandLine, false)
-					Expect(incorrectProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{first.ProcessGroupID, second.ProcessGroupID}))
+					incorrectProcesses := fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.IncorrectCommandLine,
+						false,
+					)
+					Expect(
+						incorrectProcesses,
+					).To(Equal([]fdbv1beta2.ProcessGroupID{first.ProcessGroupID, second.ProcessGroupID}))
 				})
 			})
 		})
@@ -2724,17 +3205,25 @@ var _ = Describe("cluster_controller", func() {
 			When("watching all namespaces", func() {
 				It("should trigger reconciliation for cluster nodes", func() {
 					Expect(clusterReconciler.Namespace).To(BeZero())
-					Expect(clusterReconciler.ClusterLabelKeyForNodeTrigger).To(Equal("fdb-cluster-name"))
+					Expect(
+						clusterReconciler.ClusterLabelKeyForNodeTrigger,
+					).To(Equal("fdb-cluster-name"))
 
 					for _, node := range originalNodeList.Items {
-						requests := clusterReconciler.findFoundationDBClusterForNode(context.Background(), &node)
+						requests := clusterReconciler.findFoundationDBClusterForNode(
+							context.Background(),
+							&node,
+						)
 						Expect(requests).To(HaveLen(1))
 					}
 				})
 
 				It("should not trigger reconciliation for unrelated nodes", func() {
 					Expect(clusterReconciler.Namespace).To(BeZero())
-					request := clusterReconciler.findFoundationDBClusterForNode(context.Background(), unrelatedNode)
+					request := clusterReconciler.findFoundationDBClusterForNode(
+						context.Background(),
+						unrelatedNode,
+					)
 					Expect(request).To(BeEmpty())
 				})
 
@@ -2747,15 +3236,23 @@ var _ = Describe("cluster_controller", func() {
 					})
 					It("should trigger reconciliation for cluster nodes", func() {
 						Expect(clusterReconciler.Namespace).To(Not(BeZero()))
-						Expect(clusterReconciler.ClusterLabelKeyForNodeTrigger).To(Equal("fdb-cluster-name"))
+						Expect(
+							clusterReconciler.ClusterLabelKeyForNodeTrigger,
+						).To(Equal("fdb-cluster-name"))
 
 						for _, node := range originalNodeList.Items {
-							requests := clusterReconciler.findFoundationDBClusterForNode(context.Background(), &node)
+							requests := clusterReconciler.findFoundationDBClusterForNode(
+								context.Background(),
+								&node,
+							)
 							Expect(requests).To(HaveLen(1))
 						}
 					})
 					It("should not trigger reconciliation for unrelated nodes", func() {
-						request := clusterReconciler.findFoundationDBClusterForNode(context.Background(), unrelatedNode)
+						request := clusterReconciler.findFoundationDBClusterForNode(
+							context.Background(),
+							unrelatedNode,
+						)
 						Expect(request).To(BeEmpty())
 					})
 				})
@@ -2765,15 +3262,23 @@ var _ = Describe("cluster_controller", func() {
 					})
 					It("should not trigger reconciliation for cluster nodes", func() {
 						Expect(clusterReconciler.Namespace).To(Not(BeZero()))
-						Expect(clusterReconciler.ClusterLabelKeyForNodeTrigger).To(Equal("fdb-cluster-name"))
+						Expect(
+							clusterReconciler.ClusterLabelKeyForNodeTrigger,
+						).To(Equal("fdb-cluster-name"))
 
 						for _, node := range originalNodeList.Items {
-							requests := clusterReconciler.findFoundationDBClusterForNode(context.Background(), &node)
+							requests := clusterReconciler.findFoundationDBClusterForNode(
+								context.Background(),
+								&node,
+							)
 							Expect(requests).To(BeEmpty())
 						}
 					})
 					It("should not trigger reconciliation for unrelated nodes", func() {
-						request := clusterReconciler.findFoundationDBClusterForNode(context.Background(), unrelatedNode)
+						request := clusterReconciler.findFoundationDBClusterForNode(
+							context.Background(),
+							unrelatedNode,
+						)
 						Expect(request).To(BeEmpty())
 					})
 				})
@@ -2795,7 +3300,12 @@ var _ = Describe("cluster_controller", func() {
 
 		Context("with a test process group", func() {
 			BeforeEach(func() {
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassTest, nil, cluster.GetStorageServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassTest,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2823,7 +3333,12 @@ var _ = Describe("cluster_controller", func() {
 
 		Context("with a basic storage process group", func() {
 			BeforeEach(func() {
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2852,7 +3367,12 @@ var _ = Describe("cluster_controller", func() {
 		Context("with a basic storage process group with multiple storage servers per Pod", func() {
 			BeforeEach(func() {
 				cluster.Spec.StorageServersPerPod = 2
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2896,7 +3416,12 @@ var _ = Describe("cluster_controller", func() {
 		Context("with a basic log process group with multiple log servers per Pod", func() {
 			BeforeEach(func() {
 				cluster.Spec.LogServersPerPod = 2
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassLog, nil, cluster.GetLogServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassLog,
+					nil,
+					cluster.GetLogServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3001,7 +3526,12 @@ var _ = Describe("cluster_controller", func() {
 			Context("with pods without the listen IP environment variable", func() {
 				BeforeEach(func() {
 					cluster.Status.HasListenIPsForAllPods = false
-					conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 1)
+					conf, err = internal.GetMonitorConf(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						nil,
+						1,
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -3033,7 +3563,12 @@ var _ = Describe("cluster_controller", func() {
 				cluster.Spec.MainContainer.EnableTLS = true
 				cluster.Status.RequiredAddresses.NonTLS = false
 				cluster.Status.RequiredAddresses.TLS = true
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3065,7 +3600,12 @@ var _ = Describe("cluster_controller", func() {
 				cluster.Status.RequiredAddresses.NonTLS = true
 				cluster.Status.RequiredAddresses.TLS = true
 
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3097,7 +3637,12 @@ var _ = Describe("cluster_controller", func() {
 				cluster.Status.RequiredAddresses.NonTLS = true
 				cluster.Status.RequiredAddresses.TLS = true
 
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3126,10 +3671,19 @@ var _ = Describe("cluster_controller", func() {
 		Context("with custom parameters", func() {
 			Context("with general parameters", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-						"knob_disable_posix_kernel_aio = 1",
-					}}}
-					conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_disable_posix_kernel_aio = 1",
+							},
+						},
+					}
+					conf, err = internal.GetMonitorConf(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						nil,
+						cluster.GetStorageServersPerPod(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -3159,17 +3713,28 @@ var _ = Describe("cluster_controller", func() {
 			Context("with process-class parameters", func() {
 				BeforeEach(func() {
 					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
-						fdbv1beta2.ProcessClassGeneral: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-							"knob_disable_posix_kernel_aio = 1",
-						}},
-						fdbv1beta2.ProcessClassStorage: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-							"knob_test = test1",
-						}},
-						fdbv1beta2.ProcessClassStateless: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-							"knob_test = test2",
-						}},
+						fdbv1beta2.ProcessClassGeneral: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_disable_posix_kernel_aio = 1",
+							},
+						},
+						fdbv1beta2.ProcessClassStorage: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_test = test1",
+							},
+						},
+						fdbv1beta2.ProcessClassStateless: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_test = test2",
+							},
+						},
 					}
-					conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+					conf, err = internal.GetMonitorConf(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						nil,
+						cluster.GetStorageServersPerPod(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -3203,7 +3768,12 @@ var _ = Describe("cluster_controller", func() {
 					Key:       "rack",
 					ValueFrom: "$RACK",
 				}
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3233,7 +3803,12 @@ var _ = Describe("cluster_controller", func() {
 			BeforeEach(func() {
 				cluster.Spec.Version = fdbv1beta2.Versions.Default.String()
 				cluster.Status.RunningVersion = fdbv1beta2.Versions.Default.String()
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 			})
@@ -3263,7 +3838,12 @@ var _ = Describe("cluster_controller", func() {
 		Context("with peer verification rules", func() {
 			BeforeEach(func() {
 				cluster.Spec.MainContainer.PeerVerificationRules = "S.CN=foundationdb.org"
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3293,7 +3873,12 @@ var _ = Describe("cluster_controller", func() {
 		Context("with a custom log group", func() {
 			BeforeEach(func() {
 				cluster.Spec.LogGroup = "test-fdb-cluster"
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3322,7 +3907,12 @@ var _ = Describe("cluster_controller", func() {
 		Context("with a data center", func() {
 			BeforeEach(func() {
 				cluster.Spec.DataCenter = "dc01"
-				conf, err = internal.GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = internal.GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3355,7 +3945,9 @@ var _ = Describe("cluster_controller", func() {
 			Expect(podmanager.GetProcessGroupIDFromProcessID("storage-1-1")).To(Equal("storage-1"))
 		})
 		It("can parse a process ID with a prefix", func() {
-			Expect(podmanager.GetProcessGroupIDFromProcessID("dc1-storage-1-1")).To(Equal("dc1-storage-1"))
+			Expect(
+				podmanager.GetProcessGroupIDFromProcessID("dc1-storage-1-1"),
+			).To(Equal("dc1-storage-1"))
 		})
 
 		It("can handle a process group ID with no process number", func() {
@@ -3516,7 +4108,10 @@ var _ = Describe("cluster_controller", func() {
 	})
 })
 
-func getProcessClassMap(cluster *fdbv1beta2.FoundationDBCluster, pods []corev1.Pod) map[fdbv1beta2.ProcessClass]int {
+func getProcessClassMap(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	pods []corev1.Pod,
+) map[fdbv1beta2.ProcessClass]int {
 	counts := make(map[fdbv1beta2.ProcessClass]int)
 	for _, pod := range pods {
 		processClass := internal.ProcessClassFromLabels(cluster, pod.Labels)
@@ -3526,7 +4121,11 @@ func getProcessClassMap(cluster *fdbv1beta2.FoundationDBCluster, pods []corev1.P
 }
 
 // getConfigMapHash gets the hash of the data for a cluster's dynamic config.
-func getConfigMapHash(cluster *fdbv1beta2.FoundationDBCluster, pClass fdbv1beta2.ProcessClass, pod *corev1.Pod) (string, error) {
+func getConfigMapHash(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	pClass fdbv1beta2.ProcessClass,
+	pod *corev1.Pod,
+) (string, error) {
 	configMap, err := internal.GetConfigMap(cluster)
 	if err != nil {
 		return "", err

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -58,8 +58,19 @@ type requeue struct {
 }
 
 // processRequeue interprets a requeue result from a subreconciler.
-func processRequeue(requeue *requeue, subReconciler interface{}, object runtime.Object, recorder record.EventRecorder, logger logr.Logger) (ctrl.Result, error) {
-	curLog := logger.WithValues("reconciler", fmt.Sprintf("%T", subReconciler), "requeueAfter", requeue.delay)
+func processRequeue(
+	requeue *requeue,
+	subReconciler interface{},
+	object runtime.Object,
+	recorder record.EventRecorder,
+	logger logr.Logger,
+) (ctrl.Result, error) {
+	curLog := logger.WithValues(
+		"reconciler",
+		fmt.Sprintf("%T", subReconciler),
+		"requeueAfter",
+		requeue.delay,
+	)
 	if requeue.message == "" && requeue.curError != nil {
 		requeue.message = requeue.curError.Error()
 	}

--- a/controllers/delete_pods_for_buggification.go
+++ b/controllers/delete_pods_for_buggification.go
@@ -35,10 +35,19 @@ import (
 type deletePodsForBuggification struct{}
 
 // reconcile runs the reconciler's work.
-func (d deletePodsForBuggification) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (d deletePodsForBuggification) reconcile(
+	ctx context.Context,
+	r *FoundationDBClusterReconciler,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	_ *fdbv1beta2.FoundationDBStatus,
+	logger logr.Logger,
+) *requeue {
 	crashLoopContainerProcessGroups := cluster.GetCrashLoopContainerProcessGroups()
 
-	noSchedulePods := make(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None, len(cluster.Spec.Buggify.NoSchedule))
+	noSchedulePods := make(
+		map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None,
+		len(cluster.Spec.Buggify.NoSchedule),
+	)
 	for _, processGroupID := range cluster.Spec.Buggify.NoSchedule {
 		noSchedulePods[processGroupID] = fdbv1beta2.None{}
 	}
@@ -128,7 +137,13 @@ func (d deletePodsForBuggification) reconcile(ctx context.Context, r *Foundation
 	if len(updates) > 0 {
 		logger.Info("Deleting pods", "count", len(updates))
 		r.Recorder.Event(cluster, "Normal", "UpdatingPods", "Recreating pods for buggification")
-		err := r.PodLifecycleManager.UpdatePods(logr.NewContext(ctx, logger), r, cluster, updates, true)
+		err := r.PodLifecycleManager.UpdatePods(
+			logr.NewContext(ctx, logger),
+			r,
+			cluster,
+			updates,
+			true,
+		)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/delete_pods_for_buggification_test.go
+++ b/controllers/delete_pods_for_buggification_test.go
@@ -56,14 +56,22 @@ var _ = Describe("delete_pods_for_buggification", func() {
 		Expect(generation).To(Equal(int64(1)))
 
 		originalPods = &corev1.PodList{}
-		Expect(k8sClient.List(context.TODO(), originalPods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+		Expect(
+			k8sClient.List(context.TODO(), originalPods, getListOptions(cluster)...),
+		).NotTo(HaveOccurred())
 	})
 
 	JustBeforeEach(func() {
 		err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		requeue = deletePodsForBuggification{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+		requeue = deletePodsForBuggification{}.reconcile(
+			context.TODO(),
+			clusterReconciler,
+			cluster,
+			nil,
+			globalControllerLogger,
+		)
 		if requeue != nil {
 			Expect(requeue.curError).NotTo(HaveOccurred())
 		}
@@ -78,7 +86,9 @@ var _ = Describe("delete_pods_for_buggification", func() {
 
 		It("should not delete any pods", func() {
 			pods := &corev1.PodList{}
-			Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+			Expect(
+				k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+			).NotTo(HaveOccurred())
 			Expect(pods.Items).To(ConsistOf(originalPods.Items))
 		})
 	})
@@ -92,7 +102,9 @@ var _ = Describe("delete_pods_for_buggification", func() {
 
 		When("using crashLoop", func() {
 			BeforeEach(func() {
-				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{processGroup.ProcessGroupID}
+				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{
+					processGroup.ProcessGroupID,
+				}
 			})
 
 			It("should requeue", func() {
@@ -107,7 +119,14 @@ var _ = Describe("delete_pods_for_buggification", func() {
 				Expect(len(pods.Items)).To(Equal(len(originalPods.Items) - 1))
 
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: processGroup.GetPodName(cluster)}, pod)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      processGroup.GetPodName(cluster),
+					},
+					pod,
+				)
 				Expect(err).To(HaveOccurred())
 				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 			})
@@ -115,7 +134,9 @@ var _ = Describe("delete_pods_for_buggification", func() {
 
 		When("using noSchedule", func() {
 			BeforeEach(func() {
-				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{processGroup.ProcessGroupID}
+				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{
+					processGroup.ProcessGroupID,
+				}
 			})
 
 			It("should requeue", func() {
@@ -130,7 +151,14 @@ var _ = Describe("delete_pods_for_buggification", func() {
 				Expect(len(pods.Items)).To(Equal(len(originalPods.Items) - 1))
 
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: processGroup.GetPodName(cluster)}, pod)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      processGroup.GetPodName(cluster),
+					},
+					pod,
+				)
 				Expect(err).To(HaveOccurred())
 				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 			})
@@ -149,7 +177,9 @@ var _ = Describe("delete_pods_for_buggification", func() {
 
 		It("should delete the pods", func() {
 			pods := &corev1.PodList{}
-			Expect(k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)).NotTo(HaveOccurred())
+			Expect(
+				k8sClient.List(context.TODO(), pods, getListOptions(cluster)...),
+			).NotTo(HaveOccurred())
 			Expect(len(pods.Items)).To(Equal(0))
 		})
 	})
@@ -164,7 +194,14 @@ var _ = Describe("delete_pods_for_buggification", func() {
 		When("using crashLoop", func() {
 			BeforeEach(func() {
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: processGroup.GetPodName(cluster)}, pod)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      processGroup.GetPodName(cluster),
+					},
+					pod,
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = k8sClient.Delete(context.TODO(), pod)
@@ -188,7 +225,14 @@ var _ = Describe("delete_pods_for_buggification", func() {
 				Expect(len(pods.Items)).To(Equal(len(originalPods.Items) - 1))
 
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: processGroup.GetPodName(cluster)}, pod)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      processGroup.GetPodName(cluster),
+					},
+					pod,
+				)
 				Expect(err).To(HaveOccurred())
 				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 			})
@@ -197,7 +241,14 @@ var _ = Describe("delete_pods_for_buggification", func() {
 		When("using noSchedule", func() {
 			BeforeEach(func() {
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: processGroup.GetPodName(cluster)}, pod)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      processGroup.GetPodName(cluster),
+					},
+					pod,
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = k8sClient.Delete(context.TODO(), pod)
@@ -236,7 +287,14 @@ var _ = Describe("delete_pods_for_buggification", func() {
 				Expect(len(pods.Items)).To(Equal(len(originalPods.Items) - 1))
 
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: processGroup.GetPodName(cluster)}, pod)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      processGroup.GetPodName(cluster),
+					},
+					pod,
+				)
 				Expect(err).To(HaveOccurred())
 				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 			})
@@ -253,7 +311,14 @@ var _ = Describe("delete_pods_for_buggification", func() {
 		When("using crashLoop", func() {
 			BeforeEach(func() {
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: processGroup.GetPodName(cluster)}, pod)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      processGroup.GetPodName(cluster),
+					},
+					pod,
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = k8sClient.Delete(context.TODO(), pod)
@@ -263,7 +328,9 @@ var _ = Describe("delete_pods_for_buggification", func() {
 				pod.Spec.Containers[0].Args = []string{"crash-loop"}
 				err = k8sClient.Create(context.TODO(), pod)
 				Expect(err).NotTo(HaveOccurred())
-				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{processGroup.ProcessGroupID}
+				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{
+					processGroup.ProcessGroupID,
+				}
 			})
 
 			It("should not requeue", func() {
@@ -277,7 +344,14 @@ var _ = Describe("delete_pods_for_buggification", func() {
 				Expect(len(pods.Items)).To(Equal(len(originalPods.Items)))
 
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: processGroup.GetPodName(cluster)}, pod)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      processGroup.GetPodName(cluster),
+					},
+					pod,
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -285,7 +359,14 @@ var _ = Describe("delete_pods_for_buggification", func() {
 		When("using noSchedule", func() {
 			BeforeEach(func() {
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: processGroup.GetPodName(cluster)}, pod)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      processGroup.GetPodName(cluster),
+					},
+					pod,
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = k8sClient.Delete(context.TODO(), pod)
@@ -310,7 +391,9 @@ var _ = Describe("delete_pods_for_buggification", func() {
 				pod.ResourceVersion = ""
 				err = k8sClient.Create(context.TODO(), pod)
 				Expect(err).NotTo(HaveOccurred())
-				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{processGroup.ProcessGroupID}
+				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{
+					processGroup.ProcessGroupID,
+				}
 			})
 
 			It("should not requeue", func() {
@@ -324,7 +407,14 @@ var _ = Describe("delete_pods_for_buggification", func() {
 				Expect(len(pods.Items)).To(Equal(len(originalPods.Items)))
 
 				pod := &corev1.Pod{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: processGroup.GetPodName(cluster)}, pod)
+				err = k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      processGroup.GetPodName(cluster),
+					},
+					pod,
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -335,21 +425,23 @@ var _ = Describe("delete_pods_for_buggification", func() {
 
 		BeforeEach(func() {
 			processGroup = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
-			cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: fdbv1beta2.MainContainerName,
-							Env: []corev1.EnvVar{
-								{
-									Name:  "TEST_CHANGE",
-									Value: "1",
+			cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+				fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: fdbv1beta2.MainContainerName,
+								Env: []corev1.EnvVar{
+									{
+										Name:  "TEST_CHANGE",
+										Value: "1",
+									},
 								},
 							},
 						},
 					},
-				},
-			}}}
+				}},
+			}
 			err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -365,7 +457,14 @@ var _ = Describe("delete_pods_for_buggification", func() {
 			Expect(len(pods.Items)).To(Equal(len(originalPods.Items)))
 
 			pod := &corev1.Pod{}
-			err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: processGroup.GetPodName(cluster)}, pod)
+			err = k8sClient.Get(
+				context.TODO(),
+				types.NamespacedName{
+					Namespace: cluster.Namespace,
+					Name:      processGroup.GetPodName(cluster),
+				},
+				pod,
+			)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -46,7 +46,13 @@ type excludeEntry struct {
 }
 
 // reconcile runs the reconciler's work.
-func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (e excludeProcesses) reconcile(
+	ctx context.Context,
+	r *FoundationDBClusterReconciler,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	status *fdbv1beta2.FoundationDBStatus,
+	logger logr.Logger,
+) *requeue {
 	adminClient, err := r.getAdminClient(logger, cluster)
 	if err != nil {
 		return &requeue{curError: err}
@@ -72,13 +78,20 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 	pendingExclusions := map[fdbv1beta2.ProcessGroupID]time.Time{}
 	updatePendingExclusions := map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{}
 	if cluster.GetSynchronizationMode() == fdbv1beta2.SynchronizationModeGlobal {
-		pendingExclusions, err = adminClient.GetPendingForExclusion(cluster.Spec.ProcessGroupIDPrefix)
+		pendingExclusions, err = adminClient.GetPendingForExclusion(
+			cluster.Spec.ProcessGroupIDPrefix,
+		)
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}
 	}
 
-	fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, pendingExclusions, updatePendingExclusions)
+	fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+		exclusions,
+		cluster,
+		pendingExclusions,
+		updatePendingExclusions,
+	)
 
 	// No processes have to be excluded we can directly return.
 	if len(fdbProcessesToExcludeByClass) == 0 {
@@ -110,7 +123,11 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 	}
 
 	// Make sure it's safe to exclude processes.
-	err = fdbstatus.CanSafelyExcludeProcessesWithRecoveryState(cluster, status, r.MinimumRecoveryTimeForExclusion)
+	err = fdbstatus.CanSafelyExcludeProcessesWithRecoveryState(
+		cluster,
+		status,
+		r.MinimumRecoveryTimeForExclusion,
+	)
 	if err != nil {
 		return &requeue{curError: err, delayedRequeue: true, delay: 10 * time.Second}
 	}
@@ -143,12 +160,29 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 		ongoingExclusions := ongoingExclusionsByClass[processClass]
 		processesToExclude := fdbProcessesToExcludeByClass[processClass]
 
-		allowedExclusions, missingProcesses := getAllowedExclusionsAndMissingProcesses(contextLogger, cluster, processClass, desiredProcessesMap[processClass], ongoingExclusions, r.SimulationOptions.SimulateTime)
+		allowedExclusions, missingProcesses := getAllowedExclusionsAndMissingProcesses(
+			contextLogger,
+			cluster,
+			processClass,
+			desiredProcessesMap[processClass],
+			ongoingExclusions,
+			r.SimulationOptions.SimulateTime,
+		)
 		if allowedExclusions <= 0 {
 			if processClass.IsTransaction() {
 				transactionSystemExclusionAllowed = false
 			}
-			contextLogger.Info("Waiting for missing processes before continuing with the exclusion", "missingProcesses", missingProcesses, "addressesToExclude", processesToExclude, "allowedExclusions", allowedExclusions, "ongoingExclusions", ongoingExclusions)
+			contextLogger.Info(
+				"Waiting for missing processes before continuing with the exclusion",
+				"missingProcesses",
+				missingProcesses,
+				"addressesToExclude",
+				processesToExclude,
+				"allowedExclusions",
+				allowedExclusions,
+				"ongoingExclusions",
+				ongoingExclusions,
+			)
 			allProcessesExcluded = false
 			continue
 		}
@@ -156,7 +190,17 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 		// If we are not able to exclude all processes at once print a log message.
 		if len(processesToExclude) > allowedExclusions {
 			allProcessesExcluded = false
-			contextLogger.Info("Some processes are still missing but continuing with the exclusion", "missingProcesses", missingProcesses, "addressesToExclude", processesToExclude, "allowedExclusions", allowedExclusions, "ongoingExclusions", ongoingExclusions)
+			contextLogger.Info(
+				"Some processes are still missing but continuing with the exclusion",
+				"missingProcesses",
+				missingProcesses,
+				"addressesToExclude",
+				processesToExclude,
+				"allowedExclusions",
+				allowedExclusions,
+				"ongoingExclusions",
+				ongoingExclusions,
+			)
 		}
 
 		if len(processesToExclude) < allowedExclusions {
@@ -222,7 +266,12 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 
 		// Check if all processes can be excluded, or if only a subset of processes can be excluded.
 		var allowedExclusions map[fdbv1beta2.ProcessGroupID]time.Time
-		allowedExclusions, err = coordination.AllProcessesReadyForExclusion(logger, pendingExclusions, readyExclusions, r.GlobalSynchronizationWaitDuration)
+		allowedExclusions, err = coordination.AllProcessesReadyForExclusion(
+			logger,
+			pendingExclusions,
+			readyExclusions,
+			r.GlobalSynchronizationWaitDuration,
+		)
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}
@@ -233,13 +282,24 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 
 		// Convert all the process groups that should be excluded to the right addresses based on the cluster status.
 		useLocalities := cluster.UseLocalitiesForExclusion()
-		fdbProcessesToExclude, err = coordination.GetAddressesFromCoordinationState(logger, adminClient, allowedExclusions, useLocalities, !useLocalities)
+		fdbProcessesToExclude, err = coordination.GetAddressesFromCoordinationState(
+			logger,
+			adminClient,
+			allowedExclusions,
+			useLocalities,
+			!useLocalities,
+		)
 		if err != nil {
 			return &requeue{curError: err, delayedRequeue: true}
 		}
 	}
 
-	r.Recorder.Event(cluster, corev1.EventTypeNormal, "ExcludingProcesses", fmt.Sprintf("Excluding %v", fdbProcessesToExclude))
+	r.Recorder.Event(
+		cluster,
+		corev1.EventTypeNormal,
+		"ExcludingProcesses",
+		fmt.Sprintf("Excluding %v", fdbProcessesToExclude),
+	)
 	// We use the no_wait exclusion here to trigger the exclusion without waiting for the data movement to complete.
 	// There is no need to wait for the data movement to complete in this call as later calls will verify that the
 	// data is moved and the processes are fully excluded. Using the no_wait flag here will reduce the timeout errors
@@ -259,7 +319,11 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 		_, excludedAddress := coordinatorsAddress[excludeString]
 
 		if excludedAddress || excludedLocality {
-			logger.Info("process to be excluded is also a coordinator", "excludeProcess", excludeProcess.String())
+			logger.Info(
+				"process to be excluded is also a coordinator",
+				"excludeProcess",
+				excludeProcess.String(),
+			)
 			coordinatorExcluded = true
 		}
 	}
@@ -281,13 +345,22 @@ func (e excludeProcesses) reconcile(ctx context.Context, r *FoundationDBClusterR
 
 	// If not all processes are excluded, ensure we requeue after 5 minutes.
 	if !allProcessesExcluded {
-		return &requeue{message: "Additional processes must be excluded", delay: 5 * time.Minute, delayedRequeue: true}
+		return &requeue{
+			message:        "Additional processes must be excluded",
+			delay:          5 * time.Minute,
+			delayedRequeue: true,
+		}
 	}
 
 	return nil
 }
 
-func getProcessesToExclude(exclusions []fdbv1beta2.ProcessAddress, cluster *fdbv1beta2.FoundationDBCluster, pendingExclusions map[fdbv1beta2.ProcessGroupID]time.Time, updatePendingExclusions map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction) (map[fdbv1beta2.ProcessClass][]excludeEntry, map[fdbv1beta2.ProcessClass]int) {
+func getProcessesToExclude(
+	exclusions []fdbv1beta2.ProcessAddress,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	pendingExclusions map[fdbv1beta2.ProcessGroupID]time.Time,
+	updatePendingExclusions map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction,
+) (map[fdbv1beta2.ProcessClass][]excludeEntry, map[fdbv1beta2.ProcessClass]int) {
 	fdbProcessesToExcludeByClass := make(map[fdbv1beta2.ProcessClass][]excludeEntry)
 	// This map keeps track on how many processes are currently excluded but haven't finished the exclusion yet.
 	ongoingExclusionsByClass := make(map[fdbv1beta2.ProcessClass]int)
@@ -331,7 +404,8 @@ func getProcessesToExclude(exclusions []fdbv1beta2.ProcessAddress, cluster *fdbv
 			}
 
 			if len(fdbProcessesToExcludeByClass[processGroup.ProcessClass]) == 0 {
-				fdbProcessesToExcludeByClass[processGroup.ProcessClass] = append(fdbProcessesToExcludeByClass[processGroup.ProcessClass],
+				fdbProcessesToExcludeByClass[processGroup.ProcessClass] = append(
+					fdbProcessesToExcludeByClass[processGroup.ProcessClass],
 					excludeEntry{
 						processGroupID: processGroup.ProcessGroupID,
 						addresses: []fdbv1beta2.ProcessAddress{
@@ -342,7 +416,8 @@ func getProcessesToExclude(exclusions []fdbv1beta2.ProcessAddress, cluster *fdbv
 				continue
 			}
 
-			fdbProcessesToExcludeByClass[processGroup.ProcessClass] = append(fdbProcessesToExcludeByClass[processGroup.ProcessClass],
+			fdbProcessesToExcludeByClass[processGroup.ProcessClass] = append(
+				fdbProcessesToExcludeByClass[processGroup.ProcessClass],
 				excludeEntry{
 					processGroupID: processGroup.ProcessGroupID,
 					addresses: []fdbv1beta2.ProcessAddress{
@@ -367,12 +442,18 @@ func getProcessesToExclude(exclusions []fdbv1beta2.ProcessAddress, cluster *fdbv
 			}
 
 			allAddressesExcluded = false
-			addresses = append(addresses, fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP(address)})
+			addresses = append(
+				addresses,
+				fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP(address)},
+			)
 		}
 
 		if len(addresses) > 0 {
 			entry.addresses = addresses
-			fdbProcessesToExcludeByClass[processGroup.ProcessClass] = append(fdbProcessesToExcludeByClass[processGroup.ProcessClass], entry)
+			fdbProcessesToExcludeByClass[processGroup.ProcessClass] = append(
+				fdbProcessesToExcludeByClass[processGroup.ProcessClass],
+				entry,
+			)
 		}
 
 		// Only if all known addresses are excluded we assume this is an ongoing exclusion. Otherwise, it might be that
@@ -390,7 +471,14 @@ func getProcessesToExclude(exclusions []fdbv1beta2.ProcessAddress, cluster *fdbv
 // the MissingProcesses condition this method will forbid exclusions until all process groups with this condition have
 // this condition for longer than ignoreMissingProcessDuration. The idea behind this is to try to exclude as many processes
 // at once e.g. to reduce the number of recoveries and data movement.
-func getAllowedExclusionsAndMissingProcesses(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, desiredProcessCount int, ongoingExclusions int, inSimulation bool) (int, []fdbv1beta2.ProcessGroupID) {
+func getAllowedExclusionsAndMissingProcesses(
+	logger logr.Logger,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	processClass fdbv1beta2.ProcessClass,
+	desiredProcessCount int,
+	ongoingExclusions int,
+	inSimulation bool,
+) (int, []fdbv1beta2.ProcessGroupID) {
 	// Block excludes on missing processes not marked for removal unless they are missing for a long time and the process might be broken
 	// or the namespace quota was hit.
 	missingProcesses := make([]fdbv1beta2.ProcessGroupID, 0)
@@ -411,7 +499,8 @@ func getAllowedExclusionsAndMissingProcesses(logger logr.Logger, cluster *fdbv1b
 		if missingTimestamp != nil && !inSimulation {
 			missingTime := time.Unix(*missingTimestamp, 0)
 			missingProcesses = append(missingProcesses, processGroup.ProcessGroupID)
-			logger.V(1).Info("Missing processes", "processGroupID", processGroup.ProcessGroupID, "missingTime", missingTime.String())
+			logger.V(1).
+				Info("Missing processes", "processGroupID", processGroup.ProcessGroupID, "missingTime", missingTime.String())
 
 			if time.Since(missingTime) < coordination.IgnoreMissingProcessDuration {
 				exclusionsAllowed = false
@@ -423,19 +512,36 @@ func getAllowedExclusionsAndMissingProcesses(logger logr.Logger, cluster *fdbv1b
 	}
 
 	if !exclusionsAllowed {
-		logger.Info("Found at least one missing process, that was not missing for more than 5 minutes", "missingProcesses", missingProcesses)
+		logger.Info(
+			"Found at least one missing process, that was not missing for more than 5 minutes",
+			"missingProcesses",
+			missingProcesses,
+		)
 		return 0, missingProcesses
 	}
 
-	return getAllowedExclusions(logger, validProcesses, desiredProcessCount, ongoingExclusions, cluster.DesiredFaultTolerance()), missingProcesses
+	return getAllowedExclusions(
+		logger,
+		validProcesses,
+		desiredProcessCount,
+		ongoingExclusions,
+		cluster.DesiredFaultTolerance(),
+	), missingProcesses
 }
 
 // getAllowedExclusions will return the number of allowed exclusions. If no exclusions are allowed this method will return a 0.
 // The assumption here is that we will only exclude a process if there is a replacement ready for it. We add the desired fault
 // tolerance to have some buffer to prevent cases where the operator might need to exclude more processes but there are more
 // missing processes.
-func getAllowedExclusions(logger logr.Logger, validProcesses int, desiredProcessCount int, ongoingExclusions int, faultTolerance int) int {
-	logger.V(1).Info("getAllowedExclusions", "validProcesses", validProcesses, "desiredProcessCount", desiredProcessCount, "ongoingExclusions", ongoingExclusions, "faultTolerance", faultTolerance)
+func getAllowedExclusions(
+	logger logr.Logger,
+	validProcesses int,
+	desiredProcessCount int,
+	ongoingExclusions int,
+	faultTolerance int,
+) int {
+	logger.V(1).
+		Info("getAllowedExclusions", "validProcesses", validProcesses, "desiredProcessCount", desiredProcessCount, "ongoingExclusions", ongoingExclusions, "faultTolerance", faultTolerance)
 	allowedExclusions := validProcesses + faultTolerance - desiredProcessCount - ongoingExclusions
 	if allowedExclusions < 0 {
 		return 0

--- a/controllers/exclude_processes_test.go
+++ b/controllers/exclude_processes_test.go
@@ -70,7 +70,14 @@ var _ = Describe("exclude_processes", func() {
 		JustBeforeEach(func() {
 			processCounts, err := cluster.GetProcessCountsWithDefaults()
 			Expect(err).NotTo(HaveOccurred())
-			allowedExclusions, missingProcesses = getAllowedExclusionsAndMissingProcesses(globalControllerLogger, cluster, processClass, processCounts.Map()[processClass], ongoingExclusions, false)
+			allowedExclusions, missingProcesses = getAllowedExclusionsAndMissingProcesses(
+				globalControllerLogger,
+				cluster,
+				processClass,
+				processCounts.Map()[processClass],
+				ongoingExclusions,
+				false,
+			)
 		})
 
 		When("using a small cluster", func() {
@@ -101,7 +108,9 @@ var _ = Describe("exclude_processes", func() {
 							})
 
 							It("should not allow the exclusion", func() {
-								Expect(allowedExclusions).To(BeNumerically("==", cluster.DesiredFaultTolerance()))
+								Expect(
+									allowedExclusions,
+								).To(BeNumerically("==", cluster.DesiredFaultTolerance()))
 								Expect(missingProcesses).To(BeEmpty())
 							})
 
@@ -115,8 +124,13 @@ var _ = Describe("exclude_processes", func() {
 										}
 
 										processGroupID = processGroup.ProcessGroupID
-										cluster.Status.ProcessGroups[idx].UpdateCondition(fdbv1beta2.MissingProcesses, true)
-										cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().Add(-10 * time.Minute).Unix()
+										cluster.Status.ProcessGroups[idx].UpdateCondition(
+											fdbv1beta2.MissingProcesses,
+											true,
+										)
+										cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().
+											Add(-10 * time.Minute).
+											Unix()
 										break
 									}
 								})
@@ -134,7 +148,9 @@ var _ = Describe("exclude_processes", func() {
 							})
 
 							It("should allow the exclusion", func() {
-								Expect(allowedExclusions).To(BeNumerically("==", cluster.DesiredFaultTolerance()))
+								Expect(
+									allowedExclusions,
+								).To(BeNumerically("==", cluster.DesiredFaultTolerance()))
 								Expect(missingProcesses).To(BeEmpty())
 							})
 
@@ -148,14 +164,21 @@ var _ = Describe("exclude_processes", func() {
 										}
 
 										processGroupID = processGroup.ProcessGroupID
-										cluster.Status.ProcessGroups[idx].UpdateCondition(fdbv1beta2.MissingProcesses, true)
-										cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().Add(-10 * time.Minute).Unix()
+										cluster.Status.ProcessGroups[idx].UpdateCondition(
+											fdbv1beta2.MissingProcesses,
+											true,
+										)
+										cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().
+											Add(-10 * time.Minute).
+											Unix()
 										break
 									}
 								})
 
 								It("should allow the exclusion", func() {
-									Expect(allowedExclusions).To(BeNumerically("==", cluster.DesiredFaultTolerance()-1))
+									Expect(
+										allowedExclusions,
+									).To(BeNumerically("==", cluster.DesiredFaultTolerance()-1))
 									Expect(missingProcesses).To(ConsistOf(processGroupID))
 								})
 							})
@@ -164,7 +187,10 @@ var _ = Describe("exclude_processes", func() {
 
 					When("one additional process is running", func() {
 						BeforeEach(func() {
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1337", processClass, nil))
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								fdbv1beta2.NewProcessGroupStatus("storage-1337", processClass, nil),
+							)
 							cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
 						})
 
@@ -197,19 +223,22 @@ var _ = Describe("exclude_processes", func() {
 							})
 						})
 
-						When("the additional process is marked for removal and is excluded", func() {
-							BeforeEach(func() {
-								// In this case we have no additional processes running, as the valid processes is the
-								// same as the desired count of processes.
-								cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].MarkForRemoval()
-								cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].SetExclude()
-							})
+						When(
+							"the additional process is marked for removal and is excluded",
+							func() {
+								BeforeEach(func() {
+									// In this case we have no additional processes running, as the valid processes is the
+									// same as the desired count of processes.
+									cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].MarkForRemoval()
+									cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].SetExclude()
+								})
 
-							It("should not allow the exclusion", func() {
-								Expect(allowedExclusions).To(BeNumerically("==", 0))
-								Expect(missingProcesses).To(BeEmpty())
-							})
-						})
+								It("should not allow the exclusion", func() {
+									Expect(allowedExclusions).To(BeNumerically("==", 0))
+									Expect(missingProcesses).To(BeEmpty())
+								})
+							},
+						)
 					})
 				})
 
@@ -227,10 +256,16 @@ var _ = Describe("exclude_processes", func() {
 
 					When("additional processes are running", func() {
 						BeforeEach(func() {
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1337", processClass, nil))
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								fdbv1beta2.NewProcessGroupStatus("storage-1337", processClass, nil),
+							)
 							cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
 							// Add two process groups
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1338", processClass, nil))
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								fdbv1beta2.NewProcessGroupStatus("storage-1338", processClass, nil),
+							)
 							cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
 						})
 
@@ -253,12 +288,16 @@ var _ = Describe("exclude_processes", func() {
 						When("the missing timestamp is older than 5 minutes", func() {
 							BeforeEach(func() {
 								for idx, processGroup := range cluster.Status.ProcessGroups {
-									timestamp := processGroup.GetConditionTime(fdbv1beta2.MissingProcesses)
+									timestamp := processGroup.GetConditionTime(
+										fdbv1beta2.MissingProcesses,
+									)
 									if timestamp == nil {
 										continue
 									}
 
-									cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().Add(-10 * time.Minute).Unix()
+									cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().
+										Add(-10 * time.Minute).
+										Unix()
 								}
 							})
 
@@ -315,13 +354,25 @@ var _ = Describe("exclude_processes", func() {
 
 					When("additional processes are running", func() {
 						BeforeEach(func() {
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1337", processClass, nil))
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								fdbv1beta2.NewProcessGroupStatus("storage-1337", processClass, nil),
+							)
 							cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1338", processClass, nil))
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								fdbv1beta2.NewProcessGroupStatus("storage-1338", processClass, nil),
+							)
 							cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1339", processClass, nil))
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								fdbv1beta2.NewProcessGroupStatus("storage-1339", processClass, nil),
+							)
 							cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1340", processClass, nil))
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								fdbv1beta2.NewProcessGroupStatus("storage-1340", processClass, nil),
+							)
 							cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
 						})
 
@@ -333,12 +384,16 @@ var _ = Describe("exclude_processes", func() {
 						When("the missing timestamps are older than 5 minutes", func() {
 							BeforeEach(func() {
 								for idx, processGroup := range cluster.Status.ProcessGroups {
-									timestamp := processGroup.GetConditionTime(fdbv1beta2.MissingProcesses)
+									timestamp := processGroup.GetConditionTime(
+										fdbv1beta2.MissingProcesses,
+									)
 									if timestamp == nil {
 										continue
 									}
 
-									cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().Add(-10 * time.Minute).Unix()
+									cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().
+										Add(-10 * time.Minute).
+										Unix()
 								}
 							})
 
@@ -381,13 +436,25 @@ var _ = Describe("exclude_processes", func() {
 
 					When("additional processes are running", func() {
 						BeforeEach(func() {
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1337", processClass, nil))
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								fdbv1beta2.NewProcessGroupStatus("storage-1337", processClass, nil),
+							)
 							cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1338", processClass, nil))
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								fdbv1beta2.NewProcessGroupStatus("storage-1338", processClass, nil),
+							)
 							cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1339", processClass, nil))
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								fdbv1beta2.NewProcessGroupStatus("storage-1339", processClass, nil),
+							)
 							cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1340", processClass, nil))
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								fdbv1beta2.NewProcessGroupStatus("storage-1340", processClass, nil),
+							)
 							cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
 						})
 
@@ -399,12 +466,16 @@ var _ = Describe("exclude_processes", func() {
 						When("the missing timestamps are older than 5 minutes", func() {
 							BeforeEach(func() {
 								for idx, processGroup := range cluster.Status.ProcessGroups {
-									timestamp := processGroup.GetConditionTime(fdbv1beta2.MissingProcesses)
+									timestamp := processGroup.GetConditionTime(
+										fdbv1beta2.MissingProcesses,
+									)
 									if timestamp == nil {
 										continue
 									}
 
-									cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().Add(-10 * time.Minute).Unix()
+									cluster.Status.ProcessGroups[idx].ProcessGroupConditions[0].Timestamp = time.Now().
+										Add(-10 * time.Minute).
+										Unix()
 								}
 							})
 
@@ -427,22 +498,86 @@ var _ = Describe("exclude_processes", func() {
 			cluster = &fdbv1beta2.FoundationDBCluster{
 				Status: fdbv1beta2.FoundationDBClusterStatus{
 					ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
-						{ProcessGroupID: "storage-1", ProcessClass: fdbv1beta2.ProcessClassStorage, Addresses: []string{"1.1.1.1"}},
-						{ProcessGroupID: "storage-2", ProcessClass: fdbv1beta2.ProcessClassStorage, Addresses: []string{"1.1.1.2"}},
-						{ProcessGroupID: "storage-3", ProcessClass: fdbv1beta2.ProcessClassStorage, Addresses: []string{"1.1.1.3"}},
-						{ProcessGroupID: "stateless-1", ProcessClass: fdbv1beta2.ProcessClassStateless, Addresses: []string{"1.1.1.4"}},
-						{ProcessGroupID: "stateless-2", ProcessClass: fdbv1beta2.ProcessClassStateless, Addresses: []string{"1.1.1.5"}},
-						{ProcessGroupID: "stateless-3", ProcessClass: fdbv1beta2.ProcessClassStateless, Addresses: []string{"1.1.1.6"}},
-						{ProcessGroupID: "stateless-4", ProcessClass: fdbv1beta2.ProcessClassStateless, Addresses: []string{"1.1.1.7"}},
-						{ProcessGroupID: "stateless-5", ProcessClass: fdbv1beta2.ProcessClassStateless, Addresses: []string{"1.1.1.8"}},
-						{ProcessGroupID: "stateless-6", ProcessClass: fdbv1beta2.ProcessClassStateless, Addresses: []string{"1.1.1.9"}},
-						{ProcessGroupID: "stateless-7", ProcessClass: fdbv1beta2.ProcessClassStateless, Addresses: []string{"1.1.2.1"}},
-						{ProcessGroupID: "stateless-8", ProcessClass: fdbv1beta2.ProcessClassStateless, Addresses: []string{"1.1.2.2"}},
-						{ProcessGroupID: "stateless-9", ProcessClass: fdbv1beta2.ProcessClassStateless, Addresses: []string{"1.1.2.3"}},
-						{ProcessGroupID: "log-1", ProcessClass: fdbv1beta2.ProcessClassLog, Addresses: []string{"1.1.2.4"}},
-						{ProcessGroupID: "log-2", ProcessClass: fdbv1beta2.ProcessClassLog, Addresses: []string{"1.1.2.5"}},
-						{ProcessGroupID: "log-3", ProcessClass: fdbv1beta2.ProcessClassLog, Addresses: []string{"1.1.2.6"}},
-						{ProcessGroupID: "log-4", ProcessClass: fdbv1beta2.ProcessClassLog, Addresses: []string{"1.1.2.7"}},
+						{
+							ProcessGroupID: "storage-1",
+							ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							Addresses:      []string{"1.1.1.1"},
+						},
+						{
+							ProcessGroupID: "storage-2",
+							ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							Addresses:      []string{"1.1.1.2"},
+						},
+						{
+							ProcessGroupID: "storage-3",
+							ProcessClass:   fdbv1beta2.ProcessClassStorage,
+							Addresses:      []string{"1.1.1.3"},
+						},
+						{
+							ProcessGroupID: "stateless-1",
+							ProcessClass:   fdbv1beta2.ProcessClassStateless,
+							Addresses:      []string{"1.1.1.4"},
+						},
+						{
+							ProcessGroupID: "stateless-2",
+							ProcessClass:   fdbv1beta2.ProcessClassStateless,
+							Addresses:      []string{"1.1.1.5"},
+						},
+						{
+							ProcessGroupID: "stateless-3",
+							ProcessClass:   fdbv1beta2.ProcessClassStateless,
+							Addresses:      []string{"1.1.1.6"},
+						},
+						{
+							ProcessGroupID: "stateless-4",
+							ProcessClass:   fdbv1beta2.ProcessClassStateless,
+							Addresses:      []string{"1.1.1.7"},
+						},
+						{
+							ProcessGroupID: "stateless-5",
+							ProcessClass:   fdbv1beta2.ProcessClassStateless,
+							Addresses:      []string{"1.1.1.8"},
+						},
+						{
+							ProcessGroupID: "stateless-6",
+							ProcessClass:   fdbv1beta2.ProcessClassStateless,
+							Addresses:      []string{"1.1.1.9"},
+						},
+						{
+							ProcessGroupID: "stateless-7",
+							ProcessClass:   fdbv1beta2.ProcessClassStateless,
+							Addresses:      []string{"1.1.2.1"},
+						},
+						{
+							ProcessGroupID: "stateless-8",
+							ProcessClass:   fdbv1beta2.ProcessClassStateless,
+							Addresses:      []string{"1.1.2.2"},
+						},
+						{
+							ProcessGroupID: "stateless-9",
+							ProcessClass:   fdbv1beta2.ProcessClassStateless,
+							Addresses:      []string{"1.1.2.3"},
+						},
+						{
+							ProcessGroupID: "log-1",
+							ProcessClass:   fdbv1beta2.ProcessClassLog,
+							Addresses:      []string{"1.1.2.4"},
+						},
+						{
+							ProcessGroupID: "log-2",
+							ProcessClass:   fdbv1beta2.ProcessClassLog,
+							Addresses:      []string{"1.1.2.5"},
+						},
+						{
+							ProcessGroupID: "log-3",
+							ProcessClass:   fdbv1beta2.ProcessClassLog,
+							Addresses:      []string{"1.1.2.6"},
+						},
+						{
+							ProcessGroupID: "log-4",
+							ProcessClass:   fdbv1beta2.ProcessClassLog,
+							Addresses:      []string{"1.1.2.7"},
+						},
 					},
 				},
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
@@ -458,12 +593,19 @@ var _ = Describe("exclude_processes", func() {
 			When("the synchronization mode is local", func() {
 				BeforeEach(func() {
 					cluster.Spec.Version = fdbv1beta2.Versions.MinimumVersion.String()
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeLocal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeLocal),
+					)
 				})
 
 				When("there are no exclusions", func() {
 					It("should not exclude anything", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(0))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
@@ -472,38 +614,71 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding one process", func() {
 					BeforeEach(func() {
 						processGroup := cluster.Status.ProcessGroups[0]
-						Expect(processGroup.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup
 					})
 
 					It("should report the excluded process", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-						Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-						Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+						Expect(
+							fdbProcessesToExcludeByClass,
+						).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+						Expect(
+							fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+						).To(HaveLen(1))
 						entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-						Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-						Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal("1.1.1.1"))
+						Expect(
+							entry.processGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+						).To(Equal("1.1.1.1"))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
 
 					When("the old IP address of this process group is already excluded", func() {
 						BeforeEach(func() {
 							processGroup := cluster.Status.ProcessGroups[0]
-							exclusions = append(exclusions, fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP(processGroup.Addresses[0])})
+							exclusions = append(
+								exclusions,
+								fdbv1beta2.ProcessAddress{
+									IPAddress: net.ParseIP(processGroup.Addresses[0]),
+								},
+							)
 
 							processGroup.Addresses = append(processGroup.Addresses, "100.1.100.2")
 						})
 
 						It("should report the not yet excluded address of this process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(cluster.Status.ProcessGroups[0].ProcessGroupID))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal("100.1.100.2"))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(cluster.Status.ProcessGroups[0].ProcessGroupID))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal("100.1.100.2"))
 							Expect(ongoingExclusionsByClass).To(HaveLen(0))
 						})
 					})
@@ -512,29 +687,46 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding two process", func() {
 					BeforeEach(func() {
 						processGroup1 := cluster.Status.ProcessGroups[0]
-						Expect(processGroup1.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup1.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup1.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup1
 
 						processGroup2 := cluster.Status.ProcessGroups[1]
-						Expect(processGroup2.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+						Expect(
+							processGroup2.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 						processGroup2.MarkForRemoval()
 						cluster.Status.ProcessGroups[1] = processGroup2
 					})
 
 					It("should report the excluded process", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-						Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-						Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(2))
+						Expect(
+							fdbProcessesToExcludeByClass,
+						).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+						Expect(
+							fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+						).To(HaveLen(2))
 
 						var addresses []fdbv1beta2.ProcessAddress
 						for _, entry := range fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage] {
-							Expect(entry.processGroupID).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
+							Expect(
+								entry.processGroupID,
+							).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
 							addresses = append(addresses, entry.addresses...)
 						}
 
-						Expect(fdbv1beta2.ProcessAddressesString(addresses, " ")).To(Equal("1.1.1.1 1.1.1.2"))
+						Expect(
+							fdbv1beta2.ProcessAddressesString(addresses, " "),
+						).To(Equal("1.1.1.1 1.1.1.2"))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
 				})
@@ -542,27 +734,49 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding two process with one already excluded", func() {
 					BeforeEach(func() {
 						processGroup1 := cluster.Status.ProcessGroups[0]
-						Expect(processGroup1.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup1.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup1.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup1
 
 						processGroup2 := cluster.Status.ProcessGroups[1]
-						Expect(processGroup2.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+						Expect(
+							processGroup2.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 						processGroup2.MarkForRemoval()
 						cluster.Status.ProcessGroups[1] = processGroup2
 
-						exclusions = append(exclusions, fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP(processGroup2.Addresses[0])})
+						exclusions = append(
+							exclusions,
+							fdbv1beta2.ProcessAddress{
+								IPAddress: net.ParseIP(processGroup2.Addresses[0]),
+							},
+						)
 					})
 
 					When("the exclusion has not finished", func() {
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal("1.1.1.1"))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal("1.1.1.1"))
 							Expect(ongoingExclusionsByClass).To(HaveLen(1))
 						})
 					})
@@ -570,19 +784,34 @@ var _ = Describe("exclude_processes", func() {
 					When("the exclusion has finished", func() {
 						BeforeEach(func() {
 							processGroup := cluster.Status.ProcessGroups[1]
-							Expect(processGroup.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+							Expect(
+								processGroup.ProcessGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 							processGroup.SetExclude()
 							cluster.Status.ProcessGroups[1] = processGroup
 						})
 
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal("1.1.1.1"))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal("1.1.1.1"))
 							Expect(ongoingExclusionsByClass).To(HaveLen(0))
 						})
 					})
@@ -592,12 +821,19 @@ var _ = Describe("exclude_processes", func() {
 			When("the synchronization mode is global", func() {
 				BeforeEach(func() {
 					cluster.Spec.Version = fdbv1beta2.Versions.MinimumVersion.String()
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeGlobal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeGlobal),
+					)
 				})
 
 				When("there are no exclusions", func() {
 					It("should not exclude anything", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(0))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
@@ -606,38 +842,71 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding one process", func() {
 					BeforeEach(func() {
 						processGroup := cluster.Status.ProcessGroups[0]
-						Expect(processGroup.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup
 					})
 
 					It("should report the excluded process", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-						Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-						Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+						Expect(
+							fdbProcessesToExcludeByClass,
+						).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+						Expect(
+							fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+						).To(HaveLen(1))
 						entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-						Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-						Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal("1.1.1.1"))
+						Expect(
+							entry.processGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+						).To(Equal("1.1.1.1"))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
 
 					When("the old IP address of this process group is already excluded", func() {
 						BeforeEach(func() {
 							processGroup := cluster.Status.ProcessGroups[0]
-							exclusions = append(exclusions, fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP(processGroup.Addresses[0])})
+							exclusions = append(
+								exclusions,
+								fdbv1beta2.ProcessAddress{
+									IPAddress: net.ParseIP(processGroup.Addresses[0]),
+								},
+							)
 
 							processGroup.Addresses = append(processGroup.Addresses, "100.1.100.2")
 						})
 
 						It("should report the not yet excluded address of this process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(cluster.Status.ProcessGroups[0].ProcessGroupID))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal("100.1.100.2"))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(cluster.Status.ProcessGroups[0].ProcessGroupID))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal("100.1.100.2"))
 							Expect(ongoingExclusionsByClass).To(HaveLen(0))
 						})
 					})
@@ -646,29 +915,46 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding two process", func() {
 					BeforeEach(func() {
 						processGroup1 := cluster.Status.ProcessGroups[0]
-						Expect(processGroup1.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup1.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup1.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup1
 
 						processGroup2 := cluster.Status.ProcessGroups[1]
-						Expect(processGroup2.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+						Expect(
+							processGroup2.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 						processGroup2.MarkForRemoval()
 						cluster.Status.ProcessGroups[1] = processGroup2
 					})
 
 					It("should report the excluded process", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-						Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-						Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(2))
+						Expect(
+							fdbProcessesToExcludeByClass,
+						).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+						Expect(
+							fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+						).To(HaveLen(2))
 
 						var addresses []fdbv1beta2.ProcessAddress
 						for _, entry := range fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage] {
-							Expect(entry.processGroupID).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
+							Expect(
+								entry.processGroupID,
+							).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
 							addresses = append(addresses, entry.addresses...)
 						}
 
-						Expect(fdbv1beta2.ProcessAddressesString(addresses, " ")).To(Equal("1.1.1.1 1.1.1.2"))
+						Expect(
+							fdbv1beta2.ProcessAddressesString(addresses, " "),
+						).To(Equal("1.1.1.1 1.1.1.2"))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
 				})
@@ -676,27 +962,49 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding two process with one already excluded", func() {
 					BeforeEach(func() {
 						processGroup1 := cluster.Status.ProcessGroups[0]
-						Expect(processGroup1.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup1.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup1.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup1
 
 						processGroup2 := cluster.Status.ProcessGroups[1]
-						Expect(processGroup2.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+						Expect(
+							processGroup2.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 						processGroup2.MarkForRemoval()
 						cluster.Status.ProcessGroups[1] = processGroup2
 
-						exclusions = append(exclusions, fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP(processGroup2.Addresses[0])})
+						exclusions = append(
+							exclusions,
+							fdbv1beta2.ProcessAddress{
+								IPAddress: net.ParseIP(processGroup2.Addresses[0]),
+							},
+						)
 					})
 
 					When("the exclusion has not finished", func() {
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal("1.1.1.1"))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal("1.1.1.1"))
 							Expect(ongoingExclusionsByClass).To(HaveLen(1))
 						})
 					})
@@ -704,19 +1012,34 @@ var _ = Describe("exclude_processes", func() {
 					When("the exclusion has finished", func() {
 						BeforeEach(func() {
 							processGroup := cluster.Status.ProcessGroups[1]
-							Expect(processGroup.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+							Expect(
+								processGroup.ProcessGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 							processGroup.SetExclude()
 							cluster.Status.ProcessGroups[1] = processGroup
 						})
 
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal("1.1.1.1"))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal("1.1.1.1"))
 							Expect(ongoingExclusionsByClass).To(HaveLen(0))
 						})
 					})
@@ -728,12 +1051,19 @@ var _ = Describe("exclude_processes", func() {
 			When("the synchronization mode is local", func() {
 				BeforeEach(func() {
 					cluster.Spec.Version = fdbv1beta2.Versions.SupportsLocalityBasedExclusions.String()
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeLocal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeLocal),
+					)
 				})
 
 				When("there are no exclusions", func() {
 					It("should not exclude anything", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(0))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
@@ -742,19 +1072,34 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding one process", func() {
 					BeforeEach(func() {
 						processGroup := cluster.Status.ProcessGroups[0]
-						Expect(processGroup.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup
 					})
 
 					It("should report the excluded process", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-						Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-						Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+						Expect(
+							fdbProcessesToExcludeByClass,
+						).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+						Expect(
+							fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+						).To(HaveLen(1))
 						entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-						Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-						Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
+						Expect(
+							entry.processGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+						).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
 				})
@@ -762,28 +1107,45 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding two process", func() {
 					BeforeEach(func() {
 						processGroup1 := cluster.Status.ProcessGroups[0]
-						Expect(processGroup1.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup1.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup1.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup1
 
 						processGroup2 := cluster.Status.ProcessGroups[1]
-						Expect(processGroup2.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+						Expect(
+							processGroup2.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 						processGroup2.MarkForRemoval()
 						cluster.Status.ProcessGroups[1] = processGroup2
 					})
 
 					It("should report the excluded process", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-						Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-						Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(2))
+						Expect(
+							fdbProcessesToExcludeByClass,
+						).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+						Expect(
+							fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+						).To(HaveLen(2))
 						var addresses []fdbv1beta2.ProcessAddress
 						for _, entry := range fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage] {
-							Expect(entry.processGroupID).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
+							Expect(
+								entry.processGroupID,
+							).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
 							addresses = append(addresses, entry.addresses...)
 						}
 
-						Expect(fdbv1beta2.ProcessAddressesString(addresses, " ")).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
+						Expect(
+							fdbv1beta2.ProcessAddressesString(addresses, " "),
+						).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
 				})
@@ -791,31 +1153,53 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding two process with one already excluded using IP", func() {
 					BeforeEach(func() {
 						processGroup1 := cluster.Status.ProcessGroups[0]
-						Expect(processGroup1.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup1.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup1.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup1
 
 						processGroup2 := cluster.Status.ProcessGroups[1]
-						Expect(processGroup2.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+						Expect(
+							processGroup2.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 						processGroup2.MarkForRemoval()
 						cluster.Status.ProcessGroups[1] = processGroup2
 
-						exclusions = append(exclusions, fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP(processGroup2.Addresses[0])})
+						exclusions = append(
+							exclusions,
+							fdbv1beta2.ProcessAddress{
+								IPAddress: net.ParseIP(processGroup2.Addresses[0]),
+							},
+						)
 					})
 
 					When("the exclusion has not finished", func() {
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(2))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(2))
 							var addresses []fdbv1beta2.ProcessAddress
 							for _, entry := range fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage] {
-								Expect(entry.processGroupID).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
+								Expect(
+									entry.processGroupID,
+								).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
 								addresses = append(addresses, entry.addresses...)
 							}
 
-							Expect(fdbv1beta2.ProcessAddressesString(addresses, " ")).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(addresses, " "),
+							).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
 							Expect(ongoingExclusionsByClass).To(HaveLen(0))
 						})
 					})
@@ -823,19 +1207,34 @@ var _ = Describe("exclude_processes", func() {
 					When("the exclusion has finished", func() {
 						BeforeEach(func() {
 							processGroup := cluster.Status.ProcessGroups[1]
-							Expect(processGroup.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+							Expect(
+								processGroup.ProcessGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 							processGroup.SetExclude()
 							cluster.Status.ProcessGroups[1] = processGroup
 						})
 
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
 							Expect(ongoingExclusionsByClass).To(HaveLen(0))
 						})
 					})
@@ -844,27 +1243,49 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding two process with one already excluded using locality", func() {
 					BeforeEach(func() {
 						processGroup1 := cluster.Status.ProcessGroups[0]
-						Expect(processGroup1.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup1.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup1.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup1
 
 						processGroup2 := cluster.Status.ProcessGroups[1]
-						Expect(processGroup2.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+						Expect(
+							processGroup2.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 						processGroup2.MarkForRemoval()
 						cluster.Status.ProcessGroups[1] = processGroup2
 
-						exclusions = append(exclusions, fdbv1beta2.ProcessAddress{StringAddress: processGroup2.GetExclusionString()})
+						exclusions = append(
+							exclusions,
+							fdbv1beta2.ProcessAddress{
+								StringAddress: processGroup2.GetExclusionString(),
+							},
+						)
 					})
 
 					When("the exclusion has not finished", func() {
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
 							Expect(ongoingExclusionsByClass).To(HaveLen(1))
 						})
 					})
@@ -872,19 +1293,34 @@ var _ = Describe("exclude_processes", func() {
 					When("the exclusion has finished", func() {
 						BeforeEach(func() {
 							processGroup := cluster.Status.ProcessGroups[1]
-							Expect(processGroup.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+							Expect(
+								processGroup.ProcessGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 							processGroup.SetExclude()
 							cluster.Status.ProcessGroups[1] = processGroup
 						})
 
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
 							Expect(ongoingExclusionsByClass).To(HaveLen(0))
 						})
 					})
@@ -894,12 +1330,19 @@ var _ = Describe("exclude_processes", func() {
 			When("the synchronization mode is global", func() {
 				BeforeEach(func() {
 					cluster.Spec.Version = fdbv1beta2.Versions.SupportsLocalityBasedExclusions.String()
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeGlobal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeGlobal),
+					)
 				})
 
 				When("there are no exclusions", func() {
 					It("should not exclude anything", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(0))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
@@ -908,19 +1351,34 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding one process", func() {
 					BeforeEach(func() {
 						processGroup := cluster.Status.ProcessGroups[0]
-						Expect(processGroup.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup
 					})
 
 					It("should report the excluded process", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-						Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-						Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+						Expect(
+							fdbProcessesToExcludeByClass,
+						).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+						Expect(
+							fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+						).To(HaveLen(1))
 						entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-						Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-						Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
+						Expect(
+							entry.processGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+						).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
 				})
@@ -928,28 +1386,45 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding two process", func() {
 					BeforeEach(func() {
 						processGroup1 := cluster.Status.ProcessGroups[0]
-						Expect(processGroup1.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup1.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup1.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup1
 
 						processGroup2 := cluster.Status.ProcessGroups[1]
-						Expect(processGroup2.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+						Expect(
+							processGroup2.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 						processGroup2.MarkForRemoval()
 						cluster.Status.ProcessGroups[1] = processGroup2
 					})
 
 					It("should report the excluded process", func() {
-						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+						fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+							exclusions,
+							cluster,
+							map[fdbv1beta2.ProcessGroupID]time.Time{},
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+						)
 						Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-						Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-						Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(2))
+						Expect(
+							fdbProcessesToExcludeByClass,
+						).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+						Expect(
+							fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+						).To(HaveLen(2))
 						var addresses []fdbv1beta2.ProcessAddress
 						for _, entry := range fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage] {
-							Expect(entry.processGroupID).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
+							Expect(
+								entry.processGroupID,
+							).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
 							addresses = append(addresses, entry.addresses...)
 						}
 
-						Expect(fdbv1beta2.ProcessAddressesString(addresses, " ")).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
+						Expect(
+							fdbv1beta2.ProcessAddressesString(addresses, " "),
+						).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
 						Expect(ongoingExclusionsByClass).To(HaveLen(0))
 					})
 				})
@@ -957,31 +1432,53 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding two process with one already excluded using IP", func() {
 					BeforeEach(func() {
 						processGroup1 := cluster.Status.ProcessGroups[0]
-						Expect(processGroup1.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup1.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup1.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup1
 
 						processGroup2 := cluster.Status.ProcessGroups[1]
-						Expect(processGroup2.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+						Expect(
+							processGroup2.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 						processGroup2.MarkForRemoval()
 						cluster.Status.ProcessGroups[1] = processGroup2
 
-						exclusions = append(exclusions, fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP(processGroup2.Addresses[0])})
+						exclusions = append(
+							exclusions,
+							fdbv1beta2.ProcessAddress{
+								IPAddress: net.ParseIP(processGroup2.Addresses[0]),
+							},
+						)
 					})
 
 					When("the exclusion has not finished", func() {
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(2))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(2))
 							var addresses []fdbv1beta2.ProcessAddress
 							for _, entry := range fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage] {
-								Expect(entry.processGroupID).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
+								Expect(
+									entry.processGroupID,
+								).To(Or(Equal(fdbv1beta2.ProcessGroupID("storage-1")), Equal(fdbv1beta2.ProcessGroupID("storage-2"))))
 								addresses = append(addresses, entry.addresses...)
 							}
 
-							Expect(fdbv1beta2.ProcessAddressesString(addresses, " ")).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(addresses, " "),
+							).To(Equal(fmt.Sprintf("%s %s", cluster.Status.ProcessGroups[0].GetExclusionString(), cluster.Status.ProcessGroups[1].GetExclusionString())))
 							Expect(ongoingExclusionsByClass).To(HaveLen(0))
 						})
 					})
@@ -989,19 +1486,34 @@ var _ = Describe("exclude_processes", func() {
 					When("the exclusion has finished", func() {
 						BeforeEach(func() {
 							processGroup := cluster.Status.ProcessGroups[1]
-							Expect(processGroup.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+							Expect(
+								processGroup.ProcessGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 							processGroup.SetExclude()
 							cluster.Status.ProcessGroups[1] = processGroup
 						})
 
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
 							Expect(ongoingExclusionsByClass).To(HaveLen(0))
 						})
 					})
@@ -1010,27 +1522,49 @@ var _ = Describe("exclude_processes", func() {
 				When("excluding two process with one already excluded using locality", func() {
 					BeforeEach(func() {
 						processGroup1 := cluster.Status.ProcessGroups[0]
-						Expect(processGroup1.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							processGroup1.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
 						processGroup1.MarkForRemoval()
 						cluster.Status.ProcessGroups[0] = processGroup1
 
 						processGroup2 := cluster.Status.ProcessGroups[1]
-						Expect(processGroup2.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+						Expect(
+							processGroup2.ProcessGroupID,
+						).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 						processGroup2.MarkForRemoval()
 						cluster.Status.ProcessGroups[1] = processGroup2
 
-						exclusions = append(exclusions, fdbv1beta2.ProcessAddress{StringAddress: processGroup2.GetExclusionString()})
+						exclusions = append(
+							exclusions,
+							fdbv1beta2.ProcessAddress{
+								StringAddress: processGroup2.GetExclusionString(),
+							},
+						)
 					})
 
 					When("the exclusion has not finished", func() {
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
 							Expect(ongoingExclusionsByClass).To(HaveLen(1))
 						})
 					})
@@ -1038,19 +1572,34 @@ var _ = Describe("exclude_processes", func() {
 					When("the exclusion has finished", func() {
 						BeforeEach(func() {
 							processGroup := cluster.Status.ProcessGroups[1]
-							Expect(processGroup.ProcessGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
+							Expect(
+								processGroup.ProcessGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-2")))
 							processGroup.SetExclude()
 							cluster.Status.ProcessGroups[1] = processGroup
 						})
 
 						It("should report the excluded process", func() {
-							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(exclusions, cluster, map[fdbv1beta2.ProcessGroupID]time.Time{}, map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{})
+							fdbProcessesToExcludeByClass, ongoingExclusionsByClass := getProcessesToExclude(
+								exclusions,
+								cluster,
+								map[fdbv1beta2.ProcessGroupID]time.Time{},
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{},
+							)
 							Expect(fdbProcessesToExcludeByClass).To(HaveLen(1))
-							Expect(fdbProcessesToExcludeByClass).To(HaveKey(fdbv1beta2.ProcessClassStorage))
-							Expect(fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage]).To(HaveLen(1))
+							Expect(
+								fdbProcessesToExcludeByClass,
+							).To(HaveKey(fdbv1beta2.ProcessClassStorage))
+							Expect(
+								fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage],
+							).To(HaveLen(1))
 							entry := fdbProcessesToExcludeByClass[fdbv1beta2.ProcessClassStorage][0]
-							Expect(entry.processGroupID).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
-							Expect(fdbv1beta2.ProcessAddressesString(entry.addresses, " ")).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
+							Expect(
+								entry.processGroupID,
+							).To(Equal(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								fdbv1beta2.ProcessAddressesString(entry.addresses, " "),
+							).To(Equal(cluster.Status.ProcessGroups[0].GetExclusionString()))
 							Expect(ongoingExclusionsByClass).To(HaveLen(0))
 						})
 					})
@@ -1059,9 +1608,19 @@ var _ = Describe("exclude_processes", func() {
 		})
 	})
 
-	DescribeTable("when getting the allowed exclusions", func(validProcesses int, desiredProcessCount int, ongoingExclusions int, faultTolerance int, expected int) {
-		Expect(getAllowedExclusions(GinkgoLogr, validProcesses, desiredProcessCount, ongoingExclusions, faultTolerance)).To(BeNumerically("==", expected))
-	},
+	DescribeTable(
+		"when getting the allowed exclusions",
+		func(validProcesses int, desiredProcessCount int, ongoingExclusions int, faultTolerance int, expected int) {
+			Expect(
+				getAllowedExclusions(
+					GinkgoLogr,
+					validProcesses,
+					desiredProcessCount,
+					ongoingExclusions,
+					faultTolerance,
+				),
+			).To(BeNumerically("==", expected))
+		},
 		Entry("when as many valid processes are running as desired",
 			10,
 			10,
@@ -1086,12 +1645,14 @@ var _ = Describe("exclude_processes", func() {
 			0,
 			2,
 			12),
-		Entry("when more valid processes are running than desired but there are 10 exclusions ongoing",
+		Entry(
+			"when more valid processes are running than desired but there are 10 exclusions ongoing",
 			20,
 			10,
 			10,
 			2,
-			2),
+			2,
+		),
 		Entry("when only 8 valid processes are running",
 			8,
 			10,
@@ -1127,12 +1688,20 @@ var _ = Describe("exclude_processes", func() {
 		})
 
 		JustBeforeEach(func() {
-			req = excludeProcesses{}.reconcile(context.Background(), clusterReconciler, cluster, nil, GinkgoLogr)
+			req = excludeProcesses{}.reconcile(
+				context.Background(),
+				clusterReconciler,
+				cluster,
+				nil,
+				GinkgoLogr,
+			)
 		})
 
 		When("the synchronization mode is local", func() {
 			BeforeEach(func() {
-				cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeLocal))
+				cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+					string(fdbv1beta2.SynchronizationModeLocal),
+				)
 			})
 
 			When("a coordinator should be excluded", func() {
@@ -1168,7 +1737,9 @@ var _ = Describe("exclude_processes", func() {
 
 				When("using localities", func() {
 					BeforeEach(func() {
-						cluster.Spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(true)
+						cluster.Spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(
+							true,
+						)
 					})
 
 					It("should exclude the process and change the coordinators", func() {
@@ -1180,7 +1751,9 @@ var _ = Describe("exclude_processes", func() {
 
 						_, err = reloadCluster(cluster)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(initialConnectionString).NotTo(Equal(cluster.Status.ConnectionString))
+						Expect(
+							initialConnectionString,
+						).NotTo(Equal(cluster.Status.ConnectionString))
 					})
 				})
 			})
@@ -1192,14 +1765,35 @@ var _ = Describe("exclude_processes", func() {
 
 						_, processGroupIDs, err := cluster.GetCurrentProcessGroupsAndProcessCounts()
 						Expect(err).NotTo(HaveOccurred())
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(cluster.GetNextRandomProcessGroupID(fdbv1beta2.ProcessClassLog, processGroupIDs[fdbv1beta2.ProcessClassLog]), fdbv1beta2.ProcessClassLog, nil))
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								cluster.GetNextRandomProcessGroupID(
+									fdbv1beta2.ProcessClassLog,
+									processGroupIDs[fdbv1beta2.ProcessClassLog],
+								),
+								fdbv1beta2.ProcessClassLog,
+								nil,
+							),
+						)
 						cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(cluster.GetNextRandomProcessGroupID(fdbv1beta2.ProcessClassStateless, processGroupIDs[fdbv1beta2.ProcessClassStateless]), fdbv1beta2.ProcessClassStateless, nil))
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								cluster.GetNextRandomProcessGroupID(
+									fdbv1beta2.ProcessClassStateless,
+									processGroupIDs[fdbv1beta2.ProcessClassStateless],
+								),
+								fdbv1beta2.ProcessClassStateless,
+								nil,
+							),
+						)
 						cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].ProcessGroupConditions = nil
 
 						markedForRemoval := make([]fdbv1beta2.ProcessGroupID, 0, 2)
 						for _, processGroup := range cluster.Status.ProcessGroups {
-							if !processGroup.ProcessClass.IsTransaction() || processGroup.ProcessClass == fdbv1beta2.ProcessClassClusterController {
+							if !processGroup.ProcessClass.IsTransaction() ||
+								processGroup.ProcessClass == fdbv1beta2.ProcessClassClusterController {
 								continue
 							}
 
@@ -1245,8 +1839,18 @@ var _ = Describe("exclude_processes", func() {
 							_, processGroupIDs, err := cluster.GetCurrentProcessGroupsAndProcessCounts()
 							Expect(err).NotTo(HaveOccurred())
 
-							missingProcessGroup = fdbv1beta2.NewProcessGroupStatus(cluster.GetNextRandomProcessGroupID(fdbv1beta2.ProcessClassLog, processGroupIDs[fdbv1beta2.ProcessClassLog]), fdbv1beta2.ProcessClassLog, nil)
-							cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, missingProcessGroup)
+							missingProcessGroup = fdbv1beta2.NewProcessGroupStatus(
+								cluster.GetNextRandomProcessGroupID(
+									fdbv1beta2.ProcessClassLog,
+									processGroupIDs[fdbv1beta2.ProcessClassLog],
+								),
+								fdbv1beta2.ProcessClassLog,
+								nil,
+							)
+							cluster.Status.ProcessGroups = append(
+								cluster.Status.ProcessGroups,
+								missingProcessGroup,
+							)
 							// We have to set InSimulation here to false, otherwise the MissingProcess timestamp will be ignored.
 							clusterReconciler.SimulationOptions.SimulateTime = false
 						})
@@ -1261,11 +1865,16 @@ var _ = Describe("exclude_processes", func() {
 
 						When("the transaction process is missing for more than 10 minutes", func() {
 							BeforeEach(func() {
-								missingProcessGroup.ProcessGroupConditions[0].Timestamp = time.Now().Add(-10 * time.Minute).Unix()
+								missingProcessGroup.ProcessGroupConditions[0].Timestamp = time.Now().
+									Add(-10 * time.Minute).
+									Unix()
 							})
 
 							It("should exclude the process", func() {
-								adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
+								adminClient, err := mock.NewMockAdminClientUncast(
+									cluster,
+									k8sClient,
+								)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(req).To(BeNil())
@@ -1279,7 +1888,9 @@ var _ = Describe("exclude_processes", func() {
 
 		When("the synchronization mode is global", func() {
 			BeforeEach(func() {
-				cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeGlobal))
+				cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+					string(fdbv1beta2.SynchronizationModeGlobal),
+				)
 			})
 
 			When("a coordinator should be excluded", func() {
@@ -1315,7 +1926,9 @@ var _ = Describe("exclude_processes", func() {
 
 				When("using localities", func() {
 					BeforeEach(func() {
-						cluster.Spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(true)
+						cluster.Spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(
+							true,
+						)
 					})
 
 					It("should exclude the process and change the coordinators", func() {
@@ -1327,7 +1940,9 @@ var _ = Describe("exclude_processes", func() {
 
 						_, err = reloadCluster(cluster)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(initialConnectionString).NotTo(Equal(cluster.Status.ConnectionString))
+						Expect(
+							initialConnectionString,
+						).NotTo(Equal(cluster.Status.ConnectionString))
 					})
 				})
 			})
@@ -1340,9 +1955,13 @@ var _ = Describe("exclude_processes", func() {
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(adminClient.UpdatePendingForExclusion(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-						otherProcessGroupID: fdbv1beta2.UpdateActionAdd,
-					})).To(Succeed())
+					Expect(
+						adminClient.UpdatePendingForExclusion(
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+								otherProcessGroupID: fdbv1beta2.UpdateActionAdd,
+							},
+						),
+					).To(Succeed())
 
 					adminClient.MockAdditionalProcesses([]fdbv1beta2.ProcessGroupStatus{
 						{
@@ -1366,30 +1985,41 @@ var _ = Describe("exclude_processes", func() {
 					}
 				})
 
-				When("the process group from the other cluster is not ready to be excluded", func() {
-					It("should not exclude the processes", func() {
-						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
-						Expect(err).NotTo(HaveOccurred())
+				When(
+					"the process group from the other cluster is not ready to be excluded",
+					func() {
+						It("should not exclude the processes", func() {
+							adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
+							Expect(err).NotTo(HaveOccurred())
 
-						Expect(req).NotTo(BeNil())
-						Expect(req.curError).To(MatchError(Equal("not all processes are ready: another-cluster-log-1")))
-						Expect(adminClient.ExcludedAddresses).To(BeEmpty())
-					})
-				})
+							Expect(req).NotTo(BeNil())
+							Expect(
+								req.curError,
+							).To(MatchError(Equal("not all processes are ready: another-cluster-log-1")))
+							Expect(adminClient.ExcludedAddresses).To(BeEmpty())
+						})
+					},
+				)
 
 				When("the process group from the other cluster is ready to be excluded", func() {
 					BeforeEach(func() {
 						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 						Expect(err).NotTo(HaveOccurred())
 
-						Expect(adminClient.UpdateReadyForExclusion(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-							otherProcessGroupID: fdbv1beta2.UpdateActionAdd,
-						})).To(Succeed())
+						Expect(
+							adminClient.UpdateReadyForExclusion(
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+									otherProcessGroupID: fdbv1beta2.UpdateActionAdd,
+								},
+							),
+						).To(Succeed())
 					})
 
 					When("localities are used for exclusion", func() {
 						BeforeEach(func() {
-							cluster.Spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(true)
+							cluster.Spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(
+								true,
+							)
 						})
 
 						It("should exclude the processes", func() {
@@ -1399,25 +2029,33 @@ var _ = Describe("exclude_processes", func() {
 							Expect(req).To(BeNil())
 							Expect(adminClient.ExcludedAddresses).To(HaveLen(2))
 							for excludedAddress := range adminClient.ExcludedAddresses {
-								Expect(excludedAddress).To(HavePrefix(fdbv1beta2.FDBLocalityExclusionPrefix))
+								Expect(
+									excludedAddress,
+								).To(HavePrefix(fdbv1beta2.FDBLocalityExclusionPrefix))
 							}
 						})
 					})
 
 					When("localities for exclusion are disabled", func() {
 						BeforeEach(func() {
-							cluster.Spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(false)
+							cluster.Spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(
+								false,
+							)
 							adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 							Expect(err).NotTo(HaveOccurred())
 
-							Expect(adminClient.UpdateProcessAddresses(map[fdbv1beta2.ProcessGroupID][]string{
-								otherProcessGroupID: {
-									"192.168.0.2",
-								},
-								targetedProcessGroupID: {
-									"192.168.0.3",
-								},
-							})).To(Succeed())
+							Expect(
+								adminClient.UpdateProcessAddresses(
+									map[fdbv1beta2.ProcessGroupID][]string{
+										otherProcessGroupID: {
+											"192.168.0.2",
+										},
+										targetedProcessGroupID: {
+											"192.168.0.3",
+										},
+									},
+								),
+							).To(Succeed())
 						})
 
 						It("should exclude the processes", func() {
@@ -1427,7 +2065,9 @@ var _ = Describe("exclude_processes", func() {
 							Expect(req).To(BeNil())
 							Expect(adminClient.ExcludedAddresses).To(HaveLen(2))
 							for excludedAddress := range adminClient.ExcludedAddresses {
-								Expect(excludedAddress).NotTo(HavePrefix(fdbv1beta2.FDBLocalityExclusionPrefix))
+								Expect(
+									excludedAddress,
+								).NotTo(HavePrefix(fdbv1beta2.FDBLocalityExclusionPrefix))
 							}
 						})
 					})
@@ -1444,14 +2084,19 @@ var _ = Describe("exclude_processes", func() {
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 
-					adminClient.MockAdditionTimeForGlobalCoordination = time.Now().Add(-coordination.IgnoreMissingProcessDuration)
+					adminClient.MockAdditionTimeForGlobalCoordination = time.Now().
+						Add(-coordination.IgnoreMissingProcessDuration)
 
-					Expect(adminClient.UpdatePendingForExclusion(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-						firstOtherProcessGroupID:  fdbv1beta2.UpdateActionAdd,
-						secondOtherProcessGroupID: fdbv1beta2.UpdateActionAdd,
-						thirdOtherProcessGroupID:  fdbv1beta2.UpdateActionAdd,
-						fourthOtherProcessGroupID: fdbv1beta2.UpdateActionAdd,
-					})).To(Succeed())
+					Expect(
+						adminClient.UpdatePendingForExclusion(
+							map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+								firstOtherProcessGroupID:  fdbv1beta2.UpdateActionAdd,
+								secondOtherProcessGroupID: fdbv1beta2.UpdateActionAdd,
+								thirdOtherProcessGroupID:  fdbv1beta2.UpdateActionAdd,
+								fourthOtherProcessGroupID: fdbv1beta2.UpdateActionAdd,
+							},
+						),
+					).To(Succeed())
 
 					adminClient.MockAdditionalProcesses([]fdbv1beta2.ProcessGroupStatus{
 						{
@@ -1494,32 +2139,39 @@ var _ = Describe("exclude_processes", func() {
 					}
 				})
 
-				When("the process group from the other cluster is not ready to be excluded", func() {
-					It("should only exclude one process in the local cluster", func() {
-						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
-						Expect(err).NotTo(HaveOccurred())
+				When(
+					"the process group from the other cluster is not ready to be excluded",
+					func() {
+						It("should only exclude one process in the local cluster", func() {
+							adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
+							Expect(err).NotTo(HaveOccurred())
 
-						Expect(req).NotTo(BeNil())
-						Expect(req.delayedRequeue).To(BeTrue())
-						Expect(req.delay).To(BeNumerically("==", 5*time.Minute))
-						Expect(adminClient.ExcludedAddresses).To(HaveLen(1))
+							Expect(req).NotTo(BeNil())
+							Expect(req.delayedRequeue).To(BeTrue())
+							Expect(req.delay).To(BeNumerically("==", 5*time.Minute))
+							Expect(adminClient.ExcludedAddresses).To(HaveLen(1))
 
-						for excludedAddress := range adminClient.ExcludedAddresses {
-							splits := strings.Split(excludedAddress, ":")
-							Expect(splits).To(HaveLen(2))
-							Expect(splits[1]).NotTo(HavePrefix("another-cluster"))
-						}
-					})
-				})
+							for excludedAddress := range adminClient.ExcludedAddresses {
+								splits := strings.Split(excludedAddress, ":")
+								Expect(splits).To(HaveLen(2))
+								Expect(splits[1]).NotTo(HavePrefix("another-cluster"))
+							}
+						})
+					},
+				)
 
 				When("only one process in both dcs are ready", func() {
 					BeforeEach(func() {
 						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 						Expect(err).NotTo(HaveOccurred())
 
-						Expect(adminClient.UpdateReadyForExclusion(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-							firstOtherProcessGroupID: fdbv1beta2.UpdateActionAdd,
-						})).To(Succeed())
+						Expect(
+							adminClient.UpdateReadyForExclusion(
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+									firstOtherProcessGroupID: fdbv1beta2.UpdateActionAdd,
+								},
+							),
+						).To(Succeed())
 					})
 
 					It("should exclude two processes", func() {
@@ -1532,7 +2184,9 @@ var _ = Describe("exclude_processes", func() {
 						Expect(adminClient.ExcludedAddresses).To(HaveLen(2))
 
 						for excludedAddress := range adminClient.ExcludedAddresses {
-							Expect(excludedAddress).To(HavePrefix(fdbv1beta2.FDBLocalityExclusionPrefix))
+							Expect(
+								excludedAddress,
+							).To(HavePrefix(fdbv1beta2.FDBLocalityExclusionPrefix))
 						}
 					})
 				})
@@ -1541,7 +2195,11 @@ var _ = Describe("exclude_processes", func() {
 	})
 })
 
-func createMissingProcesses(cluster *fdbv1beta2.FoundationDBCluster, count int, processClass fdbv1beta2.ProcessClass) {
+func createMissingProcesses(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	count int,
+	processClass fdbv1beta2.ProcessClass,
+) {
 	missing := 0
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.ProcessClass == processClass {

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -141,11 +141,21 @@ func collectMetrics(ch chan<- prometheus.Metric, cluster *fdbv1beta2.FoundationD
 	addGauge(descClusterStatus, boolFloat64(cluster.Status.Health.Healthy), "health")
 	addGauge(descClusterStatus, boolFloat64(cluster.Status.Health.Available), "available")
 	addGauge(descClusterStatus, boolFloat64(cluster.Status.Health.FullReplication), "replication")
-	addGauge(descClusterStatus, float64(cluster.Status.Health.DataMovementPriority), "datamovementpriority")
+	addGauge(
+		descClusterStatus,
+		float64(cluster.Status.Health.DataMovementPriority),
+		"datamovementpriority",
+	)
 	addGauge(descClusterLastReconciled, float64(cluster.Status.Generations.Reconciled))
-	addGauge(descClusterReconciled, boolFloat64(cluster.ObjectMeta.Generation == cluster.Status.Generations.Reconciled))
+	addGauge(
+		descClusterReconciled,
+		boolFloat64(cluster.ObjectMeta.Generation == cluster.Status.Generations.Reconciled),
+	)
 	addGauge(descProcessGroupsToRemove, float64(len(cluster.Spec.ProcessGroupsToRemove)))
-	addGauge(descProcessGroupsToRemoveWithoutExclusion, float64(len(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion)))
+	addGauge(
+		descProcessGroupsToRemoveWithoutExclusion,
+		float64(len(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion)),
+	)
 
 	// Calculate the process group metrics
 	conditionMap, removals, exclusions := getProcessGroupMetrics(cluster)
@@ -169,7 +179,9 @@ func collectMetrics(ch chan<- prometheus.Metric, cluster *fdbv1beta2.FoundationD
 	}
 }
 
-func getProcessGroupMetrics(cluster *fdbv1beta2.FoundationDBCluster) (map[fdbv1beta2.ProcessClass]map[fdbv1beta2.ProcessGroupConditionType]int, map[fdbv1beta2.ProcessClass]int, map[fdbv1beta2.ProcessClass]int) {
+func getProcessGroupMetrics(
+	cluster *fdbv1beta2.FoundationDBCluster,
+) (map[fdbv1beta2.ProcessClass]map[fdbv1beta2.ProcessGroupConditionType]int, map[fdbv1beta2.ProcessClass]int, map[fdbv1beta2.ProcessClass]int) {
 	metricMap := map[fdbv1beta2.ProcessClass]map[fdbv1beta2.ProcessGroupConditionType]int{}
 	removals := map[fdbv1beta2.ProcessClass]int{}
 	exclusions := map[fdbv1beta2.ProcessClass]int{}

--- a/controllers/metrics_test.go
+++ b/controllers/metrics_test.go
@@ -63,12 +63,24 @@ var _ = Describe("metrics", func() {
 		It("generate the process class metrics", func() {
 			stats, removals, exclusions := getProcessGroupMetrics(cluster)
 			Expect(len(stats)).To(BeNumerically("==", 3))
-			Expect(len(stats[fdbv1beta2.ProcessClassStorage])).To(BeNumerically("==", len(fdbv1beta2.AllProcessGroupConditionTypes())))
-			Expect(len(stats[fdbv1beta2.ProcessClassStorage])).To(BeNumerically("==", len(fdbv1beta2.AllProcessGroupConditionTypes())))
-			Expect(stats[fdbv1beta2.ProcessClassStorage][fdbv1beta2.ReadyCondition]).To(BeNumerically("==", 2))
-			Expect(stats[fdbv1beta2.ProcessClassLog][fdbv1beta2.ReadyCondition]).To(BeNumerically("==", 0))
-			Expect(stats[fdbv1beta2.ProcessClassLog][fdbv1beta2.MissingProcesses]).To(BeNumerically("==", 1))
-			Expect(stats[fdbv1beta2.ProcessClassStateless][fdbv1beta2.ReadyCondition]).To(BeNumerically("==", 1))
+			Expect(
+				len(stats[fdbv1beta2.ProcessClassStorage]),
+			).To(BeNumerically("==", len(fdbv1beta2.AllProcessGroupConditionTypes())))
+			Expect(
+				len(stats[fdbv1beta2.ProcessClassStorage]),
+			).To(BeNumerically("==", len(fdbv1beta2.AllProcessGroupConditionTypes())))
+			Expect(
+				stats[fdbv1beta2.ProcessClassStorage][fdbv1beta2.ReadyCondition],
+			).To(BeNumerically("==", 2))
+			Expect(
+				stats[fdbv1beta2.ProcessClassLog][fdbv1beta2.ReadyCondition],
+			).To(BeNumerically("==", 0))
+			Expect(
+				stats[fdbv1beta2.ProcessClassLog][fdbv1beta2.MissingProcesses],
+			).To(BeNumerically("==", 1))
+			Expect(
+				stats[fdbv1beta2.ProcessClassStateless][fdbv1beta2.ReadyCondition],
+			).To(BeNumerically("==", 1))
 			Expect(removals[fdbv1beta2.ProcessClassStorage]).To(BeNumerically("==", 1))
 			Expect(exclusions[fdbv1beta2.ProcessClassStorage]).To(BeNumerically("==", 0))
 			Expect(removals[fdbv1beta2.ProcessClassStateless]).To(BeNumerically("==", 1))

--- a/controllers/modify_backup.go
+++ b/controllers/modify_backup.go
@@ -32,7 +32,11 @@ type modifyBackup struct {
 }
 
 // reconcile runs the reconciler's work.
-func (s modifyBackup) reconcile(ctx context.Context, r *FoundationDBBackupReconciler, backup *fdbv1beta2.FoundationDBBackup) *requeue {
+func (s modifyBackup) reconcile(
+	ctx context.Context,
+	r *FoundationDBBackupReconciler,
+	backup *fdbv1beta2.FoundationDBBackup,
+) *requeue {
 	if backup.Status.BackupDetails == nil || !backup.ShouldRun() {
 		return nil
 	}

--- a/controllers/remove_services.go
+++ b/controllers/remove_services.go
@@ -36,13 +36,23 @@ import (
 type removeServices struct{}
 
 // reconcile runs the reconciler's work.
-func (u removeServices) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (u removeServices) reconcile(
+	ctx context.Context,
+	r *FoundationDBClusterReconciler,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	_ *fdbv1beta2.FoundationDBStatus,
+	logger logr.Logger,
+) *requeue {
 	if cluster.NeedsHeadlessService() {
 		return nil
 	}
 
 	existingService := &corev1.Service{}
-	err := r.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}, existingService)
+	err := r.Get(
+		ctx,
+		client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name},
+		existingService,
+	)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil

--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -36,7 +36,13 @@ import (
 type replaceFailedProcessGroups struct{}
 
 // return non-nil requeue if a process has been replaced
-func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (c replaceFailedProcessGroups) reconcile(
+	ctx context.Context,
+	r *FoundationDBClusterReconciler,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	status *fdbv1beta2.FoundationDBStatus,
+	logger logr.Logger,
+) *requeue {
 	// If the EmptyMonitorConf setting is set we expect that all fdb processes in this part of the cluster are missing. In order
 	// to prevent the operator from replacing any process groups we skip this reconciliation here.
 	if cluster.Spec.Buggify.EmptyMonitorConf {
@@ -63,13 +69,28 @@ func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *Foundation
 	// If the database is unavailable skip further steps as the operator is not able to make any good decision about the automatic
 	// replacements.
 	if !status.Client.DatabaseStatus.Available {
-		logger.Info("Skipping replaceFailedProcessGroups reconciler as the database is not available.")
-		return &requeue{message: "cluster is not available", delayedRequeue: true, delay: 5 * time.Second}
+		logger.Info(
+			"Skipping replaceFailedProcessGroups reconciler as the database is not available.",
+		)
+		return &requeue{
+			message:        "cluster is not available",
+			delayedRequeue: true,
+			delay:          5 * time.Second,
+		}
 	}
 
 	// Only replace process groups without an address, if the cluster has the desired fault tolerance and is available.
-	hasDesiredFaultTolerance := fdbstatus.HasDesiredFaultToleranceFromStatus(logger, status, cluster)
-	hasReplacement, hasMoreFailedProcesses := replacements.ReplaceFailedProcessGroups(logger, cluster, status, hasDesiredFaultTolerance)
+	hasDesiredFaultTolerance := fdbstatus.HasDesiredFaultToleranceFromStatus(
+		logger,
+		status,
+		cluster,
+	)
+	hasReplacement, hasMoreFailedProcesses := replacements.ReplaceFailedProcessGroups(
+		logger,
+		cluster,
+		status,
+		hasDesiredFaultTolerance,
+	)
 	// If the reconciler replaced at least one process group we want to update the status and requeue.
 	if hasReplacement {
 		err := r.updateOrApply(ctx, cluster)
@@ -83,7 +104,11 @@ func (c replaceFailedProcessGroups) reconcile(ctx context.Context, r *Foundation
 	// If there are more failed processes that are not yet automatically replaced, we want the controller to requeue this
 	// request to make sure it takes another attempt to replace the faulty process group(s).
 	if hasMoreFailedProcesses {
-		return &requeue{message: "More failed process groups are detected", delayedRequeue: true, delay: 5 * time.Minute}
+		return &requeue{
+			message:        "More failed process groups are detected",
+			delayedRequeue: true,
+			delay:          5 * time.Minute,
+		}
 	}
 
 	return nil

--- a/controllers/replace_misconfigured_process_groups.go
+++ b/controllers/replace_misconfigured_process_groups.go
@@ -36,16 +36,35 @@ import (
 type replaceMisconfiguredProcessGroups struct{}
 
 // reconcile runs the reconciler's work.
-func (c replaceMisconfiguredProcessGroups) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (c replaceMisconfiguredProcessGroups) reconcile(
+	ctx context.Context,
+	r *FoundationDBClusterReconciler,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	_ *fdbv1beta2.FoundationDBStatus,
+	logger logr.Logger,
+) *requeue {
 	// During an ongoing version incompatible upgrade, we don't want to replace process groups because they are misconfigured,
 	// This could lead to some side effects and delay the upgrade process. It's better up perform the replacements after
 	// the cluster is upgraded.
 	if cluster.IsBeingUpgradedWithVersionIncompatibleVersion() {
-		logger.Info("Replacements because of misconfiguration are skipped because of an ongoing version incompatible upgrade")
-		return &requeue{message: "Replacements because of misconfiguration are skipped because of an ongoing version incompatible upgrade", delayedRequeue: true, delay: 5 * time.Second}
+		logger.Info(
+			"Replacements because of misconfiguration are skipped because of an ongoing version incompatible upgrade",
+		)
+		return &requeue{
+			message:        "Replacements because of misconfiguration are skipped because of an ongoing version incompatible upgrade",
+			delayedRequeue: true,
+			delay:          5 * time.Second,
+		}
 	}
 
-	hasReplacements, err := replacements.ReplaceMisconfiguredProcessGroups(ctx, r.PodLifecycleManager, r, logger, cluster, r.ReplaceOnSecurityContextChange)
+	hasReplacements, err := replacements.ReplaceMisconfiguredProcessGroups(
+		ctx,
+		r.PodLifecycleManager,
+		r,
+		logger,
+		cluster,
+		r.ReplaceOnSecurityContextChange,
+	)
 	if err != nil {
 		return &requeue{curError: err}
 	}

--- a/controllers/replace_misconfigured_process_groups_test.go
+++ b/controllers/replace_misconfigured_process_groups_test.go
@@ -22,6 +22,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,7 +41,9 @@ var _ = Describe("replace_misconfigured_process_groups", func() {
 			result, err := reconcileCluster(cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
-			Expect(k8sClient.Get(context.TODO(), ctrlClient.ObjectKeyFromObject(cluster), cluster)).NotTo(HaveOccurred())
+			Expect(
+				k8sClient.Get(context.TODO(), ctrlClient.ObjectKeyFromObject(cluster), cluster),
+			).NotTo(HaveOccurred())
 
 			version, err := fdbv1beta2.ParseFdbVersion(cluster.Spec.Version)
 			Expect(err).NotTo(HaveOccurred())
@@ -48,10 +51,18 @@ var _ = Describe("replace_misconfigured_process_groups", func() {
 		})
 
 		It("should not perform any replacements and requeue", func() {
-			result := replaceMisconfiguredProcessGroups{}.reconcile(context.Background(), clusterReconciler, cluster, nil, testLogger)
+			result := replaceMisconfiguredProcessGroups{}.reconcile(
+				context.Background(),
+				clusterReconciler,
+				cluster,
+				nil,
+				testLogger,
+			)
 			Expect(result).NotTo(BeNil())
 			Expect(result.delayedRequeue).To(BeTrue())
-			Expect(result.message).To(Equal("Replacements because of misconfiguration are skipped because of an ongoing version incompatible upgrade"))
+			Expect(
+				result.message,
+			).To(Equal("Replacements because of misconfiguration are skipped because of an ongoing version incompatible upgrade"))
 		})
 	})
 })

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -33,7 +33,11 @@ import (
 )
 
 func reloadRestore(restore *fdbv1beta2.FoundationDBRestore) error {
-	return k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: restore.Namespace, Name: restore.Name}, restore)
+	return k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{Namespace: restore.Namespace, Name: restore.Name},
+		restore,
+	)
 }
 
 var _ = Describe("restore_controller", func() {
@@ -61,7 +65,11 @@ var _ = Describe("restore_controller", func() {
 			generation, err := reloadCluster(cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(generation).NotTo(Equal(0))
-			err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, cluster)
+			err = k8sClient.Get(
+				context.TODO(),
+				types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name},
+				cluster,
+			)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = k8sClient.Create(context.TODO(), restore)
@@ -75,7 +83,11 @@ var _ = Describe("restore_controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(restore.Status.Running).To(BeTrue())
 
-			err = k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}, cluster)
+			err = k8sClient.Get(
+				context.TODO(),
+				types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name},
+				cluster,
+			)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -84,14 +96,22 @@ var _ = Describe("restore_controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
 			Expect(reloadRestore(restore)).To(Succeed())
-			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: restore.Namespace, Name: restore.Name}, cluster)).To(Succeed())
+			Expect(
+				k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{Namespace: restore.Namespace, Name: restore.Name},
+					cluster,
+				),
+			).To(Succeed())
 		})
 
 		When("reconciling a new restore", func() {
 			It("should start a restore", func() {
 				status, err := adminClient.GetRestoreStatus()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(status).To(ContainSubstring("blobstore://test@test-service:443/test-backup?bucket=fdb-backups"))
+				Expect(
+					status,
+				).To(ContainSubstring("blobstore://test@test-service:443/test-backup?bucket=fdb-backups"))
 			})
 		})
 

--- a/controllers/start_backup.go
+++ b/controllers/start_backup.go
@@ -31,8 +31,13 @@ type startBackup struct {
 }
 
 // reconcile runs the reconciler's work.
-func (s startBackup) reconcile(ctx context.Context, r *FoundationDBBackupReconciler, backup *fdbv1beta2.FoundationDBBackup) *requeue {
-	if !backup.ShouldRun() || (backup.Status.BackupDetails != nil && backup.Status.BackupDetails.Running) {
+func (s startBackup) reconcile(
+	ctx context.Context,
+	r *FoundationDBBackupReconciler,
+	backup *fdbv1beta2.FoundationDBBackup,
+) *requeue {
+	if !backup.ShouldRun() ||
+		(backup.Status.BackupDetails != nil && backup.Status.BackupDetails.Running) {
 		return nil
 	}
 
@@ -44,7 +49,11 @@ func (s startBackup) reconcile(ctx context.Context, r *FoundationDBBackupReconci
 		_ = adminClient.Close()
 	}()
 
-	err = adminClient.StartBackup(backup.BackupURL(), backup.SnapshotPeriodSeconds(), backup.Spec.EncryptionKeyPath)
+	err = adminClient.StartBackup(
+		backup.BackupURL(),
+		backup.SnapshotPeriodSeconds(),
+		backup.Spec.EncryptionKeyPath,
+	)
 	if err != nil {
 		return &requeue{curError: err}
 	}

--- a/controllers/start_restore.go
+++ b/controllers/start_restore.go
@@ -32,7 +32,11 @@ type startRestore struct {
 }
 
 // reconcile runs the reconciler's work.
-func (s startRestore) reconcile(ctx context.Context, r *FoundationDBRestoreReconciler, restore *fdbv1beta2.FoundationDBRestore) *requeue {
+func (s startRestore) reconcile(
+	ctx context.Context,
+	r *FoundationDBRestoreReconciler,
+	restore *fdbv1beta2.FoundationDBRestore,
+) *requeue {
 	adminClient, err := r.adminClientForRestore(ctx, restore)
 	if err != nil {
 		return &requeue{curError: err}
@@ -48,7 +52,11 @@ func (s startRestore) reconcile(ctx context.Context, r *FoundationDBRestoreRecon
 
 	// TODO (johscheuer): Make use of the status.state setting to see if the restore was started.
 	if len(strings.TrimSpace(status)) == 0 {
-		err = adminClient.StartRestore(restore.BackupURL(), restore.Spec.KeyRanges, restore.Spec.EncryptionKeyPath)
+		err = adminClient.StartRestore(
+			restore.BackupURL(),
+			restore.Spec.KeyRanges,
+			restore.Spec.EncryptionKeyPath,
+		)
 		if err != nil {
 			return &requeue{curError: err}
 		}

--- a/controllers/stop_backup.go
+++ b/controllers/stop_backup.go
@@ -31,8 +31,13 @@ type stopBackup struct {
 }
 
 // reconcile runs the reconciler's work.
-func (s stopBackup) reconcile(ctx context.Context, r *FoundationDBBackupReconciler, backup *fdbv1beta2.FoundationDBBackup) *requeue {
-	if backup.ShouldRun() || backup.Status.BackupDetails == nil || !backup.Status.BackupDetails.Running {
+func (s stopBackup) reconcile(
+	ctx context.Context,
+	r *FoundationDBBackupReconciler,
+	backup *fdbv1beta2.FoundationDBBackup,
+) *requeue {
+	if backup.ShouldRun() || backup.Status.BackupDetails == nil ||
+		!backup.Status.BackupDetails.Running {
 		return nil
 	}
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -147,7 +147,11 @@ func reconcileRestore(restore *fdbv1beta2.FoundationDBRestore) (reconcile.Result
 	return reconcileObject(restoreReconciler, restore.ObjectMeta, requeueLimit)
 }
 
-func reconcileObject(reconciler reconcile.Reconciler, metadata metav1.ObjectMeta, requeueLimit int) (reconcile.Result, error) {
+func reconcileObject(
+	reconciler reconcile.Reconciler,
+	metadata metav1.ObjectMeta,
+	requeueLimit int,
+) (reconcile.Result, error) {
 	attempts := requeueLimit + 1
 	result := reconcile.Result{Requeue: true}
 	var err error
@@ -155,7 +159,15 @@ func reconcileObject(reconciler reconcile.Reconciler, metadata metav1.ObjectMeta
 		globalControllerLogger.Info("Running test reconciliation", "Attempts", attempts)
 		attempts--
 
-		result, err = reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: metadata.Namespace, Name: metadata.Name}})
+		result, err = reconciler.Reconcile(
+			context.TODO(),
+			reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: metadata.Namespace,
+					Name:      metadata.Name,
+				},
+			},
+		)
 		if err != nil {
 			globalControllerLogger.Error(err, "Error in reconciliation")
 			break

--- a/controllers/toggle_backup_paused.go
+++ b/controllers/toggle_backup_paused.go
@@ -31,7 +31,11 @@ import (
 type toggleBackupPaused struct{}
 
 // reconcile runs the reconciler's work.
-func (s toggleBackupPaused) reconcile(ctx context.Context, r *FoundationDBBackupReconciler, backup *fdbv1beta2.FoundationDBBackup) *requeue {
+func (s toggleBackupPaused) reconcile(
+	ctx context.Context,
+	r *FoundationDBBackupReconciler,
+	backup *fdbv1beta2.FoundationDBBackup,
+) *requeue {
 	if backup.Status.BackupDetails == nil {
 		if backup.ShouldRun() {
 			return &requeue{message: "Cannot toggle backup state because backup is not running"}

--- a/controllers/update_config_map.go
+++ b/controllers/update_config_map.go
@@ -37,13 +37,23 @@ import (
 type updateConfigMap struct{}
 
 // reconcile runs the reconciler's work.
-func (u updateConfigMap) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (u updateConfigMap) reconcile(
+	ctx context.Context,
+	r *FoundationDBClusterReconciler,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	_ *fdbv1beta2.FoundationDBStatus,
+	logger logr.Logger,
+) *requeue {
 	configMap, err := internal.GetConfigMap(cluster)
 	if err != nil {
 		return &requeue{curError: err}
 	}
 	existing := &corev1.ConfigMap{}
-	err = r.Get(ctx, types.NamespacedName{Namespace: configMap.Namespace, Name: configMap.Name}, existing)
+	err = r.Get(
+		ctx,
+		types.NamespacedName{Namespace: configMap.Namespace, Name: configMap.Name},
+		existing,
+	)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			logger.V(1).Info("Creating config map", "name", configMap.Name)

--- a/controllers/update_database_configuration_test.go
+++ b/controllers/update_database_configuration_test.go
@@ -45,7 +45,13 @@ var _ = Describe("update_database_configuration", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = updateDatabaseConfiguration{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+		requeue = updateDatabaseConfiguration{}.reconcile(
+			context.TODO(),
+			clusterReconciler,
+			cluster,
+			nil,
+			globalControllerLogger,
+		)
 	})
 
 	When("the cluster is not yet configured", func() {
@@ -115,7 +121,9 @@ var _ = Describe("update_database_configuration", func() {
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(adminClient.DatabaseConfiguration).NotTo(BeNil())
-					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal(fdbv1beta2.RedundancyModeTriple))
+					Expect(
+						adminClient.DatabaseConfiguration.RedundancyMode,
+					).To(Equal(fdbv1beta2.RedundancyModeTriple))
 					Expect(adminClient.DatabaseConfiguration).NotTo(Equal(initialConfiguration))
 				})
 			})
@@ -138,13 +146,17 @@ var _ = Describe("update_database_configuration", func() {
 
 				It("should not update the configuration", func() {
 					Expect(requeue).NotTo(BeNil())
-					Expect(requeue.message).To(Equal("Configuration change is not safe: cluster is unavailable, cannot change configuration, will retry"))
+					Expect(
+						requeue.message,
+					).To(Equal("Configuration change is not safe: cluster is unavailable, cannot change configuration, will retry"))
 					Expect(cluster.Status.Configured).To(BeTrue())
 
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(adminClient.DatabaseConfiguration).NotTo(BeNil())
-					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal(fdbv1beta2.RedundancyModeDouble))
+					Expect(
+						adminClient.DatabaseConfiguration.RedundancyMode,
+					).To(Equal(fdbv1beta2.RedundancyModeDouble))
 				})
 			})
 
@@ -172,54 +184,65 @@ var _ = Describe("update_database_configuration", func() {
 
 				It("should not update the configuration", func() {
 					Expect(requeue).NotTo(BeNil())
-					Expect(requeue.message).To(Equal("Configuration change is not safe: data distribution is not healthy: primary, will retry"))
+					Expect(
+						requeue.message,
+					).To(Equal("Configuration change is not safe: data distribution is not healthy: primary, will retry"))
 					Expect(cluster.Status.Configured).To(BeTrue())
 
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(adminClient.DatabaseConfiguration).NotTo(BeNil())
-					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal(fdbv1beta2.RedundancyModeDouble))
+					Expect(
+						adminClient.DatabaseConfiguration.RedundancyMode,
+					).To(Equal(fdbv1beta2.RedundancyModeDouble))
 				})
 			})
 
-			When("the database contains a message indicating that the configuration is not readable", func() {
-				BeforeEach(func() {
-					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
-					Expect(err).NotTo(HaveOccurred())
-					adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
-						Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
-							DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
-								Available: true,
-							},
-						},
-						Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
-							Messages: []fdbv1beta2.FoundationDBStatusMessage{
-								{
-									Name: "unreadable_configuration",
+			When(
+				"the database contains a message indicating that the configuration is not readable",
+				func() {
+					BeforeEach(func() {
+						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
+						Expect(err).NotTo(HaveOccurred())
+						adminClient.FrozenStatus = &fdbv1beta2.FoundationDBStatus{
+							Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+								DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+									Available: true,
 								},
 							},
-							DatabaseConfiguration: *adminClient.DatabaseConfiguration,
-							Data: fdbv1beta2.FoundationDBStatusDataStatistics{
-								State: fdbv1beta2.FoundationDBStatusDataState{
-									Healthy: true,
-									Name:    "primary",
+							Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+								Messages: []fdbv1beta2.FoundationDBStatusMessage{
+									{
+										Name: "unreadable_configuration",
+									},
+								},
+								DatabaseConfiguration: *adminClient.DatabaseConfiguration,
+								Data: fdbv1beta2.FoundationDBStatusDataStatistics{
+									State: fdbv1beta2.FoundationDBStatusDataState{
+										Healthy: true,
+										Name:    "primary",
+									},
 								},
 							},
-						},
-					}
-				})
+						}
+					})
 
-				It("should not update the configuration", func() {
-					Expect(requeue).NotTo(BeNil())
-					Expect(requeue.message).To(Equal("Configuration change is not safe: status contains error message: unreadable_configuration, will retry"))
-					Expect(cluster.Status.Configured).To(BeTrue())
+					It("should not update the configuration", func() {
+						Expect(requeue).NotTo(BeNil())
+						Expect(
+							requeue.message,
+						).To(Equal("Configuration change is not safe: status contains error message: unreadable_configuration, will retry"))
+						Expect(cluster.Status.Configured).To(BeTrue())
 
-					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(adminClient.DatabaseConfiguration).NotTo(BeNil())
-					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal(fdbv1beta2.RedundancyModeDouble))
-				})
-			})
+						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(adminClient.DatabaseConfiguration).NotTo(BeNil())
+						Expect(
+							adminClient.DatabaseConfiguration.RedundancyMode,
+						).To(Equal(fdbv1beta2.RedundancyModeDouble))
+					})
+				},
+			)
 
 			When("the last recovery was less than 60 seconds ago", func() {
 				BeforeEach(func() {
@@ -253,13 +276,17 @@ var _ = Describe("update_database_configuration", func() {
 
 				It("should not update the configuration", func() {
 					Expect(requeue).NotTo(BeNil())
-					Expect(requeue.message).To(Equal("Configuration change is not safe: clusters last recovery was 0.10 seconds ago, wait until the last recovery was 60 seconds ago, will retry"))
+					Expect(
+						requeue.message,
+					).To(Equal("Configuration change is not safe: clusters last recovery was 0.10 seconds ago, wait until the last recovery was 60 seconds ago, will retry"))
 					Expect(cluster.Status.Configured).To(BeTrue())
 
 					adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(adminClient.DatabaseConfiguration).NotTo(BeNil())
-					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal(fdbv1beta2.RedundancyModeDouble))
+					Expect(
+						adminClient.DatabaseConfiguration.RedundancyMode,
+					).To(Equal(fdbv1beta2.RedundancyModeDouble))
 				})
 			})
 		})

--- a/controllers/update_lock_configuration.go
+++ b/controllers/update_lock_configuration.go
@@ -33,8 +33,15 @@ import (
 type updateLockConfiguration struct{}
 
 // reconcile runs the reconciler's work.
-func (updateLockConfiguration) reconcile(_ context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
-	if len(cluster.Spec.LockOptions.DenyList) == 0 || !cluster.ShouldUseLocks() || !cluster.Status.Configured {
+func (updateLockConfiguration) reconcile(
+	_ context.Context,
+	r *FoundationDBClusterReconciler,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	_ *fdbv1beta2.FoundationDBStatus,
+	logger logr.Logger,
+) *requeue {
+	if len(cluster.Spec.LockOptions.DenyList) == 0 || !cluster.ShouldUseLocks() ||
+		!cluster.Status.Configured {
 		return nil
 	}
 

--- a/controllers/update_lock_configuration_test.go
+++ b/controllers/update_lock_configuration_test.go
@@ -61,7 +61,13 @@ var _ = Describe("update_lock_configuration", func() {
 	})
 
 	JustBeforeEach(func() {
-		requeue = updateLockConfiguration{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+		requeue = updateLockConfiguration{}.reconcile(
+			context.TODO(),
+			clusterReconciler,
+			cluster,
+			nil,
+			globalControllerLogger,
+		)
 		if requeue != nil {
 			Expect(requeue.curError).NotTo(HaveOccurred())
 		}
@@ -81,7 +87,10 @@ var _ = Describe("update_lock_configuration", func() {
 
 	Context("with an entry in the deny list", func() {
 		BeforeEach(func() {
-			cluster.Spec.LockOptions.DenyList = append(cluster.Spec.LockOptions.DenyList, fdbv1beta2.LockDenyListEntry{ID: "dc2"})
+			cluster.Spec.LockOptions.DenyList = append(
+				cluster.Spec.LockOptions.DenyList,
+				fdbv1beta2.LockDenyListEntry{ID: "dc2"},
+			)
 		})
 
 		It("should not requeue", func() {
@@ -101,9 +110,14 @@ var _ = Describe("update_lock_configuration", func() {
 
 	Context("with an entry to remove from the deny list", func() {
 		BeforeEach(func() {
-			err = lockClient.UpdateDenyList([]fdbv1beta2.LockDenyListEntry{{ID: "dc2"}, {ID: "dc3"}})
+			err = lockClient.UpdateDenyList(
+				[]fdbv1beta2.LockDenyListEntry{{ID: "dc2"}, {ID: "dc3"}},
+			)
 			Expect(err).NotTo(HaveOccurred())
-			cluster.Spec.LockOptions.DenyList = append(cluster.Spec.LockOptions.DenyList, fdbv1beta2.LockDenyListEntry{ID: "dc2", Allow: true})
+			cluster.Spec.LockOptions.DenyList = append(
+				cluster.Spec.LockOptions.DenyList,
+				fdbv1beta2.LockDenyListEntry{ID: "dc2", Allow: true},
+			)
 		})
 
 		It("should not requeue", func() {

--- a/controllers/update_metadata.go
+++ b/controllers/update_metadata.go
@@ -35,7 +35,13 @@ import (
 type updateMetadata struct{}
 
 // reconcile runs the reconciler's work.
-func (updateMetadata) reconcile(ctx context.Context, r *FoundationDBClusterReconciler, cluster *fdbv1beta2.FoundationDBCluster, _ *fdbv1beta2.FoundationDBStatus, logger logr.Logger) *requeue {
+func (updateMetadata) reconcile(
+	ctx context.Context,
+	r *FoundationDBClusterReconciler,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	_ *fdbv1beta2.FoundationDBStatus,
+	logger logr.Logger,
+) *requeue {
 	var shouldRequeue bool
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.IsMarkedForRemoval() {
@@ -76,18 +82,31 @@ func (updateMetadata) reconcile(ctx context.Context, r *FoundationDBClusterRecon
 		}
 
 		pvc := &corev1.PersistentVolumeClaim{}
-		err = r.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: processGroup.GetPvcName(cluster)}, pvc)
+		err = r.Get(
+			ctx,
+			client.ObjectKey{Namespace: cluster.Namespace, Name: processGroup.GetPvcName(cluster)},
+			pvc,
+		)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				logger.V(1).Info("Could not find PVC for process group ID",
 					"processGroupID", processGroup.ProcessGroupID)
 				continue
 			}
-			logger.Error(err, "Could not get PVC for process group ID", "processGroupID", processGroup.ProcessGroupID)
+			logger.Error(
+				err,
+				"Could not get PVC for process group ID",
+				"processGroupID",
+				processGroup.ProcessGroupID,
+			)
 			continue
 		}
 
-		metadata := internal.GetPvcMetadata(cluster, processGroup.ProcessClass, processGroup.ProcessGroupID)
+		metadata := internal.GetPvcMetadata(
+			cluster,
+			processGroup.ProcessClass,
+			processGroup.ProcessGroupID,
+		)
 		if metadata.Annotations == nil {
 			metadata.Annotations = make(map[string]string, 1)
 		}

--- a/controllers/update_pod_config_test.go
+++ b/controllers/update_pod_config_test.go
@@ -44,16 +44,30 @@ var _ = Describe("updatePodConfig", func() {
 
 		processGroup := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
 		Expect(processGroup).NotTo(BeNil())
-		pod, err = clusterReconciler.PodLifecycleManager.GetPod(context.TODO(), clusterReconciler, cluster, processGroup.GetPodName(cluster))
+		pod, err = clusterReconciler.PodLifecycleManager.GetPod(
+			context.TODO(),
+			clusterReconciler,
+			cluster,
+			processGroup.GetPodName(cluster),
+		)
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, container := range pod.Spec.Containers {
-			pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{Ready: true, Name: container.Name})
+			pod.Status.ContainerStatuses = append(
+				pod.Status.ContainerStatuses,
+				corev1.ContainerStatus{Ready: true, Name: container.Name},
+			)
 		}
 	})
 
 	JustBeforeEach(func() {
-		req = updatePodConfig{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+		req = updatePodConfig{}.reconcile(
+			context.TODO(),
+			clusterReconciler,
+			cluster,
+			nil,
+			globalControllerLogger,
+		)
 	})
 
 	Context("with a reconciled cluster", func() {

--- a/controllers/update_pods_test.go
+++ b/controllers/update_pods_test.go
@@ -57,7 +57,9 @@ var _ = Describe("update_pods", func() {
 			result, err := reconcileCluster(cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
-			Expect(k8sClient.Get(context.TODO(), ctrlClient.ObjectKeyFromObject(cluster), cluster)).NotTo(HaveOccurred())
+			Expect(
+				k8sClient.Get(context.TODO(), ctrlClient.ObjectKeyFromObject(cluster), cluster),
+			).NotTo(HaveOccurred())
 
 			updates = map[string][]*corev1.Pod{
 				"zone1": {
@@ -65,7 +67,9 @@ var _ = Describe("update_pods", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "Pod1",
 							Labels: map[string]string{
-								fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+								fdbv1beta2.FDBProcessClassLabel: string(
+									fdbv1beta2.ProcessClassStorage,
+								),
 							},
 						},
 					},
@@ -73,7 +77,9 @@ var _ = Describe("update_pods", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "Pod2",
 							Labels: map[string]string{
-								fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+								fdbv1beta2.FDBProcessClassLabel: string(
+									fdbv1beta2.ProcessClassStorage,
+								),
 							},
 						},
 					},
@@ -83,7 +89,9 @@ var _ = Describe("update_pods", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "Pod3",
 							Labels: map[string]string{
-								fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+								fdbv1beta2.FDBProcessClassLabel: string(
+									fdbv1beta2.ProcessClassStorage,
+								),
 							},
 						},
 					},
@@ -91,7 +99,9 @@ var _ = Describe("update_pods", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "Pod4",
 							Labels: map[string]string{
-								fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+								fdbv1beta2.FDBProcessClassLabel: string(
+									fdbv1beta2.ProcessClassStorage,
+								),
 							},
 						},
 					},
@@ -101,7 +111,12 @@ var _ = Describe("update_pods", func() {
 
 		DescribeTable("should delete the Pods based on the deletion mode",
 			func(input testCase) {
-				_, deletion, err := getPodsToDelete(&fdbv1beta2.FoundationDBCluster{}, input.deletionMode, updates, input.maintenanceZone)
+				_, deletion, err := getPodsToDelete(
+					&fdbv1beta2.FoundationDBCluster{},
+					input.deletionMode,
+					updates,
+					input.maintenanceZone,
+				)
 				if input.expectedErr != nil {
 					Expect(err).To(Equal(input.expectedErr))
 				}
@@ -160,10 +175,18 @@ var _ = Describe("update_pods", func() {
 			})
 
 			It("should not perform any updates and requeue", func() {
-				result := updatePods{}.reconcile(context.Background(), clusterReconciler, cluster, nil, testLogger)
+				result := updatePods{}.reconcile(
+					context.Background(),
+					clusterReconciler,
+					cluster,
+					nil,
+					testLogger,
+				)
 				Expect(result).NotTo(BeNil())
 				Expect(result.delayedRequeue).To(BeTrue())
-				Expect(result.message).To(Equal("Pod updates are skipped because of an ongoing version incompatible upgrade"))
+				Expect(
+					result.message,
+				).To(Equal("Pod updates are skipped because of an ongoing version incompatible upgrade"))
 			})
 		})
 	})
@@ -236,7 +259,9 @@ var _ = Describe("update_pods", func() {
 				cluster = &fdbv1beta2.FoundationDBCluster{
 					Spec: fdbv1beta2.FoundationDBClusterSpec{
 						AutomationOptions: fdbv1beta2.FoundationDBClusterAutomationOptions{
-							IgnoreTerminatingPodsSeconds: pointer.Int(int(5 * time.Minute.Seconds())),
+							IgnoreTerminatingPodsSeconds: pointer.Int(
+								int(5 * time.Minute.Seconds()),
+							),
 						},
 					},
 				}
@@ -266,13 +291,20 @@ var _ = Describe("update_pods", func() {
 			result, err := reconcileCluster(cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
-			Expect(k8sClient.Get(context.TODO(), ctrlClient.ObjectKeyFromObject(cluster), cluster)).NotTo(HaveOccurred())
+			Expect(
+				k8sClient.Get(context.TODO(), ctrlClient.ObjectKeyFromObject(cluster), cluster),
+			).NotTo(HaveOccurred())
 
 			processGroup = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
 		})
 
 		JustBeforeEach(func() {
-			processGroupsWithFaultDomains = getFaultDomainsWithUnavailablePods(context.Background(), globalControllerLogger, clusterReconciler, cluster)
+			processGroupsWithFaultDomains = getFaultDomainsWithUnavailablePods(
+				context.Background(),
+				globalControllerLogger,
+				clusterReconciler,
+				cluster,
+			)
 		})
 
 		When("a Process Group has a Pod with pending condition", func() {
@@ -307,10 +339,20 @@ var _ = Describe("update_pods", func() {
 
 		When("a Process Group has a Pod marked for deletion", func() {
 			BeforeEach(func() {
-				pods, err := clusterReconciler.PodLifecycleManager.GetPods(context.TODO(), clusterReconciler, cluster, internal.GetSinglePodListOptions(cluster, processGroup.ProcessGroupID)...)
+				pods, err := clusterReconciler.PodLifecycleManager.GetPods(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					internal.GetSinglePodListOptions(cluster, processGroup.ProcessGroupID)...)
 				Expect(err).NotTo(HaveOccurred())
 				pods[0].DeletionTimestamp = &metav1.Time{Time: time.Now()}
-				err = clusterReconciler.PodLifecycleManager.UpdatePods(context.TODO(), clusterReconciler, cluster, []*corev1.Pod{pods[0]}, true)
+				err = clusterReconciler.PodLifecycleManager.UpdatePods(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					[]*corev1.Pod{pods[0]},
+					true,
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("should be marked as unavailable", func() {
@@ -320,9 +362,17 @@ var _ = Describe("update_pods", func() {
 
 		When("a Process Group has no matching Pod", func() {
 			BeforeEach(func() {
-				pods, err := clusterReconciler.PodLifecycleManager.GetPods(context.TODO(), clusterReconciler, cluster, internal.GetSinglePodListOptions(cluster, processGroup.ProcessGroupID)...)
+				pods, err := clusterReconciler.PodLifecycleManager.GetPods(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					internal.GetSinglePodListOptions(cluster, processGroup.ProcessGroupID)...)
 				Expect(err).NotTo(HaveOccurred())
-				err = clusterReconciler.PodLifecycleManager.DeletePod(context.TODO(), clusterReconciler, pods[0])
+				err = clusterReconciler.PodLifecycleManager.DeletePod(
+					context.TODO(),
+					clusterReconciler,
+					pods[0],
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("should be marked as unavailable", func() {
@@ -347,7 +397,13 @@ var _ = Describe("update_pods", func() {
 			status, err := adminClient.GetStatus()
 			Expect(err).NotTo(HaveOccurred())
 			clusterReconciler.SimulationOptions.SimulateZones = false
-			updates, updateErr = getPodsToUpdate(context.Background(), globalControllerLogger, clusterReconciler, cluster, getProcessesByProcessGroup(cluster, status))
+			updates, updateErr = getPodsToUpdate(
+				context.Background(),
+				globalControllerLogger,
+				clusterReconciler,
+				cluster,
+				getProcessesByProcessGroup(cluster, status),
+			)
 		})
 
 		When("the cluster has no changes", func() {
@@ -378,7 +434,9 @@ var _ = Describe("update_pods", func() {
 		When("there is a spec change for all processes", func() {
 			BeforeEach(func() {
 				storageSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
-				storageSettings.PodTemplate.Spec.Tolerations = []corev1.Toleration{{Key: "test", Operator: "Exists", Effect: "NoSchedule"}}
+				storageSettings.PodTemplate.Spec.Tolerations = []corev1.Toleration{
+					{Key: "test", Operator: "Exists", Effect: "NoSchedule"},
+				}
 				cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = storageSettings
 				Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 			})
@@ -412,7 +470,10 @@ var _ = Describe("update_pods", func() {
 				When("the process group has a MissingPod condition less than 90 seconds", func() {
 					BeforeEach(func() {
 						picked.UpdateCondition(fdbv1beta2.MissingPod, true)
-						picked.UpdateConditionTime(fdbv1beta2.MissingPod, time.Now().Add(-50*time.Second).Unix())
+						picked.UpdateConditionTime(
+							fdbv1beta2.MissingPod,
+							time.Now().Add(-50*time.Second).Unix(),
+						)
 					})
 
 					It("should return an error and an empty map", func() {
@@ -421,17 +482,23 @@ var _ = Describe("update_pods", func() {
 					})
 				})
 
-				When("the process group has a MissingPod condition for more than 90 seconds", func() {
-					BeforeEach(func() {
-						picked.UpdateCondition(fdbv1beta2.MissingPod, true)
-						picked.UpdateConditionTime(fdbv1beta2.MissingPod, time.Now().Add(-120*time.Second).Unix())
-					})
+				When(
+					"the process group has a MissingPod condition for more than 90 seconds",
+					func() {
+						BeforeEach(func() {
+							picked.UpdateCondition(fdbv1beta2.MissingPod, true)
+							picked.UpdateConditionTime(
+								fdbv1beta2.MissingPod,
+								time.Now().Add(-120*time.Second).Unix(),
+							)
+						})
 
-					It("should return no error updates", func() {
-						Expect(updates).To(HaveLen(3))
-						Expect(updateErr).NotTo(HaveOccurred())
-					})
-				})
+						It("should return no error updates", func() {
+							Expect(updates).To(HaveLen(3))
+							Expect(updateErr).NotTo(HaveOccurred())
+						})
+					},
+				)
 			})
 
 			When("a Pod was recently created", func() {
@@ -441,7 +508,14 @@ var _ = Describe("update_pods", func() {
 					picked = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
 
 					podList := &corev1.PodList{}
-					Expect(k8sClient.List(context.Background(), podList, ctrlClient.InNamespace(cluster.Namespace), ctrlClient.MatchingLabels(cluster.GetMatchLabels()))).To(Succeed())
+					Expect(
+						k8sClient.List(
+							context.Background(),
+							podList,
+							ctrlClient.InNamespace(cluster.Namespace),
+							ctrlClient.MatchingLabels(cluster.GetMatchLabels()),
+						),
+					).To(Succeed())
 
 					for _, pod := range podList.Items {
 						currentPod := pod.DeepCopy()
@@ -490,49 +564,79 @@ var _ = Describe("update_pods", func() {
 
 					It("should return an error and an empty map", func() {
 						Expect(updates).To(HaveLen(0))
-						Expect(updateErr).To(MatchError(And(ContainSubstring("was recently created and the processes are not yet running"), ContainSubstring(string(picked.ProcessGroupID)))))
+						Expect(
+							updateErr,
+						).To(MatchError(And(ContainSubstring("was recently created and the processes are not yet running"), ContainSubstring(string(picked.ProcessGroupID)))))
 					})
 				})
 
-				When("the process is running but the uptime seconds is greater than the pod uptime ", func() {
-					It("should return an error and an empty map", func() {
-						Expect(updates).To(HaveLen(0))
-						Expect(updateErr).To(MatchError(And(ContainSubstring("was recently created but the process uptime reports old uptime"), ContainSubstring(string(picked.ProcessGroupID)))))
-					})
-				})
+				When(
+					"the process is running but the uptime seconds is greater than the pod uptime ",
+					func() {
+						It("should return an error and an empty map", func() {
+							Expect(updates).To(HaveLen(0))
+							Expect(
+								updateErr,
+							).To(MatchError(And(ContainSubstring("was recently created but the process uptime reports old uptime"), ContainSubstring(string(picked.ProcessGroupID)))))
+						})
+					},
+				)
 
-				When("the process is running and the uptime seconds is less than the pod uptime ", func() {
-					BeforeEach(func() {
-						pod := &corev1.Pod{}
-						Expect(k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: picked.GetPodName(cluster), Namespace: cluster.Namespace}, pod)).To(Succeed())
+				When(
+					"the process is running and the uptime seconds is less than the pod uptime ",
+					func() {
+						BeforeEach(func() {
+							pod := &corev1.Pod{}
+							Expect(
+								k8sClient.Get(
+									context.Background(),
+									ctrlClient.ObjectKey{
+										Name:      picked.GetPodName(cluster),
+										Namespace: cluster.Namespace,
+									},
+									pod,
+								),
+							).To(Succeed())
 
-						pod.CreationTimestamp = metav1.NewTime(time.Now().Add(-6 * time.Hour))
-						Expect(k8sClient.Delete(context.Background(), pod)).To(Succeed())
+							pod.CreationTimestamp = metav1.NewTime(time.Now().Add(-6 * time.Hour))
+							Expect(k8sClient.Delete(context.Background(), pod)).To(Succeed())
 
-						creationTimestamp := time.Now().Add(-24 * time.Hour)
-						// We have to recreate the pod
-						pod.ObjectMeta = metav1.ObjectMeta{
-							Name:        pod.Name,
-							Namespace:   pod.Namespace,
-							Annotations: pod.Annotations,
-							Labels:      pod.Labels,
-							// Default uptime is 60000 seconds.
-							CreationTimestamp: metav1.NewTime(creationTimestamp),
-						}
+							creationTimestamp := time.Now().Add(-24 * time.Hour)
+							// We have to recreate the pod
+							pod.ObjectMeta = metav1.ObjectMeta{
+								Name:        pod.Name,
+								Namespace:   pod.Namespace,
+								Annotations: pod.Annotations,
+								Labels:      pod.Labels,
+								// Default uptime is 60000 seconds.
+								CreationTimestamp: metav1.NewTime(creationTimestamp),
+							}
 
-						// Recreate Pod
-						Expect(k8sClient.Create(context.Background(), pod)).To(Succeed())
+							// Recreate Pod
+							Expect(k8sClient.Create(context.Background(), pod)).To(Succeed())
 
-						newPod := &corev1.Pod{}
-						Expect(k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: picked.GetPodName(cluster), Namespace: cluster.Namespace}, newPod)).To(Succeed())
-						Expect(newPod.CreationTimestamp.Time.Unix()).To(Equal(creationTimestamp.Unix()))
-					})
+							newPod := &corev1.Pod{}
+							Expect(
+								k8sClient.Get(
+									context.Background(),
+									ctrlClient.ObjectKey{
+										Name:      picked.GetPodName(cluster),
+										Namespace: cluster.Namespace,
+									},
+									newPod,
+								),
+							).To(Succeed())
+							Expect(
+								newPod.CreationTimestamp.Time.Unix(),
+							).To(Equal(creationTimestamp.Unix()))
+						})
 
-					It("should return not error", func() {
-						Expect(updates).To(HaveLen(4))
-						Expect(updateErr).NotTo(HaveOccurred())
-					})
-				})
+						It("should return not error", func() {
+							Expect(updates).To(HaveLen(4))
+							Expect(updateErr).NotTo(HaveOccurred())
+						})
+					},
+				)
 			})
 		})
 
@@ -554,7 +658,10 @@ var _ = Describe("update_pods", func() {
 		When("two process groups have with pods in pending state", func() {
 			BeforeEach(func() {
 				for _, processGroup := range internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 2) {
-					processGroup.ProcessGroupConditions = append(processGroup.ProcessGroupConditions, fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.PodPending))
+					processGroup.ProcessGroupConditions = append(
+						processGroup.ProcessGroupConditions,
+						fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.PodPending),
+					)
 				}
 			})
 
@@ -563,7 +670,9 @@ var _ = Describe("update_pods", func() {
 					cluster.Spec.MaxZonesWithUnavailablePods = pointer.Int(3)
 					// Update all processes
 					settings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
-					settings.PodTemplate.Spec.Tolerations = []corev1.Toleration{{Key: "test", Operator: "Exists", Effect: "NoSchedule"}}
+					settings.PodTemplate.Spec.Tolerations = []corev1.Toleration{
+						{Key: "test", Operator: "Exists", Effect: "NoSchedule"},
+					}
 					cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = settings
 					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
@@ -582,7 +691,9 @@ var _ = Describe("update_pods", func() {
 					if settings.PodTemplate == nil {
 						settings.PodTemplate = &corev1.PodTemplateSpec{}
 					}
-					settings.PodTemplate.Spec.Tolerations = []corev1.Toleration{{Key: "test", Operator: "Exists", Effect: "NoSchedule"}}
+					settings.PodTemplate.Spec.Tolerations = []corev1.Toleration{
+						{Key: "test", Operator: "Exists", Effect: "NoSchedule"},
+					}
 					cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = settings
 					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})
@@ -598,7 +709,9 @@ var _ = Describe("update_pods", func() {
 					cluster.Spec.MaxZonesWithUnavailablePods = pointer.Int(1)
 					// Update all processes
 					settings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
-					settings.PodTemplate.Spec.Tolerations = []corev1.Toleration{{Key: "test", Operator: "Exists", Effect: "NoSchedule"}}
+					settings.PodTemplate.Spec.Tolerations = []corev1.Toleration{
+						{Key: "test", Operator: "Exists", Effect: "NoSchedule"},
+					}
 					cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = settings
 					Expect(k8sClient.Update(context.TODO(), cluster)).NotTo(HaveOccurred())
 				})

--- a/controllers/update_restore_status.go
+++ b/controllers/update_restore_status.go
@@ -33,7 +33,11 @@ type updateRestoreStatus struct {
 }
 
 // reconcile runs the reconciler's work.
-func (updateRestoreStatus) reconcile(ctx context.Context, r *FoundationDBRestoreReconciler, restore *fdbv1beta2.FoundationDBRestore) *requeue {
+func (updateRestoreStatus) reconcile(
+	ctx context.Context,
+	r *FoundationDBRestoreReconciler,
+	restore *fdbv1beta2.FoundationDBRestore,
+) *requeue {
 	adminClient, err := r.adminClientForRestore(ctx, restore)
 	if err != nil {
 		return &requeue{curError: err}

--- a/controllers/update_restore_status_test.go
+++ b/controllers/update_restore_status_test.go
@@ -27,10 +27,16 @@ import (
 )
 
 var _ = Describe("update_restore_status_test", func() {
-	DescribeTable("when parsing the status from the restore status output", func(input string, expected fdbv1beta2.FoundationDBRestoreState) {
-		Expect(parseRestoreStatus(input)).To(Equal(expected))
-	},
+	DescribeTable(
+		"when parsing the status from the restore status output",
+		func(input string, expected fdbv1beta2.FoundationDBRestoreState) {
+			Expect(parseRestoreStatus(input)).To(Equal(expected))
+		},
 		Entry("empty status", "", fdbv1beta2.UnknownFoundationDBRestoreState),
-		Entry("completed status", "Tag: default  UID: 3213  State: completed  Blocks: 5/5  BlocksInProgress: 0  Files: 74  BytesWritten: 2303  CurrentVersion: 123 FirstConsistentVersion: 321  ApplyVersionLag: 0  LastError: None  URL: blobstore://.. Range: ''-'\xff'  Range: '\xff\x02/blobRange/'-'\xff\x02/blobRange0'  Range: '\xff/metacluster/clusterRegistration'-'\xff/metacluster/clusterRegistration\x00'  Range: '\xff/tagQuota/'-'\xff/tagQuota0'  Range: '\xff/tenant/'-'\xff/tenant0'  AddPrefix: ''  RemovePrefix: ''  Version: 123", fdbv1beta2.CompletedFoundationDBRestoreState),
+		Entry(
+			"completed status",
+			"Tag: default  UID: 3213  State: completed  Blocks: 5/5  BlocksInProgress: 0  Files: 74  BytesWritten: 2303  CurrentVersion: 123 FirstConsistentVersion: 321  ApplyVersionLag: 0  LastError: None  URL: blobstore://.. Range: ''-'\xff'  Range: '\xff\x02/blobRange/'-'\xff\x02/blobRange0'  Range: '\xff/metacluster/clusterRegistration'-'\xff/metacluster/clusterRegistration\x00'  Range: '\xff/tagQuota/'-'\xff/tagQuota0'  Range: '\xff/tenant/'-'\xff/tenant0'  AddPrefix: ''  RemovePrefix: ''  Version: 123",
+			fdbv1beta2.CompletedFoundationDBRestoreState,
+		),
 	)
 })

--- a/controllers/update_sidecar_versions_test.go
+++ b/controllers/update_sidecar_versions_test.go
@@ -28,7 +28,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func createClusterSpec(sidecarOverrides fdbv1beta2.ContainerOverrides, processes map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings) *fdbv1beta2.FoundationDBCluster {
+func createClusterSpec(
+	sidecarOverrides fdbv1beta2.ContainerOverrides,
+	processes map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings,
+) *fdbv1beta2.FoundationDBCluster {
 	cluster := internal.CreateDefaultCluster()
 
 	cluster.Spec.SidecarContainer = sidecarOverrides
@@ -71,15 +74,20 @@ var _ = Describe("update_sidecar_versions", func() {
 				testCase{
 					pClass: fdbv1beta2.ProcessClassStorage,
 					cluster: createClusterSpec(
-						fdbv1beta2.ContainerOverrides{ImageConfigs: []fdbv1beta2.ImageConfig{{BaseImage: "sidecar-override"}}},
-						map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{}),
+						fdbv1beta2.ContainerOverrides{
+							ImageConfigs: []fdbv1beta2.ImageConfig{{BaseImage: "sidecar-override"}},
+						},
+						map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{},
+					),
 					hasError: false,
 				}, "sidecar-override:7.1.57-1"),
 			Entry("settings override sidecar",
 				testCase{
 					pClass: fdbv1beta2.ProcessClassStorage,
 					cluster: createClusterSpec(
-						fdbv1beta2.ContainerOverrides{ImageConfigs: []fdbv1beta2.ImageConfig{{BaseImage: "sidecar-override"}}},
+						fdbv1beta2.ContainerOverrides{
+							ImageConfigs: []fdbv1beta2.ImageConfig{{BaseImage: "sidecar-override"}},
+						},
 						map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
 							fdbv1beta2.ProcessClassGeneral: {
 								PodTemplate: &corev1.PodTemplateSpec{
@@ -93,14 +101,17 @@ var _ = Describe("update_sidecar_versions", func() {
 									},
 								},
 							},
-						}),
+						},
+					),
 					hasError: false,
 				}, "settings-override:7.1.57-1"),
 			Entry("settings override sidecar with tag without override",
 				testCase{
 					pClass: fdbv1beta2.ProcessClassStorage,
 					cluster: createClusterSpec(
-						fdbv1beta2.ContainerOverrides{ImageConfigs: []fdbv1beta2.ImageConfig{{BaseImage: "sidecar-override"}}},
+						fdbv1beta2.ContainerOverrides{
+							ImageConfigs: []fdbv1beta2.ImageConfig{{BaseImage: "sidecar-override"}},
+						},
 						map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
 							fdbv1beta2.ProcessClassGeneral: {
 								PodTemplate: &corev1.PodTemplateSpec{
@@ -114,7 +125,8 @@ var _ = Describe("update_sidecar_versions", func() {
 									},
 								},
 							},
-						}),
+						},
+					),
 					hasError: true,
 				}, ""),
 		)

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -76,23 +76,49 @@ var _ = Describe("update_status", func() {
 			}
 
 			pickedProcessGroup = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
-			pod, err = clusterReconciler.PodLifecycleManager.GetPod(context.TODO(), clusterReconciler, cluster, pickedProcessGroup.GetPodName(cluster))
+			pod, err = clusterReconciler.PodLifecycleManager.GetPod(
+				context.TODO(),
+				clusterReconciler,
+				cluster,
+				pickedProcessGroup.GetPodName(cluster),
+			)
 			Expect(err).NotTo(HaveOccurred())
 			node = &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: pod.Spec.NodeName},
 			}
 
-			globalControllerLogger.Info("Target processGroupStatus Info", "ProcessGroupID", pickedProcessGroup.ProcessGroupID,
-				"Conditions size", len(pickedProcessGroup.ProcessGroupConditions),
-				"Conditions", pickedProcessGroup.ProcessGroupConditions)
+			globalControllerLogger.Info(
+				"Target processGroupStatus Info",
+				"ProcessGroupID",
+				pickedProcessGroup.ProcessGroupID,
+				"Conditions size",
+				len(pickedProcessGroup.ProcessGroupConditions),
+				"Conditions",
+				pickedProcessGroup.ProcessGroupConditions,
+			)
 		})
 
 		When("process group's node is tainted", func() {
 			JustBeforeEach(func() {
-				globalControllerLogger.Info("Taint node", "Node name", pod.Name, "Node taints", node.Spec.Taints)
+				globalControllerLogger.Info(
+					"Taint node",
+					"Node name",
+					pod.Name,
+					"Node taints",
+					node.Spec.Taints,
+				)
 				Expect(k8sClient.Update(context.TODO(), node)).NotTo(HaveOccurred())
 
-				err = validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], pickedProcessGroup, cluster.IsTaintFeatureDisabled(), logger)
+				err = validateProcessGroup(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					pod,
+					pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey],
+					pickedProcessGroup,
+					cluster.IsTaintFeatureDisabled(),
+					logger,
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -110,7 +136,9 @@ var _ = Describe("update_status", func() {
 
 				It("should get NodeTaintDetected condition", func() {
 					Expect(len(pickedProcessGroup.ProcessGroupConditions)).To(Equal(1))
-					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(Equal(nil))
+					Expect(
+						pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected),
+					).NotTo(Equal(nil))
 				})
 			})
 
@@ -118,18 +146,25 @@ var _ = Describe("update_status", func() {
 				BeforeEach(func() {
 					node.Spec.Taints = []corev1.Taint{
 						{
-							Key:       taintKeyMaintenance,
-							Value:     "rack_maintenance",
-							Effect:    corev1.TaintEffectNoExecute,
-							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1))},
+							Key:    taintKeyMaintenance,
+							Value:  "rack_maintenance",
+							Effect: corev1.TaintEffectNoExecute,
+							TimeAdded: &metav1.Time{
+								Time: time.Now().
+									Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1)),
+							},
 						},
 					}
 				})
 
 				It("should get both NodeTaintDetected and NodeTaintReplacing condition", func() {
 					Expect(pickedProcessGroup.ProcessGroupConditions).To(HaveLen(2))
-					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(Equal(nil))
-					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(Equal(nil))
+					Expect(
+						pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected),
+					).NotTo(Equal(nil))
+					Expect(
+						pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing),
+					).NotTo(Equal(nil))
 				})
 			})
 
@@ -137,10 +172,13 @@ var _ = Describe("update_status", func() {
 				BeforeEach(func() {
 					node.Spec.Taints = []corev1.Taint{
 						{
-							Key:       taintKeyMaintenance,
-							Value:     "rack_maintenance",
-							Effect:    corev1.TaintEffectNoExecute,
-							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1))},
+							Key:    taintKeyMaintenance,
+							Value:  "rack_maintenance",
+							Effect: corev1.TaintEffectNoExecute,
+							TimeAdded: &metav1.Time{
+								Time: time.Now().
+									Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1)),
+							},
 						},
 					}
 					// Disable cluster's taint mechanism
@@ -163,11 +201,24 @@ var _ = Describe("update_status", func() {
 						},
 					}
 
-					err = validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], pickedProcessGroup, cluster.IsTaintFeatureDisabled(), logger)
+					err = validateProcessGroup(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						pod,
+						pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey],
+						pickedProcessGroup,
+						cluster.IsTaintFeatureDisabled(),
+						logger,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pickedProcessGroup.ProcessGroupConditions).To(HaveLen(2))
-					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(Equal(nil))
-					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(Equal(nil))
+					Expect(
+						pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected),
+					).NotTo(Equal(nil))
+					Expect(
+						pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing),
+					).NotTo(Equal(nil))
 				})
 			})
 
@@ -175,10 +226,13 @@ var _ = Describe("update_status", func() {
 				BeforeEach(func() {
 					node.Spec.Taints = []corev1.Taint{
 						{
-							Key:       taintKeyWildcard,
-							Value:     "rack_maintenance",
-							Effect:    corev1.TaintEffectNoExecute,
-							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Second * time.Duration(taintKeyWildcardDuration+1))},
+							Key:    taintKeyWildcard,
+							Value:  "rack_maintenance",
+							Effect: corev1.TaintEffectNoExecute,
+							TimeAdded: &metav1.Time{
+								Time: time.Now().
+									Add(-time.Second * time.Duration(taintKeyWildcardDuration+1)),
+							},
 						},
 					}
 					// Disable cluster's taint mechanism
@@ -195,10 +249,13 @@ var _ = Describe("update_status", func() {
 				BeforeEach(func() {
 					node.Spec.Taints = []corev1.Taint{
 						{
-							Key:       taintKeyUnhealthy,
-							Value:     "rack_maintenance",
-							Effect:    corev1.TaintEffectNoExecute,
-							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Second * time.Duration(taintKeyUnhealthyDuration+1))},
+							Key:    taintKeyUnhealthy,
+							Value:  "rack_maintenance",
+							Effect: corev1.TaintEffectNoExecute,
+							TimeAdded: &metav1.Time{
+								Time: time.Now().
+									Add(-time.Second * time.Duration(taintKeyUnhealthyDuration+1)),
+							},
 						},
 					}
 					// Only handle taintKeyMaintenance taint key
@@ -224,11 +281,24 @@ var _ = Describe("update_status", func() {
 						},
 					}
 
-					err = validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], pickedProcessGroup, cluster.IsTaintFeatureDisabled(), logger)
+					err = validateProcessGroup(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						pod,
+						pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey],
+						pickedProcessGroup,
+						cluster.IsTaintFeatureDisabled(),
+						logger,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pickedProcessGroup.ProcessGroupConditions).To(HaveLen(2))
-					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(BeNil())
-					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(BeNil())
+					Expect(
+						pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected),
+					).NotTo(BeNil())
+					Expect(
+						pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing),
+					).NotTo(BeNil())
 				})
 			})
 
@@ -236,25 +306,51 @@ var _ = Describe("update_status", func() {
 				BeforeEach(func() {
 					node.Spec.Taints = []corev1.Taint{
 						{
-							Key:       taintKeyMaintenance,
-							Value:     taintValue,
-							Effect:    corev1.TaintEffectNoExecute,
-							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1))},
+							Key:    taintKeyMaintenance,
+							Value:  taintValue,
+							Effect: corev1.TaintEffectNoExecute,
+							TimeAdded: &metav1.Time{
+								Time: time.Now().
+									Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1)),
+							},
 						},
 					}
 				})
 
 				It("shouldn't keep NodeTaintReplacing condition", func() {
 					Expect(len(pickedProcessGroup.ProcessGroupConditions)).To(Equal(2))
-					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected)).NotTo(BeNil())
-					Expect(pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing)).NotTo(BeNil())
+					Expect(
+						pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintDetected),
+					).NotTo(BeNil())
+					Expect(
+						pickedProcessGroup.GetCondition(fdbv1beta2.NodeTaintReplacing),
+					).NotTo(BeNil())
 
 					// Remove the node taint
 					node.Spec.Taints = nil
 					Expect(k8sClient.Update(context.TODO(), node)).NotTo(HaveOccurred())
-					globalControllerLogger.Info("Remove node taint", "Node name", pod.Name, "Node taints", node.Spec.Taints, "Now", time.Now())
+					globalControllerLogger.Info(
+						"Remove node taint",
+						"Node name",
+						pod.Name,
+						"Node taints",
+						node.Spec.Taints,
+						"Now",
+						time.Now(),
+					)
 
-					Expect(validateProcessGroup(context.TODO(), clusterReconciler, cluster, pod, pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey], pickedProcessGroup, cluster.IsTaintFeatureDisabled(), logger)).NotTo(HaveOccurred())
+					Expect(
+						validateProcessGroup(
+							context.TODO(),
+							clusterReconciler,
+							cluster,
+							pod,
+							pod.ObjectMeta.Annotations[fdbv1beta2.LastConfigMapKey],
+							pickedProcessGroup,
+							cluster.IsTaintFeatureDisabled(),
+							logger,
+						),
+					).NotTo(HaveOccurred())
 					Expect(pickedProcessGroup.ProcessGroupConditions).To(BeEmpty())
 				})
 			})
@@ -274,48 +370,102 @@ var _ = Describe("update_status", func() {
 			Expect(setupClusterForTest(cluster)).NotTo(HaveOccurred())
 
 			pickedProcessGroup = internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 1)[0]
-			storagePod, err = clusterReconciler.PodLifecycleManager.GetPod(context.TODO(), clusterReconciler, cluster, pickedProcessGroup.GetPodName(cluster))
+			storagePod, err = clusterReconciler.PodLifecycleManager.GetPod(
+				context.TODO(),
+				clusterReconciler,
+				cluster,
+				pickedProcessGroup.GetPodName(cluster),
+			)
 			Expect(err).NotTo(HaveOccurred())
 			for _, container := range storagePod.Spec.Containers {
-				storagePod.Status.ContainerStatuses = append(storagePod.Status.ContainerStatuses, corev1.ContainerStatus{Ready: true, Name: container.Name})
+				storagePod.Status.ContainerStatuses = append(
+					storagePod.Status.ContainerStatuses,
+					corev1.ContainerStatus{Ready: true, Name: container.Name},
+				)
 			}
 
 			adminClient, err = mock.NewMockAdminClientUncast(cluster, k8sClient)
 			Expect(err).NotTo(HaveOccurred())
 
 			configMap = &corev1.ConfigMap{}
-			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name + "-config"}, configMap)).NotTo(HaveOccurred())
+			Expect(
+				k8sClient.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Namespace: cluster.Namespace,
+						Name:      cluster.Name + "-config",
+					},
+					configMap,
+				),
+			).NotTo(HaveOccurred())
 		})
 
 		JustBeforeEach(func() {
 			databaseStatus, err := adminClient.GetStatus()
 			Expect(err).NotTo(HaveOccurred())
-			processMap = make(map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessInfo)
+			processMap = make(
+				map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessInfo,
+			)
 			for _, process := range databaseStatus.Cluster.Processes {
 				processID, ok := process.Locality[fdbv1beta2.FDBLocalityProcessIDKey]
 				// if the processID is not set we fall back to the instanceID
 				if !ok {
 					processID = process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]
 				}
-				processMap[fdbv1beta2.ProcessGroupID(processID)] = append(processMap[fdbv1beta2.ProcessGroupID(processID)], process)
+				processMap[fdbv1beta2.ProcessGroupID(processID)] = append(
+					processMap[fdbv1beta2.ProcessGroupID(processID)],
+					process,
+				)
 			}
 		})
 
 		When("process group has no Pod", func() {
 			BeforeEach(func() {
-				Expect(k8sClient.Delete(context.Background(), &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: pickedProcessGroup.GetPodName(cluster), Namespace: cluster.Namespace}})).NotTo(HaveOccurred())
+				Expect(
+					k8sClient.Delete(
+						context.Background(),
+						&corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      pickedProcessGroup.GetPodName(cluster),
+								Namespace: cluster.Namespace,
+							},
+						},
+					),
+				).NotTo(HaveOccurred())
 			})
 
 			It("should be added to the failing Pods", func() {
-				Expect(validateProcessGroup(context.TODO(), clusterReconciler, cluster, nil, "", pickedProcessGroup, cluster.IsTaintFeatureDisabled(), logger)).NotTo(HaveOccurred())
+				Expect(
+					validateProcessGroup(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						nil,
+						"",
+						pickedProcessGroup,
+						cluster.IsTaintFeatureDisabled(),
+						logger,
+					),
+				).NotTo(HaveOccurred())
 				Expect(pickedProcessGroup.ProcessGroupConditions).To(HaveLen(1))
-				Expect(pickedProcessGroup.ProcessGroupConditions[0].ProcessGroupConditionType).To(Equal(fdbv1beta2.MissingPod))
+				Expect(
+					pickedProcessGroup.ProcessGroupConditions[0].ProcessGroupConditionType,
+				).To(Equal(fdbv1beta2.MissingPod))
 			})
 		})
 
 		When("a process group is fine", func() {
 			It("should not get any condition assigned", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 				for _, processGroup := range cluster.Status.ProcessGroups {
@@ -327,11 +477,22 @@ var _ = Describe("update_status", func() {
 		When("the command line is too long", func() {
 			BeforeEach(func() {
 				// Generate a random long string
-				cluster.Spec.MainContainer.PeerVerificationRules = internal.GenerateRandomString(10000)
+				cluster.Spec.MainContainer.PeerVerificationRules = internal.GenerateRandomString(
+					10000,
+				)
 			})
 
 			It("should not get any condition assigned", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).To(HaveOccurred())
 				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 				// We expect that no conditions are added in this case.
@@ -348,12 +509,33 @@ var _ = Describe("update_status", func() {
 
 			It("should get a condition assigned", func() {
 				dummyPod := &corev1.Pod{}
-				Expect(k8sClient.Get(context.TODO(), ctrlClient.ObjectKeyFromObject(storagePod), dummyPod)).To(HaveOccurred())
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				Expect(
+					k8sClient.Get(
+						context.TODO(),
+						ctrlClient.ObjectKeyFromObject(storagePod),
+						dummyPod,
+					),
+				).To(HaveOccurred())
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 
-				missingProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.MissingPod, false)
-				Expect(missingProcesses).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				missingProcesses := fdbv1beta2.FilterByCondition(
+					cluster.Status.ProcessGroups,
+					fdbv1beta2.MissingPod,
+					false,
+				)
+				Expect(
+					missingProcesses,
+				).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
 				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 		})
@@ -364,11 +546,26 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get the ProcessIsMarkedAsExcluded condition", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 
-				incorrectProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.ProcessIsMarkedAsExcluded, false)
-				Expect(incorrectProcesses).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				incorrectProcesses := fdbv1beta2.FilterByCondition(
+					cluster.Status.ProcessGroups,
+					fdbv1beta2.ProcessIsMarkedAsExcluded,
+					false,
+				)
+				Expect(
+					incorrectProcesses,
+				).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
 				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 		})
@@ -379,25 +576,57 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 
-				incorrectProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectCommandLine, false)
-				Expect(incorrectProcesses).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				incorrectProcesses := fdbv1beta2.FilterByCondition(
+					cluster.Status.ProcessGroups,
+					fdbv1beta2.IncorrectCommandLine,
+					false,
+				)
+				Expect(
+					incorrectProcesses,
+				).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
 				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 
 			When("the process group is marked for removal", func() {
 				BeforeEach(func() {
-					cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}
+					cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{
+						pickedProcessGroup.ProcessGroupID,
+					}
 				})
 
 				It("should get a condition assigned", func() {
-					err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+					err := validateProcessGroups(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						&cluster.Status,
+						processMap,
+						configMap,
+						logger,
+						"",
+					)
 					Expect(err).NotTo(HaveOccurred())
 
-					incorrectProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectCommandLine, false)
-					Expect(incorrectProcesses).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+					incorrectProcesses := fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.IncorrectCommandLine,
+						false,
+					)
+					Expect(
+						incorrectProcesses,
+					).To(ConsistOf([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
 					Expect(pickedProcessGroup.IsMarkedForRemoval()).To(BeTrue())
 					Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 				})
@@ -410,20 +639,46 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 
-				missingProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.MissingProcesses, false)
+				missingProcesses := fdbv1beta2.FilterByCondition(
+					cluster.Status.ProcessGroups,
+					fdbv1beta2.MissingProcesses,
+					false,
+				)
 				Expect(missingProcesses).To(ConsistOf(pickedProcessGroup.ProcessGroupID))
 				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 
 			When("no processes are provided in the process map", func() {
 				It("should not get a condition assigned", func() {
-					err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessInfo{}, configMap, logger, "")
+					err := validateProcessGroups(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						&cluster.Status,
+						map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessInfo{},
+						configMap,
+						logger,
+						"",
+					)
 					Expect(err).NotTo(HaveOccurred())
 
-					missingProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.MissingProcesses, false)
+					missingProcesses := fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.MissingProcesses,
+						false,
+					)
 					Expect(missingProcesses).To(BeEmpty())
 				})
 			})
@@ -436,12 +691,41 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a IncorrectPodSpec condition assigned", func() {
-				Expect(validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")).To(Succeed())
-				incorrectPods := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectPodSpec, false)
-				Expect(incorrectPods).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				Expect(
+					validateProcessGroups(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						&cluster.Status,
+						processMap,
+						configMap,
+						logger,
+						"",
+					),
+				).To(Succeed())
+				incorrectPods := fdbv1beta2.FilterByCondition(
+					cluster.Status.ProcessGroups,
+					fdbv1beta2.IncorrectPodSpec,
+					false,
+				)
+				Expect(
+					incorrectPods,
+				).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
 				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
-				Expect(fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectPodMetadata, false)).To(BeEmpty())
-				Expect(fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectConfigMap, false)).To(BeEmpty())
+				Expect(
+					fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.IncorrectPodMetadata,
+						false,
+					),
+				).To(BeEmpty())
+				Expect(
+					fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.IncorrectConfigMap,
+						false,
+					),
+				).To(BeEmpty())
 			})
 		})
 
@@ -453,12 +737,41 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("should get a IncorrectPodMetadata condition assigned", func() {
-					Expect(validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")).NotTo(HaveOccurred())
-					incorrectPods := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectPodMetadata, false)
-					Expect(incorrectPods).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+					Expect(
+						validateProcessGroups(
+							context.TODO(),
+							clusterReconciler,
+							cluster,
+							&cluster.Status,
+							processMap,
+							configMap,
+							logger,
+							"",
+						),
+					).NotTo(HaveOccurred())
+					incorrectPods := fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.IncorrectPodMetadata,
+						false,
+					)
+					Expect(
+						incorrectPods,
+					).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
 					Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
-					Expect(fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectPodSpec, false)).To(BeEmpty())
-					Expect(fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectConfigMap, false)).To(BeEmpty())
+					Expect(
+						fdbv1beta2.FilterByCondition(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.IncorrectPodSpec,
+							false,
+						),
+					).To(BeEmpty())
+					Expect(
+						fdbv1beta2.FilterByCondition(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.IncorrectConfigMap,
+							false,
+						),
+					).To(BeEmpty())
 				})
 			})
 		})
@@ -471,12 +784,41 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("should get a IncorrectConfigMap condition assigned", func() {
-					Expect(validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")).NotTo(HaveOccurred())
-					incorrectPods := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectConfigMap, false)
-					Expect(incorrectPods).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+					Expect(
+						validateProcessGroups(
+							context.TODO(),
+							clusterReconciler,
+							cluster,
+							&cluster.Status,
+							processMap,
+							configMap,
+							logger,
+							"",
+						),
+					).NotTo(HaveOccurred())
+					incorrectPods := fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.IncorrectConfigMap,
+						false,
+					)
+					Expect(
+						incorrectPods,
+					).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
 					Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
-					Expect(fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectPodSpec, false)).To(BeEmpty())
-					Expect(fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.IncorrectPodMetadata, false)).To(BeEmpty())
+					Expect(
+						fdbv1beta2.FilterByCondition(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.IncorrectPodSpec,
+							false,
+						),
+					).To(BeEmpty())
+					Expect(
+						fdbv1beta2.FilterByCondition(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.IncorrectPodMetadata,
+							false,
+						),
+					).To(BeEmpty())
 				})
 			})
 		})
@@ -486,16 +828,33 @@ var _ = Describe("update_status", func() {
 			BeforeEach(func() {
 				// We cannot use the k8sClient.MockStuckTermination() method because the deletionTimestamp must be
 				// older than 5 minutes to detect the Pod as PodFailed.
-				storagePod.SetDeletionTimestamp(&metav1.Time{Time: time.Now().Add(-10 * time.Minute)})
+				storagePod.SetDeletionTimestamp(
+					&metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
+				)
 				Expect(k8sClient.Update(context.Background(), storagePod)).NotTo(HaveOccurred())
 			})
 
 			It("should get a condition assigned", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 
-				missingProcesses := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.PodFailing, false)
-				Expect(missingProcesses).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				missingProcesses := fdbv1beta2.FilterByCondition(
+					cluster.Status.ProcessGroups,
+					fdbv1beta2.PodFailing,
+					false,
+				)
+				Expect(
+					missingProcesses,
+				).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
 				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 		})
@@ -507,11 +866,26 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 
-				failingPods := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.PodFailing, false)
-				Expect(failingPods).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				failingPods := fdbv1beta2.FilterByCondition(
+					cluster.Status.ProcessGroups,
+					fdbv1beta2.PodFailing,
+					false,
+				)
+				Expect(
+					failingPods,
+				).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
 				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 		})
@@ -523,20 +897,50 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should get a condition assigned", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 
-				failingPods := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.PodFailing, false)
-				Expect(failingPods).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
+				failingPods := fdbv1beta2.FilterByCondition(
+					cluster.Status.ProcessGroups,
+					fdbv1beta2.PodFailing,
+					false,
+				)
+				Expect(
+					failingPods,
+				).To(Equal([]fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}))
 				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 			})
 
 			When("the process group is under maintenance", func() {
 				It("should not set the conditions", func() {
 					processGroup := cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-4]
-					Expect(validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, processGroup.FaultDomain)).NotTo(HaveOccurred())
+					Expect(
+						validateProcessGroups(
+							context.TODO(),
+							clusterReconciler,
+							cluster,
+							&cluster.Status,
+							processMap,
+							configMap,
+							logger,
+							processGroup.FaultDomain,
+						),
+					).NotTo(HaveOccurred())
 
-					failingPods := fdbv1beta2.FilterByCondition(cluster.Status.ProcessGroups, fdbv1beta2.PodFailing, false)
+					failingPods := fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.PodFailing,
+						false,
+					)
 					Expect(failingPods).To(BeEmpty())
 					Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 				})
@@ -547,11 +951,22 @@ var _ = Describe("update_status", func() {
 			BeforeEach(func() {
 				storagePod.Status.Phase = corev1.PodFailed
 				Expect(k8sClient.Update(context.TODO(), storagePod)).NotTo(HaveOccurred())
-				cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}
+				cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{
+					pickedProcessGroup.ProcessGroupID,
+				}
 			})
 
 			It("should mark the process group for removal", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				removalCount := 0
@@ -575,11 +990,22 @@ var _ = Describe("update_status", func() {
 				storagePod.Status.Phase = corev1.PodFailed
 				err = k8sClient.Update(context.TODO(), storagePod)
 				Expect(err).NotTo(HaveOccurred())
-				cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = []fdbv1beta2.ProcessGroupID{pickedProcessGroup.ProcessGroupID}
+				cluster.Spec.ProcessGroupsToRemoveWithoutExclusion = []fdbv1beta2.ProcessGroupID{
+					pickedProcessGroup.ProcessGroupID,
+				}
 			})
 
 			It("should be mark the process group for removal without exclusion", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				removalCount := 0
@@ -610,13 +1036,24 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should mark the process group as unreachable", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				unreachableCount := 0
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					if processGroup.ProcessGroupID == unreachableProcessGroup {
-						Expect(processGroup.GetConditionTime(fdbv1beta2.SidecarUnreachable)).NotTo(BeNil())
+						Expect(
+							processGroup.GetConditionTime(fdbv1beta2.SidecarUnreachable),
+						).NotTo(BeNil())
 						unreachableCount++
 						continue
 					}
@@ -634,7 +1071,16 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("should remove the condition", func() {
-					err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+					err := validateProcessGroups(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						&cluster.Status,
+						processMap,
+						configMap,
+						logger,
+						"",
+					)
 					Expect(err).NotTo(HaveOccurred())
 
 					unreachableCount := 0
@@ -643,7 +1089,9 @@ var _ = Describe("update_status", func() {
 							unreachableCount++
 							continue
 						}
-						Expect(processGroup.GetConditionTime(fdbv1beta2.SidecarUnreachable)).To(BeNil())
+						Expect(
+							processGroup.GetConditionTime(fdbv1beta2.SidecarUnreachable),
+						).To(BeNil())
 					}
 
 					Expect(unreachableCount).To(BeNumerically("==", 0))
@@ -661,7 +1109,16 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should mark the process group as Pod pending", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				pendingCount := 0
@@ -687,7 +1144,16 @@ var _ = Describe("update_status", func() {
 			})
 
 			It("should remove the exclusion", func() {
-				err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+				err := validateProcessGroups(
+					context.TODO(),
+					clusterReconciler,
+					cluster,
+					&cluster.Status,
+					processMap,
+					configMap,
+					logger,
+					"",
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 				for _, processGroup := range cluster.Status.ProcessGroups {
@@ -707,13 +1173,26 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("should update the incorrect sidecar image condition", func() {
-					err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+					err := validateProcessGroups(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						&cluster.Status,
+						processMap,
+						configMap,
+						logger,
+						"",
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 					for _, processGroup := range cluster.Status.ProcessGroups {
 						Expect(processGroup.ProcessGroupConditions).To(HaveLen(2))
-						Expect(processGroup.ProcessGroupConditions[0].ProcessGroupConditionType).To(Equal(fdbv1beta2.IncorrectCommandLine))
-						Expect(processGroup.ProcessGroupConditions[1].ProcessGroupConditionType).To(Equal(fdbv1beta2.IncorrectSidecarImage))
+						Expect(
+							processGroup.ProcessGroupConditions[0].ProcessGroupConditionType,
+						).To(Equal(fdbv1beta2.IncorrectCommandLine))
+						Expect(
+							processGroup.ProcessGroupConditions[1].ProcessGroupConditionType,
+						).To(Equal(fdbv1beta2.IncorrectSidecarImage))
 					}
 				})
 			})
@@ -726,14 +1205,29 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("should update the incorrect sidecar image condition", func() {
-					err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+					err := validateProcessGroups(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						&cluster.Status,
+						processMap,
+						configMap,
+						logger,
+						"",
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 					for _, processGroup := range cluster.Status.ProcessGroups {
 						Expect(processGroup.ProcessGroupConditions).To(HaveLen(3))
-						Expect(processGroup.ProcessGroupConditions[0].ProcessGroupConditionType).To(Equal(fdbv1beta2.IncorrectCommandLine))
-						Expect(processGroup.ProcessGroupConditions[1].ProcessGroupConditionType).To(Equal(fdbv1beta2.IncorrectPodSpec))
-						Expect(processGroup.ProcessGroupConditions[2].ProcessGroupConditionType).To(Equal(fdbv1beta2.IncorrectSidecarImage))
+						Expect(
+							processGroup.ProcessGroupConditions[0].ProcessGroupConditionType,
+						).To(Equal(fdbv1beta2.IncorrectCommandLine))
+						Expect(
+							processGroup.ProcessGroupConditions[1].ProcessGroupConditionType,
+						).To(Equal(fdbv1beta2.IncorrectPodSpec))
+						Expect(
+							processGroup.ProcessGroupConditions[2].ProcessGroupConditionType,
+						).To(Equal(fdbv1beta2.IncorrectSidecarImage))
 					}
 				})
 			})
@@ -749,13 +1243,26 @@ var _ = Describe("update_status", func() {
 				})
 
 				It("should update the incorrect sidecar image condition", func() {
-					err := validateProcessGroups(context.TODO(), clusterReconciler, cluster, &cluster.Status, processMap, configMap, logger, "")
+					err := validateProcessGroups(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						&cluster.Status,
+						processMap,
+						configMap,
+						logger,
+						"",
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
 					for _, processGroup := range cluster.Status.ProcessGroups {
 						Expect(processGroup.ProcessGroupConditions).To(HaveLen(2))
-						Expect(processGroup.ProcessGroupConditions[0].ProcessGroupConditionType).To(Equal(fdbv1beta2.IncorrectPodSpec))
-						Expect(processGroup.ProcessGroupConditions[1].ProcessGroupConditionType).To(Equal(fdbv1beta2.IncorrectSidecarImage))
+						Expect(
+							processGroup.ProcessGroupConditions[0].ProcessGroupConditionType,
+						).To(Equal(fdbv1beta2.IncorrectPodSpec))
+						Expect(
+							processGroup.ProcessGroupConditions[1].ProcessGroupConditionType,
+						).To(Equal(fdbv1beta2.IncorrectSidecarImage))
 					}
 				})
 			})
@@ -785,7 +1292,13 @@ var _ = Describe("update_status", func() {
 		JustBeforeEach(func() {
 			err = internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			requeue = updateStatus{}.reconcile(context.TODO(), clusterReconciler, cluster, nil, globalControllerLogger)
+			requeue = updateStatus{}.reconcile(
+				context.TODO(),
+				clusterReconciler,
+				cluster,
+				nil,
+				globalControllerLogger,
+			)
 			if requeue != nil {
 				Expect(requeue.curError).NotTo(HaveOccurred())
 			}
@@ -840,9 +1353,13 @@ var _ = Describe("update_status", func() {
 		})
 	})
 
-	DescribeTable("when getting the running version from the running processes", func(versionMap map[string]int, fallback string, expected string) {
-		Expect(getRunningVersion(globalControllerLogger, versionMap, fallback)).To(Equal(expected))
-	},
+	DescribeTable(
+		"when getting the running version from the running processes",
+		func(versionMap map[string]int, fallback string, expected string) {
+			Expect(
+				getRunningVersion(globalControllerLogger, versionMap, fallback),
+			).To(Equal(expected))
+		},
 		Entry("when nearly all processes running on the new version", map[string]int{
 			"7.1.11": 1,
 			"7.1.15": 99,
@@ -854,7 +1371,8 @@ var _ = Describe("update_status", func() {
 			"7.1.11": 50,
 			"7.1.15": 50,
 		}, "0", "7.1.15"),
-		Entry("when the versionMap is empty", map[string]int{}, "7.1.15", "7.1.15"))
+		Entry("when the versionMap is empty", map[string]int{}, "7.1.15", "7.1.15"),
+	)
 
 	When("updating the fault domains based on the cluster status", func() {
 		var processes map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessInfo
@@ -915,7 +1433,9 @@ var _ = Describe("update_status", func() {
 						continue
 					}
 
-					Expect(string(processGroup.FaultDomain)).To(And(HavePrefix(string(processGroup.ProcessGroupID)), HaveSuffix("zone")))
+					Expect(
+						string(processGroup.FaultDomain),
+					).To(And(HavePrefix(string(processGroup.ProcessGroupID)), HaveSuffix("zone")))
 				}
 			})
 		})
@@ -954,7 +1474,9 @@ var _ = Describe("update_status", func() {
 						continue
 					}
 
-					Expect(string(processGroup.FaultDomain)).To(And(HavePrefix(string(processGroup.ProcessGroupID)), HaveSuffix("zone")))
+					Expect(
+						string(processGroup.FaultDomain),
+					).To(And(HavePrefix(string(processGroup.ProcessGroupID)), HaveSuffix("zone")))
 				}
 			})
 		})
@@ -1002,7 +1524,9 @@ var _ = Describe("update_status", func() {
 						continue
 					}
 
-					Expect(string(processGroup.FaultDomain)).To(And(HavePrefix(string(processGroup.ProcessGroupID)), HaveSuffix("zone")))
+					Expect(
+						string(processGroup.FaultDomain),
+					).To(And(HavePrefix(string(processGroup.ProcessGroupID)), HaveSuffix("zone")))
 				}
 			})
 		})

--- a/e2e/chaos-mesh/api/v1alpha1/networkchaos_types.go
+++ b/e2e/chaos-mesh/api/v1alpha1/networkchaos_types.go
@@ -119,41 +119,41 @@ type NetworkChaosSpec struct {
 
 // NetworkChaosStatus defines the observed state of NetworkChaos
 type NetworkChaosStatus struct {
-	ChaosStatus `json:",inline"`
+	ChaosStatus `                 json:",inline"`
 	// Instances always specifies podnetworkchaos generation or empty
 	Instances map[string]int64 `json:"instances,omitempty"`
 }
 
 // DelaySpec defines detail of a delay action
 type DelaySpec struct {
-	Latency     string       `json:"latency" webhook:"Duration"`
-	Correlation string       `json:"correlation,omitempty" default:"0" webhook:"FloatStr"`
-	Jitter      string       `json:"jitter,omitempty" default:"0ms" webhook:"Duration"`
+	Latency     string       `json:"latency"               webhook:"Duration"`
+	Correlation string       `json:"correlation,omitempty" webhook:"FloatStr" default:"0"`
+	Jitter      string       `json:"jitter,omitempty"      webhook:"Duration" default:"0ms"`
 	Reorder     *ReorderSpec `json:"reorder,omitempty"`
 }
 
 // LossSpec defines detail of a loss action
 type LossSpec struct {
-	Loss        string `json:"loss" webhook:"FloatStr"`
-	Correlation string `json:"correlation,omitempty" default:"0" webhook:"FloatStr"`
+	Loss        string `json:"loss"                  webhook:"FloatStr"`
+	Correlation string `json:"correlation,omitempty" webhook:"FloatStr" default:"0"`
 }
 
 // DuplicateSpec defines detail of a duplicate action
 type DuplicateSpec struct {
-	Duplicate   string `json:"duplicate" webhook:"FloatStr"`
-	Correlation string `json:"correlation,omitempty" default:"0" webhook:"FloatStr"`
+	Duplicate   string `json:"duplicate"             webhook:"FloatStr"`
+	Correlation string `json:"correlation,omitempty" webhook:"FloatStr" default:"0"`
 }
 
 // CorruptSpec defines detail of a corrupt action
 type CorruptSpec struct {
-	Corrupt     string `json:"corrupt" webhook:"FloatStr"`
-	Correlation string `json:"correlation,omitempty" default:"0" webhook:"FloatStr"`
+	Corrupt     string `json:"corrupt"               webhook:"FloatStr"`
+	Correlation string `json:"correlation,omitempty" webhook:"FloatStr" default:"0"`
 }
 
 // BandwidthSpec defines detail of bandwidth limit.
 type BandwidthSpec struct {
 	// Rate is the speed knob. Allows bps, kbps, mbps, gbps, tbps unit. bps means bytes per second.
-	Rate string `json:"rate" webhook:"Rate"`
+	Rate string `json:"rate"               webhook:"Rate"`
 	// Limit is the number of bytes that can be queued waiting for tokens to become available.
 	Limit uint32 `json:"limit"`
 	// Buffer is the maximum amount of bytes that tokens can be available for instantaneously.
@@ -172,8 +172,8 @@ type BandwidthSpec struct {
 
 // ReorderSpec defines details of packet reorder.
 type ReorderSpec struct {
-	Reorder     string `json:"reorder" webhook:"FloatStr"`
-	Correlation string `json:"correlation,omitempty" default:"0" webhook:"FloatStr"`
+	Reorder     string `json:"reorder"               webhook:"FloatStr"`
+	Correlation string `json:"correlation,omitempty" webhook:"FloatStr" default:"0"`
 	Gap         int    `json:"gap"`
 }
 

--- a/e2e/chaos-mesh/api/v1alpha1/physical_machine_chaos_types.go
+++ b/e2e/chaos-mesh/api/v1alpha1/physical_machine_chaos_types.go
@@ -144,7 +144,9 @@ func (spec *PhysicalMachineSelectorSpec) Empty() bool {
 		return true
 	}
 	if len(spec.AnnotationSelectors) != 0 || len(spec.FieldSelectors) != 0 || len(spec.LabelSelectors) != 0 ||
-		len(spec.Namespaces) != 0 || len(spec.PhysicalMachines) != 0 || len(spec.ExpressionSelectors) != 0 {
+		len(spec.Namespaces) != 0 ||
+		len(spec.PhysicalMachines) != 0 ||
+		len(spec.ExpressionSelectors) != 0 {
 		return false
 	}
 	return true
@@ -527,7 +529,7 @@ type RedisCommonSpec struct {
 }
 
 type RedisExpirationSpec struct {
-	RedisCommonSpec `json:",inline"`
+	RedisCommonSpec `       json:",inline"`
 	// The expiration of the keys
 	Expiration string `json:"expiration,omitempty"`
 	// The keys to be expired
@@ -537,13 +539,13 @@ type RedisExpirationSpec struct {
 }
 
 type RedisPenetrationSpec struct {
-	RedisCommonSpec `json:",inline"`
+	RedisCommonSpec `    json:",inline"`
 	// The number of requests to be sent
 	RequestNum int `json:"requestNum,omitempty"`
 }
 
 type RedisCacheLimitSpec struct {
-	RedisCommonSpec `json:",inline"`
+	RedisCommonSpec `       json:",inline"`
 	// The size of `maxmemory`
 	Size string `json:"cacheSize,omitempty"`
 	// Specifies maxmemory as a percentage of the original value
@@ -551,7 +553,7 @@ type RedisCacheLimitSpec struct {
 }
 
 type RedisSentinelRestartSpec struct {
-	RedisCommonSpec `json:",inline"`
+	RedisCommonSpec `       json:",inline"`
 	// The path of Sentinel conf
 	Conf string `json:"conf,omitempty"`
 	// The control flag determines whether to flush config
@@ -561,7 +563,7 @@ type RedisSentinelRestartSpec struct {
 }
 
 type RedisSentinelStopSpec struct {
-	RedisCommonSpec `json:",inline"`
+	RedisCommonSpec `       json:",inline"`
 	// The path of Sentinel conf
 	Conf string `json:"conf,omitempty"`
 	// The control flag determines whether to flush config
@@ -584,7 +586,7 @@ type KafkaCommonSpec struct {
 }
 
 type KafkaFillSpec struct {
-	KafkaCommonSpec `json:",inline"`
+	KafkaCommonSpec `       json:",inline"`
 	// The size of each message
 	MessageSize uint `json:"messageSize,omitempty"`
 	// The max bytes to fill
@@ -594,7 +596,7 @@ type KafkaFillSpec struct {
 }
 
 type KafkaFloodSpec struct {
-	KafkaCommonSpec `json:",inline"`
+	KafkaCommonSpec `     json:",inline"`
 	// The size of each message
 	MessageSize uint `json:"messageSize,omitempty"`
 	// The number of worker threads
@@ -632,7 +634,7 @@ type HTTPAbortSpec struct {
 }
 
 type HTTPDelaySpec struct {
-	HTTPCommonSpec `json:",inline"`
+	HTTPCommonSpec `       json:",inline"`
 	// Delay represents the delay of the target request/response
 	Delay string `json:"delay"`
 }

--- a/e2e/chaos-mesh/api/v1alpha1/physical_machine_chaos_types.go
+++ b/e2e/chaos-mesh/api/v1alpha1/physical_machine_chaos_types.go
@@ -143,7 +143,8 @@ func (spec *PhysicalMachineSelectorSpec) Empty() bool {
 	if spec == nil {
 		return true
 	}
-	if len(spec.AnnotationSelectors) != 0 || len(spec.FieldSelectors) != 0 || len(spec.LabelSelectors) != 0 ||
+	if len(spec.AnnotationSelectors) != 0 || len(spec.FieldSelectors) != 0 ||
+		len(spec.LabelSelectors) != 0 ||
 		len(spec.Namespaces) != 0 ||
 		len(spec.PhysicalMachines) != 0 ||
 		len(spec.ExpressionSelectors) != 0 {

--- a/e2e/chaos-mesh/api/v1alpha1/podhttpchaos_types.go
+++ b/e2e/chaos-mesh/api/v1alpha1/podhttpchaos_types.go
@@ -192,7 +192,7 @@ type PodHttpChaos struct {
 
 // PodHttpChaosList contains a list of PodHttpChaos
 type PodHttpChaosList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `               json:",inline"`
+	metav1.ListMeta `               json:"metadata,omitempty"`
 	Items           []PodHttpChaos `json:"items"`
 }

--- a/e2e/chaos-mesh/api/v1alpha1/schedule_types.go
+++ b/e2e/chaos-mesh/api/v1alpha1/schedule_types.go
@@ -84,8 +84,8 @@ func (in *Schedule) IsPaused() bool {
 
 // ScheduleList contains a list of Schedule
 type ScheduleList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `           json:",inline"`
+	metav1.ListMeta `           json:"metadata,omitempty"`
 	Items           []Schedule `json:"items"`
 }
 

--- a/e2e/chaos-mesh/api/v1alpha1/statuscheck_types.go
+++ b/e2e/chaos-mesh/api/v1alpha1/statuscheck_types.go
@@ -191,8 +191,8 @@ type HTTPStatusCheck struct {
 
 // StatusCheckList contains a list of StatusCheck
 type StatusCheckList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `              json:",inline"`
+	metav1.ListMeta `              json:"metadata,omitempty"`
 	Items           []StatusCheck `json:"items"`
 }
 

--- a/e2e/chaos-mesh/api/v1alpha1/stresschaos_types.go
+++ b/e2e/chaos-mesh/api/v1alpha1/stresschaos_types.go
@@ -67,7 +67,7 @@ type StressChaosSpec struct {
 
 // StressChaosStatus defines the observed state of StressChaos
 type StressChaosStatus struct {
-	ChaosStatus `json:",inline"`
+	ChaosStatus `                          json:",inline"`
 	// Instances always specifies stressing instances
 	Instances map[string]StressInstance `json:"instances,omitempty"`
 }
@@ -160,7 +160,7 @@ type MemoryStressor struct {
 
 // CPUStressor defines how to stress CPU out
 type CPUStressor struct {
-	Stressor `json:",inline"`
+	Stressor `     json:",inline"`
 	// Load specifies P percent loading per CPU worker. 0 is effectively a sleep (no load) and 100
 	// is full loading.
 	Load *int `json:"load,omitempty"`

--- a/e2e/chaos-mesh/api/v1alpha1/workflow_types.go
+++ b/e2e/chaos-mesh/api/v1alpha1/workflow_types.go
@@ -104,7 +104,7 @@ type Template struct {
 	// ConditionalBranches describes the conditional branches of custom tasks. Only used when Type is TypeTask.
 	ConditionalBranches []ConditionalBranch `json:"conditionalBranches,omitempty"`
 	// EmbedChaos describe the chaos to be injected with chaos nodes. Only used when Type is Type<Something>Chaos.
-	*EmbedChaos `json:",inline"`
+	*EmbedChaos `                       json:",inline"`
 	// Schedule describe the Schedule(describing scheduled chaos) to be injected with chaos nodes. Only used when Type is TypeSchedule.
 	Schedule *ChaosOnlyScheduleSpec `json:"schedule,omitempty"`
 	// StatusCheck describe the behavior of StatusCheck. Only used when Type is TypeStatusCheck.
@@ -145,8 +145,8 @@ type Task struct {
 }
 
 type WorkflowList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `           json:",inline"`
+	metav1.ListMeta `           json:"metadata,omitempty"`
 	Items           []Workflow `json:"items"`
 }
 

--- a/e2e/chaos-mesh/api/v1alpha1/workflownode_types.go
+++ b/e2e/chaos-mesh/api/v1alpha1/workflownode_types.go
@@ -111,8 +111,8 @@ type WorkflowNodeCondition struct {
 }
 
 type WorkflowNodeList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `               json:",inline"`
+	metav1.ListMeta `               json:"metadata,omitempty"`
 	Items           []WorkflowNode `json:"items"`
 }
 

--- a/e2e/fixtures/blobstore.go
+++ b/e2e/fixtures/blobstore.go
@@ -175,7 +175,8 @@ type blobstoreConfig struct {
 
 // CreateBlobstoreIfAbsent creates the blobstore Deployment based on the template.
 func (factory *Factory) CreateBlobstoreIfAbsent(namespace string) {
-	seaweedFSDeploymentTemplate, err := template.New("seaweedFSDeployment").Parse(seaweedFSDeployment)
+	seaweedFSDeploymentTemplate, err := template.New("seaweedFSDeployment").
+		Parse(seaweedFSDeployment)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	buf := bytes.Buffer{}
 	gomega.Expect(seaweedFSDeploymentTemplate.Execute(&buf, &blobstoreConfig{
@@ -230,7 +231,12 @@ func (factory *Factory) waitUntilBlobstorePodsRunning(namespace string) {
 
 			// If the Pod is not running after 120 seconds we delete it and let the Deployment controller create a new Pod.
 			if time.Since(pod.CreationTimestamp.Time).Seconds() > 120.0 {
-				log.Println("seaweedfs Pod", pod.Name, "not running after 120 seconds, going to delete this Pod, status:", pod.Status)
+				log.Println(
+					"seaweedfs Pod",
+					pod.Name,
+					"not running after 120 seconds, going to delete this Pod, status:",
+					pod.Status,
+				)
 				err := factory.GetControllerRuntimeClient().Delete(context.Background(), &pod)
 				if k8serrors.IsNotFound(err) {
 					continue

--- a/e2e/fixtures/certificate_generator.go
+++ b/e2e/fixtures/certificate_generator.go
@@ -73,7 +73,13 @@ func (factory *Factory) GenerateCertificate() (*corev1.Secret, error) {
 		SubjectKeyId:          caKeyID,
 		AuthorityKeyId:        caKeyID,
 	}
-	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivateKey.PublicKey, caPrivateKey)
+	caBytes, err := x509.CreateCertificate(
+		rand.Reader,
+		ca,
+		ca,
+		&caPrivateKey.PublicKey,
+		caPrivateKey,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/fixtures/chaos_common.go
+++ b/e2e/fixtures/chaos_common.go
@@ -173,7 +173,8 @@ func (factory *Factory) CreateExperiment(chaos client.Object) *ChaosMeshExperime
 	}
 	factory.addChaosExperiment(experiment)
 
-	gomega.Expect(factory.waitUntilExperimentRunning(experiment, chaos)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(factory.waitUntilExperimentRunning(experiment, chaos)).
+		NotTo(gomega.HaveOccurred())
 
 	return &experiment
 }

--- a/e2e/fixtures/chaos_disk.go
+++ b/e2e/fixtures/chaos_disk.go
@@ -29,35 +29,71 @@ import (
 
 // InjectDiskFailure injects a disk failure for all Pods selected by the selector.
 func (factory *Factory) InjectDiskFailure(selector chaosmesh.PodSelectorSpec) *ChaosMeshExperiment {
-	return factory.InjectDiskFailureWithPath(selector, "/var/fdb/data", "/var/fdb/data/**/*", []chaosmesh.IoMethod{
-		chaosmesh.Write,
-		chaosmesh.Read,
-		chaosmesh.Open,
-		chaosmesh.Flush,
-		chaosmesh.Fsync,
-	}, []string{fdbv1beta2.MainContainerName})
+	return factory.InjectDiskFailureWithPath(
+		selector,
+		"/var/fdb/data",
+		"/var/fdb/data/**/*",
+		[]chaosmesh.IoMethod{
+			chaosmesh.Write,
+			chaosmesh.Read,
+			chaosmesh.Open,
+			chaosmesh.Flush,
+			chaosmesh.Fsync,
+		},
+		[]string{fdbv1beta2.MainContainerName},
+	)
 }
 
 // InjectDiskFailureWithDuration injects a disk failure for all Pods selected by the selector for the specified duration.
-func (factory *Factory) InjectDiskFailureWithDuration(selector chaosmesh.PodSelectorSpec, duration string) *ChaosMeshExperiment {
-	return factory.InjectDiskFailureWithPathAndDuration(selector, "/var/fdb/data", "/var/fdb/data/**/*", []chaosmesh.IoMethod{
-		chaosmesh.Write,
-		chaosmesh.Read,
-		chaosmesh.Open,
-		chaosmesh.Flush,
-		chaosmesh.Fsync,
-	}, []string{fdbv1beta2.MainContainerName}, duration)
+func (factory *Factory) InjectDiskFailureWithDuration(
+	selector chaosmesh.PodSelectorSpec,
+	duration string,
+) *ChaosMeshExperiment {
+	return factory.InjectDiskFailureWithPathAndDuration(
+		selector,
+		"/var/fdb/data",
+		"/var/fdb/data/**/*",
+		[]chaosmesh.IoMethod{
+			chaosmesh.Write,
+			chaosmesh.Read,
+			chaosmesh.Open,
+			chaosmesh.Flush,
+			chaosmesh.Fsync,
+		},
+		[]string{fdbv1beta2.MainContainerName},
+		duration,
+	)
 }
 
 // InjectDiskFailureWithPath injects a disk failure for all Pods selected by the selector. volumePath and path can be used to specify the affected files and methods
 // allow to specify the affected methods.
-func (factory *Factory) InjectDiskFailureWithPath(selector chaosmesh.PodSelectorSpec, volumePath string, path string, methods []chaosmesh.IoMethod, containers []string) *ChaosMeshExperiment {
-	return factory.InjectDiskFailureWithPathAndDuration(selector, volumePath, path, methods, containers, ChaosDurationForever)
+func (factory *Factory) InjectDiskFailureWithPath(
+	selector chaosmesh.PodSelectorSpec,
+	volumePath string,
+	path string,
+	methods []chaosmesh.IoMethod,
+	containers []string,
+) *ChaosMeshExperiment {
+	return factory.InjectDiskFailureWithPathAndDuration(
+		selector,
+		volumePath,
+		path,
+		methods,
+		containers,
+		ChaosDurationForever,
+	)
 }
 
 // InjectDiskFailureWithPathAndDuration injects a disk failure for all Pods selected by the selector. volumePath and path can be used to specify the affected files and methods
 // allow to specify the affected methods. duration will define how long the chaos is injected.
-func (factory *Factory) InjectDiskFailureWithPathAndDuration(selector chaosmesh.PodSelectorSpec, volumePath string, path string, methods []chaosmesh.IoMethod, containers []string, duration string) *ChaosMeshExperiment {
+func (factory *Factory) InjectDiskFailureWithPathAndDuration(
+	selector chaosmesh.PodSelectorSpec,
+	volumePath string,
+	path string,
+	methods []chaosmesh.IoMethod,
+	containers []string,
+	duration string,
+) *ChaosMeshExperiment {
 	return factory.CreateExperiment(&chaosmesh.IOChaos{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      factory.RandStringRunes(32),
@@ -84,7 +120,10 @@ func (factory *Factory) InjectDiskFailureWithPathAndDuration(selector chaosmesh.
 }
 
 // InjectIOLatency injects IOLatency for single pod.
-func (factory *Factory) InjectIOLatency(selector chaosmesh.PodSelectorSpec, delay string) *ChaosMeshExperiment {
+func (factory *Factory) InjectIOLatency(
+	selector chaosmesh.PodSelectorSpec,
+	delay string,
+) *ChaosMeshExperiment {
 	return factory.CreateExperiment(&chaosmesh.IOChaos{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      factory.RandStringRunes(32),

--- a/e2e/fixtures/chaos_http.go
+++ b/e2e/fixtures/chaos_http.go
@@ -28,7 +28,10 @@ import (
 
 // InjectHTTPClientChaosWrongResultFdbMonitorConf  this method can be used to simulate a bad response from the operator to the sidecar. Currently this method returns as body the value "wrong"
 // when the operator does a request against the check_hash/fdbmonitor.conf endpoint, e.g. during upgrades.
-func (factory *Factory) InjectHTTPClientChaosWrongResultFdbMonitorConf(selector chaosmesh.PodSelectorSpec, namespace string) *ChaosMeshExperiment {
+func (factory *Factory) InjectHTTPClientChaosWrongResultFdbMonitorConf(
+	selector chaosmesh.PodSelectorSpec,
+	namespace string,
+) *ChaosMeshExperiment {
 	return factory.CreateExperiment(&chaosmesh.HTTPChaos{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      factory.RandStringRunes(32),

--- a/e2e/fixtures/chaos_network.go
+++ b/e2e/fixtures/chaos_network.go
@@ -43,7 +43,12 @@ func ensurePodPhaseSelectorIsSet(selector *chaosmesh.PodSelectorSpec) {
 }
 
 // InjectNetworkLoss injects network loss between the source and the target.
-func (factory *Factory) InjectNetworkLoss(lossPercentage string, source chaosmesh.PodSelectorSpec, target chaosmesh.PodSelectorSpec, direction chaosmesh.Direction) *ChaosMeshExperiment {
+func (factory *Factory) InjectNetworkLoss(
+	lossPercentage string,
+	source chaosmesh.PodSelectorSpec,
+	target chaosmesh.PodSelectorSpec,
+	direction chaosmesh.Direction,
+) *ChaosMeshExperiment {
 	ensurePodPhaseSelectorIsSet(&source)
 	ensurePodPhaseSelectorIsSet(&target)
 
@@ -76,7 +81,10 @@ func (factory *Factory) InjectNetworkLoss(lossPercentage string, source chaosmes
 }
 
 // InjectNetworkLossBetweenPods Injects network loss b/w each combination of podGroups.
-func (factory *Factory) InjectNetworkLossBetweenPods(pods []chaosmesh.PodSelectorSpec, loss string) {
+func (factory *Factory) InjectNetworkLossBetweenPods(
+	pods []chaosmesh.PodSelectorSpec,
+	loss string,
+) {
 	count := len(pods)
 	for i := 0; i < count; i++ {
 		for j := i + 1; j < count; j++ {
@@ -103,7 +111,10 @@ func (factory *Factory) InjectPartition(selector chaosmesh.PodSelectorSpec) *Cha
 }
 
 // InjectPartitionWithExternalTargets injects a partition to the provided selector with the external targets
-func (factory *Factory) InjectPartitionWithExternalTargets(selector chaosmesh.PodSelectorSpec, externalTargets []string) *ChaosMeshExperiment {
+func (factory *Factory) InjectPartitionWithExternalTargets(
+	selector chaosmesh.PodSelectorSpec,
+	externalTargets []string,
+) *ChaosMeshExperiment {
 	return factory.injectPartitionBetween(selector, nil, chaosmesh.Both, externalTargets)
 }
 
@@ -173,7 +184,12 @@ func (factory *Factory) InjectPartitionOnSomeTargetPods(
 }
 
 // InjectNetworkLatency injects network latency between the source and the target.
-func (factory *Factory) InjectNetworkLatency(source chaosmesh.PodSelectorSpec, target chaosmesh.PodSelectorSpec, direction chaosmesh.Direction, delay *chaosmesh.DelaySpec) *ChaosMeshExperiment {
+func (factory *Factory) InjectNetworkLatency(
+	source chaosmesh.PodSelectorSpec,
+	target chaosmesh.PodSelectorSpec,
+	direction chaosmesh.Direction,
+	delay *chaosmesh.DelaySpec,
+) *ChaosMeshExperiment {
 	ensurePodPhaseSelectorIsSet(&source)
 	ensurePodPhaseSelectorIsSet(&target)
 

--- a/e2e/fixtures/chaos_pod.go
+++ b/e2e/fixtures/chaos_pod.go
@@ -26,7 +26,11 @@ import (
 )
 
 // ScheduleInjectPodKill schedules a Pod Kill action.
-func (factory *Factory) ScheduleInjectPodKill(target chaosmesh.PodSelectorSpec, schedule string, mode chaosmesh.SelectorMode) *ChaosMeshExperiment {
+func (factory *Factory) ScheduleInjectPodKill(
+	target chaosmesh.PodSelectorSpec,
+	schedule string,
+	mode chaosmesh.SelectorMode,
+) *ChaosMeshExperiment {
 	return factory.scheduleInjectPod(
 		chaosmesh.PodSelector{
 			Selector: target,
@@ -38,7 +42,12 @@ func (factory *Factory) ScheduleInjectPodKill(target chaosmesh.PodSelectorSpec, 
 }
 
 // ScheduleInjectPodKillWithName schedules a Pod Kill action with the specified name.
-func (factory *Factory) ScheduleInjectPodKillWithName(target chaosmesh.PodSelectorSpec, schedule string, mode chaosmesh.SelectorMode, name string) *ChaosMeshExperiment {
+func (factory *Factory) ScheduleInjectPodKillWithName(
+	target chaosmesh.PodSelectorSpec,
+	schedule string,
+	mode chaosmesh.SelectorMode,
+	name string,
+) *ChaosMeshExperiment {
 	return factory.scheduleInjectPod(
 		chaosmesh.PodSelector{
 			Selector: target,
@@ -49,7 +58,12 @@ func (factory *Factory) ScheduleInjectPodKillWithName(target chaosmesh.PodSelect
 		name)
 }
 
-func (factory *Factory) scheduleInjectPod(target chaosmesh.PodSelector, schedule string, action chaosmesh.PodChaosAction, name string) *ChaosMeshExperiment {
+func (factory *Factory) scheduleInjectPod(
+	target chaosmesh.PodSelector,
+	schedule string,
+	action chaosmesh.PodChaosAction,
+	name string,
+) *ChaosMeshExperiment {
 	return factory.CreateExperiment(&chaosmesh.Schedule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/e2e/fixtures/chaos_stress.go
+++ b/e2e/fixtures/chaos_stress.go
@@ -27,7 +27,12 @@ import (
 )
 
 // InjectPodStress injects pod stress on the target.
-func (factory *Factory) InjectPodStress(target chaosmesh.PodSelectorSpec, containerNames []string, memoryStressor *chaosmesh.MemoryStressor, cpuStressor *chaosmesh.CPUStressor) *ChaosMeshExperiment {
+func (factory *Factory) InjectPodStress(
+	target chaosmesh.PodSelectorSpec,
+	containerNames []string,
+	memoryStressor *chaosmesh.MemoryStressor,
+	cpuStressor *chaosmesh.CPUStressor,
+) *ChaosMeshExperiment {
 	return factory.CreateExperiment(&chaosmesh.StressChaos{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      factory.RandStringRunes(32),

--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -167,7 +167,12 @@ func (config *ClusterConfig) SetDefaults(factory *Factory) {
 				return
 			}
 
-			log.Println("FoundationDBCluster", fdbCluster.Name(), "successfully created in", fdbCluster.Namespace())
+			log.Println(
+				"FoundationDBCluster",
+				fdbCluster.Name(),
+				"successfully created in",
+				fdbCluster.Namespace(),
+			)
 		}
 	}
 
@@ -305,7 +310,10 @@ func (input *customParameterInput) getCustomParameter() fdbv1beta2.FoundationDBC
 	return fdbv1beta2.FoundationDBCustomParameter(input.key + "=" + input.value)
 }
 
-func addKnobIfMissing(inputs []customParameterInput, customParameters []fdbv1beta2.FoundationDBCustomParameter) fdbv1beta2.FoundationDBCustomParameters {
+func addKnobIfMissing(
+	inputs []customParameterInput,
+	customParameters []fdbv1beta2.FoundationDBCustomParameter,
+) fdbv1beta2.FoundationDBCustomParameters {
 	hasKnob := map[string]fdbv1beta2.None{}
 	// Check which knobs are already set.
 	for _, customParameter := range customParameters {
@@ -330,7 +338,9 @@ func addKnobIfMissing(inputs []customParameterInput, customParameters []fdbv1bet
 	return customParameters
 }
 
-func (config *ClusterConfig) getCustomParametersForProcessClass(processClass fdbv1beta2.ProcessClass) fdbv1beta2.FoundationDBCustomParameters {
+func (config *ClusterConfig) getCustomParametersForProcessClass(
+	processClass fdbv1beta2.ProcessClass,
+) fdbv1beta2.FoundationDBCustomParameters {
 	requiredKnobs := []customParameterInput{
 		{
 			key:   "trace_format",

--- a/e2e/fixtures/cluster_config_test.go
+++ b/e2e/fixtures/cluster_config_test.go
@@ -29,12 +29,14 @@ import (
 )
 
 var _ = Describe("Cluster configuration", func() {
-	DescribeTable("when generating the Pod resources", func(config *ClusterConfig, processClass fdbv1beta2.ProcessClass, expected corev1.ResourceList) {
-		config.SetDefaults(&Factory{options: &FactoryOptions{}})
-		generated := config.generatePodResources(processClass)
-		Expect(generated.Cpu().String()).To(Equal(expected.Cpu().String()))
-		Expect(generated.Memory().String()).To(Equal(expected.Memory().String()))
-	},
+	DescribeTable(
+		"when generating the Pod resources",
+		func(config *ClusterConfig, processClass fdbv1beta2.ProcessClass, expected corev1.ResourceList) {
+			config.SetDefaults(&Factory{options: &FactoryOptions{}})
+			generated := config.generatePodResources(processClass)
+			Expect(generated.Cpu().String()).To(Equal(expected.Cpu().String()))
+			Expect(generated.Memory().String()).To(Equal(expected.Memory().String()))
+		},
 		Entry("empty config for general process class",
 			&ClusterConfig{
 				Name:                "test",
@@ -113,7 +115,8 @@ var _ = Describe("Cluster configuration", func() {
 				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("16Gi"),
 			}),
-		Entry("performance config for storage process class with multiple storage servers per disk with custom memory",
+		Entry(
+			"performance config for storage process class with multiple storage servers per disk with custom memory",
 			&ClusterConfig{
 				StorageServerPerPod: 2,
 				Name:                "test",
@@ -126,7 +129,8 @@ var _ = Describe("Cluster configuration", func() {
 			corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2"),
 				corev1.ResourceMemory: resource.MustParse("32Gi"),
-			}),
+			},
+		),
 		Entry("empty config for general process class for kind",
 			&ClusterConfig{
 				cloudProvider: "kind",

--- a/e2e/fixtures/fdb_backup.go
+++ b/e2e/fixtures/fdb_backup.go
@@ -245,7 +245,9 @@ func (fdbBackup *FdbBackup) GetBackupPods() *corev1.PodList {
 	gomega.Expect(fdbBackup.fdbCluster.factory.GetControllerRuntimeClient().List(context.Background(), podList,
 		client.InNamespace(fdbBackup.fdbCluster.Namespace()),
 		client.MatchingLabels(map[string]string{fdbv1beta2.BackupDeploymentPodLabel: fdbBackup.fdbCluster.Name() + "-backup-agents"}),
-	)).NotTo(gomega.HaveOccurred())
+	),
+	).
+		NotTo(gomega.HaveOccurred())
 
 	return podList
 }

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -82,7 +82,14 @@ func (fdbCluster *FdbCluster) ExecuteCmdOnPod(
 	command string,
 	printOutput bool,
 ) (string, string, error) {
-	return fdbCluster.factory.ExecuteCmd(context.Background(), pod.Namespace, pod.Name, container, command, printOutput)
+	return fdbCluster.factory.ExecuteCmd(
+		context.Background(),
+		pod.Namespace,
+		pod.Name,
+		container,
+		command,
+		printOutput,
+	)
 }
 
 func (factory *Factory) createFdbClusterObject(
@@ -286,7 +293,11 @@ func (fdbCluster *FdbCluster) waitForReconciliationToGeneration(
 		return false
 	}
 
-	err := fdbCluster.WaitUntilWithForceReconcile(pollTimeInSeconds, timeOutInSeconds, checkIfReconciliationIsDone)
+	err := fdbCluster.WaitUntilWithForceReconcile(
+		pollTimeInSeconds,
+		timeOutInSeconds,
+		checkIfReconciliationIsDone,
+	)
 	if creationTracker != nil {
 		creationTracker.report()
 	}
@@ -295,7 +306,11 @@ func (fdbCluster *FdbCluster) waitForReconciliationToGeneration(
 }
 
 // WaitUntilWithForceReconcile will wait either until the checkMethod returns true or until the timeout is hit.
-func (fdbCluster *FdbCluster) WaitUntilWithForceReconcile(pollTimeInSeconds int, timeOutInSeconds int, checkMethod func(cluster *fdbv1beta2.FoundationDBCluster) bool) error {
+func (fdbCluster *FdbCluster) WaitUntilWithForceReconcile(
+	pollTimeInSeconds int,
+	timeOutInSeconds int,
+	checkMethod func(cluster *fdbv1beta2.FoundationDBCluster) bool,
+) error {
 	// Printout the initial state of the cluster before we moving forward waiting for the checkMethod to return true.
 	fdbCluster.factory.DumpState(fdbCluster)
 
@@ -425,7 +440,9 @@ func (fdbCluster *FdbCluster) UpdateClusterStatus() {
 //
 //		// Make sure the operator picks up the work again
 //		fdbCluster.SetSkipReconciliation(false)
-func (fdbCluster *FdbCluster) UpdateClusterStatusWithStatus(desiredStatus *fdbv1beta2.FoundationDBClusterStatus) {
+func (fdbCluster *FdbCluster) UpdateClusterStatusWithStatus(
+	desiredStatus *fdbv1beta2.FoundationDBClusterStatus,
+) {
 	fetchedCluster := &fdbv1beta2.FoundationDBCluster{}
 
 	// This is flaky. It sometimes responds with an error saying that the object has been updated.
@@ -466,7 +483,9 @@ func (fdbCluster *FdbCluster) UpdateClusterSpec() {
 //	spec.Version = "7.1.27" // Make your changes.
 //
 //	fdbCluster.UpdateClusterSpecWithSpec(spec) // Update the spec.
-func (fdbCluster *FdbCluster) UpdateClusterSpecWithSpec(desiredSpec *fdbv1beta2.FoundationDBClusterSpec) {
+func (fdbCluster *FdbCluster) UpdateClusterSpecWithSpec(
+	desiredSpec *fdbv1beta2.FoundationDBClusterSpec,
+) {
 	fetchedCluster := &fdbv1beta2.FoundationDBCluster{}
 
 	// This is flaky. It sometimes responds with an error saying that the object has been updated.
@@ -580,7 +599,9 @@ func (fdbCluster *FdbCluster) GetPod(name string) *corev1.Pod {
 }
 
 // GetPodIDs returns all the process group IDs for all Pods of this cluster that have the matching process class.
-func (fdbCluster *FdbCluster) GetPodIDs(processClass fdbv1beta2.ProcessClass) map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None {
+func (fdbCluster *FdbCluster) GetPodIDs(
+	processClass fdbv1beta2.ProcessClass,
+) map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None {
 	pods := fdbCluster.GetPods()
 
 	podIDs := make(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None, len(pods.Items))
@@ -677,14 +698,17 @@ func (fdbCluster *FdbCluster) SetTransactionServerPerPod(
 // ReplacePod replaces the provided Pod if it's part of the FoundationDBCluster.
 func (fdbCluster *FdbCluster) ReplacePod(pod corev1.Pod, waitForReconcile bool) {
 	cluster := fdbCluster.GetCluster()
-	fdbCluster.cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{GetProcessGroupID(pod)}
+	fdbCluster.cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{
+		GetProcessGroupID(pod),
+	}
 	fdbCluster.UpdateClusterSpec()
 
 	if !waitForReconcile {
 		return
 	}
 
-	gomega.Expect(fdbCluster.WaitForReconciliation(SoftReconcileOption(true), MinimumGenerationOption(cluster.Generation+1))).NotTo(gomega.HaveOccurred())
+	gomega.Expect(fdbCluster.WaitForReconciliation(SoftReconcileOption(true), MinimumGenerationOption(cluster.Generation+1))).
+		NotTo(gomega.HaveOccurred())
 }
 
 // ReplacePods replaces the provided Pods in the current FoundationDBCluster.
@@ -798,7 +822,9 @@ func (fdbCluster *FdbCluster) SetPodAsUnschedulable(pod corev1.Pod) {
 
 // SetProcessGroupsAsUnschedulable sets the provided process groups on the NoSchedule list of the current FoundationDBCluster. This will make
 // sure that the Pod is stuck in Pending.
-func (fdbCluster *FdbCluster) SetProcessGroupsAsUnschedulable(processGroups []fdbv1beta2.ProcessGroupID) {
+func (fdbCluster *FdbCluster) SetProcessGroupsAsUnschedulable(
+	processGroups []fdbv1beta2.ProcessGroupID,
+) {
 	fdbCluster.cluster.Spec.Buggify.NoSchedule = processGroups
 	fdbCluster.UpdateClusterSpec()
 }
@@ -832,7 +858,12 @@ func (fdbCluster *FdbCluster) SetTLS(
 	enableMainContainerTLS bool,
 	enableSidecarContainerTLS bool,
 ) error {
-	log.Println("updating the TLS setting for main container:", enableMainContainerTLS, "for sidecar container:", enableSidecarContainerTLS)
+	log.Println(
+		"updating the TLS setting for main container:",
+		enableMainContainerTLS,
+		"for sidecar container:",
+		enableSidecarContainerTLS,
+	)
 	fdbCluster.cluster.Spec.MainContainer.EnableTLS = enableMainContainerTLS
 	fdbCluster.cluster.Spec.SidecarContainer.EnableTLS = enableSidecarContainerTLS
 	fdbCluster.UpdateClusterSpec()
@@ -916,7 +947,11 @@ func (fdbCluster *FdbCluster) WaitForPodRemoval(pod *corev1.Pod) {
 	log.Printf("waiting until the pod %s/%s is deleted", pod.Namespace, pod.Name)
 	counter := 0
 	forceReconcile := 10
-	errDescription := fmt.Sprintf("pod %s/%s was not removed in the expected time", pod.Namespace, pod.Name)
+	errDescription := fmt.Sprintf(
+		"pod %s/%s was not removed in the expected time",
+		pod.Namespace,
+		pod.Name,
+	)
 	fetchedPod := &corev1.Pod{}
 	gomega.Eventually(func() bool {
 		err := fdbCluster.getClient().
@@ -1032,7 +1067,9 @@ func (fdbCluster *FdbCluster) UpgradeCluster(version string, waitForReconciliati
 
 	if waitForReconciliation {
 		log.Println("Waiting for generation:", fdbCluster.cluster.Generation)
-		return fdbCluster.WaitForReconciliation(MinimumGenerationOption(fdbCluster.cluster.Generation))
+		return fdbCluster.WaitForReconciliation(
+			MinimumGenerationOption(fdbCluster.cluster.Generation),
+		)
 	}
 
 	return nil
@@ -1120,7 +1157,10 @@ func (fdbCluster *FdbCluster) SetEmptyMonitorConf(enable bool) error {
 }
 
 // SetClusterTaintConfig set fdbCluster's TaintReplacementOptions
-func (fdbCluster *FdbCluster) SetClusterTaintConfig(taintOption []fdbv1beta2.TaintReplacementOption, taintReplacementTimeSeconds *int) {
+func (fdbCluster *FdbCluster) SetClusterTaintConfig(
+	taintOption []fdbv1beta2.TaintReplacementOption,
+	taintReplacementTimeSeconds *int,
+) {
 	curClusterSpec := fdbCluster.GetCluster().Spec.DeepCopy()
 	curClusterSpec.AutomationOptions.Replacements.TaintReplacementOptions = taintOption
 	curClusterSpec.AutomationOptions.Replacements.TaintReplacementTimeSeconds = taintReplacementTimeSeconds
@@ -1220,7 +1260,10 @@ func (fdbCluster *FdbCluster) CheckPodIsDeleted(podName string) bool {
 
 // EnsurePodIsDeletedWithCustomTimeout validates that a Pod is either not existing or is marked as deleted with a non-zero deletion timestamp.
 // It times out after timeoutMinutes.
-func (fdbCluster *FdbCluster) EnsurePodIsDeletedWithCustomTimeout(podName string, timeoutMinutes int) {
+func (fdbCluster *FdbCluster) EnsurePodIsDeletedWithCustomTimeout(
+	podName string,
+	timeoutMinutes int,
+) {
 	lastForceReconcile := time.Now()
 	gomega.Eventually(func() bool {
 		// Force a reconciliation every minute to ensure the deletion will be done in a more timely manner (without
@@ -1313,11 +1356,16 @@ func (fdbCluster *FdbCluster) SetIgnoreDuringRestart(processes []fdbv1beta2.Proc
 }
 
 // UpdateContainerImage sets the image for the provided Pod for the provided container.
-func (fdbCluster *FdbCluster) UpdateContainerImage(pod *corev1.Pod, containerName string, image string) {
+func (fdbCluster *FdbCluster) UpdateContainerImage(
+	pod *corev1.Pod,
+	containerName string,
+	image string,
+) {
 	gomega.Eventually(func(g gomega.Gomega) error {
 		updatePod := &corev1.Pod{}
 
-		g.Expect(fdbCluster.getClient().Get(context.Background(), client.ObjectKeyFromObject(pod), updatePod)).To(gomega.Succeed())
+		g.Expect(fdbCluster.getClient().Get(context.Background(), client.ObjectKeyFromObject(pod), updatePod)).
+			To(gomega.Succeed())
 
 		for idx, container := range updatePod.Spec.Containers {
 			if container.Name != containerName {
@@ -1327,7 +1375,8 @@ func (fdbCluster *FdbCluster) UpdateContainerImage(pod *corev1.Pod, containerNam
 			updatePod.Spec.Containers[idx].Image = image
 		}
 
-		return fdbCluster.factory.GetControllerRuntimeClient().Update(context.Background(), updatePod)
+		return fdbCluster.factory.GetControllerRuntimeClient().
+			Update(context.Background(), updatePod)
 	}).ShouldNot(gomega.HaveOccurred())
 }
 
@@ -1389,7 +1438,10 @@ func (fdbCluster *FdbCluster) ValidateProcessesCount(
 	fdbCluster.UpdateAnnotationsAndLabels(annotations, labels)
 
 */
-func (fdbCluster *FdbCluster) UpdateAnnotationsAndLabels(annotations map[string]string, labels map[string]string) {
+func (fdbCluster *FdbCluster) UpdateAnnotationsAndLabels(
+	annotations map[string]string,
+	labels map[string]string,
+) {
 	// Update the annotations and labels.
 	gomega.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		fetchedCluster := &fdbv1beta2.FoundationDBCluster{}
@@ -1420,7 +1472,8 @@ func (fdbCluster *FdbCluster) UpdateAnnotationsAndLabels(annotations map[string]
 func (fdbCluster *FdbCluster) VerifyVersion(version string) {
 	gomega.Expect(fdbCluster.WaitUntilWithForceReconcile(2, 600, func(cluster *fdbv1beta2.FoundationDBCluster) bool {
 		return cluster.Status.RunningVersion == version
-	})).NotTo(gomega.HaveOccurred())
+	})).
+		NotTo(gomega.HaveOccurred())
 }
 
 // UpgradeAndVerify will upgrade the cluster to the new version and perform a check at the end that the running version
@@ -1488,7 +1541,9 @@ func (fdbCluster *FdbCluster) EnsureTeamTrackersHaveMinReplicas() {
 }
 
 // GetListOfUIDsFromVolumeClaims will return of list of UIDs for the current volume claims for the provided processes class.
-func (fdbCluster *FdbCluster) GetListOfUIDsFromVolumeClaims(processClass fdbv1beta2.ProcessClass) []types.UID {
+func (fdbCluster *FdbCluster) GetListOfUIDsFromVolumeClaims(
+	processClass fdbv1beta2.ProcessClass,
+) []types.UID {
 	volumesClaims := fdbCluster.GetVolumeClaimsForProcesses(processClass)
 
 	uids := make([]types.UID, 0, len(volumesClaims.Items))
@@ -1505,10 +1560,12 @@ func (fdbCluster *FdbCluster) UpdateConnectionString(connectionString string) {
 	fdbCluster.UpdateClusterSpec()
 
 	cm := &corev1.ConfigMap{}
-	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Get(context.Background(), client.ObjectKey{Namespace: fdbCluster.Namespace(), Name: fdbCluster.Name() + "-config"}, cm)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Get(context.Background(), client.ObjectKey{Namespace: fdbCluster.Namespace(), Name: fdbCluster.Name() + "-config"}, cm)).
+		NotTo(gomega.HaveOccurred())
 	gomega.Expect(cm.Data).To(gomega.HaveKey(fdbv1beta2.ClusterFileKey))
 	cm.Data[fdbv1beta2.ClusterFileKey] = connectionString
-	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Update(context.Background(), cm)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Update(context.Background(), cm)).
+		NotTo(gomega.HaveOccurred())
 }
 
 // CreateTesterDeployment will create a deployment that runs tester processes with the specified number of replicas.
@@ -1520,13 +1577,25 @@ func (fdbCluster *FdbCluster) CreateTesterDeployment(replicas int) *appsv1.Deplo
 		fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassTest),
 	}
 
-	mainImage := fdbv1beta2.SelectImageConfig(fdbCluster.factory.GetMainContainerOverrides(false, fdbCluster.cluster.UseUnifiedImage()).ImageConfigs, fdbCluster.cluster.Spec.Version).Image()
+	mainImage := fdbv1beta2.SelectImageConfig(fdbCluster.factory.GetMainContainerOverrides(false, fdbCluster.cluster.UseUnifiedImage()).ImageConfigs, fdbCluster.cluster.Spec.Version).
+		Image()
 
 	var initArgs []string
 	var sidecarImage string
 	if fdbCluster.cluster.UseUnifiedImage() {
 		sidecarImage = mainImage
-		initArgs = []string{"--mode", "init", "--input-dir", "/var/input-files", "--output-dir", "/var/output-files", "--require-not-empty", "fdb.cluster", "--copy-file", "fdb.cluster"}
+		initArgs = []string{
+			"--mode",
+			"init",
+			"--input-dir",
+			"/var/input-files",
+			"--output-dir",
+			"/var/output-files",
+			"--require-not-empty",
+			"fdb.cluster",
+			"--copy-file",
+			"fdb.cluster",
+		}
 	} else {
 		sidecarImage = fdbv1beta2.SelectImageConfig(fdbCluster.factory.GetSidecarContainerOverrides(fdbCluster.cluster.UseUnifiedImage()).ImageConfigs, fdbCluster.cluster.Spec.Version).Image()
 		initArgs = []string{"--init-mode", "--require-not-empty", "fdb.cluster", "--copy-file", "fdb.cluster"}
@@ -1563,8 +1632,10 @@ func (fdbCluster *FdbCluster) CreateTesterDeployment(replicas int) *appsv1.Deplo
 							ImagePullPolicy: fdbCluster.factory.getImagePullPolicy(),
 							Image:           sidecarImage,
 							SecurityContext: &corev1.SecurityContext{
-								Privileged:               pointer.Bool(true),
-								AllowPrivilegeEscalation: pointer.Bool(true), // for performance profiling
+								Privileged: pointer.Bool(true),
+								AllowPrivilegeEscalation: pointer.Bool(
+									true,
+								), // for performance profiling
 								ReadOnlyRootFilesystem: pointer.Bool(
 									false,
 								), // to allow I/O chaos to succeed
@@ -1588,8 +1659,10 @@ func (fdbCluster *FdbCluster) CreateTesterDeployment(replicas int) *appsv1.Deplo
 							ImagePullPolicy: fdbCluster.factory.getImagePullPolicy(),
 							Image:           mainImage,
 							SecurityContext: &corev1.SecurityContext{
-								Privileged:               pointer.Bool(true),
-								AllowPrivilegeEscalation: pointer.Bool(true), // for performance profiling
+								Privileged: pointer.Bool(true),
+								AllowPrivilegeEscalation: pointer.Bool(
+									true,
+								), // for performance profiling
 								ReadOnlyRootFilesystem: pointer.Bool(
 									false,
 								), // to allow I/O chaos to succeed
@@ -1721,7 +1794,8 @@ func (fdbCluster *FdbCluster) CreateTesterDeployment(replicas int) *appsv1.Deplo
 		},
 	}
 
-	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Create(context.Background(), deploy)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Create(context.Background(), deploy)).
+		NotTo(gomega.HaveOccurred())
 	gomega.Eventually(func(g gomega.Gomega) int {
 		pods := &corev1.PodList{}
 

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -29,7 +29,9 @@ import (
 )
 
 // GenerateFDBClusterSpec will generate a *fdbv1beta2.FoundationDBCluster based on the input ClusterConfig.
-func (factory *Factory) GenerateFDBClusterSpec(config *ClusterConfig) *fdbv1beta2.FoundationDBCluster {
+func (factory *Factory) GenerateFDBClusterSpec(
+	config *ClusterConfig,
+) *fdbv1beta2.FoundationDBCluster {
 	config.SetDefaults(factory)
 
 	return factory.createFDBClusterSpec(
@@ -75,10 +77,15 @@ func (factory *Factory) createFDBClusterSpec(
 			StorageServersPerPod:          config.StorageServerPerPod,
 			LogServersPerPod:              config.LogServersPerPod,
 			LogGroup:                      config.Namespace + "-" + config.Name,
-			MainContainer:                 factory.GetMainContainerOverrides(config.DebugSymbols, useUnifiedImage),
-			ImageType:                     &imageType,
-			SidecarContainer:              factory.GetSidecarContainerOverrides(config.DebugSymbols),
-			FaultDomain:                   faultDomain,
+			MainContainer: factory.GetMainContainerOverrides(
+				config.DebugSymbols,
+				useUnifiedImage,
+			),
+			ImageType: &imageType,
+			SidecarContainer: factory.GetSidecarContainerOverrides(
+				config.DebugSymbols,
+			),
+			FaultDomain: faultDomain,
 			AutomationOptions: fdbv1beta2.FoundationDBClusterAutomationOptions{
 				// We have to wait long enough to ensure the operator is not recreating too many Pods at the same time.
 				WaitBetweenRemovalsSeconds: pointer.Int(0),
@@ -320,7 +327,9 @@ func (factory *Factory) createProcesses(
 				config,
 			),
 			VolumeClaimTemplate: claimTemplate,
-			CustomParameters:    config.getCustomParametersForProcessClass(fdbv1beta2.ProcessClassGeneral),
+			CustomParameters: config.getCustomParametersForProcessClass(
+				fdbv1beta2.ProcessClassGeneral,
+			),
 		},
 		fdbv1beta2.ProcessClassStorage: {
 			PodTemplate: factory.createPodTemplate(
@@ -328,7 +337,9 @@ func (factory *Factory) createProcesses(
 				config,
 			),
 			VolumeClaimTemplate: claimTemplate,
-			CustomParameters:    config.getCustomParametersForProcessClass(fdbv1beta2.ProcessClassStorage),
+			CustomParameters: config.getCustomParametersForProcessClass(
+				fdbv1beta2.ProcessClassStorage,
+			),
 		},
 	}
 }

--- a/e2e/fixtures/fdb_cluster_test.go
+++ b/e2e/fixtures/fdb_cluster_test.go
@@ -26,10 +26,12 @@ import (
 )
 
 var _ = Describe("FDB Cluster", func() {
-	DescribeTable("when generating the reconciliation options", func(expected *ReconciliationOptions, options ...func(*ReconciliationOptions)) {
-		reconciliationOptions := MakeReconciliationOptionsStruct(options...)
-		Expect(reconciliationOptions).To(Equal(expected))
-	},
+	DescribeTable(
+		"when generating the reconciliation options",
+		func(expected *ReconciliationOptions, options ...func(*ReconciliationOptions)) {
+			reconciliationOptions := MakeReconciliationOptionsStruct(options...)
+			Expect(reconciliationOptions).To(Equal(expected))
+		},
 		Entry("No options provided",
 			&ReconciliationOptions{
 				timeOutInSeconds:  1800,

--- a/e2e/fixtures/fdb_data_loader.go
+++ b/e2e/fixtures/fdb_data_loader.go
@@ -331,7 +331,8 @@ func (factory *Factory) CreateDataLoaderIfAbsentWithWait(cluster *FdbCluster, wa
 	t, err := template.New("dataLoaderJob").Parse(dataLoaderJobTemplate)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	buf := bytes.Buffer{}
-	gomega.Expect(t.Execute(&buf, factory.getDataLoaderConfig(cluster))).NotTo(gomega.HaveOccurred())
+	gomega.Expect(t.Execute(&buf, factory.getDataLoaderConfig(cluster))).
+		NotTo(gomega.HaveOccurred())
 	decoder := yamlutil.NewYAMLOrJSONDecoder(&buf, 100000)
 	for {
 		var rawObj runtime.RawExtension
@@ -413,14 +414,28 @@ func (factory *Factory) WaitUntilDataLoaderIsDone(cluster *FdbCluster) {
 			).NotTo(gomega.HaveOccurred())
 
 			for _, condition := range job.Status.Conditions {
-				log.Println("Type:", condition.Type, "Reason", condition.Reason, "Message", condition.Message)
+				log.Println(
+					"Type:",
+					condition.Type,
+					"Reason",
+					condition.Reason,
+					"Message",
+					condition.Message,
+				)
 			}
 		}
 
 		var runningPods int
 		for _, pod := range pods.Items {
 			if shouldPrint {
-				log.Println("Pod:", pod.Name, "Phase:", pod.Status.Phase, "Messages:", pod.Status.Message)
+				log.Println(
+					"Pod:",
+					pod.Name,
+					"Phase:",
+					pod.Status.Phase,
+					"Messages:",
+					pod.Status.Message,
+				)
 			}
 
 			if pod.Status.Phase == corev1.PodRunning {

--- a/e2e/fixtures/fdb_operator_fixtures.go
+++ b/e2e/fixtures/fdb_operator_fixtures.go
@@ -182,7 +182,8 @@ func (factory *Factory) ensureHAFdbClusterExists(
 		options,
 	)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	gomega.Expect(fdb.WaitForReconciliation(CreationTrackerLoggerOption(config.CreationTracker))).ToNot(gomega.HaveOccurred())
+	gomega.Expect(fdb.WaitForReconciliation(CreationTrackerLoggerOption(config.CreationTracker))).
+		ToNot(gomega.HaveOccurred())
 	log.Printf("primary cluster is reconciled in namespaces=%s", namespaces)
 
 	cluster, err := factory.getClusterStatus(fdb.GetPrimary().Name(), fdb.GetPrimary().Namespace())
@@ -205,7 +206,8 @@ func (factory *Factory) ensureHAFdbClusterExists(
 	}
 
 	// Wait until clusters are ready
-	gomega.Expect(fdb.WaitForReconciliation(CreationTrackerLoggerOption(config.CreationTracker))).ToNot(gomega.HaveOccurred())
+	gomega.Expect(fdb.WaitForReconciliation(CreationTrackerLoggerOption(config.CreationTracker))).
+		ToNot(gomega.HaveOccurred())
 
 	config.CreationCallback(fdb.GetPrimary())
 

--- a/e2e/fixtures/fdb_restore.go
+++ b/e2e/fixtures/fdb_restore.go
@@ -65,7 +65,8 @@ func waitForRestoreToComplete(backup *FdbBackup) {
 	lastReconcile := time.Now()
 	gomega.Eventually(func(g gomega.Gomega) fdbv1beta2.FoundationDBRestoreState {
 		restore := &fdbv1beta2.FoundationDBRestore{}
-		g.Expect(ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(backup.backup), restore)).To(gomega.Succeed())
+		g.Expect(ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(backup.backup), restore)).
+			To(gomega.Succeed())
 		log.Println("restore state:", restore.Status.State)
 
 		if time.Since(lastReconcile) > time.Minute {

--- a/e2e/fixtures/fixtures.go
+++ b/e2e/fixtures/fixtures.go
@@ -129,7 +129,11 @@ func CheckInvariant(
 		close(quit)
 		waitGroup.Wait()
 		if testFailed {
-			return fmt.Errorf("invariant %s failed for %s", invariantName, longestFailureDuration.String())
+			return fmt.Errorf(
+				"invariant %s failed for %s",
+				invariantName,
+				longestFailureDuration.String(),
+			)
 		}
 		return nil
 	})

--- a/e2e/fixtures/ha_fdb_cluster.go
+++ b/e2e/fixtures/ha_fdb_cluster.go
@@ -170,7 +170,8 @@ func (haFDBCluster *HaFdbCluster) SetDatabaseConfiguration(
 	config fdbv1beta2.DatabaseConfiguration,
 ) {
 	for _, fdbCluster := range haFDBCluster.clusters {
-		gomega.Expect(fdbCluster.SetDatabaseConfiguration(config, false)).NotTo(gomega.HaveOccurred())
+		gomega.Expect(fdbCluster.SetDatabaseConfiguration(config, false)).
+			NotTo(gomega.HaveOccurred())
 	}
 }
 
@@ -252,7 +253,11 @@ func (haFDBCluster *HaFdbCluster) UpgradeClusterWithTimeout(
 	for _, cluster := range haFDBCluster.GetAllClusters() {
 		singleCluster := cluster // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
-			return singleCluster.WaitForReconciliation(MinimumGenerationOption(expectedGenerations[singleCluster.Name()]), TimeOutInSecondsOption(timeout), PollTimeInSecondsOption(30))
+			return singleCluster.WaitForReconciliation(
+				MinimumGenerationOption(expectedGenerations[singleCluster.Name()]),
+				TimeOutInSecondsOption(timeout),
+				PollTimeInSecondsOption(30),
+			)
 		})
 	}
 
@@ -267,8 +272,10 @@ func (haFDBCluster *HaFdbCluster) DumpState() {
 }
 
 // SetCustomParameters sets the custom parameters for the provided process class.
-func (haFDBCluster *HaFdbCluster) SetCustomParameters(customParameters map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters,
-	waitForReconcile bool) error {
+func (haFDBCluster *HaFdbCluster) SetCustomParameters(
+	customParameters map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters,
+	waitForReconcile bool,
+) error {
 	var wg errgroup.Group
 	for _, cluster := range haFDBCluster.clusters {
 		clusterCopy := cluster
@@ -306,16 +313,24 @@ func (haFDBCluster *HaFdbCluster) VerifyVersion(version string) {
 	for _, cluster := range haFDBCluster.GetAllClusters() {
 		singleCluster := cluster // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
-			return singleCluster.WaitUntilWithForceReconcile(2, 600, func(cluster *fdbv1beta2.FoundationDBCluster) bool {
-				return cluster.Status.RunningVersion == version
-			})
+			return singleCluster.WaitUntilWithForceReconcile(
+				2,
+				600,
+				func(cluster *fdbv1beta2.FoundationDBCluster) bool {
+					return cluster.Status.RunningVersion == version
+				},
+			)
 		})
 	}
 
 	// Add more context to the error.
 	err := g.Wait()
 	if err != nil {
-		err = fmt.Errorf("timeout waiting for all clusters to be upgraded to %s, original error: %w", version, err)
+		err = fmt.Errorf(
+			"timeout waiting for all clusters to be upgraded to %s, original error: %w",
+			version,
+			err,
+		)
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }

--- a/e2e/fixtures/images_test.go
+++ b/e2e/fixtures/images_test.go
@@ -27,10 +27,12 @@ import (
 )
 
 var _ = Describe("image setup", func() {
-	DescribeTable("when generating the sidecar image configuration", func(factory *Factory, debugSymbols bool, expected fdbv1beta2.ContainerOverrides) {
-		result := factory.GetSidecarContainerOverrides(debugSymbols)
-		Expect(result.ImageConfigs).To(ConsistOf(expected.ImageConfigs))
-	},
+	DescribeTable(
+		"when generating the sidecar image configuration",
+		func(factory *Factory, debugSymbols bool, expected fdbv1beta2.ContainerOverrides) {
+			result := factory.GetSidecarContainerOverrides(debugSymbols)
+			Expect(result.ImageConfigs).To(ConsistOf(expected.ImageConfigs))
+		},
 		Entry("no version mapping and no debug symbols",
 			&Factory{
 				options: &FactoryOptions{
@@ -232,10 +234,12 @@ var _ = Describe("image setup", func() {
 		),
 	)
 
-	DescribeTable("when generating the main image configuration", func(factory *Factory, debugSymbols bool, unifiedImage bool, expected fdbv1beta2.ContainerOverrides) {
-		result := factory.GetMainContainerOverrides(debugSymbols, unifiedImage)
-		Expect(result.ImageConfigs).To(ConsistOf(expected.ImageConfigs))
-	},
+	DescribeTable(
+		"when generating the main image configuration",
+		func(factory *Factory, debugSymbols bool, unifiedImage bool, expected fdbv1beta2.ContainerOverrides) {
+			result := factory.GetMainContainerOverrides(debugSymbols, unifiedImage)
+			Expect(result.ImageConfigs).To(ConsistOf(expected.ImageConfigs))
+		},
 		Entry("no version mapping and no debug symbols",
 			&Factory{
 				options: &FactoryOptions{

--- a/e2e/fixtures/kubernetes_fixtures.go
+++ b/e2e/fixtures/kubernetes_fixtures.go
@@ -46,7 +46,8 @@ const (
 // factory.getRandomizedNamespaceName() checks if the username is valid to be used in the namespace name. If so this
 // method will return the namespace name as the username a hyphen and 8 random chars.
 func (factory *Factory) getRandomizedNamespaceName() string {
-	gomega.Expect(factory.userName).To(gomega.MatchRegexp(namespaceRegEx), "user name contains invalid characters")
+	gomega.Expect(factory.userName).
+		To(gomega.MatchRegexp(namespaceRegEx), "user name contains invalid characters")
 	name := factory.userName + "-" + testSuiteName + "-" + factory.RandStringRunes(8)
 	log.Println("namespace:", name, "length:", len(name))
 	return name
@@ -106,11 +107,20 @@ func (factory *Factory) createNamespace(suffix string) string {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		namespaceResource := &corev1.Namespace{}
-		err = factory.controllerRuntimeClient.Get(ctx.Background(), client.ObjectKey{Namespace: "", Name: namespace}, namespaceResource)
+		err = factory.controllerRuntimeClient.Get(
+			ctx.Background(),
+			client.ObjectKey{Namespace: "", Name: namespace},
+			namespaceResource,
+		)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		if namespaceResource.Annotations[testSuiteNameAnnotation] != testSuiteName {
-			err = fmt.Errorf("namespace %s already in use by test suite: %s, current test suite: %s", namespace, namespaceResource.Annotations[testSuiteNameAnnotation], testSuiteName)
+			err = fmt.Errorf(
+				"namespace %s already in use by test suite: %s, current test suite: %s",
+				namespace,
+				namespaceResource.Annotations[testSuiteNameAnnotation],
+				testSuiteName,
+			)
 			log.Println(err.Error())
 			return err
 		}
@@ -154,7 +164,11 @@ func (factory *Factory) createNamespace(suffix string) string {
 
 		gomega.Eventually(func() error {
 			podList := &corev1.PodList{}
-			err := factory.controllerRuntimeClient.List(ctx.Background(), podList, client.InNamespace(namespace))
+			err := factory.controllerRuntimeClient.List(
+				ctx.Background(),
+				podList,
+				client.InNamespace(namespace),
+			)
 			if err != nil {
 				return err
 			}
@@ -209,7 +223,11 @@ func (factory *Factory) checkIfNamespaceIsTerminating(name string) error {
 	}
 
 	// If the namespace is in terminating, we have to check if any pods are stuck in terminating with a finalizer set.
-	log.Printf("Namespace: %s is in terminating state since: %s will wait until the namespace is deleted", namespace.Name, deletionTimestamp.String())
+	log.Printf(
+		"Namespace: %s is in terminating state since: %s will wait until the namespace is deleted",
+		namespace.Name,
+		deletionTimestamp.String(),
+	)
 	podList := &corev1.PodList{}
 	err = controllerClient.List(ctx.Background(), podList, client.InNamespace(name))
 	if err != nil {
@@ -223,7 +241,11 @@ func (factory *Factory) checkIfNamespaceIsTerminating(name string) error {
 		}
 	}
 
-	return fmt.Errorf("namespace %s is still in terminating state since %s", name, deletionTimestamp.String())
+	return fmt.Errorf(
+		"namespace %s is still in terminating state since %s",
+		name,
+		deletionTimestamp.String(),
+	)
 }
 
 func (factory *Factory) ensureNamespaceExists(namespace string) error {
@@ -356,7 +378,10 @@ func (factory *Factory) ensureRBACSetupExists(namespace string) {
 
 // LoadControllerRuntimeFromContext will load a client.Client from the provided context. The context must be existing in the
 // kube config.
-func LoadControllerRuntimeFromContext(context string, configScheme *runtime.Scheme) (client.Client, error) {
+func LoadControllerRuntimeFromContext(
+	context string,
+	configScheme *runtime.Scheme,
+) (client.Client, error) {
 	kubeConfig, err := config.GetConfigWithContext(context)
 	if err != nil {
 		return nil, err

--- a/e2e/fixtures/options.go
+++ b/e2e/fixtures/options.go
@@ -204,17 +204,21 @@ func (options *FactoryOptions) BindFlags(fs *flag.FlagSet) {
 		false,
 		"defines if the operator should make use of server side apply.",
 	)
-	fs.StringVar(&options.clusterName,
+	fs.StringVar(
+		&options.clusterName,
 		"cluster-name",
 		"",
 		"if defined, the test suite will create a cluster with the specified name or update the setting of an existing cluster."+
-			"For multi-region clusters, this will define the prefix for all clusters.")
-	fs.StringVar(&options.fdbVersionTagMapping,
+			"For multi-region clusters, this will define the prefix for all clusters.",
+	)
+	fs.StringVar(
+		&options.fdbVersionTagMapping,
 		"fdb-version-tag-mapping",
 		"",
 		"if defined, the test suite will use this information to map the image tag to the specified version. Multiple entries can be"+
 			"provided by separating them with a \",\". The mapping must have the format $version:$tag, e.g. 7.1.57:7.1.57-testing."+
-			"This option will only work for the main container with the split image (sidecar).")
+			"This option will only work for the main container with the split image (sidecar).",
+	)
 	fs.StringVar(
 		&options.seaweedFSImage,
 		"seaweedfs-image",
@@ -233,10 +237,12 @@ func (options *FactoryOptions) BindFlags(fs *flag.FlagSet) {
 		"local",
 		"defines the synchronization mode that should be used. Only applies for multi-region clusters.",
 	)
-	fs.DurationVar(&options.defaultUnavailableThreshold,
+	fs.DurationVar(
+		&options.defaultUnavailableThreshold,
 		"default-unavailable-threshold",
 		30*time.Second,
-		"defines the default unavailability threshold. If the database is unavailable for a longer period the test will fail if unavailability checks are enabled.")
+		"defines the default unavailability threshold. If the database is unavailable for a longer period the test will fail if unavailability checks are enabled.",
+	)
 }
 
 func (options *FactoryOptions) validateFlags() error {
@@ -326,7 +332,10 @@ func (options *FactoryOptions) validateSynchronizationMode() error {
 		return nil
 	}
 
-	return fmt.Errorf("synchronizationMode must be either \"local\" or \"global\", got :\"%s\"", mode)
+	return fmt.Errorf(
+		"synchronizationMode must be either \"local\" or \"global\", got :\"%s\"",
+		mode,
+	)
 }
 
 func validateVersion(label string, version string) error {
@@ -359,7 +368,10 @@ func (options *FactoryOptions) validateFDBVersionTagMapping() error {
 	for _, mapping := range mappings {
 		versionMapping := strings.Split(mapping, ":")
 		if len(versionMapping) != 2 {
-			return fmt.Errorf("mapping %s is invalid, expected format is $version:$tag", versionMapping)
+			return fmt.Errorf(
+				"mapping %s is invalid, expected format is $version:$tag",
+				versionMapping,
+			)
 		}
 	}
 
@@ -405,7 +417,12 @@ func getTagWithSuffix(tag string, isSidecar bool, debugSymbols bool) string {
 	return tag + tagSuffix
 }
 
-func (options *FactoryOptions) getImageVersionConfig(baseImage string, versionTag string, isSidecar bool, debugSymbols bool) []fdbv1beta2.ImageConfig {
+func (options *FactoryOptions) getImageVersionConfig(
+	baseImage string,
+	versionTag string,
+	isSidecar bool,
+	debugSymbols bool,
+) []fdbv1beta2.ImageConfig {
 	if options.fdbVersionTagMapping == "" {
 		var versionMapping fdbv1beta2.ImageConfig
 
@@ -441,7 +458,11 @@ func (options *FactoryOptions) getImageVersionConfig(baseImage string, versionTa
 		imageConfig[idx] = fdbv1beta2.ImageConfig{
 			BaseImage: baseImage,
 			Version:   strings.TrimSpace(versionMapping[0]),
-			Tag:       getTagWithSuffix(strings.TrimSpace(versionMapping[1]), isSidecar, debugSymbols),
+			Tag: getTagWithSuffix(
+				strings.TrimSpace(versionMapping[1]),
+				isSidecar,
+				debugSymbols,
+			),
 		}
 	}
 

--- a/e2e/fixtures/pods.go
+++ b/e2e/fixtures/pods.go
@@ -52,7 +52,14 @@ func (factory *Factory) RandomPickPod(input []corev1.Pod, count int) []corev1.Po
 	for _, pod := range input {
 		// Skip pods that are marked for deletion
 		if !pod.DeletionTimestamp.IsZero() {
-			log.Println("skipping pod marked for deletion, name:", pod.Name, "namespace:", pod.Namespace, "deletionTimestampL", pod.DeletionTimestamp.String())
+			log.Println(
+				"skipping pod marked for deletion, name:",
+				pod.Name,
+				"namespace:",
+				pod.Namespace,
+				"deletionTimestampL",
+				pod.DeletionTimestamp.String(),
+			)
 			continue
 		}
 
@@ -115,11 +122,13 @@ func (factory *Factory) SetFinalizerForPod(pod *corev1.Pod, finalizers []string)
 	controllerClient := factory.GetControllerRuntimeClient()
 	gomega.Eventually(func(g gomega.Gomega) bool {
 		fetchedPod := &corev1.Pod{}
-		g.Expect(controllerClient.Get(context.Background(), client.ObjectKeyFromObject(pod), fetchedPod)).NotTo(gomega.HaveOccurred())
+		g.Expect(controllerClient.Get(context.Background(), client.ObjectKeyFromObject(pod), fetchedPod)).
+			NotTo(gomega.HaveOccurred())
 
 		if !equality.Semantic.DeepEqual(finalizers, fetchedPod.Finalizers) {
 			fetchedPod.SetFinalizers(finalizers)
-			g.Expect(controllerClient.Update(context.Background(), fetchedPod)).NotTo(gomega.HaveOccurred())
+			g.Expect(controllerClient.Update(context.Background(), fetchedPod)).
+				NotTo(gomega.HaveOccurred())
 		}
 
 		g.Expect(fetchedPod.Finalizers).To(gomega.ConsistOf(finalizers))

--- a/e2e/fixtures/singleton.go
+++ b/e2e/fixtures/singleton.go
@@ -112,7 +112,10 @@ func getSingleton(options *FactoryOptions) (*singleton, error) {
 		}
 
 		var controllerClient client.Client
-		controllerClient, initializedError = LoadControllerRuntimeFromContext(options.context, curScheme)
+		controllerClient, initializedError = LoadControllerRuntimeFromContext(
+			options.context,
+			curScheme,
+		)
 		if initializedError != nil {
 			return
 		}

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -77,7 +77,12 @@ func (fdbCluster *FdbCluster) RunFdbCliCommandInOperator(
 		)
 
 		if err != nil {
-			return fmt.Errorf("could not run the command: \"%s\": got an error: %w, stderr: %s", command, err, stderr)
+			return fmt.Errorf(
+				"could not run the command: \"%s\": got an error: %w, stderr: %s",
+				command,
+				err,
+				stderr,
+			)
 		}
 
 		return nil
@@ -283,7 +288,12 @@ func (fdbCluster *FdbCluster) StatusInvariantChecker(
 // checkAvailability returns nil if the cluster is reachable. If the cluster is unreachable an error will be returned.
 func checkAvailability(status *fdbv1beta2.FoundationDBStatus) error {
 	if !status.Client.DatabaseStatus.Available {
-		log.Println("client messages", status.Client.Messages, "cluster messages", status.Cluster.Messages)
+		log.Println(
+			"client messages",
+			status.Client.Messages,
+			"cluster messages",
+			status.Cluster.Messages,
+		)
 		return fmt.Errorf("cluster is not available")
 	}
 
@@ -303,7 +313,9 @@ func (fdbCluster *FdbCluster) InvariantClusterStatusAvailableWithThreshold(
 
 // InvariantClusterStatusAvailable checks if the cluster is available the whole test with the default unavailable threshold.
 func (fdbCluster *FdbCluster) InvariantClusterStatusAvailable() error {
-	return fdbCluster.InvariantClusterStatusAvailableWithThreshold(fdbCluster.factory.GetDefaultUnavailableThreshold())
+	return fdbCluster.InvariantClusterStatusAvailableWithThreshold(
+		fdbCluster.factory.GetDefaultUnavailableThreshold(),
+	)
 }
 
 // GetProcessCount returns the number of processes having the specified role
@@ -433,7 +445,9 @@ func (fdbCluster *FdbCluster) GetCommandlineForProcessesPerClass() map[fdbv1beta
 }
 
 // GetCommandlineForProcessesPerClassWithStatus fetches the commandline args for all processes except of the specified class.
-func (fdbCluster *FdbCluster) GetCommandlineForProcessesPerClassWithStatus(status *fdbv1beta2.FoundationDBStatus) map[fdbv1beta2.ProcessClass][]string {
+func (fdbCluster *FdbCluster) GetCommandlineForProcessesPerClassWithStatus(
+	status *fdbv1beta2.FoundationDBStatus,
+) map[fdbv1beta2.ProcessClass][]string {
 	knobs := map[fdbv1beta2.ProcessClass][]string{}
 	for _, process := range status.Cluster.Processes {
 		if _, ok := knobs[process.ProcessClass]; !ok {
@@ -502,7 +516,10 @@ func Unprintable(val string) ([]byte, error) {
 			case 'x':
 				{
 					if i+2 >= len(val) {
-						return nil, fmt.Errorf("not have two chars after \\x when unprint [%s]", val)
+						return nil, fmt.Errorf(
+							"not have two chars after \\x when unprint [%s]",
+							val,
+						)
 					}
 					d1, err := unhex(val[i+1])
 					if err != nil {

--- a/e2e/fixtures/test_runner.go
+++ b/e2e/fixtures/test_runner.go
@@ -66,7 +66,13 @@ func RunGinkgoTests(t *testing.T, name string) {
 // take care of including the command line flags from Ginkgo and the testing framework.
 func InitFlags() *FactoryOptions {
 	testing.Init()
-	_, err := types.NewAttachedGinkgoFlagSet(flag.CommandLine, types.GinkgoFlags{}, nil, types.GinkgoFlagSections{}, types.GinkgoFlagSection{})
+	_, err := types.NewAttachedGinkgoFlagSet(
+		flag.CommandLine,
+		types.GinkgoFlags{},
+		nil,
+		types.GinkgoFlagSections{},
+		types.GinkgoFlagSection{},
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/e2e/fixtures/upgrade_test_configuration.go
+++ b/e2e/fixtures/upgrade_test_configuration.go
@@ -62,7 +62,11 @@ func parseUpgradeVersionPair(upgradeConfig string) *UpgradeTestConfiguration {
 	}
 
 	if !initialVersion.SupportsVersionChange(targetVersion) {
-		log.Fatalf("version change from \"%s\" to \"%s\" is not supported", versions[0], versions[1])
+		log.Fatalf(
+			"version change from \"%s\" to \"%s\" is not supported",
+			versions[0],
+			versions[1],
+		)
 	}
 
 	return &UpgradeTestConfiguration{
@@ -112,7 +116,14 @@ func GenerateUpgradeTableEntries(options *FactoryOptions) []ginkgo.TableEntry {
 
 	tests := make([]ginkgo.TableEntry, 0, len(upgradeTests))
 	for _, upgradeTest := range getUpgradeVersions(upgradeString) {
-		tests = append(tests, ginkgo.Entry(nil, upgradeTest.InitialVersion.String(), upgradeTest.TargetVersion.String()))
+		tests = append(
+			tests,
+			ginkgo.Entry(
+				nil,
+				upgradeTest.InitialVersion.String(),
+				upgradeTest.TargetVersion.String(),
+			),
+		)
 	}
 
 	return tests

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -180,7 +180,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				},
 			}, pointer.Int(1))
 
-			Expect(len(fdbCluster.GetCluster().Spec.AutomationOptions.Replacements.TaintReplacementOptions)).To(BeNumerically(">=", 1))
+			Expect(
+				len(
+					fdbCluster.GetCluster().Spec.AutomationOptions.Replacements.TaintReplacementOptions,
+				),
+			).To(BeNumerically(">=", 1))
 
 			Expect(*fdbCluster.GetAutomationOptions().Replacements.Enabled).To(BeTrue())
 		})
@@ -188,7 +192,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		AfterEach(func() {
 			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
 			// Reset taint related options to default value in e2e test
-			fdbCluster.SetClusterTaintConfig([]fdbv1beta2.TaintReplacementOption{}, pointer.Int(150))
+			fdbCluster.SetClusterTaintConfig(
+				[]fdbv1beta2.TaintReplacementOption{},
+				pointer.Int(150),
+			)
 			// untaint the nodes
 			log.Printf("AfterEach Cleanup: Untaint the single node:%s\n", taintedNode.Name)
 			historyTaintedNodes[taintedNode.Name] = fdbv1beta2.None{}
@@ -212,20 +219,32 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				taintedNode = fdbCluster.GetNode(replacedPod.Spec.NodeName)
 				taintedNode.Spec.Taints = []corev1.Taint{
 					{
-						Key:       taintKeyMaintenance,
-						Value:     "rack_maintenance",
-						Effect:    corev1.TaintEffectPreferNoSchedule,
-						TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1))},
+						Key:    taintKeyMaintenance,
+						Value:  "rack_maintenance",
+						Effect: corev1.TaintEffectPreferNoSchedule,
+						TimeAdded: &metav1.Time{
+							Time: time.Now().
+								Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1)),
+						},
 					},
 				}
-				log.Printf("Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n", replacedPod.Name,
-					taintedNode.Name, taintedNode.Spec.Taints, taintedNode.Spec.Taints[0].TimeAdded.Time, time.Now())
+				log.Printf(
+					"Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n",
+					replacedPod.Name,
+					taintedNode.Name,
+					taintedNode.Spec.Taints,
+					taintedNode.Spec.Taints[0].TimeAdded.Time,
+					time.Now(),
+				)
 				fdbCluster.UpdateNode(taintedNode)
 
 				err := fdbCluster.WaitForReconciliation()
 				Expect(err).NotTo(HaveOccurred())
 
-				fdbCluster.EnsurePodIsDeletedWithCustomTimeout(replacedPod.Name, ensurePodIsDeletedTimeoutMinutes)
+				fdbCluster.EnsurePodIsDeletedWithCustomTimeout(
+					replacedPod.Name,
+					ensurePodIsDeletedTimeoutMinutes,
+				)
 			})
 
 			It("should remove all Pods whose Nodes are tainted", func() {
@@ -235,14 +254,23 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					node := fdbCluster.GetNode(pod.Spec.NodeName)
 					node.Spec.Taints = []corev1.Taint{
 						{
-							Key:       taintKeyMaintenance,
-							Value:     "rack_maintenance",
-							Effect:    corev1.TaintEffectPreferNoSchedule,
-							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Millisecond * time.Duration(taintKeyMaintenanceDuration*1000+int64(factory.Intn(1000))))},
+							Key:    taintKeyMaintenance,
+							Value:  "rack_maintenance",
+							Effect: corev1.TaintEffectPreferNoSchedule,
+							TimeAdded: &metav1.Time{
+								Time: time.Now().
+									Add(-time.Millisecond * time.Duration(taintKeyMaintenanceDuration*1000+int64(factory.Intn(1000)))),
+							},
 						},
 					}
-					log.Printf("Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n", pod.Name,
-						node.Name, node.Spec.Taints, node.Spec.Taints[0].TimeAdded.Time, time.Now())
+					log.Printf(
+						"Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n",
+						pod.Name,
+						node.Name,
+						node.Spec.Taints,
+						node.Spec.Taints[0].TimeAdded.Time,
+						time.Now(),
+					)
 					fdbCluster.UpdateNode(node)
 					taintedNodes = append(taintedNodes, node)
 				}
@@ -252,7 +280,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 				for i, pod := range replacedPods {
 					log.Printf("Ensure %dth pod:%s is deleted\n", i, pod.Name)
-					fdbCluster.EnsurePodIsDeletedWithCustomTimeout(pod.Name, ensurePodIsDeletedTimeoutMinutes)
+					fdbCluster.EnsurePodIsDeletedWithCustomTimeout(
+						pod.Name,
+						ensurePodIsDeletedTimeoutMinutes,
+					)
 				}
 			})
 		})
@@ -272,7 +303,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				}, pointer.Int(1))
 
 				automationOptions := fdbCluster.GetAutomationOptions()
-				Expect(len(automationOptions.Replacements.TaintReplacementOptions)).To(BeNumerically(">=", 1))
+				Expect(
+					len(automationOptions.Replacements.TaintReplacementOptions),
+				).To(BeNumerically(">=", 1))
 				Expect(*automationOptions.Replacements.Enabled).To(BeTrue())
 
 			})
@@ -283,20 +316,32 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				node := fdbCluster.GetNode(replacedPod.Spec.NodeName)
 				node.Spec.Taints = []corev1.Taint{
 					{
-						Key:       taintKeyMaintenance,
-						Value:     "rack_maintenance",
-						Effect:    corev1.TaintEffectPreferNoSchedule,
-						TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1))},
+						Key:    taintKeyMaintenance,
+						Value:  "rack_maintenance",
+						Effect: corev1.TaintEffectPreferNoSchedule,
+						TimeAdded: &metav1.Time{
+							Time: time.Now().
+								Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1)),
+						},
 					},
 				}
-				log.Printf("Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n", replacedPod.Name,
-					node.Name, node.Spec.Taints, node.Spec.Taints[0].TimeAdded.Time, time.Now())
+				log.Printf(
+					"Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n",
+					replacedPod.Name,
+					node.Name,
+					node.Spec.Taints,
+					node.Spec.Taints[0].TimeAdded.Time,
+					time.Now(),
+				)
 				fdbCluster.UpdateNode(node)
 
 				err := fdbCluster.WaitForReconciliation()
 				Expect(err).NotTo(HaveOccurred())
 
-				fdbCluster.EnsurePodIsDeletedWithCustomTimeout(replacedPod.Name, ensurePodIsDeletedTimeoutMinutes)
+				fdbCluster.EnsurePodIsDeletedWithCustomTimeout(
+					replacedPod.Name,
+					ensurePodIsDeletedTimeoutMinutes,
+				)
 			})
 
 			It("should eventually remove all Pods whose Nodes are tainted", func() {
@@ -306,14 +351,23 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					node := fdbCluster.GetNode(pod.Spec.NodeName)
 					node.Spec.Taints = []corev1.Taint{
 						{
-							Key:       taintKeyMaintenance,
-							Value:     "rack_maintenance",
-							Effect:    corev1.TaintEffectPreferNoSchedule,
-							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Millisecond * time.Duration(taintKeyStarDuration*1000+int64(factory.Intn(1000))))},
+							Key:    taintKeyMaintenance,
+							Value:  "rack_maintenance",
+							Effect: corev1.TaintEffectPreferNoSchedule,
+							TimeAdded: &metav1.Time{
+								Time: time.Now().
+									Add(-time.Millisecond * time.Duration(taintKeyStarDuration*1000+int64(factory.Intn(1000)))),
+							},
 						},
 					}
-					log.Printf("Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n", pod.Name,
-						node.Name, node.Spec.Taints, node.Spec.Taints[0].TimeAdded.Time, time.Now())
+					log.Printf(
+						"Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n",
+						pod.Name,
+						node.Name,
+						node.Spec.Taints,
+						node.Spec.Taints[0].TimeAdded.Time,
+						time.Now(),
+					)
 					fdbCluster.UpdateNode(node)
 				}
 
@@ -322,7 +376,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 				for i, pod := range replacedPods {
 					log.Printf("Ensure %dth pod:%s is deleted\n", i, pod.Name)
-					fdbCluster.EnsurePodIsDeletedWithCustomTimeout(pod.Name, ensurePodIsDeletedTimeoutMinutes)
+					fdbCluster.EnsurePodIsDeletedWithCustomTimeout(
+						pod.Name,
+						ensurePodIsDeletedTimeoutMinutes,
+					)
 				}
 			})
 		})
@@ -333,10 +390,15 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			BeforeEach(func() {
 				// Custom TaintReplacementOptions to taintKeyStar
-				fdbCluster.SetClusterTaintConfig([]fdbv1beta2.TaintReplacementOption{}, pointer.Int(1))
+				fdbCluster.SetClusterTaintConfig(
+					[]fdbv1beta2.TaintReplacementOption{},
+					pointer.Int(1),
+				)
 
 				automationOptions := fdbCluster.GetAutomationOptions()
-				Expect(len(automationOptions.Replacements.TaintReplacementOptions)).To(BeNumerically("==", 0))
+				Expect(
+					len(automationOptions.Replacements.TaintReplacementOptions),
+				).To(BeNumerically("==", 0))
 				Expect(*automationOptions.Replacements.Enabled).To(BeTrue())
 
 			})
@@ -345,33 +407,54 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				targetPods := factory.RandomPickPod(initialPods.Items, numNodesTainted)
 				var targetPodProcessGroupIDs []fdbv1beta2.ProcessGroupID
 				for _, pod := range targetPods {
-					targetPodProcessGroupIDs = append(targetPodProcessGroupIDs, internal.GetProcessGroupIDFromMeta(fdbCluster.GetCluster(), pod.ObjectMeta))
+					targetPodProcessGroupIDs = append(
+						targetPodProcessGroupIDs,
+						internal.GetProcessGroupIDFromMeta(fdbCluster.GetCluster(), pod.ObjectMeta),
+					)
 					// Taint replacePod's node
 					node := fdbCluster.GetNode(pod.Spec.NodeName)
 					node.Spec.Taints = []corev1.Taint{
 						{
-							Key:       taintKeyMaintenance,
-							Value:     "rack_maintenance",
-							Effect:    corev1.TaintEffectPreferNoSchedule,
-							TimeAdded: &metav1.Time{Time: time.Now().Add(-time.Millisecond * time.Duration(taintKeyStarDuration*1000+int64(factory.Intn(1000))))},
+							Key:    taintKeyMaintenance,
+							Value:  "rack_maintenance",
+							Effect: corev1.TaintEffectPreferNoSchedule,
+							TimeAdded: &metav1.Time{
+								Time: time.Now().
+									Add(-time.Millisecond * time.Duration(taintKeyStarDuration*1000+int64(factory.Intn(1000)))),
+							},
 						},
 					}
-					log.Printf("Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n", pod.Name,
-						node.Name, node.Spec.Taints, node.Spec.Taints[0].TimeAdded.Time, time.Now())
+					log.Printf(
+						"Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n",
+						pod.Name,
+						node.Name,
+						node.Spec.Taints,
+						node.Spec.Taints[0].TimeAdded.Time,
+						time.Now(),
+					)
 					fdbCluster.UpdateNode(node)
 				}
 
 				Consistently(func() bool {
 					for _, groupID := range targetPodProcessGroupIDs {
-						processGroupStatus := fdbv1beta2.FindProcessGroupByID(fdbCluster.GetCluster().Status.ProcessGroups, groupID)
+						processGroupStatus := fdbv1beta2.FindProcessGroupByID(
+							fdbCluster.GetCluster().Status.ProcessGroups,
+							groupID,
+						)
 						Expect(processGroupStatus).NotTo(BeNil())
-						Expect(processGroupStatus.GetCondition(fdbv1beta2.NodeTaintDetected)).To(BeNil())
+						Expect(
+							processGroupStatus.GetCondition(fdbv1beta2.NodeTaintDetected),
+						).To(BeNil())
 					}
 					return true
 				}).WithTimeout(time.Duration(*fdbCluster.GetAutomationOptions().Replacements.TaintReplacementTimeSeconds-1) * time.Second).WithPolling(1 * time.Second).Should(BeTrue())
 
 				// Wait for operator to replace the pod
-				time.Sleep(time.Second * time.Duration(*fdbCluster.GetAutomationOptions().Replacements.TaintReplacementTimeSeconds+1))
+				time.Sleep(
+					time.Second * time.Duration(
+						*fdbCluster.GetAutomationOptions().Replacements.TaintReplacementTimeSeconds+1,
+					),
+				)
 				err := fdbCluster.WaitForReconciliation()
 				Expect(err).NotTo(HaveOccurred())
 
@@ -430,12 +513,18 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
 			// Make sure we reset the previous behaviour.
 			spec := fdbCluster.GetCluster().Spec.DeepCopy()
-			spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(useLocalitiesForExclusion)
+			spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(
+				useLocalitiesForExclusion,
+			)
 			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.GetCluster().UseLocalitiesForExclusion()).To(Equal(useLocalitiesForExclusion))
+			Expect(
+				fdbCluster.GetCluster().UseLocalitiesForExclusion(),
+			).To(Equal(useLocalitiesForExclusion))
 
 			// Making sure we included back all the process groups after exclusion is complete.
-			Expect(fdbCluster.GetStatus().Cluster.DatabaseConfiguration.ExcludedServers).To(BeEmpty())
+			Expect(
+				fdbCluster.GetStatus().Cluster.DatabaseConfiguration.ExcludedServers,
+			).To(BeEmpty())
 
 			if factory.ChaosTestsEnabled() {
 				scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(
@@ -467,7 +556,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				if !fdbVersion.SupportsLocalityBasedExclusions() {
-					Skip("provided FDB version: " + cluster.GetRunningVersion() + " doesn't support locality based exclusions")
+					Skip(
+						"provided FDB version: " + cluster.GetRunningVersion() + " doesn't support locality based exclusions",
+					)
 				}
 
 				spec := cluster.Spec.DeepCopy()
@@ -477,7 +568,12 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			})
 
 			It("should remove the targeted Pod", func() {
-				Expect(pointer.BoolDeref(fdbCluster.GetCluster().Spec.AutomationOptions.UseLocalitiesForExclusion, false)).To(BeTrue())
+				Expect(
+					pointer.BoolDeref(
+						fdbCluster.GetCluster().Spec.AutomationOptions.UseLocalitiesForExclusion,
+						false,
+					),
+				).To(BeTrue())
 				fdbCluster.EnsurePodIsDeleted(replacedPod.Name)
 			})
 		})
@@ -496,12 +592,18 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				expectedPodCnt,
 				expectedStorageProcessesCnt,
 			)
-			fdbCluster.ValidateProcessesCount(fdbv1beta2.ProcessClassStorage, expectedPodCnt, expectedStorageProcessesCnt)
+			fdbCluster.ValidateProcessesCount(
+				fdbv1beta2.ProcessClassStorage,
+				expectedPodCnt,
+				expectedStorageProcessesCnt,
+			)
 		})
 
 		AfterEach(func() {
 			log.Printf("set storage server per pod to %d", initialStorageServerPerPod)
-			Expect(fdbCluster.SetStorageServerPerPod(initialStorageServerPerPod)).ShouldNot(HaveOccurred())
+			Expect(
+				fdbCluster.SetStorageServerPerPod(initialStorageServerPerPod),
+			).ShouldNot(HaveOccurred())
 			log.Printf(
 				"expectedPodCnt: %d, expectedStorageProcessesCnt: %d",
 				expectedPodCnt,
@@ -523,7 +625,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				expectedPodCnt,
 				expectedPodCnt*serverPerPod,
 			)
-			fdbCluster.ValidateProcessesCount(fdbv1beta2.ProcessClassStorage, expectedPodCnt, expectedPodCnt*serverPerPod)
+			fdbCluster.ValidateProcessesCount(
+				fdbv1beta2.ProcessClassStorage,
+				expectedPodCnt,
+				expectedPodCnt*serverPerPod,
+			)
 		})
 	})
 
@@ -674,7 +780,12 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		AfterEach(func() {
-			Expect(fdbCluster.SetTLS(initialTLSSetting, fdbCluster.GetCluster().Spec.SidecarContainer.EnableTLS)).NotTo(HaveOccurred())
+			Expect(
+				fdbCluster.SetTLS(
+					initialTLSSetting,
+					fdbCluster.GetCluster().Spec.SidecarContainer.EnableTLS,
+				),
+			).NotTo(HaveOccurred())
 			Expect(fdbCluster.HasTLSEnabled()).To(Equal(initialTLSSetting))
 			checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), initialTLSSetting)
 		})
@@ -683,7 +794,12 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		It("should update the TLS setting  and keep the cluster available", func() {
 			// Only change the TLS setting for the cluster and not for the sidecar otherwise we have to recreate
 			// all Pods which takes a long time since we recreate the Pods one by one.
-			Expect(fdbCluster.SetTLS(!initialTLSSetting, fdbCluster.GetCluster().Spec.SidecarContainer.EnableTLS)).NotTo(HaveOccurred())
+			Expect(
+				fdbCluster.SetTLS(
+					!initialTLSSetting,
+					fdbCluster.GetCluster().Spec.SidecarContainer.EnableTLS,
+				),
+			).NotTo(HaveOccurred())
 			Expect(fdbCluster.HasTLSEnabled()).To(Equal(!initialTLSSetting))
 			checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), !initialTLSSetting)
 		})
@@ -813,79 +929,95 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			})
 		})
 
-		When("more Pods are partitioned than the automatic replacement can replace concurrently", func() {
-			var partitionedPods []corev1.Pod
-			var concurrentReplacements int
-			var experiments []*fixtures.ChaosMeshExperiment
-			creationTimestamps := map[string]metav1.Time{}
+		When(
+			"more Pods are partitioned than the automatic replacement can replace concurrently",
+			func() {
+				var partitionedPods []corev1.Pod
+				var concurrentReplacements int
+				var experiments []*fixtures.ChaosMeshExperiment
+				creationTimestamps := map[string]metav1.Time{}
 
-			BeforeEach(func() {
-				concurrentReplacements = fdbCluster.GetCluster().GetMaxConcurrentAutomaticReplacements()
-				// Allow to replace 1 Pod concurrently
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
-				spec.AutomationOptions.Replacements.MaxConcurrentReplacements = pointer.Int(1)
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				BeforeEach(func() {
+					concurrentReplacements = fdbCluster.GetCluster().
+						GetMaxConcurrentAutomaticReplacements()
+					// Allow to replace 1 Pod concurrently
+					spec := fdbCluster.GetCluster().Spec.DeepCopy()
+					spec.AutomationOptions.Replacements.MaxConcurrentReplacements = pointer.Int(1)
+					fdbCluster.UpdateClusterSpecWithSpec(spec)
 
-				// Make sure we disable automatic replacements to prevent the case that the operator replaces one Pod
-				// before the partitioned is injected.
-				Expect(fdbCluster.SetAutoReplacements(false, 30*time.Second)).ShouldNot(HaveOccurred())
+					// Make sure we disable automatic replacements to prevent the case that the operator replaces one Pod
+					// before the partitioned is injected.
+					Expect(
+						fdbCluster.SetAutoReplacements(false, 30*time.Second),
+					).ShouldNot(HaveOccurred())
 
-				// Pick 2 Pods, so the operator has to replace them one after another
-				partitionedPods = factory.RandomPickPod(fdbCluster.GetStatelessPods().Items, 3)
-				for _, partitionedPod := range partitionedPods {
-					pod := partitionedPod
-					log.Printf("partition Pod: %s", pod.Name)
-					experiments = append(experiments, factory.InjectPartitionBetween(
-						fixtures.PodSelector(&pod),
-						chaosmesh.PodSelectorSpec{
-							GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
-								Namespaces:     []string{pod.Namespace},
-								LabelSelectors: fdbCluster.GetCachedCluster().GetMatchLabels(),
+					// Pick 2 Pods, so the operator has to replace them one after another
+					partitionedPods = factory.RandomPickPod(fdbCluster.GetStatelessPods().Items, 3)
+					for _, partitionedPod := range partitionedPods {
+						pod := partitionedPod
+						log.Printf("partition Pod: %s", pod.Name)
+						experiments = append(experiments, factory.InjectPartitionBetween(
+							fixtures.PodSelector(&pod),
+							chaosmesh.PodSelectorSpec{
+								GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
+									Namespaces:     []string{pod.Namespace},
+									LabelSelectors: fdbCluster.GetCachedCluster().GetMatchLabels(),
+								},
 							},
-						},
-					))
+						))
 
-					creationTimestamps[pod.Name] = pod.CreationTimestamp
-				}
-
-				// Make sure the status can settle
-				time.Sleep(1 * time.Minute)
-
-				// Now we can enable the replacements.
-				Expect(fdbCluster.SetAutoReplacements(true, 30*time.Second)).ShouldNot(HaveOccurred())
-			})
-
-			AfterEach(func() {
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
-				spec.AutomationOptions.Replacements.MaxConcurrentReplacements = pointer.Int(concurrentReplacements)
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
-				for _, experiment := range experiments {
-					factory.DeleteChaosMeshExperimentSafe(experiment)
-				}
-			})
-
-			It("should replace the all partitioned Pod", func() {
-				Eventually(func() bool {
-					allUpdatedOrRemoved := true
-					for _, pod := range fdbCluster.GetStatelessPods().Items {
-						creationTime, exists := creationTimestamps[pod.Name]
-						// If the Pod doesn't exist we can assume it was updated.
-						if !exists {
-							continue
-						}
-
-						log.Println(pod.Name, "creation time map:", creationTime.String(), "creation time metadata:", pod.CreationTimestamp.String())
-						// The current creation timestamp of the Pod is after the initial creation
-						// timestamp, so the Pod was replaced.
-						if pod.CreationTimestamp.Compare(creationTime.Time) < 1 {
-							allUpdatedOrRemoved = false
-						}
+						creationTimestamps[pod.Name] = pod.CreationTimestamp
 					}
 
-					return allUpdatedOrRemoved
+					// Make sure the status can settle
+					time.Sleep(1 * time.Minute)
+
+					// Now we can enable the replacements.
+					Expect(
+						fdbCluster.SetAutoReplacements(true, 30*time.Second),
+					).ShouldNot(HaveOccurred())
 				})
-			})
-		})
+
+				AfterEach(func() {
+					spec := fdbCluster.GetCluster().Spec.DeepCopy()
+					spec.AutomationOptions.Replacements.MaxConcurrentReplacements = pointer.Int(
+						concurrentReplacements,
+					)
+					fdbCluster.UpdateClusterSpecWithSpec(spec)
+					for _, experiment := range experiments {
+						factory.DeleteChaosMeshExperimentSafe(experiment)
+					}
+				})
+
+				It("should replace the all partitioned Pod", func() {
+					Eventually(func() bool {
+						allUpdatedOrRemoved := true
+						for _, pod := range fdbCluster.GetStatelessPods().Items {
+							creationTime, exists := creationTimestamps[pod.Name]
+							// If the Pod doesn't exist we can assume it was updated.
+							if !exists {
+								continue
+							}
+
+							log.Println(
+								pod.Name,
+								"creation time map:",
+								creationTime.String(),
+								"creation time metadata:",
+								pod.CreationTimestamp.String(),
+							)
+							// The current creation timestamp of the Pod is after the initial creation
+							// timestamp, so the Pod was replaced.
+							if pod.CreationTimestamp.Compare(creationTime.Time) < 1 {
+								allUpdatedOrRemoved = false
+							}
+						}
+
+						return allUpdatedOrRemoved
+					})
+				})
+			},
+		)
 
 		When("a Pod has a bad disk", func() {
 			var podWithIOError corev1.Pod
@@ -898,7 +1030,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				initialPods := fdbCluster.GetStoragePods()
 				podWithIOError = factory.RandomPickOnePod(initialPods.Items)
 				log.Printf("Injecting I/O chaos to %s for 1 minute", podWithIOError.Name)
-				exp = factory.InjectDiskFailureWithDuration(fixtures.PodSelector(&podWithIOError), "1m")
+				exp = factory.InjectDiskFailureWithDuration(
+					fixtures.PodSelector(&podWithIOError),
+					"1m",
+				)
 
 				log.Printf("iochaos injected to %s", podWithIOError.Name)
 				// File creation should fail due to I/O error
@@ -944,36 +1079,50 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			It("should remove the targeted process", func() {
 				processGroupID := fixtures.GetProcessGroupID(podWithIOError)
 				// Wait until the process group is marked to be removed.
-				Expect(fdbCluster.WaitUntilWithForceReconcile(1, 600, func(cluster *fdbv1beta2.FoundationDBCluster) bool {
-					for _, processGroup := range cluster.Status.ProcessGroups {
-						if processGroup.ProcessGroupID != processGroupID {
-							continue
-						}
+				Expect(
+					fdbCluster.WaitUntilWithForceReconcile(
+						1,
+						600,
+						func(cluster *fdbv1beta2.FoundationDBCluster) bool {
+							for _, processGroup := range cluster.Status.ProcessGroups {
+								if processGroup.ProcessGroupID != processGroupID {
+									continue
+								}
 
-						return processGroup.RemovalTimestamp != nil
-					}
+								return processGroup.RemovalTimestamp != nil
+							}
 
-					return false
-				})).NotTo(HaveOccurred())
+							return false
+						},
+					),
+				).NotTo(HaveOccurred())
 
 				// Wait until the process group is removed
-				Expect(fdbCluster.WaitUntilWithForceReconcile(1, 1200, func(cluster *fdbv1beta2.FoundationDBCluster) bool {
-					for _, processGroup := range cluster.Status.ProcessGroups {
-						if processGroup.ProcessGroupID != processGroupID {
-							continue
-						}
+				Expect(
+					fdbCluster.WaitUntilWithForceReconcile(
+						1,
+						1200,
+						func(cluster *fdbv1beta2.FoundationDBCluster) bool {
+							for _, processGroup := range cluster.Status.ProcessGroups {
+								if processGroup.ProcessGroupID != processGroupID {
+									continue
+								}
 
-						// At this point the process group still exists.
-						return false
-					}
+								// At this point the process group still exists.
+								return false
+							}
 
-					return true
-				})).NotTo(HaveOccurred())
+							return true
+						},
+					),
+				).NotTo(HaveOccurred())
 			})
 		})
 
 		AfterEach(func() {
-			Expect(fdbCluster.SetAutoReplacements(true, initialReplaceTime)).ShouldNot(HaveOccurred())
+			Expect(
+				fdbCluster.SetAutoReplacements(true, initialReplaceTime),
+			).ShouldNot(HaveOccurred())
 			factory.DeleteChaosMeshExperimentSafe(exp)
 		})
 	})
@@ -1040,7 +1189,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var replacedPods []corev1.Pod
 
 		BeforeEach(func() {
-			fdbCluster.ReplacePods(factory.RandomPickPod(fdbCluster.GetStatelessPods().Items, 4), true)
+			fdbCluster.ReplacePods(
+				factory.RandomPickPod(fdbCluster.GetStatelessPods().Items, 4),
+				true,
+			)
 		})
 
 		AfterEach(func() {
@@ -1072,7 +1224,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		It("should replace the Pod stuck in Terminating state", func() {
-			Expect(fdbCluster.GetPodsNames()).Should(Or(HaveLen(len(podsBeforeReplacement)+1), HaveLen(len(podsBeforeReplacement))))
+			Expect(
+				fdbCluster.GetPodsNames(),
+			).Should(Or(HaveLen(len(podsBeforeReplacement)+1), HaveLen(len(podsBeforeReplacement))))
 		})
 	})
 
@@ -1083,7 +1237,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			)).ShouldNot(HaveOccurred())
 		})
 
-		DescribeTable("changing coordinator selection",
+		DescribeTable(
+			"changing coordinator selection",
 			func(setting []fdbv1beta2.CoordinatorSelectionSetting, expectedProcessClassList []fdbv1beta2.ProcessClass) {
 				Expect(fdbCluster.UpdateCoordinatorSelection(setting)).ShouldNot(HaveOccurred())
 				pods := fdbCluster.GetCoordinators()
@@ -1173,7 +1328,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		AfterEach(func() {
 			log.Printf("set log servers per Pod to %d", initialLogServerPerPod)
-			Expect(fdbCluster.SetLogServersPerPod(initialLogServerPerPod, true)).ShouldNot(HaveOccurred())
+			Expect(
+				fdbCluster.SetLogServersPerPod(initialLogServerPerPod, true),
+			).ShouldNot(HaveOccurred())
 			log.Printf(
 				"expectedPodCnt: %d, expectedProcessesCnt: %d",
 				expectedPodCnt,
@@ -1193,7 +1350,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				expectedPodCnt,
 				expectedPodCnt*serverPerPod,
 			)
-			fdbCluster.ValidateProcessesCount(fdbv1beta2.ProcessClassLog, expectedPodCnt, expectedPodCnt*serverPerPod)
+			fdbCluster.ValidateProcessesCount(
+				fdbv1beta2.ProcessClassLog,
+				expectedPodCnt,
+				expectedPodCnt*serverPerPod,
+			)
 		})
 	})
 
@@ -1217,7 +1378,13 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		AfterEach(func() {
 			log.Printf("set log servers per Pod to %d", initialLogServerPerPod)
-			Expect(fdbCluster.SetTransactionServerPerPod(initialLogServerPerPod, expectedLogProcessesCnt, true)).ShouldNot(HaveOccurred())
+			Expect(
+				fdbCluster.SetTransactionServerPerPod(
+					initialLogServerPerPod,
+					expectedLogProcessesCnt,
+					true,
+				),
+			).ShouldNot(HaveOccurred())
 			log.Printf(
 				"expectedPodCnt: %d, expectedProcessesCnt: %d",
 				expectedPodCnt,
@@ -1228,16 +1395,29 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}).Should(BeNumerically("==", expectedPodCnt))
 		})
 
-		It("should update the log servers to the expected amount and should create transaction Pods", func() {
-			serverPerPod := initialLogServerPerPod * 2
-			Expect(fdbCluster.SetTransactionServerPerPod(serverPerPod, expectedLogProcessesCnt, true)).ShouldNot(HaveOccurred())
-			log.Printf(
-				"expectedPodCnt: %d, expectedProcessesCnt: %d",
-				expectedPodCnt,
-				expectedPodCnt*serverPerPod,
-			)
-			fdbCluster.ValidateProcessesCount(fdbv1beta2.ProcessClassTransaction, expectedPodCnt, expectedPodCnt*serverPerPod)
-		})
+		It(
+			"should update the log servers to the expected amount and should create transaction Pods",
+			func() {
+				serverPerPod := initialLogServerPerPod * 2
+				Expect(
+					fdbCluster.SetTransactionServerPerPod(
+						serverPerPod,
+						expectedLogProcessesCnt,
+						true,
+					),
+				).ShouldNot(HaveOccurred())
+				log.Printf(
+					"expectedPodCnt: %d, expectedProcessesCnt: %d",
+					expectedPodCnt,
+					expectedPodCnt*serverPerPod,
+				)
+				fdbCluster.ValidateProcessesCount(
+					fdbv1beta2.ProcessClassTransaction,
+					expectedPodCnt,
+					expectedPodCnt*serverPerPod,
+				)
+			},
+		)
 	})
 
 	When("Migrating a cluster to a different storage class", func() {
@@ -1428,7 +1608,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		BeforeEach(func() {
 			initialPods := fdbCluster.GetStatelessPods()
 			podMarkedForRemoval = factory.RandomPickOnePod(initialPods.Items)
-			log.Println("Setting Pod", podMarkedForRemoval.Name, "to be blocked to be removed and mark it for removal.")
+			log.Println(
+				"Setting Pod",
+				podMarkedForRemoval.Name,
+				"to be blocked to be removed and mark it for removal.",
+			)
 			processGroupID = fixtures.GetProcessGroupID(podMarkedForRemoval)
 			fdbCluster.SetBuggifyBlockRemoval([]fdbv1beta2.ProcessGroupID{processGroupID})
 			fdbCluster.ReplacePod(podMarkedForRemoval, false)
@@ -1448,7 +1632,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 						continue
 					}
 
-					return !processGroup.ExclusionTimestamp.IsZero() && !processGroup.RemovalTimestamp.IsZero()
+					return !processGroup.ExclusionTimestamp.IsZero() &&
+						!processGroup.RemovalTimestamp.IsZero()
 				}
 
 				return false
@@ -1465,25 +1650,46 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var initialReplacementDuration time.Duration
 
 		BeforeEach(func() {
-			initialReplacementDuration = time.Duration(fdbCluster.GetCachedCluster().GetFailureDetectionTimeSeconds()) * time.Second
+			initialReplacementDuration = time.Duration(
+				fdbCluster.GetCachedCluster().GetFailureDetectionTimeSeconds(),
+			) * time.Second
 			// Get the current Process Group ID numbers that are in use.
-			_, processGroupIDs, err := fdbCluster.GetCluster().GetCurrentProcessGroupsAndProcessCounts()
+			_, processGroupIDs, err := fdbCluster.GetCluster().
+				GetCurrentProcessGroupsAndProcessCounts()
 			Expect(err).NotTo(HaveOccurred())
 
 			// Make sure the operator doesn't modify the status.
 			fdbCluster.SetSkipReconciliation(true)
 			cluster := fdbCluster.GetCluster()
 			status := cluster.Status.DeepCopy() // Fetch the current status.
-			processGroupID = cluster.GetNextRandomProcessGroupID(fdbv1beta2.ProcessClassStateless, processGroupIDs[fdbv1beta2.ProcessClassStateless])
-			status.ProcessGroups = append(status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(processGroupID, fdbv1beta2.ProcessClassStateless, nil))
+			processGroupID = cluster.GetNextRandomProcessGroupID(
+				fdbv1beta2.ProcessClassStateless,
+				processGroupIDs[fdbv1beta2.ProcessClassStateless],
+			)
+			status.ProcessGroups = append(
+				status.ProcessGroups,
+				fdbv1beta2.NewProcessGroupStatus(
+					processGroupID,
+					fdbv1beta2.ProcessClassStateless,
+					nil,
+				),
+			)
 			fdbCluster.UpdateClusterStatusWithStatus(status)
 
-			log.Println("Next process group ID", processGroupID, "current processGroupIDs for stateless processes", processGroupIDs[fdbv1beta2.ProcessClassStateless])
+			log.Println(
+				"Next process group ID",
+				processGroupID,
+				"current processGroupIDs for stateless processes",
+				processGroupIDs[fdbv1beta2.ProcessClassStateless],
+			)
 
 			// Make sure the new Pod will be stuck in unschedulable.
 			fdbCluster.SetProcessGroupsAsUnschedulable([]fdbv1beta2.ProcessGroupID{processGroupID})
 			// Now replace a random Pod for replacement to force the cluster to create a new Pod.
-			fdbCluster.ReplacePod(factory.RandomPickOnePod(fdbCluster.GetStatelessPods().Items), false)
+			fdbCluster.ReplacePod(
+				factory.RandomPickOnePod(fdbCluster.GetStatelessPods().Items),
+				false,
+			)
 
 			// Allow the operator again to reconcile.
 			fdbCluster.SetSkipReconciliation(false)
@@ -1506,16 +1712,25 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			Expect(fdbCluster.ClearBuggifyNoSchedule(true)).NotTo(HaveOccurred())
 			// Make sure we cleaned up the process groups to remove.
 			Expect(fdbCluster.ClearProcessGroupsToRemove())
-			Expect(fdbCluster.SetAutoReplacements(true, initialReplacementDuration)).NotTo(HaveOccurred())
+			Expect(
+				fdbCluster.SetAutoReplacements(true, initialReplacementDuration),
+			).NotTo(HaveOccurred())
 		})
 
 		When("automatic replacements are disabled", func() {
 			BeforeEach(func() {
-				Expect(fdbCluster.SetAutoReplacementsWithWait(false, 10*time.Hour, false)).NotTo(HaveOccurred())
+				Expect(
+					fdbCluster.SetAutoReplacementsWithWait(false, 10*time.Hour, false),
+				).NotTo(HaveOccurred())
 			})
 
 			It("should not remove the Pod as long as it is unschedulable", func() {
-				log.Println("Make sure process group", processGroupID, "is stuck in Pending state with Pod", podName)
+				log.Println(
+					"Make sure process group",
+					processGroupID,
+					"is stuck in Pending state with Pod",
+					podName,
+				)
 				// Make sure the Pod is stuck in pending for 2 minutes
 				Consistently(func() corev1.PodPhase {
 					return fdbCluster.GetPod(podName).Status.Phase
@@ -1525,14 +1740,24 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		When("automatic replacements are enabled", func() {
 			BeforeEach(func() {
-				Expect(fdbCluster.SetAutoReplacementsWithWait(true, 1*time.Minute, false)).NotTo(HaveOccurred())
+				Expect(
+					fdbCluster.SetAutoReplacementsWithWait(true, 1*time.Minute, false),
+				).NotTo(HaveOccurred())
 			})
 
 			It("should remove the Pod", func() {
-				log.Println("Make sure process group", processGroupID, "gets replaced with Pod", podName)
+				log.Println(
+					"Make sure process group",
+					processGroupID,
+					"gets replaced with Pod",
+					podName,
+				)
 				// Make sure the process group is removed after some time.
 				Eventually(func() *fdbv1beta2.ProcessGroupStatus {
-					return fdbv1beta2.FindProcessGroupByID(fdbCluster.GetCluster().Status.ProcessGroups, processGroupID)
+					return fdbv1beta2.FindProcessGroupByID(
+						fdbCluster.GetCluster().Status.ProcessGroups,
+						processGroupID,
+					)
 				}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(BeNil())
 
 				// Make sure the Pod is actually deleted after some time.
@@ -1544,80 +1769,102 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	})
 
 	// this test took ~8min to run for me, so I think it is best to just have the one test
-	When("replacing Pods due to securityContext changes (General spec change = log + stateless)", func() {
-		var podsNotToReplace, podsToReplace []string
-		var originalPodSpec, modifiedPodSpec, originalStoragePodSpec *corev1.PodSpec
-		var initialPodUpdateStrategy fdbv1beta2.PodUpdateStrategy
+	When(
+		"replacing Pods due to securityContext changes (General spec change = log + stateless)",
+		func() {
+			var podsNotToReplace, podsToReplace []string
+			var originalPodSpec, modifiedPodSpec, originalStoragePodSpec *corev1.PodSpec
+			var initialPodUpdateStrategy fdbv1beta2.PodUpdateStrategy
 
-		BeforeEach(func() {
-			originalPodSpec = fdbCluster.GetPodTemplateSpec(fdbv1beta2.ProcessClassGeneral)
-			originalStoragePodSpec = fdbCluster.GetPodTemplateSpec(fdbv1beta2.ProcessClassStorage)
-			Expect(originalPodSpec).NotTo(BeNil())
-			modifiedPodSpec = originalPodSpec.DeepCopy()
-			Expect(modifiedPodSpec.SecurityContext).NotTo(BeNil())
-			if originalPodSpec.SecurityContext.FSGroupChangePolicy != nil {
-				Expect(*originalPodSpec.SecurityContext.FSGroupChangePolicy).NotTo(Equal(corev1.FSGroupChangeOnRootMismatch))
-			}
-			modifiedPodSpec.SecurityContext.FSGroupChangePolicy = &[]corev1.PodFSGroupChangePolicy{corev1.FSGroupChangeOnRootMismatch}[0]
-			for _, logPod := range fdbCluster.GetLogPods().Items {
-				podsToReplace = append(podsToReplace, logPod.Name)
-			}
-			for _, statelessPod := range fdbCluster.GetStatelessPods().Items {
-				podsToReplace = append(podsToReplace, statelessPod.Name)
-			}
-			for _, storagePod := range fdbCluster.GetStoragePods().Items {
-				podsToReplace = append(podsToReplace, storagePod.Name)
-			}
-			// if we do not set the PodUpdateStrategy to delete, then the pods will get replaced for the spec change,
-			// meaning we cannot test the security context change on non-storage pods unless we use PodUpdateStrategyDelete
-			// (and storage pod use would make the test take ~5min longer)
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
-			initialPodUpdateStrategy = spec.AutomationOptions.PodUpdateStrategy
-			spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyDelete
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.SetPodTemplateSpec(fdbv1beta2.ProcessClassGeneral, modifiedPodSpec, false)).NotTo(HaveOccurred())
-		})
+			BeforeEach(func() {
+				originalPodSpec = fdbCluster.GetPodTemplateSpec(fdbv1beta2.ProcessClassGeneral)
+				originalStoragePodSpec = fdbCluster.GetPodTemplateSpec(
+					fdbv1beta2.ProcessClassStorage,
+				)
+				Expect(originalPodSpec).NotTo(BeNil())
+				modifiedPodSpec = originalPodSpec.DeepCopy()
+				Expect(modifiedPodSpec.SecurityContext).NotTo(BeNil())
+				if originalPodSpec.SecurityContext.FSGroupChangePolicy != nil {
+					Expect(
+						*originalPodSpec.SecurityContext.FSGroupChangePolicy,
+					).NotTo(Equal(corev1.FSGroupChangeOnRootMismatch))
+				}
+				modifiedPodSpec.SecurityContext.FSGroupChangePolicy = &[]corev1.PodFSGroupChangePolicy{corev1.FSGroupChangeOnRootMismatch}[0]
+				for _, logPod := range fdbCluster.GetLogPods().Items {
+					podsToReplace = append(podsToReplace, logPod.Name)
+				}
+				for _, statelessPod := range fdbCluster.GetStatelessPods().Items {
+					podsToReplace = append(podsToReplace, statelessPod.Name)
+				}
+				for _, storagePod := range fdbCluster.GetStoragePods().Items {
+					podsToReplace = append(podsToReplace, storagePod.Name)
+				}
+				// if we do not set the PodUpdateStrategy to delete, then the pods will get replaced for the spec change,
+				// meaning we cannot test the security context change on non-storage pods unless we use PodUpdateStrategyDelete
+				// (and storage pod use would make the test take ~5min longer)
+				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				initialPodUpdateStrategy = spec.AutomationOptions.PodUpdateStrategy
+				spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyDelete
+				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				Expect(
+					fdbCluster.SetPodTemplateSpec(
+						fdbv1beta2.ProcessClassGeneral,
+						modifiedPodSpec,
+						false,
+					),
+				).NotTo(HaveOccurred())
+			})
 
-		AfterEach(func() {
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
-			spec.AutomationOptions.PodUpdateStrategy = initialPodUpdateStrategy
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.SetPodTemplateSpec(fdbv1beta2.ProcessClassGeneral, originalPodSpec, true)).NotTo(HaveOccurred())
-		})
+			AfterEach(func() {
+				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				spec.AutomationOptions.PodUpdateStrategy = initialPodUpdateStrategy
+				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				Expect(
+					fdbCluster.SetPodTemplateSpec(
+						fdbv1beta2.ProcessClassGeneral,
+						originalPodSpec,
+						true,
+					),
+				).NotTo(HaveOccurred())
+			})
 
-		It("should replace all the log pods (which had the securityContext change)", func() {
-			lastForcedReconciliationTime := time.Now()
-			forceReconcileDuration := 4 * time.Minute
-			Eventually(func(g Gomega) {
-				// Force a reconcile if needed to make sure we speed up the reconciliation if needed.
-				if time.Since(lastForcedReconciliationTime) >= forceReconcileDuration {
-					fdbCluster.ForceReconcile()
-					lastForcedReconciliationTime = time.Now()
-				}
+			It("should replace all the log pods (which had the securityContext change)", func() {
+				lastForcedReconciliationTime := time.Now()
+				forceReconcileDuration := 4 * time.Minute
+				Eventually(func(g Gomega) {
+					// Force a reconcile if needed to make sure we speed up the reconciliation if needed.
+					if time.Since(lastForcedReconciliationTime) >= forceReconcileDuration {
+						fdbCluster.ForceReconcile()
+						lastForcedReconciliationTime = time.Now()
+					}
 
-				// check that we replaced the pods we should have and did not replace others
-				currentPods := fdbCluster.GetPodsNames()
-				g.Expect(currentPods).NotTo(ContainElements(podsToReplace))
-				g.Expect(currentPods).To(ContainElements(podsNotToReplace))
-				// check that General template pods (Log + Stateless) are replaced with the new security context
-				logPods := fdbCluster.GetLogPods()
-				for _, pod := range logPods.Items {
-					g.Expect(pod.Spec.SecurityContext.FSGroupChangePolicy).ToNot(BeNil())
-					g.Expect(*pod.Spec.SecurityContext.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch))
-				}
-				statelessPods := fdbCluster.GetStatelessPods()
-				for _, pod := range statelessPods.Items {
-					g.Expect(pod.Spec.SecurityContext.FSGroupChangePolicy).ToNot(BeNil())
-					g.Expect(*pod.Spec.SecurityContext.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch))
-				}
-				// ensure that we only changed pods that are expected to be changed (i.e. don't touch storage)
-				storagePods := fdbCluster.GetStoragePods()
-				for _, pod := range storagePods.Items {
-					g.Expect(pod.Spec.SecurityContext).To(Equal(originalStoragePodSpec.SecurityContext))
-				}
-			}).WithTimeout(15 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
-		})
-	})
+					// check that we replaced the pods we should have and did not replace others
+					currentPods := fdbCluster.GetPodsNames()
+					g.Expect(currentPods).NotTo(ContainElements(podsToReplace))
+					g.Expect(currentPods).To(ContainElements(podsNotToReplace))
+					// check that General template pods (Log + Stateless) are replaced with the new security context
+					logPods := fdbCluster.GetLogPods()
+					for _, pod := range logPods.Items {
+						g.Expect(pod.Spec.SecurityContext.FSGroupChangePolicy).ToNot(BeNil())
+						g.Expect(*pod.Spec.SecurityContext.FSGroupChangePolicy).
+							To(Equal(corev1.FSGroupChangeOnRootMismatch))
+					}
+					statelessPods := fdbCluster.GetStatelessPods()
+					for _, pod := range statelessPods.Items {
+						g.Expect(pod.Spec.SecurityContext.FSGroupChangePolicy).ToNot(BeNil())
+						g.Expect(*pod.Spec.SecurityContext.FSGroupChangePolicy).
+							To(Equal(corev1.FSGroupChangeOnRootMismatch))
+					}
+					// ensure that we only changed pods that are expected to be changed (i.e. don't touch storage)
+					storagePods := fdbCluster.GetStoragePods()
+					for _, pod := range storagePods.Items {
+						g.Expect(pod.Spec.SecurityContext).
+							To(Equal(originalStoragePodSpec.SecurityContext))
+					}
+				}).WithTimeout(15 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			})
+		},
+	)
 
 	When("migrating a cluster to make use of DNS in the cluster file", func() {
 		BeforeEach(func() {
@@ -1705,7 +1952,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			pod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
 			log.Printf("exclude Pod: %s", pod.Name)
 			Expect(pod.Status.PodIP).NotTo(BeEmpty())
-			_, _ = fdbCluster.RunFdbCliCommandInOperator(fmt.Sprintf("exclude %s", pod.Status.PodIP), false, 30)
+			_, _ = fdbCluster.RunFdbCliCommandInOperator(
+				fmt.Sprintf("exclude %s", pod.Status.PodIP),
+				false,
+				30,
+			)
 			// Make sure we trigger a reconciliation to speed up the exclusion detection.
 			fdbCluster.ForceReconcile()
 		})
@@ -1719,7 +1970,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		AfterEach(func() {
-			Expect(fdbCluster.SetAutoReplacements(true, initialReplaceTime)).ShouldNot(HaveOccurred())
+			Expect(
+				fdbCluster.SetAutoReplacements(true, initialReplaceTime),
+			).ShouldNot(HaveOccurred())
 		})
 	})
 
@@ -1745,7 +1998,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				break
 			}
 
-			_, _ = fdbCluster.RunFdbCliCommandInOperator(fmt.Sprintf("maintenance on %s 3600", targetProcessGroup.FaultDomain), false, 30)
+			_, _ = fdbCluster.RunFdbCliCommandInOperator(
+				fmt.Sprintf("maintenance on %s 3600", targetProcessGroup.FaultDomain),
+				false,
+				30,
+			)
 
 			// Partition the Pod
 			pod := fdbCluster.GetPod(targetProcessGroup.GetPodName(fdbCluster.GetCachedCluster()))
@@ -1779,7 +2036,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		AfterEach(func() {
 			factory.DeleteChaosMeshExperimentSafe(exp)
-			Expect(fdbCluster.SetAutoReplacements(true, initialReplaceTime)).ShouldNot(HaveOccurred())
+			Expect(
+				fdbCluster.SetAutoReplacements(true, initialReplaceTime),
+			).ShouldNot(HaveOccurred())
 			fdbCluster.RunFdbCliCommandInOperator("maintenance off", false, 30)
 		})
 	})
@@ -1854,7 +2113,12 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			spec.DatabaseConfiguration.RoleCounts.GrvProxies = 0
 			spec.DatabaseConfiguration.RoleCounts.CommitProxies = 0
 
-			fmt.Println("Original:", fixtures.ToJSON(originalRoleCounts), "new roleCounts:", fixtures.ToJSON(spec.DatabaseConfiguration.RoleCounts))
+			fmt.Println(
+				"Original:",
+				fixtures.ToJSON(originalRoleCounts),
+				"new roleCounts:",
+				fixtures.ToJSON(spec.DatabaseConfiguration.RoleCounts),
+			)
 			fdbCluster.UpdateClusterSpecWithSpec(spec)
 			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
 		})
@@ -1866,25 +2130,35 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
 		})
 
-		It("should configure the database to run with GRV and commit proxies but keep the proxies in the status field of the FoundationDB resource", func() {
-			// Make sure GRV and commit proxies are configured.
-			status := fdbCluster.GetStatus()
-			Expect(status.Cluster.DatabaseConfiguration.RoleCounts.CommitProxies).To(BeNumerically(">", 0))
-			Expect(status.Cluster.DatabaseConfiguration.RoleCounts.GrvProxies).To(BeNumerically(">", 0))
-			Expect(status.Cluster.DatabaseConfiguration.RoleCounts.Proxies).NotTo(BeZero())
+		It(
+			"should configure the database to run with GRV and commit proxies but keep the proxies in the status field of the FoundationDB resource",
+			func() {
+				// Make sure GRV and commit proxies are configured.
+				status := fdbCluster.GetStatus()
+				Expect(
+					status.Cluster.DatabaseConfiguration.RoleCounts.CommitProxies,
+				).To(BeNumerically(">", 0))
+				Expect(
+					status.Cluster.DatabaseConfiguration.RoleCounts.GrvProxies,
+				).To(BeNumerically(">", 0))
+				Expect(status.Cluster.DatabaseConfiguration.RoleCounts.Proxies).NotTo(BeZero())
 
-			fmt.Println("Status configuration:", fixtures.ToJSON(status.Cluster.DatabaseConfiguration))
-			// Verify the FoundationDB Cluster resource
-			cluster := fdbCluster.GetCluster()
-			// Make sure that the spec of the FoundationDB resource only has proxies defined.
-			Expect(cluster.Spec.DatabaseConfiguration.RoleCounts.GrvProxies).To(BeZero())
-			Expect(cluster.Spec.DatabaseConfiguration.RoleCounts.CommitProxies).To(BeZero())
-			Expect(cluster.Spec.DatabaseConfiguration.RoleCounts.Proxies).NotTo(BeZero())
-			// Make sure that the status of the FoundationDB resource only has proxies defined.
-			Expect(cluster.Status.DatabaseConfiguration.RoleCounts.GrvProxies).To(BeZero())
-			Expect(cluster.Status.DatabaseConfiguration.RoleCounts.CommitProxies).To(BeZero())
-			Expect(cluster.Status.DatabaseConfiguration.RoleCounts.Proxies).NotTo(BeZero())
-		})
+				fmt.Println(
+					"Status configuration:",
+					fixtures.ToJSON(status.Cluster.DatabaseConfiguration),
+				)
+				// Verify the FoundationDB Cluster resource
+				cluster := fdbCluster.GetCluster()
+				// Make sure that the spec of the FoundationDB resource only has proxies defined.
+				Expect(cluster.Spec.DatabaseConfiguration.RoleCounts.GrvProxies).To(BeZero())
+				Expect(cluster.Spec.DatabaseConfiguration.RoleCounts.CommitProxies).To(BeZero())
+				Expect(cluster.Spec.DatabaseConfiguration.RoleCounts.Proxies).NotTo(BeZero())
+				// Make sure that the status of the FoundationDB resource only has proxies defined.
+				Expect(cluster.Status.DatabaseConfiguration.RoleCounts.GrvProxies).To(BeZero())
+				Expect(cluster.Status.DatabaseConfiguration.RoleCounts.CommitProxies).To(BeZero())
+				Expect(cluster.Status.DatabaseConfiguration.RoleCounts.Proxies).NotTo(BeZero())
+			},
+		)
 	})
 
 	When("running with tester processes", func() {
@@ -1974,38 +2248,64 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			})
 		})
 
-		When("there is a unidirectional partition between the tester and the rest of the cluster", func() {
-			var exp *fixtures.ChaosMeshExperiment
+		When(
+			"there is a unidirectional partition between the tester and the rest of the cluster",
+			func() {
+				var exp *fixtures.ChaosMeshExperiment
 
-			BeforeEach(func() {
-				// Make sure the operator is not taking any action as long as we are preparing the setup
-				fdbCluster.SetSkipReconciliation(true)
+				BeforeEach(func() {
+					// Make sure the operator is not taking any action as long as we are preparing the setup
+					fdbCluster.SetSkipReconciliation(true)
 
-				var partitionedPod corev1.Pod
+					var partitionedPod corev1.Pod
 
-				pods := fdbCluster.GetPods()
-				for _, pod := range pods.Items {
-					if fixtures.GetProcessClass(pod) != fdbv1beta2.ProcessClassTest {
-						continue
+					pods := fdbCluster.GetPods()
+					for _, pod := range pods.Items {
+						if fixtures.GetProcessClass(pod) != fdbv1beta2.ProcessClassTest {
+							continue
+						}
+
+						partitionedPod = pod
 					}
 
-					partitionedPod = pod
-				}
-
-				log.Printf("partition Pod: %s", partitionedPod.Name)
-				exp = factory.InjectPartitionBetweenWithDirection(
-					fixtures.PodSelector(&partitionedPod),
-					chaosmesh.PodSelectorSpec{
-						GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
-							Namespaces:     []string{partitionedPod.Namespace},
-							LabelSelectors: fdbCluster.GetCachedCluster().GetMatchLabels(),
+					log.Printf("partition Pod: %s", partitionedPod.Name)
+					exp = factory.InjectPartitionBetweenWithDirection(
+						fixtures.PodSelector(&partitionedPod),
+						chaosmesh.PodSelectorSpec{
+							GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
+								Namespaces:     []string{partitionedPod.Namespace},
+								LabelSelectors: fdbCluster.GetCachedCluster().GetMatchLabels(),
+							},
 						},
-					},
-					chaosmesh.From,
-				)
+						chaosmesh.From,
+					)
 
-				if !fdbAutomaticallyRemoveOldTester {
-					// Wait until the cluster shows the unreachable process.
+					if !fdbAutomaticallyRemoveOldTester {
+						// Wait until the cluster shows the unreachable process.
+						Eventually(func() []string {
+							status := fdbCluster.GetStatus()
+
+							messages := make([]string, 0, len(status.Cluster.Messages))
+							for _, message := range status.Cluster.Messages {
+								messages = append(messages, message.Name)
+							}
+
+							log.Println("current messages:", messages)
+
+							return messages
+						}).WithPolling(1 * time.Second).WithTimeout(2 * time.Minute).MustPassRepeatedly(5).Should(ContainElements("status_incomplete", "unreachable_processes"))
+					}
+
+					// Let the operator fix the issue.
+					fdbCluster.SetSkipReconciliation(false)
+				})
+
+				AfterEach(func() {
+					factory.DeleteChaosMeshExperimentSafe(exp)
+				})
+
+				It("should show the status without any messages", func() {
+					// The operator should be restarting the cluster controller and this should clean the unreachable_processes
 					Eventually(func() []string {
 						status := fdbCluster.GetStatus()
 
@@ -2017,33 +2317,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 						log.Println("current messages:", messages)
 
 						return messages
-					}).WithPolling(1 * time.Second).WithTimeout(2 * time.Minute).MustPassRepeatedly(5).Should(ContainElements("status_incomplete", "unreachable_processes"))
-				}
-
-				// Let the operator fix the issue.
-				fdbCluster.SetSkipReconciliation(false)
-			})
-
-			AfterEach(func() {
-				factory.DeleteChaosMeshExperimentSafe(exp)
-			})
-
-			It("should show the status without any messages", func() {
-				// The operator should be restarting the cluster controller and this should clean the unreachable_processes
-				Eventually(func() []string {
-					status := fdbCluster.GetStatus()
-
-					messages := make([]string, 0, len(status.Cluster.Messages))
-					for _, message := range status.Cluster.Messages {
-						messages = append(messages, message.Name)
-					}
-
-					log.Println("current messages:", messages)
-
-					return messages
-				}).WithPolling(1 * time.Second).WithTimeout(5 * time.Minute).MustPassRepeatedly(5).Should(BeEmpty())
-			})
-		})
+					}).WithPolling(1 * time.Second).WithTimeout(5 * time.Minute).MustPassRepeatedly(5).Should(BeEmpty())
+				})
+			},
+		)
 	})
 
 	When("the cluster makes use of DNS in the cluster file", func() {
@@ -2083,12 +2360,17 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					fdbCluster.GetClusterSpec().AutomationOptions.Replacements.FailureDetectionTimeSeconds,
 					90,
 				)) * time.Second
-				Expect(fdbCluster.SetAutoReplacements(false, 30*time.Hour)).ShouldNot(HaveOccurred())
+				Expect(
+					fdbCluster.SetAutoReplacements(false, 30*time.Hour),
+				).ShouldNot(HaveOccurred())
 				// Make sure the operator is not taking any action to prevent any race condition.
 				fdbCluster.SetSkipReconciliation(true)
 
 				// Delete all Pods, including the operator pods.
-				Expect(factory.GetControllerRuntimeClient().DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.InNamespace(fdbCluster.Namespace()))).To(Succeed())
+				Expect(
+					factory.GetControllerRuntimeClient().
+						DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.InNamespace(fdbCluster.Namespace())),
+				).To(Succeed())
 
 				// Make sure the Pods are all deleted.
 				Eventually(func() []corev1.Pod {
@@ -2113,7 +2395,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			AfterEach(func() {
 				fdbCluster.SetSkipReconciliation(false)
-				Expect(fdbCluster.SetAutoReplacements(true, initialReplaceTime)).ShouldNot(HaveOccurred())
+				Expect(
+					fdbCluster.SetAutoReplacements(true, initialReplaceTime),
+				).ShouldNot(HaveOccurred())
 			})
 		})
 	})
@@ -2150,7 +2434,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			var newCPURequest, initialCPURequest resource.Quantity
 
 			BeforeEach(func() {
-				initialVolumeClaims = fdbCluster.GetListOfUIDsFromVolumeClaims(fdbv1beta2.ProcessClassStorage)
+				initialVolumeClaims = fdbCluster.GetListOfUIDsFromVolumeClaims(
+					fdbv1beta2.ProcessClassStorage,
+				)
 				spec := fdbCluster.GetCluster().Spec.DeepCopy()
 				initialCPURequest = spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
 				newCPURequest = initialCPURequest.DeepCopy()
@@ -2176,7 +2462,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			It("should replace all storage pods", func() {
 				// A replacement of a storage pod will create a new PVC. After reconciliation the set of PVCs should be completely changed.
-				Expect(initialVolumeClaims).NotTo(ContainElements(fdbCluster.GetListOfUIDsFromVolumeClaims(fdbv1beta2.ProcessClassStorage)), "PVC should not be present in the new set of PVCs")
+				Expect(
+					initialVolumeClaims,
+				).NotTo(ContainElements(fdbCluster.GetListOfUIDsFromVolumeClaims(fdbv1beta2.ProcessClassStorage)), "PVC should not be present in the new set of PVCs")
 			})
 		})
 	})
@@ -2190,7 +2478,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			cluster := fdbCluster.GetCluster()
 			spec := cluster.Spec.DeepCopy()
 			// TODO (johscheuer): Once the new CRD is available change this to ResetMaintenanceMode.
-			spec.AutomationOptions.MaintenanceModeOptions.UseMaintenanceModeChecker = pointer.Bool(true)
+			spec.AutomationOptions.MaintenanceModeOptions.UseMaintenanceModeChecker = pointer.Bool(
+				true,
+			)
 			fdbCluster.UpdateClusterSpecWithSpec(spec)
 
 			for _, processGroup := range cluster.Status.ProcessGroups {
@@ -2208,9 +2498,14 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			key := cluster.GetMaintenancePrefix() + "/" + string(pickedProcessGroup.ProcessGroupID)
 			Eventually(func(g Gomega) error {
 				timestampByteBuffer := new(bytes.Buffer)
-				g.Expect(binary.Write(timestampByteBuffer, binary.LittleEndian, time.Now().Unix())).NotTo(HaveOccurred())
+				g.Expect(binary.Write(timestampByteBuffer, binary.LittleEndian, time.Now().Unix())).
+					NotTo(HaveOccurred())
 				g.Expect(timestampByteBuffer.Bytes()).NotTo(BeEmpty())
-				cmd := fmt.Sprintf("writemode on; option on ACCESS_SYSTEM_KEYS; set %s %s", fixtures.FdbPrintable([]byte(key)), fixtures.FdbPrintable(timestampByteBuffer.Bytes()))
+				cmd := fmt.Sprintf(
+					"writemode on; option on ACCESS_SYSTEM_KEYS; set %s %s",
+					fixtures.FdbPrintable([]byte(key)),
+					fixtures.FdbPrintable(timestampByteBuffer.Bytes()),
+				)
 				_, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(cmd, true, 20)
 
 				return err
@@ -2247,7 +2542,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		AfterEach(func() {
 			spec := fdbCluster.GetCluster().Spec.DeepCopy()
 			// TODO (johscheuer): Once the new CRD is available change this to ResetMaintenanceMode.
-			spec.AutomationOptions.MaintenanceModeOptions.UseMaintenanceModeChecker = pointer.Bool(false)
+			spec.AutomationOptions.MaintenanceModeOptions.UseMaintenanceModeChecker = pointer.Bool(
+				false,
+			)
 			fdbCluster.UpdateClusterSpecWithSpec(spec)
 		})
 	})
@@ -2356,7 +2653,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					g.Expect(process.Locality).NotTo(BeEmpty())
 					g.Expect(process.Locality).To(HaveKey(localityKey))
 					g.Expect(process.Locality).To(HaveKey(fdbv1beta2.FDBLocalityInstanceIDKey))
-					g.Expect(process.Locality[localityKey]).To(Equal(process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]))
+					g.Expect(process.Locality[localityKey]).
+						To(Equal(process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]))
 				}
 
 				return true
@@ -2404,7 +2702,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				return err
 			}, 5*time.Minute).ShouldNot(HaveOccurred())
 
-			exp = factory.InjectPartitionWithExternalTargets(fixtures.PodSelector(&selectedPod), []string{kubernetesServiceHost})
+			exp = factory.InjectPartitionWithExternalTargets(
+				fixtures.PodSelector(&selectedPod),
+				[]string{kubernetesServiceHost},
+			)
 			// Make sure that the partition takes effect.
 			Eventually(func() error {
 				_, _, err := factory.ExecuteCmdOnPod(
@@ -2457,7 +2758,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 				var runningProcesses int
 				for _, process := range status.Cluster.Processes {
-					if process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey] != string(selectedProcessGroupID) {
+					if process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey] != string(
+						selectedProcessGroupID,
+					) {
 						continue
 					}
 
@@ -2479,7 +2782,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			Expect(restarts).To(BeNumerically("==", initialRestarts))
 
 			// Restart all the processes, to ensure they are running with the expected parameters.
-			stdout, stderr, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry("kill; kill all; sleep 10", true, 60)
+			stdout, stderr, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(
+				"kill; kill all; sleep 10",
+				true,
+				60,
+			)
 			log.Println("stdout", stdout, "stderr", stderr, "err", err)
 
 			// Delete the partition, this allows the partitioned Pod to update its annotations again.
@@ -2542,7 +2849,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				}
 			}
 
-			Expect(fdbCluster.SetPodTemplateSpec(fdbv1beta2.ProcessClassStorage, spec, true)).NotTo(HaveOccurred())
+			Expect(
+				fdbCluster.SetPodTemplateSpec(fdbv1beta2.ProcessClassStorage, spec, true),
+			).NotTo(HaveOccurred())
 		})
 
 		It("should have enabled the node watch feature on all Pods", func() {
@@ -2596,7 +2905,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			isolatedPod = factory.RandomPickOnePod(fdbCluster.GetStatelessPods().Items)
 			isolatedPod.Annotations[fdbv1beta2.IsolateProcessGroupAnnotation] = "true"
-			Expect(factory.GetControllerRuntimeClient().Update(context.Background(), &isolatedPod)).NotTo(HaveOccurred())
+			Expect(
+				factory.GetControllerRuntimeClient().Update(context.Background(), &isolatedPod),
+			).NotTo(HaveOccurred())
 			fdbCluster.ReplacePod(isolatedPod, false)
 		})
 
@@ -2610,7 +2921,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 						continue
 					}
 
-					g.Expect(process.Locality).NotTo(HaveKeyWithValue(fdbv1beta2.FDBLocalityInstanceIDKey, processGroupID))
+					g.Expect(process.Locality).
+						NotTo(HaveKeyWithValue(fdbv1beta2.FDBLocalityInstanceIDKey, processGroupID))
 				}
 
 				return true
@@ -2626,9 +2938,14 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 		AfterEach(func() {
 			pod := &corev1.Pod{}
-			Expect(factory.GetControllerRuntimeClient().Get(context.Background(), ctrlClient.ObjectKey{Name: isolatedPod.Name, Namespace: isolatedPod.Namespace}, pod)).NotTo(HaveOccurred())
+			Expect(
+				factory.GetControllerRuntimeClient().
+					Get(context.Background(), ctrlClient.ObjectKey{Name: isolatedPod.Name, Namespace: isolatedPod.Namespace}, pod),
+			).NotTo(HaveOccurred())
 			pod.Annotations[fdbv1beta2.IsolateProcessGroupAnnotation] = "false"
-			Expect(factory.GetControllerRuntimeClient().Update(context.Background(), pod)).NotTo(HaveOccurred())
+			Expect(
+				factory.GetControllerRuntimeClient().Update(context.Background(), pod),
+			).NotTo(HaveOccurred())
 		})
 	})
 
@@ -2686,7 +3003,12 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		BeforeEach(func() {
 			pickedPod = factory.RandomPickOnePod(fdbCluster.GetStatelessPods().Items)
 			pickedProcessGroupID = fixtures.GetProcessGroupID(pickedPod)
-			log.Println("pickedProcessGroupID", pickedProcessGroupID, "pickedPod", pickedPod.Status.PodIP)
+			log.Println(
+				"pickedProcessGroupID",
+				pickedProcessGroupID,
+				"pickedPod",
+				pickedPod.Status.PodIP,
+			)
 
 			spec := fdbCluster.GetCluster().Spec.DeepCopy()
 			spec.AutomationOptions.RemovalMode = fdbv1beta2.PodUpdateModeNone
@@ -2694,31 +3016,41 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			fdbCluster.ReplacePod(pickedPod, false)
 			var pickedProcessGroup *fdbv1beta2.ProcessGroupStatus
-			Expect(fdbCluster.WaitUntilWithForceReconcile(1, 900, func(cluster *fdbv1beta2.FoundationDBCluster) bool {
-				for _, processGroup := range cluster.Status.ProcessGroups {
-					if processGroup.ProcessGroupID != pickedProcessGroupID {
-						continue
-					}
+			Expect(
+				fdbCluster.WaitUntilWithForceReconcile(
+					1,
+					900,
+					func(cluster *fdbv1beta2.FoundationDBCluster) bool {
+						for _, processGroup := range cluster.Status.ProcessGroups {
+							if processGroup.ProcessGroupID != pickedProcessGroupID {
+								continue
+							}
 
-					initialExclusionTimestamp = processGroup.ExclusionTimestamp
-					pickedProcessGroup = processGroup
-					break
-				}
+							initialExclusionTimestamp = processGroup.ExclusionTimestamp
+							pickedProcessGroup = processGroup
+							break
+						}
 
-				log.Println("initialExclusionTimestamp", initialExclusionTimestamp)
-				return initialExclusionTimestamp != nil
-			})).NotTo(HaveOccurred(), "process group is missing the exclusion timestamp")
+						log.Println("initialExclusionTimestamp", initialExclusionTimestamp)
+						return initialExclusionTimestamp != nil
+					},
+				),
+			).NotTo(HaveOccurred(), "process group is missing the exclusion timestamp")
 
 			var excludedServer fdbv1beta2.ExcludedServers
 			if fdbCluster.GetCluster().UseLocalitiesForExclusion() {
 				Expect(pickedProcessGroup).NotTo(BeNil())
-				excludedServer = fdbv1beta2.ExcludedServers{Locality: pickedProcessGroup.GetExclusionString()}
+				excludedServer = fdbv1beta2.ExcludedServers{
+					Locality: pickedProcessGroup.GetExclusionString(),
+				}
 			} else {
 				excludedServer = fdbv1beta2.ExcludedServers{Address: pickedPod.Status.PodIP}
 			}
 
 			// Ensure that the IP is excluded
-			Expect(fdbCluster.GetStatus().Cluster.DatabaseConfiguration.ExcludedServers).To(ContainElements(excludedServer))
+			Expect(
+				fdbCluster.GetStatus().Cluster.DatabaseConfiguration.ExcludedServers,
+			).To(ContainElements(excludedServer))
 		})
 
 		AfterEach(func() {
@@ -2736,19 +3068,26 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			It("should be excluded a second time", func() {
 				var newExclusionTimestamp *metav1.Time
 
-				Expect(fdbCluster.WaitUntilWithForceReconcile(1, 900, func(cluster *fdbv1beta2.FoundationDBCluster) bool {
-					for _, processGroup := range cluster.Status.ProcessGroups {
-						if processGroup.ProcessGroupID != pickedProcessGroupID {
-							continue
-						}
+				Expect(
+					fdbCluster.WaitUntilWithForceReconcile(
+						1,
+						900,
+						func(cluster *fdbv1beta2.FoundationDBCluster) bool {
+							for _, processGroup := range cluster.Status.ProcessGroups {
+								if processGroup.ProcessGroupID != pickedProcessGroupID {
+									continue
+								}
 
-						newExclusionTimestamp = processGroup.ExclusionTimestamp
-						log.Println("ProcessGroup:", processGroup.String())
-						break
-					}
+								newExclusionTimestamp = processGroup.ExclusionTimestamp
+								log.Println("ProcessGroup:", processGroup.String())
+								break
+							}
 
-					return newExclusionTimestamp != nil && !newExclusionTimestamp.Equal(initialExclusionTimestamp)
-				})).NotTo(HaveOccurred(), "process group is missing the exclusion timestamp")
+							return newExclusionTimestamp != nil &&
+								!newExclusionTimestamp.Equal(initialExclusionTimestamp)
+						},
+					),
+				).NotTo(HaveOccurred(), "process group is missing the exclusion timestamp")
 				Expect(initialExclusionTimestamp.Before(newExclusionTimestamp)).To(BeTrue())
 				Expect(initialExclusionTimestamp).NotTo(Equal(newExclusionTimestamp))
 			})
@@ -2775,7 +3114,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			spec := fdbCluster.GetCluster().Spec.DeepCopy()
 			spec.Routing.PodIPFamily = nil
 			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.WaitForReconciliation(fixtures.SoftReconcileOption(true))).To(Succeed())
+			Expect(
+				fdbCluster.WaitForReconciliation(fixtures.SoftReconcileOption(true)),
+			).To(Succeed())
 		})
 
 		It("should replace all pods and configure them properly", func() {
@@ -2789,12 +3130,21 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				}
 
 				if pod.Status.Phase != corev1.PodRunning {
-					log.Println("ignoring pod:", pod.Name, "with pod phase", pod.Status.Phase, "message:", pod.Status.Message)
+					log.Println(
+						"ignoring pod:",
+						pod.Name,
+						"with pod phase",
+						pod.Status.Phase,
+						"message:",
+						pod.Status.Message,
+					)
 					continue
 				}
 
 				newPods = append(newPods, pod.Name)
-				Expect(pod.Annotations).To(HaveKeyWithValue(fdbv1beta2.IPFamilyAnnotation, podIPFamilyString))
+				Expect(
+					pod.Annotations,
+				).To(HaveKeyWithValue(fdbv1beta2.IPFamilyAnnotation, podIPFamilyString))
 			}
 
 			Expect(newPods).NotTo(ContainElements(initialPods))

--- a/e2e/test_operator_ha_failure/operator_ha_failure_test.go
+++ b/e2e/test_operator_ha_failure/operator_ha_failure_test.go
@@ -49,7 +49,9 @@ func init() {
 
 var _ = BeforeSuite(func() {
 	factory = fixtures.CreateFactory(testOptions)
-	fdbCluster = factory.CreateFdbHaCluster(fixtures.DefaultClusterConfigWithHaMode(fixtures.HaFourZoneSingleSat, false), factory.GetClusterOptions()...)
+	fdbCluster = factory.CreateFdbHaCluster(
+		fixtures.DefaultClusterConfigWithHaMode(fixtures.HaFourZoneSingleSat, false),
+		factory.GetClusterOptions()...)
 
 	// In order to test the robustness of the operator we try to kill the operator Pods every minute.
 	if factory.ChaosTestsEnabled() {
@@ -187,9 +189,21 @@ var _ = Describe("Operator HA Failure tests", Label("e2e"), func() {
 		It("should fail-over and cause data loss", func() {
 			remote := fdbCluster.GetRemote()
 			// Pick one operator pod and execute the recovery command
-			operatorPod := factory.RandomPickOnePod(factory.GetOperatorPods(remote.Namespace()).Items)
+			operatorPod := factory.RandomPickOnePod(
+				factory.GetOperatorPods(remote.Namespace()).Items,
+			)
 			log.Println("operatorPod:", operatorPod.Name)
-			stdout, stderr, err := factory.ExecuteCmdOnPod(context.Background(), &operatorPod, "manager", fmt.Sprintf("kubectl-fdb -n %s recover-multi-region-cluster --version-check=false --wait=false %s", remote.Namespace(), remote.Name()), false)
+			stdout, stderr, err := factory.ExecuteCmdOnPod(
+				context.Background(),
+				&operatorPod,
+				"manager",
+				fmt.Sprintf(
+					"kubectl-fdb -n %s recover-multi-region-cluster --version-check=false --wait=false %s",
+					remote.Namespace(),
+					remote.Name(),
+				),
+				false,
+			)
 			log.Println("stdout:", stdout, "stderr:", stderr)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
+++ b/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
@@ -52,7 +52,11 @@ var _ = AfterSuite(func() {
 	}
 })
 
-func clusterSetupWithHealthCheckOption(beforeVersion string, enableOperatorPodChaos bool, enableHealthCheck bool) {
+func clusterSetupWithHealthCheckOption(
+	beforeVersion string,
+	enableOperatorPodChaos bool,
+	enableHealthCheck bool,
+) {
 	// We set the before version here to overwrite the before version from the specific flag
 	// the specific flag will be removed in the future.
 	factory.SetBeforeVersion(beforeVersion)

--- a/e2e/test_operator_maintenance_mode/operator_maintenance_mode_test.go
+++ b/e2e/test_operator_maintenance_mode/operator_maintenance_mode_test.go
@@ -100,7 +100,11 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 			}
 
 			// Set the maintenance mode for 4 minutes.
-			fdbCluster.RunFdbCliCommandInOperator(fmt.Sprintf("maintenance on %s 240", faultDomain), false, 60)
+			fdbCluster.RunFdbCliCommandInOperator(
+				fmt.Sprintf("maintenance on %s 240", faultDomain),
+				false,
+				60,
+			)
 
 			// Set this Pod as unschedulable to keep it pending.
 			fdbCluster.SetPodAsUnschedulable(failingStoragePod)
@@ -169,7 +173,11 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 			BeforeEach(func() {
 				// Set the maintenance mode for a long duration, e.g. 2h hours to make sure the mode is not timing out
 				// but actually is being reset.
-				fdbCluster.RunFdbCliCommandInOperator(fmt.Sprintf("maintenance on %s 7200", faultDomain), false, 60)
+				fdbCluster.RunFdbCliCommandInOperator(
+					fmt.Sprintf("maintenance on %s 7200", faultDomain),
+					false,
+					60,
+				)
 			})
 
 			AfterEach(func() {
@@ -205,7 +213,9 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 				fdbCluster.SetCrashLoopContainers([]fdbv1beta2.CrashLoopContainerObject{
 					{
 						ContainerName: fdbv1beta2.MainContainerName,
-						Targets:       []fdbv1beta2.ProcessGroupID{fixtures.GetProcessGroupID(podToRecreate)},
+						Targets: []fdbv1beta2.ProcessGroupID{
+							fixtures.GetProcessGroupID(podToRecreate),
+						},
 					},
 				}, false)
 				factory.DeletePod(&podToRecreate)
@@ -230,7 +240,11 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 			BeforeEach(func() {
 				// Set the maintenance mode for a long duration, e.g. 2h hours to make sure the mode is not timing out
 				// but actually is being reset.
-				fdbCluster.RunFdbCliCommandInOperator(fmt.Sprintf("maintenance on %s 7200", faultDomain), false, 60)
+				fdbCluster.RunFdbCliCommandInOperator(
+					fmt.Sprintf("maintenance on %s 7200", faultDomain),
+					false,
+					60,
+				)
 			})
 
 			AfterEach(func() {
@@ -273,7 +287,11 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 				initialStoragePods = counts.Storage
 				// Set the maintenance mode for a long duration, e.g. 2h hours to make sure the mode is not timing out
 				// but actually is being reset.
-				fdbCluster.RunFdbCliCommandInOperator(fmt.Sprintf("maintenance on %s 7200", faultDomain), false, 60)
+				fdbCluster.RunFdbCliCommandInOperator(
+					fmt.Sprintf("maintenance on %s 7200", faultDomain),
+					false,
+					60,
+				)
 			})
 
 			AfterEach(func() {

--- a/e2e/test_operator_migrations/operator_migration_test.go
+++ b/e2e/test_operator_migrations/operator_migration_test.go
@@ -134,7 +134,9 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 
 		BeforeEach(func() {
 			spec := fdbCluster.GetCluster().Spec.DeepCopy()
-			initialEngine := spec.DatabaseConfiguration.NormalizeConfiguration(fdbCluster.GetCluster()).StorageEngine
+			initialEngine := spec.DatabaseConfiguration.NormalizeConfiguration(
+				fdbCluster.GetCluster(),
+			).StorageEngine
 			log.Println("initialEngine", initialEngine)
 			if initialEngine == fdbv1beta2.StorageEngineSSD2 {
 				newStorageEngine = fdbv1beta2.StorageEngineRocksDbV1

--- a/e2e/test_operator_plugin/operator_plugin_test.go
+++ b/e2e/test_operator_plugin/operator_plugin_test.go
@@ -71,10 +71,21 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 		It("should print the version", func() {
 			// Pick one operator pod and execute the kubectl version command to ensure that kubectl-fdb is present
 			// and can be executed.
-			operatorPod := factory.RandomPickOnePod(factory.GetOperatorPods(fdbCluster.GetPrimary().Namespace()).Items)
+			operatorPod := factory.RandomPickOnePod(
+				factory.GetOperatorPods(fdbCluster.GetPrimary().Namespace()).Items,
+			)
 			log.Println("operatorPod:", operatorPod.Name)
 			Eventually(func(g Gomega) string {
-				stdout, stderr, err := factory.ExecuteCmdOnPod(context.Background(), &operatorPod, "manager", fmt.Sprintf("kubectl-fdb -n %s --version-check=false version", fdbCluster.GetPrimary().Namespace()), false)
+				stdout, stderr, err := factory.ExecuteCmdOnPod(
+					context.Background(),
+					&operatorPod,
+					"manager",
+					fmt.Sprintf(
+						"kubectl-fdb -n %s --version-check=false version",
+						fdbCluster.GetPrimary().Namespace(),
+					),
+					false,
+				)
 				g.Expect(err).NotTo(HaveOccurred(), stderr)
 				return stdout
 			}).WithTimeout(10 * time.Minute).WithPolling(2 * time.Second).Should(And(ContainSubstring("kubectl-fdb build information:"), ContainSubstring("foundationdb-operator:")))
@@ -115,17 +126,20 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 			var wg errgroup.Group
 			log.Println("Delete Pods in primary")
 			wg.Go(func() error {
-				return factory.GetControllerRuntimeClient().DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.MatchingLabels(primary.GetResourceLabels()), ctrlClient.InNamespace(primary.Namespace()))
+				return factory.GetControllerRuntimeClient().
+					DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.MatchingLabels(primary.GetResourceLabels()), ctrlClient.InNamespace(primary.Namespace()))
 			})
 
 			log.Println("Delete Pods in primary satellite")
 			wg.Go(func() error {
-				return factory.GetControllerRuntimeClient().DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.MatchingLabels(primarySatellite.GetResourceLabels()), ctrlClient.InNamespace(primarySatellite.Namespace()))
+				return factory.GetControllerRuntimeClient().
+					DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.MatchingLabels(primarySatellite.GetResourceLabels()), ctrlClient.InNamespace(primarySatellite.Namespace()))
 			})
 
 			log.Println("Delete Pods in remote satellite")
 			wg.Go(func() error {
-				return factory.GetControllerRuntimeClient().DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.MatchingLabels(remoteSatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))
+				return factory.GetControllerRuntimeClient().
+					DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.MatchingLabels(remoteSatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))
 			})
 
 			Expect(wg.Wait()).NotTo(HaveOccurred())
@@ -135,21 +149,24 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 			// Ensure that all the pods are deleted.
 			Eventually(func(g Gomega) []corev1.Pod {
 				pods := &corev1.PodList{}
-				g.Expect(factory.GetControllerRuntimeClient().List(context.Background(), pods, ctrlClient.MatchingLabels(primary.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).To(Succeed())
+				g.Expect(factory.GetControllerRuntimeClient().List(context.Background(), pods, ctrlClient.MatchingLabels(primary.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).
+					To(Succeed())
 
 				return pods.Items
 			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeEmpty())
 
 			Eventually(func(g Gomega) []corev1.Pod {
 				pods := &corev1.PodList{}
-				g.Expect(factory.GetControllerRuntimeClient().List(context.Background(), pods, ctrlClient.MatchingLabels(primarySatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).To(Succeed())
+				g.Expect(factory.GetControllerRuntimeClient().List(context.Background(), pods, ctrlClient.MatchingLabels(primarySatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).
+					To(Succeed())
 
 				return pods.Items
 			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeEmpty())
 
 			Eventually(func(g Gomega) []corev1.Pod {
 				pods := &corev1.PodList{}
-				g.Expect(factory.GetControllerRuntimeClient().List(context.Background(), pods, ctrlClient.MatchingLabels(remoteSatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).To(Succeed())
+				g.Expect(factory.GetControllerRuntimeClient().List(context.Background(), pods, ctrlClient.MatchingLabels(remoteSatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).
+					To(Succeed())
 
 				return pods.Items
 			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeEmpty())
@@ -167,9 +184,21 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 			It("should recover the coordinators", func() {
 				remote := fdbCluster.GetRemote()
 				// Pick one operator pod and execute the recovery command
-				operatorPod := factory.RandomPickOnePod(factory.GetOperatorPods(remote.Namespace()).Items)
+				operatorPod := factory.RandomPickOnePod(
+					factory.GetOperatorPods(remote.Namespace()).Items,
+				)
 				log.Println("operatorPod:", operatorPod.Name)
-				stdout, stderr, err := factory.ExecuteCmdOnPod(context.Background(), &operatorPod, "manager", fmt.Sprintf("kubectl-fdb -n %s recover-multi-region-cluster --version-check=false --wait=false %s", remote.Namespace(), remote.Name()), false)
+				stdout, stderr, err := factory.ExecuteCmdOnPod(
+					context.Background(),
+					&operatorPod,
+					"manager",
+					fmt.Sprintf(
+						"kubectl-fdb -n %s recover-multi-region-cluster --version-check=false --wait=false %s",
+						remote.Namespace(),
+						remote.Name(),
+					),
+					false,
+				)
 				log.Println("stdout:", stdout, "stderr:", stderr)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -185,7 +214,9 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 				Expect(remote.WaitForReconciliation()).To(Succeed())
 
 				log.Println("new connection string:", remote.GetCluster().Status.ConnectionString)
-				connectionString, err := fdbv1beta2.ParseConnectionString(remote.GetCluster().Status.ConnectionString)
+				connectionString, err := fdbv1beta2.ParseConnectionString(
+					remote.GetCluster().Status.ConnectionString,
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, coordinator := range connectionString.Coordinators {
@@ -204,9 +235,21 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 			It("should recover the coordinators", func() {
 				remote := fdbCluster.GetRemote()
 				// Pick one operator pod and execute the recovery command
-				operatorPod := factory.RandomPickOnePod(factory.GetOperatorPods(remote.Namespace()).Items)
+				operatorPod := factory.RandomPickOnePod(
+					factory.GetOperatorPods(remote.Namespace()).Items,
+				)
 				log.Println("operatorPod:", operatorPod.Name)
-				stdout, stderr, err := factory.ExecuteCmdOnPod(context.Background(), &operatorPod, "manager", fmt.Sprintf("kubectl-fdb -n %s recover-multi-region-cluster --version-check=false --wait=false %s", remote.Namespace(), remote.Name()), false)
+				stdout, stderr, err := factory.ExecuteCmdOnPod(
+					context.Background(),
+					&operatorPod,
+					"manager",
+					fmt.Sprintf(
+						"kubectl-fdb -n %s recover-multi-region-cluster --version-check=false --wait=false %s",
+						remote.Namespace(),
+						remote.Name(),
+					),
+					false,
+				)
 				log.Println("stdout:", stdout, "stderr:", stderr)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
+++ b/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
@@ -111,7 +111,9 @@ var _ = Describe("Operator with three data hall", Label("e2e"), func() {
 
 	It("should bring up the cluster with three data hall redundancy", func() {
 		status := fdbCluster.GetStatus()
-		Expect(status.Cluster.DatabaseConfiguration.RedundancyMode).To(Equal(fdbv1beta2.RedundancyModeThreeDataHall))
+		Expect(
+			status.Cluster.DatabaseConfiguration.RedundancyMode,
+		).To(Equal(fdbv1beta2.RedundancyModeThreeDataHall))
 		for _, process := range status.Cluster.Processes {
 			Expect(process.Locality).To(HaveKey(fdbv1beta2.FDBLocalityDataHallKey))
 		}
@@ -154,12 +156,18 @@ var _ = Describe("Operator with three data hall", Label("e2e"), func() {
 			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
 			// Make sure we reset the previous behaviour.
 			spec := fdbCluster.GetCluster().Spec.DeepCopy()
-			spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(useLocalitiesForExclusion)
+			spec.AutomationOptions.UseLocalitiesForExclusion = pointer.Bool(
+				useLocalitiesForExclusion,
+			)
 			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.GetCluster().UseLocalitiesForExclusion()).To(Equal(useLocalitiesForExclusion))
+			Expect(
+				fdbCluster.GetCluster().UseLocalitiesForExclusion(),
+			).To(Equal(useLocalitiesForExclusion))
 
 			// Making sure we included back all the process groups after exclusion is complete.
-			Expect(fdbCluster.GetStatus().Cluster.DatabaseConfiguration.ExcludedServers).To(BeEmpty())
+			Expect(
+				fdbCluster.GetStatus().Cluster.DatabaseConfiguration.ExcludedServers,
+			).To(BeEmpty())
 
 			if factory.ChaosTestsEnabled() {
 				scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(
@@ -192,7 +200,9 @@ var _ = Describe("Operator with three data hall", Label("e2e"), func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				if !fdbVersion.SupportsLocalityBasedExclusions() {
-					Skip("provided FDB version: " + cluster.GetRunningVersion() + " doesn't support locality based exclusions")
+					Skip(
+						"provided FDB version: " + cluster.GetRunningVersion() + " doesn't support locality based exclusions",
+					)
 				}
 
 				spec := cluster.Spec.DeepCopy()
@@ -202,7 +212,12 @@ var _ = Describe("Operator with three data hall", Label("e2e"), func() {
 			})
 
 			It("should remove the targeted Pod", func() {
-				Expect(pointer.BoolDeref(fdbCluster.GetCluster().Spec.AutomationOptions.UseLocalitiesForExclusion, false)).To(BeTrue())
+				Expect(
+					pointer.BoolDeref(
+						fdbCluster.GetCluster().Spec.AutomationOptions.UseLocalitiesForExclusion,
+						false,
+					),
+				).To(BeTrue())
 				fdbCluster.EnsurePodIsDeleted(replacedPod.Name)
 			})
 		})

--- a/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
@@ -266,7 +266,11 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			// will update the sidecar and then the I/O chaos will be gone. So we prepare the faulty Pod to already
 			// be using the new sidecar image and then we inject IO chaos.
 			sidecarImage := fdbCluster.GetSidecarImageForVersion(targetVersion)
-			fdbCluster.UpdateContainerImage(&faultyPod, fdbv1beta2.SidecarContainerName, sidecarImage)
+			fdbCluster.UpdateContainerImage(
+				&faultyPod,
+				fdbv1beta2.SidecarContainerName,
+				sidecarImage,
+			)
 
 			Eventually(func() bool {
 				pod := fdbCluster.GetPod(faultyPod.Name)
@@ -306,7 +310,8 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 					faultyPod,
 					fdbv1beta2.SidecarContainerName,
 					"cat /var/output-files/fdbmonitor.conf && echo '\n' >> /var/output-files/fdbmonitor.conf",
-					false)
+					false,
+				)
 
 				log.Println(stdout, stderr)
 
@@ -333,7 +338,10 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 					}
 
 					for _, condition := range processGroup.ProcessGroupConditions {
-						log.Println(processGroup.ProcessGroupID, string(condition.ProcessGroupConditionType))
+						log.Println(
+							processGroup.ProcessGroupID,
+							string(condition.ProcessGroupConditionType),
+						)
 					}
 
 					if !processGroup.MatchesConditions(expectedConditions) {
@@ -354,7 +362,9 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			// Ensure the upgrade proceeds and is able to finish.
 			fdbCluster.VerifyVersion(targetVersion)
 		},
-		EntryDescription("Upgrade from %[1]s to %[2]s and one process has the fdbmonitor.conf file not ready"),
+		EntryDescription(
+			"Upgrade from %[1]s to %[2]s and one process has the fdbmonitor.conf file not ready",
+		),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
 
@@ -380,7 +390,11 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			// will update the sidecar and then the sidecar will copy the binaries at start-up. So we prepare the faulty Pod to already
 			// be using the new sidecar image and then we delete he new fdbserver binary.
 			sidecarImage := fdbCluster.GetSidecarImageForVersion(targetVersion)
-			fdbCluster.UpdateContainerImage(&faultyPod, fdbv1beta2.SidecarContainerName, sidecarImage)
+			fdbCluster.UpdateContainerImage(
+				&faultyPod,
+				fdbv1beta2.SidecarContainerName,
+				sidecarImage,
+			)
 
 			Eventually(func() bool {
 				pod := fdbCluster.GetPod(faultyPod.Name)
@@ -448,7 +462,10 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 					}
 
 					for _, condition := range processGroup.ProcessGroupConditions {
-						log.Println(processGroup.ProcessGroupID, string(condition.ProcessGroupConditionType))
+						log.Println(
+							processGroup.ProcessGroupID,
+							string(condition.ProcessGroupConditionType),
+						)
 					}
 
 					if !processGroup.MatchesConditions(expectedConditions) {

--- a/e2e/test_operator_velocity/operator_velocity_test.go
+++ b/e2e/test_operator_velocity/operator_velocity_test.go
@@ -107,7 +107,16 @@ func CheckKnobRollout(
 	rolloutDuration := time.Since(startTime)
 	finalGeneration := primary.GetStatus().Cluster.Generation
 
-	log.Println("Knob rollout took", rolloutDuration.String(), "initialGeneration", initialGeneration, "finalGeneration", finalGeneration, "recoveryCount", (finalGeneration-initialGeneration)/2)
+	log.Println(
+		"Knob rollout took",
+		rolloutDuration.String(),
+		"initialGeneration",
+		initialGeneration,
+		"finalGeneration",
+		finalGeneration,
+		"recoveryCount",
+		(finalGeneration-initialGeneration)/2,
+	)
 	// If the synchronization mode is global, we expect to see only a single recovery. Since those tests are running on
 	// a real cluster we add some additional buffer of one additional recovery. We check for an increase of 4 generation
 	// because FDB increase the current generation by 2 if a recovery is triggered.
@@ -314,9 +323,12 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 				fdbCluster,
 				newGeneralCustomParameters,
 				newStorageCustomParameters,
-				normalKnobRolloutTimeoutSeconds+int(fdbCluster.GetPrimary().GetCluster().GetLockDuration().Seconds()),
+				normalKnobRolloutTimeoutSeconds+int(
+					fdbCluster.GetPrimary().GetCluster().GetLockDuration().Seconds(),
+				),
 				totalGeneralProcessCount,
-				totalStorageProcessCount-(1*fdbCluster.GetPrimary().GetStorageServerPerPod()))
+				totalStorageProcessCount-(1*fdbCluster.GetPrimary().GetStorageServerPerPod()),
+			)
 		})
 	})
 
@@ -343,9 +355,12 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 				fdbCluster,
 				newGeneralCustomParameters,
 				newStorageCustomParameters,
-				normalKnobRolloutTimeoutSeconds+int(fdbCluster.GetPrimary().GetCluster().GetLockDuration().Seconds()),
+				normalKnobRolloutTimeoutSeconds+int(
+					fdbCluster.GetPrimary().GetCluster().GetLockDuration().Seconds(),
+				),
 				totalGeneralProcessCount,
-				totalStorageProcessCount)
+				totalStorageProcessCount,
+			)
 		})
 	})
 })

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -44,16 +44,20 @@ var _ = Describe("admin_client_test", func() {
 	When("parsing the connection string", func() {
 		DescribeTable("it should return the correct connection string",
 			func(input string, expected string) {
-				connectingString, err := fdbv1beta2.ParseConnectionString(cleanConnectionStringOutput(input))
+				connectingString, err := fdbv1beta2.ParseConnectionString(
+					cleanConnectionStringOutput(input),
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(connectingString.String()).To(Equal(expected))
 			},
-			Entry("with a correct response from FDB",
+			Entry(
+				"with a correct response from FDB",
 				">>> option on ACCESS_SYSTEM_KEYS\\nOption enabled for all transactions\\n>>> get \\\\xff/coordinators\\n`\\\\xff/coordinators' is `fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@100.82.81.253:4500:tls,100.82.71.5:4500:tls,100.82.119.151:4500:tls,100.82.122.125:4500:tls,100.82.76.240:4500:tls'\\n",
 				"fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@100.82.81.253:4500:tls,100.82.71.5:4500:tls,100.82.119.151:4500:tls,100.82.122.125:4500:tls,100.82.76.240:4500:tls",
 			),
 
-			Entry("without the byte string response",
+			Entry(
+				"without the byte string response",
 				"fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@100.82.81.253:4500:tls,100.82.71.5:4500:tls,100.82.119.151:4500:tls,100.82.122.125:4500:tls,100.82.76.240:4500:tls",
 				"fdb_cluster_52v1bpr8:rhUbBjrtyweZBQO1U3Td81zyP9d46yEh@100.82.81.253:4500:tls,100.82.71.5:4500:tls,100.82.119.151:4500:tls,100.82.122.125:4500:tls,100.82.76.240:4500:tls",
 			),
@@ -195,19 +199,21 @@ var _ = Describe("admin_client_test", func() {
 		)
 	})
 
-	DescribeTable("getting the args for the command", func(command cliCommand, client *cliAdminClient, traceOption string, traceFormat string, expectedArgs []string, expectedTimeout time.Duration) {
-		Expect(client).NotTo(BeNil())
-		if traceOption != "" {
-			GinkgoT().Setenv(fdbv1beta2.EnvNameFDBTraceLogDirPath, traceOption)
-		}
-		if traceFormat != "" {
-			GinkgoT().Setenv("FDB_NETWORK_OPTION_TRACE_FORMAT", traceFormat)
-		}
+	DescribeTable(
+		"getting the args for the command",
+		func(command cliCommand, client *cliAdminClient, traceOption string, traceFormat string, expectedArgs []string, expectedTimeout time.Duration) {
+			Expect(client).NotTo(BeNil())
+			if traceOption != "" {
+				GinkgoT().Setenv(fdbv1beta2.EnvNameFDBTraceLogDirPath, traceOption)
+			}
+			if traceFormat != "" {
+				GinkgoT().Setenv("FDB_NETWORK_OPTION_TRACE_FORMAT", traceFormat)
+			}
 
-		args, timeout := client.getArgsAndTimeout(command, "test")
-		Expect(timeout).To(Equal(expectedTimeout))
-		Expect(args).To(HaveExactElements(expectedArgs))
-	},
+			args, timeout := client.getArgsAndTimeout(command, "test")
+			Expect(timeout).To(Equal(expectedTimeout))
+			Expect(args).To(HaveExactElements(expectedArgs))
+		},
 		Entry("using fdbcli and trace options are disabled",
 			cliCommand{
 				args:    []string{"--version"},
@@ -883,24 +889,27 @@ protocol fdb00b071010000`,
 			quorumNotReachableStatus = string(quorumNotReachableStatusOut)
 		})
 
-		When("the fdbcli call for the previous version returns that the quorum is reachable", func() {
-			BeforeEach(func() {
-				mockRunner = &mockCommandRunner{
-					mockedError: nil,
-					mockedOutputPerBinary: map[string]string{
-						previousBinary: quorumReachableStatus,
-						newBinary:      quorumNotReachableStatus,
-					},
-				}
-			})
+		When(
+			"the fdbcli call for the previous version returns that the quorum is reachable",
+			func() {
+				BeforeEach(func() {
+					mockRunner = &mockCommandRunner{
+						mockedError: nil,
+						mockedOutputPerBinary: map[string]string{
+							previousBinary: quorumReachableStatus,
+							newBinary:      quorumNotReachableStatus,
+						},
+					}
+				})
 
-			It("should report the previous version", func() {
-				Expect(version).To(Equal(previousVersion))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(mockRunner.receivedBinary).To(HaveLen(1))
-				Expect(mockRunner.receivedBinary[0]).To(HaveSuffix("7.1/" + fdbcliStr))
-			})
-		})
+				It("should report the previous version", func() {
+					Expect(version).To(Equal(previousVersion))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(mockRunner.receivedBinary).To(HaveLen(1))
+					Expect(mockRunner.receivedBinary[0]).To(HaveSuffix("7.1/" + fdbcliStr))
+				})
+			},
+		)
 
 		When("the fdbcli call for the new version returns that the quorum is reachable", func() {
 			BeforeEach(func() {
@@ -950,15 +959,20 @@ protocol fdb00b071010000`,
 		}}
 
 		When("the cluster is upgraded ", func() {
-			Expect(getKillCommand(addresses, true)).To(Equal("kill; kill 192.168.0.2:4500; sleep 1; kill 192.168.0.2:4500; sleep 5"))
+			Expect(
+				getKillCommand(addresses, true),
+			).To(Equal("kill; kill 192.168.0.2:4500; sleep 1; kill 192.168.0.2:4500; sleep 5"))
 		})
 
 		When("the cluster is not upgraded", func() {
-			Expect(getKillCommand(addresses, false)).To(Equal("kill; kill 192.168.0.2:4500; sleep 5"))
+			Expect(
+				getKillCommand(addresses, false),
+			).To(Equal("kill; kill 192.168.0.2:4500; sleep 5"))
 		})
 	})
 
-	DescribeTable("starting backup with different versions",
+	DescribeTable(
+		"starting backup with different versions",
 		func(version string, encryptionKeyPath string, shouldHaveEncryptionFlag bool) {
 			mockRunner := &mockCommandRunner{
 				mockedError:  nil,
@@ -993,17 +1007,25 @@ protocol fdb00b071010000`,
 			))
 
 			if shouldHaveEncryptionFlag {
-				Expect(mockRunner.receivedArgs[0]).To(ContainElements("--encryption-key-file", encryptionKeyPath))
+				Expect(
+					mockRunner.receivedArgs[0],
+				).To(ContainElements("--encryption-key-file", encryptionKeyPath))
 			} else {
 				Expect(mockRunner.receivedArgs[0]).ToNot(ContainElement("--encryption-key-file"))
 			}
 		},
-		Entry("version that doesn't support backup encryption with key", "7.1.25", "/path/to/key", false),
+		Entry(
+			"version that doesn't support backup encryption with key",
+			"7.1.25",
+			"/path/to/key",
+			false,
+		),
 		Entry("version that supports backup encryption without key", "7.3.1", "", false),
 		Entry("version that supports backup encryption with key", "7.3.1", "/path/to/key", true),
 	)
 
-	DescribeTable("starting restore with different versions",
+	DescribeTable(
+		"starting restore with different versions",
 		func(version string, encryptionKeyPath string, keyRanges []fdbv1beta2.FoundationDBKeyRange, shouldHaveEncryptionFlag bool, shouldHaveKeyRanges bool) {
 			mockRunner := &mockCommandRunner{
 				mockedError:  nil,
@@ -1034,7 +1056,9 @@ protocol fdb00b071010000`,
 			))
 
 			if shouldHaveEncryptionFlag {
-				Expect(mockRunner.receivedArgs[0]).To(ContainElements("--encryption-key-file", encryptionKeyPath))
+				Expect(
+					mockRunner.receivedArgs[0],
+				).To(ContainElements("--encryption-key-file", encryptionKeyPath))
 			} else {
 				Expect(mockRunner.receivedArgs[0]).ToNot(ContainElement("--encryption-key-file"))
 			}
@@ -1046,9 +1070,37 @@ protocol fdb00b071010000`,
 				Expect(mockRunner.receivedArgs[0]).ToNot(ContainElement("-k"))
 			}
 		},
-		Entry("test key ranges", "7.1.25", "", []fdbv1beta2.FoundationDBKeyRange{{Start: "\\x00", End: "\\xFF"}}, false, true),
-		Entry("version that doesn't support backup encryption with encryption key", "7.1.25", "/path/to/key", nil, false, false),
-		Entry("version that supports backup encryption without key", "7.3.1", "", nil, false, false),
-		Entry("version that supports backup encryption with key", "7.3.1", "/path/to/key", nil, true, false),
+		Entry(
+			"test key ranges",
+			"7.1.25",
+			"",
+			[]fdbv1beta2.FoundationDBKeyRange{{Start: "\\x00", End: "\\xFF"}},
+			false,
+			true,
+		),
+		Entry(
+			"version that doesn't support backup encryption with encryption key",
+			"7.1.25",
+			"/path/to/key",
+			nil,
+			false,
+			false,
+		),
+		Entry(
+			"version that supports backup encryption without key",
+			"7.3.1",
+			"",
+			nil,
+			false,
+			false,
+		),
+		Entry(
+			"version that supports backup encryption with key",
+			"7.3.1",
+			"/path/to/key",
+			nil,
+			true,
+			false,
+		),
 	)
 })

--- a/fdbclient/command_runner.go
+++ b/fdbclient/command_runner.go
@@ -66,7 +66,11 @@ func getEnvironmentVariablesWithoutExcludedFdbEnv() []string {
 	return cmdEnvironmentVariables
 }
 
-func (runner *realCommandRunner) runCommand(ctx context.Context, name string, arg ...string) ([]byte, error) {
+func (runner *realCommandRunner) runCommand(
+	ctx context.Context,
+	name string,
+	arg ...string,
+) ([]byte, error) {
 	execCommand := exec.CommandContext(ctx, name, arg...)
 	execCommand.Env = getEnvironmentVariablesWithoutExcludedFdbEnv()
 	runner.log.Info("Running command", "path", execCommand.Path, "args", execCommand.Args)
@@ -90,7 +94,11 @@ type mockCommandRunner struct {
 	callIdx int
 }
 
-func (runner *mockCommandRunner) runCommand(_ context.Context, name string, arg ...string) ([]byte, error) {
+func (runner *mockCommandRunner) runCommand(
+	_ context.Context,
+	name string,
+	arg ...string,
+) ([]byte, error) {
 	defer func() {
 		runner.callIdx++
 	}()

--- a/fdbclient/command_runner_test.go
+++ b/fdbclient/command_runner_test.go
@@ -67,8 +67,12 @@ var _ = Describe("command_runner", func() {
 
 		It("should exclude the listed FDB variables but include all others", func() {
 			Expect(envVariablesKeys).NotTo(ContainElement(fdbv1beta2.EnvNameFDBExternalClientDir))
-			Expect(envVariablesKeys).NotTo(ContainElement(fdbv1beta2.EnvNameFDBIgnoreExternalClientFailures))
-			Expect(envVariablesKeys).NotTo(ContainElement(fdbv1beta2.EnvNameClientThreadsPerVersion))
+			Expect(
+				envVariablesKeys,
+			).NotTo(ContainElement(fdbv1beta2.EnvNameFDBIgnoreExternalClientFailures))
+			Expect(
+				envVariablesKeys,
+			).NotTo(ContainElement(fdbv1beta2.EnvNameClientThreadsPerVersion))
 			Expect(envVariablesKeys).To(ContainElement(fdbv1beta2.EnvNameTLSCert))
 		})
 	})

--- a/fdbclient/common_test.go
+++ b/fdbclient/common_test.go
@@ -72,7 +72,11 @@ var _ = Describe("common_test", func() {
 
 		When("the cluster file exist with the correct content", func() {
 			BeforeEach(func() {
-				err := os.WriteFile(path.Join(GinkgoT().TempDir(), uid), []byte(connectionString), 0777)
+				err := os.WriteFile(
+					path.Join(GinkgoT().TempDir(), uid),
+					[]byte(connectionString),
+					0777,
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/internal/buggify/buggify.go
+++ b/internal/buggify/buggify.go
@@ -24,12 +24,18 @@ import fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta
 
 // FilterBlockedRemovals will remove all matching process groups from the processGroupsToRemove slice that are defined in
 // the BlockRemoval.
-func FilterBlockedRemovals(cluster *fdbv1beta2.FoundationDBCluster, processGroupsToRemove []*fdbv1beta2.ProcessGroupStatus) []*fdbv1beta2.ProcessGroupStatus {
+func FilterBlockedRemovals(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	processGroupsToRemove []*fdbv1beta2.ProcessGroupStatus,
+) []*fdbv1beta2.ProcessGroupStatus {
 	if len(cluster.Spec.Buggify.BlockRemoval) == 0 {
 		return processGroupsToRemove
 	}
 
-	blockedProcessGroups := make(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None, len(cluster.Spec.Buggify.BlockRemoval))
+	blockedProcessGroups := make(
+		map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None,
+		len(cluster.Spec.Buggify.BlockRemoval),
+	)
 	for _, blockedProcessGroup := range cluster.Spec.Buggify.BlockRemoval {
 		blockedProcessGroups[blockedProcessGroup] = fdbv1beta2.None{}
 	}
@@ -48,13 +54,23 @@ func FilterBlockedRemovals(cluster *fdbv1beta2.FoundationDBCluster, processGroup
 
 // FilterIgnoredProcessGroups removes all addresses from the addresses slice that are associated with a process group that should be ignored
 // during a restart.
-func FilterIgnoredProcessGroups(cluster *fdbv1beta2.FoundationDBCluster, addresses []fdbv1beta2.ProcessAddress, status *fdbv1beta2.FoundationDBStatus) ([]fdbv1beta2.ProcessAddress, bool) {
+func FilterIgnoredProcessGroups(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	addresses []fdbv1beta2.ProcessAddress,
+	status *fdbv1beta2.FoundationDBStatus,
+) ([]fdbv1beta2.ProcessAddress, bool) {
 	if len(cluster.Spec.Buggify.IgnoreDuringRestart) == 0 {
 		return addresses, false
 	}
 
-	ignoredIDs := make(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None, len(cluster.Spec.Buggify.IgnoreDuringRestart))
-	ignoredAddresses := make(map[string]fdbv1beta2.None, len(cluster.Spec.Buggify.IgnoreDuringRestart))
+	ignoredIDs := make(
+		map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None,
+		len(cluster.Spec.Buggify.IgnoreDuringRestart),
+	)
+	ignoredAddresses := make(
+		map[string]fdbv1beta2.None,
+		len(cluster.Spec.Buggify.IgnoreDuringRestart),
+	)
 
 	for _, id := range cluster.Spec.Buggify.IgnoreDuringRestart {
 		ignoredIDs[id] = fdbv1beta2.None{}

--- a/internal/buggify/buggify_test.go
+++ b/internal/buggify/buggify_test.go
@@ -27,9 +27,13 @@ import (
 )
 
 var _ = Describe("Buggify", func() {
-	DescribeTable("filtering blocked removals", func(cluster *fdbv1beta2.FoundationDBCluster, initialProcessGroupsToRemove []*fdbv1beta2.ProcessGroupStatus, expected []*fdbv1beta2.ProcessGroupStatus) {
-		Expect(FilterBlockedRemovals(cluster, initialProcessGroupsToRemove)).To(ConsistOf(expected))
-	},
+	DescribeTable(
+		"filtering blocked removals",
+		func(cluster *fdbv1beta2.FoundationDBCluster, initialProcessGroupsToRemove []*fdbv1beta2.ProcessGroupStatus, expected []*fdbv1beta2.ProcessGroupStatus) {
+			Expect(
+				FilterBlockedRemovals(cluster, initialProcessGroupsToRemove),
+			).To(ConsistOf(expected))
+		},
 		Entry("No process group is defined to be filtered",
 			&fdbv1beta2.FoundationDBCluster{},
 			nil,
@@ -126,7 +130,8 @@ var _ = Describe("Buggify", func() {
 				},
 			},
 		),
-		Entry("One matching process group and one non-matching process group is defined to be filtered",
+		Entry(
+			"One matching process group and one non-matching process group is defined to be filtered",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
 					Buggify: fdbv1beta2.BuggifyConfig{

--- a/internal/configmap_helper.go
+++ b/internal/configmap_helper.go
@@ -69,7 +69,12 @@ func GetConfigMap(cluster *fdbv1beta2.FoundationDBCluster) (*corev1.ConfigMap, e
 		if _, useUnifiedImage := imageTypes[fdbv1beta2.ImageTypeUnified]; useUnifiedImage {
 			// The serversPerPod argument will be ignored in the config of the unified image as the values are directly
 			// interpolated in the fdb-kubernetes-monitor, based on the "--process-count" command line flag.
-			filename, jsonData, err := getDataForMonitorConf(cluster, fdbv1beta2.ImageTypeUnified, processClass, 0)
+			filename, jsonData, err := getDataForMonitorConf(
+				cluster,
+				fdbv1beta2.ImageTypeUnified,
+				processClass,
+				0,
+			)
 			if err != nil {
 				return nil, err
 			}
@@ -99,7 +104,18 @@ func GetConfigMap(cluster *fdbv1beta2.FoundationDBCluster) (*corev1.ConfigMap, e
 			}
 
 			for _, serversPerPod := range serversPerPodSlice {
-				err := setMonitorConfForFilename(cluster, data, GetConfigMapMonitorConfEntry(processClass, fdbv1beta2.ImageTypeSplit, serversPerPod), connectionString, processClass, serversPerPod)
+				err := setMonitorConfForFilename(
+					cluster,
+					data,
+					GetConfigMapMonitorConfEntry(
+						processClass,
+						fdbv1beta2.ImageTypeSplit,
+						serversPerPod,
+					),
+					connectionString,
+					processClass,
+					serversPerPod,
+				)
 				if err != nil {
 					return nil, err
 				}
@@ -139,7 +155,12 @@ func getConfigMapName(clusterName string) string {
 	return fmt.Sprintf("%s-config", clusterName)
 }
 
-func getDataForMonitorConf(cluster *fdbv1beta2.FoundationDBCluster, imageType fdbv1beta2.ImageType, pClass fdbv1beta2.ProcessClass, serversPerPod int) (string, []byte, error) {
+func getDataForMonitorConf(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	imageType fdbv1beta2.ImageType,
+	pClass fdbv1beta2.ProcessClass,
+	serversPerPod int,
+) (string, []byte, error) {
 	config := GetMonitorProcessConfiguration(cluster, pClass, serversPerPod, imageType)
 	jsonData, err := json.Marshal(config)
 	if err != nil {
@@ -149,7 +170,14 @@ func getDataForMonitorConf(cluster *fdbv1beta2.FoundationDBCluster, imageType fd
 	return filename, jsonData, nil
 }
 
-func setMonitorConfForFilename(cluster *fdbv1beta2.FoundationDBCluster, data map[string]string, filename string, connectionString string, processClass fdbv1beta2.ProcessClass, serversPerPod int) error {
+func setMonitorConfForFilename(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	data map[string]string,
+	filename string,
+	connectionString string,
+	processClass fdbv1beta2.ProcessClass,
+	serversPerPod int,
+) error {
 	if connectionString == "" {
 		data[filename] = ""
 	} else {
@@ -164,7 +192,11 @@ func setMonitorConfForFilename(cluster *fdbv1beta2.FoundationDBCluster, data map
 }
 
 // GetConfigMapMonitorConfEntry returns the specific key for the monitor conf in the ConfigMap
-func GetConfigMapMonitorConfEntry(pClass fdbv1beta2.ProcessClass, imageType fdbv1beta2.ImageType, serversPerPod int) string {
+func GetConfigMapMonitorConfEntry(
+	pClass fdbv1beta2.ProcessClass,
+	imageType fdbv1beta2.ImageType,
+	serversPerPod int,
+) string {
 	if imageType == fdbv1beta2.ImageTypeUnified {
 		return fmt.Sprintf("fdbmonitor-conf-%s-json", pClass)
 	}
@@ -178,7 +210,12 @@ func GetConfigMapMonitorConfEntry(pClass fdbv1beta2.ProcessClass, imageType fdbv
 // cluster's dynamic conf.
 //
 // This will omit keys that we do not expect the Pods to reference e.g. for storage Pods only include the storage config.
-func GetDynamicConfHash(configMap *corev1.ConfigMap, pClass fdbv1beta2.ProcessClass, imageType fdbv1beta2.ImageType, serversPerPod int) (string, error) {
+func GetDynamicConfHash(
+	configMap *corev1.ConfigMap,
+	pClass fdbv1beta2.ProcessClass,
+	imageType fdbv1beta2.ImageType,
+	serversPerPod int,
+) (string, error) {
 	fields := []string{
 		fdbv1beta2.ClusterFileKey,
 		GetConfigMapMonitorConfEntry(pClass, imageType, serversPerPod),

--- a/internal/configmap_helper_test.go
+++ b/internal/configmap_helper_test.go
@@ -75,9 +75,13 @@ var _ = Describe("configmap_helper", func() {
 				expectedConf, err := GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 1)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(configMap.Data[fdbv1beta2.ClusterFileKey]).To(Equal("operator-test:asdfasf@127.0.0.1:4501"))
+				Expect(
+					configMap.Data[fdbv1beta2.ClusterFileKey],
+				).To(Equal("operator-test:asdfasf@127.0.0.1:4501"))
 				Expect(configMap.Data["fdbmonitor-conf-storage"]).To(Equal(expectedConf))
-				Expect(configMap.Data[fdbv1beta2.RunningVersionKey]).To(Equal(fdbv1beta2.Versions.Default.String()))
+				Expect(
+					configMap.Data[fdbv1beta2.RunningVersionKey],
+				).To(Equal(fdbv1beta2.Versions.Default.String()))
 				Expect(configMap.Data[fdbv1beta2.SidecarConfKey]).To(Equal(""))
 			})
 		})
@@ -93,7 +97,12 @@ var _ = Describe("configmap_helper", func() {
 				config := monitorapi.ProcessConfiguration{}
 				err = json.Unmarshal([]byte(jsonData), &config)
 				Expect(err).NotTo(HaveOccurred())
-				expectedConfig := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				expectedConfig := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config).To(Equal(expectedConfig))
 			})
 
@@ -143,13 +152,25 @@ var _ = Describe("configmap_helper", func() {
 					cluster.Status.ImageTypes = []fdbv1beta2.ImageType{"split"}
 				})
 				It("includes the data for both configurations", func() {
-					expectedConf, err := GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 1)
+					expectedConf, err := GetMonitorConf(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						nil,
+						1,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(configMap.Data["fdbmonitor-conf-storage"]).To(Equal(expectedConf))
 
-					expectedConf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 2)
+					expectedConf, err = GetMonitorConf(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						nil,
+						2,
+					)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(configMap.Data["fdbmonitor-conf-storage-density-2"]).To(Equal(expectedConf))
+					Expect(
+						configMap.Data["fdbmonitor-conf-storage-density-2"],
+					).To(Equal(expectedConf))
 				})
 			})
 
@@ -166,7 +187,12 @@ var _ = Describe("configmap_helper", func() {
 					config := monitorapi.ProcessConfiguration{}
 					err = json.Unmarshal([]byte(jsonData), &config)
 					Expect(err).NotTo(HaveOccurred())
-					expectedConfig := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+					expectedConfig := GetMonitorProcessConfiguration(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						1,
+						fdbv1beta2.ImageTypeUnified,
+					)
 					Expect(config).To(Equal(expectedConfig))
 
 					jsonData, present = configMap.Data["fdbmonitor-conf-storage-json"]
@@ -174,7 +200,12 @@ var _ = Describe("configmap_helper", func() {
 					config = monitorapi.ProcessConfiguration{}
 					err = json.Unmarshal([]byte(jsonData), &config)
 					Expect(err).NotTo(HaveOccurred())
-					expectedConfig = GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 2, fdbv1beta2.ImageTypeUnified)
+					expectedConfig = GetMonitorProcessConfiguration(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						2,
+						fdbv1beta2.ImageTypeUnified,
+					)
 					Expect(config).To(Equal(expectedConfig))
 				})
 			})
@@ -213,7 +244,12 @@ var _ = Describe("configmap_helper", func() {
 					config := monitorapi.ProcessConfiguration{}
 					err = json.Unmarshal([]byte(jsonData), &config)
 					Expect(err).NotTo(HaveOccurred())
-					expectedConfig := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassLog, 1, fdbv1beta2.ImageTypeUnified)
+					expectedConfig := GetMonitorProcessConfiguration(
+						cluster,
+						fdbv1beta2.ProcessClassLog,
+						1,
+						fdbv1beta2.ImageTypeUnified,
+					)
 					Expect(config).To(Equal(expectedConfig))
 
 					jsonData, present = configMap.Data["fdbmonitor-conf-log-json"]
@@ -221,7 +257,12 @@ var _ = Describe("configmap_helper", func() {
 					config = monitorapi.ProcessConfiguration{}
 					err = json.Unmarshal([]byte(jsonData), &config)
 					Expect(err).NotTo(HaveOccurred())
-					expectedConfig = GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassLog, 2, fdbv1beta2.ImageTypeUnified)
+					expectedConfig = GetMonitorProcessConfiguration(
+						cluster,
+						fdbv1beta2.ProcessClassLog,
+						2,
+						fdbv1beta2.ImageTypeUnified,
+					)
 					Expect(config).To(Equal(expectedConfig))
 				})
 
@@ -231,7 +272,10 @@ var _ = Describe("configmap_helper", func() {
 		Context("with custom resource labels", func() {
 			BeforeEach(func() {
 				cluster.Spec.LabelConfig = fdbv1beta2.LabelConfig{
-					MatchLabels:    map[string]string{"fdb-custom-name": cluster.Name, "fdb-managed-by-operator": "true"},
+					MatchLabels: map[string]string{
+						"fdb-custom-name":         cluster.Name,
+						"fdb-managed-by-operator": "true",
+					},
 					ResourceLabels: map[string]string{"fdb-new-custom-name": cluster.Name},
 				}
 			})
@@ -262,7 +306,9 @@ var _ = Describe("configmap_helper", func() {
 				})
 
 				It("should populate the CA file", func() {
-					Expect(configMap.Data[fdbv1beta2.CaFileKey]).To(Equal("-----BEGIN CERTIFICATE-----\nMIIFyDCCA7ACCQDqRnbTl1OkcTANBgkqhkiG9w0BAQsFADCBpTELMAkGA1UEBhMC\n---CERT2----"))
+					Expect(
+						configMap.Data[fdbv1beta2.CaFileKey],
+					).To(Equal("-----BEGIN CERTIFICATE-----\nMIIFyDCCA7ACCQDqRnbTl1OkcTANBgkqhkiG9w0BAQsFADCBpTELMAkGA1UEBhMC\n---CERT2----"))
 				})
 			})
 		})

--- a/internal/coordination/coordination.go
+++ b/internal/coordination/coordination.go
@@ -50,7 +50,11 @@ type WaitTimeError struct {
 
 // Error returns the error string for this error.
 func (err WaitTimeError) Error() string {
-	return fmt.Sprintf("last pending process group was added: %s ago, wait time for pending additions is: %s", err.timeSinceLastPendingWasAdded.String(), err.waitTime.String())
+	return fmt.Sprintf(
+		"last pending process group was added: %s ago, wait time for pending additions is: %s",
+		err.timeSinceLastPendingWasAdded.String(),
+		err.waitTime.String(),
+	)
 }
 
 // GetWaitTime returns the difference between the wait time and the time since the last pending process group was added.
@@ -61,8 +65,18 @@ func (err WaitTimeError) GetWaitTime() time.Duration {
 
 // AllProcessesReady will return all the process groups that are in the pending and ready list. If the time since the
 // last update was made is earlier than the wait time, a WaitTimeError will be returned.
-func AllProcessesReady(logger logr.Logger, pendingProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, readyProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, waitTime time.Duration) error {
-	notReadyProcesses, _, err := getNotReadyProcesses(logger, pendingProcessGroups, readyProcessGroups, waitTime)
+func AllProcessesReady(
+	logger logr.Logger,
+	pendingProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time,
+	readyProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time,
+	waitTime time.Duration,
+) error {
+	notReadyProcesses, _, err := getNotReadyProcesses(
+		logger,
+		pendingProcessGroups,
+		readyProcessGroups,
+		waitTime,
+	)
 	if err != nil {
 		return err
 	}
@@ -72,16 +86,29 @@ func AllProcessesReady(logger logr.Logger, pendingProcessGroups map[fdbv1beta2.P
 	}
 
 	if len(pendingProcessGroups) != len(readyProcessGroups) {
-		return fmt.Errorf("not all processes are ready: mismatch in %d pending processes and %d ready processes", len(pendingProcessGroups), len(readyProcessGroups))
+		return fmt.Errorf(
+			"not all processes are ready: mismatch in %d pending processes and %d ready processes",
+			len(pendingProcessGroups),
+			len(readyProcessGroups),
+		)
 	}
 
 	return nil
 }
 
-func getNotReadyProcesses(logger logr.Logger, pendingProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, readyProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, waitTime time.Duration) ([]string, time.Time, error) {
+func getNotReadyProcesses(
+	logger logr.Logger,
+	pendingProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time,
+	readyProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time,
+	waitTime time.Duration,
+) ([]string, time.Time, error) {
 	timestampLastAdded := time.Time{}
 
-	notReadyProcesses := make([]string, 0, max(len(pendingProcessGroups)-len(readyProcessGroups), 0))
+	notReadyProcesses := make(
+		[]string,
+		0,
+		max(len(pendingProcessGroups)-len(readyProcessGroups), 0),
+	)
 	for pending, timestamp := range pendingProcessGroups {
 		// Tester processes are not managed over the global coordination.
 		if pending.GetProcessClass() == fdbv1beta2.ProcessClassTest {
@@ -102,7 +129,11 @@ func getNotReadyProcesses(logger logr.Logger, pendingProcessGroups map[fdbv1beta
 		}
 
 		notReadyProcesses = append(notReadyProcesses, string(pending))
-		logger.Info("found process group in pending list but not in ready list", "processGroupID", pending)
+		logger.Info(
+			"found process group in pending list but not in ready list",
+			"processGroupID",
+			pending,
+		)
 	}
 
 	// Check if the last addition was longer ago than the wait time duration.
@@ -119,8 +150,18 @@ func getNotReadyProcesses(logger logr.Logger, pendingProcessGroups map[fdbv1beta
 // AllProcessesReadyForExclusion will return all the process groups that are in the pending and ready list. If the time since the
 // last update was made is earlier than the wait time, a WaitTimeError will be returned. It implements a similar logic to the
 // AllProcessesReady with some modifications for the exclude reconciler to ensure that the excludes can mode forward.
-func AllProcessesReadyForExclusion(logger logr.Logger, pendingProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, readyProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, waitTime time.Duration) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
-	notReadyProcesses, timestampLastAdded, err := getNotReadyProcesses(logger, pendingProcessGroups, readyProcessGroups, waitTime)
+func AllProcessesReadyForExclusion(
+	logger logr.Logger,
+	pendingProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time,
+	readyProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time,
+	waitTime time.Duration,
+) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
+	notReadyProcesses, timestampLastAdded, err := getNotReadyProcesses(
+		logger,
+		pendingProcessGroups,
+		readyProcessGroups,
+		waitTime,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +172,10 @@ func AllProcessesReadyForExclusion(logger logr.Logger, pendingProcessGroups map[
 		// If there was a change in the last 5 minutes (or longer), we will return an error message and wait for the processes
 		// to get  ready.
 		if time.Since(timestampLastAdded) < max(5*waitTime, IgnoreMissingProcessDuration) {
-			return nil, fmt.Errorf("not all processes are ready: %v", strings.Join(notReadyProcesses, ","))
+			return nil, fmt.Errorf(
+				"not all processes are ready: %v",
+				strings.Join(notReadyProcesses, ","),
+			)
 		}
 
 		// In case that we already waited for 5 minutes, start the exclusion on the processes that are marked to be ready.
@@ -140,14 +184,24 @@ func AllProcessesReadyForExclusion(logger logr.Logger, pendingProcessGroups map[
 	}
 
 	if len(pendingProcessGroups) != len(readyProcessGroups) {
-		return nil, fmt.Errorf("not all processes are ready: mismatch in %d pending processes and %d ready processes", len(pendingProcessGroups), len(readyProcessGroups))
+		return nil, fmt.Errorf(
+			"not all processes are ready: mismatch in %d pending processes and %d ready processes",
+			len(pendingProcessGroups),
+			len(readyProcessGroups),
+		)
 	}
 
 	return readyProcessGroups, nil
 }
 
 // GetAddressesFromCoordinationState will return the addresses based on the coordination state. If addresses should be included, the process address(es) are included in the result, and if localities should be included, the localities are included in the result too.
-func GetAddressesFromCoordinationState(logger logr.Logger, adminClient fdbadminclient.AdminClient, processGroups map[fdbv1beta2.ProcessGroupID]time.Time, includeLocalities bool, includeAddresses bool) ([]fdbv1beta2.ProcessAddress, error) {
+func GetAddressesFromCoordinationState(
+	logger logr.Logger,
+	adminClient fdbadminclient.AdminClient,
+	processGroups map[fdbv1beta2.ProcessGroupID]time.Time,
+	includeLocalities bool,
+	includeAddresses bool,
+) ([]fdbv1beta2.ProcessAddress, error) {
 	addresses := make([]fdbv1beta2.ProcessAddress, 0, len(processGroups))
 
 	// When addresses are required and should be returned.
@@ -160,7 +214,8 @@ func GetAddressesFromCoordinationState(logger logr.Logger, adminClient fdbadminc
 		for processGroupID := range processGroups {
 			currentAddresses, ok := processAddresses[processGroupID]
 			if !ok {
-				logger.V(1).Info("Missing addresses in coordination state", "processGroupID", processGroupID)
+				logger.V(1).
+					Info("Missing addresses in coordination state", "processGroupID", processGroupID)
 				continue
 			}
 
@@ -179,7 +234,11 @@ func GetAddressesFromCoordinationState(logger logr.Logger, adminClient fdbadminc
 	if includeLocalities {
 		for processGroupID := range processGroups {
 			addresses = append(addresses, fdbv1beta2.ProcessAddress{
-				StringAddress: fmt.Sprintf("%s:%s", fdbv1beta2.FDBLocalityExclusionPrefix, processGroupID),
+				StringAddress: fmt.Sprintf(
+					"%s:%s",
+					fdbv1beta2.FDBLocalityExclusionPrefix,
+					processGroupID,
+				),
 			})
 		}
 	}
@@ -188,7 +247,11 @@ func GetAddressesFromCoordinationState(logger logr.Logger, adminClient fdbadminc
 }
 
 // GetAddressesFromStatus will return the process addresses for the provided processGroups based on the provided machine-readable status.
-func GetAddressesFromStatus(logger logr.Logger, status *fdbv1beta2.FoundationDBStatus, processGroups map[fdbv1beta2.ProcessGroupID]time.Time) []fdbv1beta2.ProcessAddress {
+func GetAddressesFromStatus(
+	logger logr.Logger,
+	status *fdbv1beta2.FoundationDBStatus,
+	processGroups map[fdbv1beta2.ProcessGroupID]time.Time,
+) []fdbv1beta2.ProcessAddress {
 	addresses := make([]fdbv1beta2.ProcessAddress, 0, len(processGroups))
 	visited := make(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None, len(processGroups))
 	for _, process := range status.Cluster.Processes {
@@ -199,7 +262,11 @@ func GetAddressesFromStatus(logger logr.Logger, status *fdbv1beta2.FoundationDBS
 
 		processID, ok := process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]
 		if !ok {
-			logger.Info("Ignore process with missing locality field", "address", process.Address.String())
+			logger.Info(
+				"Ignore process with missing locality field",
+				"address",
+				process.Address.String(),
+			)
 			continue
 		}
 
@@ -220,14 +287,21 @@ func GetAddressesFromStatus(logger logr.Logger, status *fdbv1beta2.FoundationDBS
 			missing[processGroupID] = fdbv1beta2.None{}
 		}
 
-		logger.Info("Not all requested process groups are part of the machine-readable status", "missingProcessGroups", missing)
+		logger.Info(
+			"Not all requested process groups are part of the machine-readable status",
+			"missingProcessGroups",
+			missing,
+		)
 	}
 
 	return addresses
 }
 
 // GetProcessesFromProcessMap returns the slice of processes matching the process group ID.
-func GetProcessesFromProcessMap(processGroupID fdbv1beta2.ProcessGroupID, processesMap map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessInfo) []fdbv1beta2.FoundationDBStatusProcessInfo {
+func GetProcessesFromProcessMap(
+	processGroupID fdbv1beta2.ProcessGroupID,
+	processesMap map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessInfo,
+) []fdbv1beta2.FoundationDBStatusProcessInfo {
 	if len(processesMap) == 0 {
 		return nil
 	}
@@ -246,7 +320,12 @@ func GetProcessesFromProcessMap(processGroupID fdbv1beta2.ProcessGroupID, proces
 
 // UpdateGlobalCoordinationState will update the state for global synchronization. If the synchronization mode is local,
 // this method will skip all work.
-func UpdateGlobalCoordinationState(logger logr.Logger, cluster *fdbv1beta2.FoundationDBCluster, adminClient fdbadminclient.AdminClient, processesMap map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessInfo) error {
+func UpdateGlobalCoordinationState(
+	logger logr.Logger,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	adminClient fdbadminclient.AdminClient,
+	processesMap map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessInfo,
+) error {
 	// If the synchronization mode is local (default) skip all work. If the mode is changed from global to local
 	// the human operator must clean up.
 	if cluster.GetSynchronizationMode() == fdbv1beta2.SynchronizationModeLocal {
@@ -259,7 +338,9 @@ func UpdateGlobalCoordinationState(logger logr.Logger, cluster *fdbv1beta2.Found
 
 	// Read all data from the lists to get the current state. If a prefix is provided to the get methods, only
 	// process groups with the additional sub path will be returned.
-	pendingForExclusion, err := adminClient.GetPendingForExclusion(cluster.Spec.ProcessGroupIDPrefix)
+	pendingForExclusion, err := adminClient.GetPendingForExclusion(
+		cluster.Spec.ProcessGroupIDPrefix,
+	)
 	if err != nil {
 		return err
 	}
@@ -274,7 +355,9 @@ func UpdateGlobalCoordinationState(logger logr.Logger, cluster *fdbv1beta2.Found
 		return err
 	}
 
-	pendingForInclusion, err := adminClient.GetPendingForInclusion(cluster.Spec.ProcessGroupIDPrefix)
+	pendingForInclusion, err := adminClient.GetPendingForInclusion(
+		cluster.Spec.ProcessGroupIDPrefix,
+	)
 	if err != nil {
 		return err
 	}
@@ -366,7 +449,8 @@ func UpdateGlobalCoordinationState(logger logr.Logger, cluster *fdbv1beta2.Found
 
 			addresses, ok := processAddresses[processGroup.ProcessGroupID]
 			if !ok || slices.Compare(addresses, processGroup.Addresses) != 0 {
-				logger.V(1).Info("updating process addresses in coordination state", "processGroupID", processGroup.ProcessGroupID, "addresses", processGroup.Addresses)
+				logger.V(1).
+					Info("updating process addresses in coordination state", "processGroupID", processGroup.ProcessGroupID, "addresses", processGroup.Addresses)
 				updatesProcessAddresses[processGroup.ProcessGroupID] = processGroup.Addresses
 			}
 
@@ -375,7 +459,8 @@ func UpdateGlobalCoordinationState(logger logr.Logger, cluster *fdbv1beta2.Found
 
 		// If the process groups is missing long enough to be ignored, ensure that it's removed from the pending
 		// and the ready list.
-		if processGroup.GetConditionTime(fdbv1beta2.IncorrectCommandLine) != nil && !restarts.ShouldBeIgnoredBecauseMissing(logger, cluster, processGroup) {
+		if processGroup.GetConditionTime(fdbv1beta2.IncorrectCommandLine) != nil &&
+			!restarts.ShouldBeIgnoredBecauseMissing(logger, cluster, processGroup) {
 			// Check if the process group is present in pendingForRestart.
 			// If not add it to the according set.
 			if _, ok := pendingForRestart[processGroup.ProcessGroupID]; !ok {
@@ -454,7 +539,11 @@ func UpdateGlobalCoordinationState(logger logr.Logger, cluster *fdbv1beta2.Found
 
 // addUnvisitedProcessGroupsToBeRemoved will add all the updates that were not visited to the updates as being deleted.
 // This will ensure that removed process groups will be removed from the set.
-func addUnvisitedProcessGroupsToBeRemoved(pendingSet map[fdbv1beta2.ProcessGroupID]time.Time, updates map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction, visited map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None) {
+func addUnvisitedProcessGroupsToBeRemoved(
+	pendingSet map[fdbv1beta2.ProcessGroupID]time.Time,
+	updates map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction,
+	visited map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None,
+) {
 	for processGroupID := range pendingSet {
 		// If the process group was not visited the process group was removed and all the
 		// associated entries should be removed too.

--- a/internal/coordination/coordination_test.go
+++ b/internal/coordination/coordination_test.go
@@ -61,7 +61,9 @@ var _ = Describe("operator_coordination", func() {
 		JustBeforeEach(func() {
 			adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(UpdateGlobalCoordinationState(logr.Discard(), cluster, adminClient, nil)).To(Succeed())
+			Expect(
+				UpdateGlobalCoordinationState(logr.Discard(), cluster, adminClient, nil),
+			).To(Succeed())
 		})
 
 		When("a process group is marked for removal", func() {
@@ -72,7 +74,9 @@ var _ = Describe("operator_coordination", func() {
 
 			When("the synchronization mode is local", func() {
 				BeforeEach(func() {
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeLocal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeLocal),
+					)
 				})
 
 				It("shouldn't update anything", func() {
@@ -87,7 +91,9 @@ var _ = Describe("operator_coordination", func() {
 
 			When("the synchronization mode is global", func() {
 				BeforeEach(func() {
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeGlobal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeGlobal),
+					)
 				})
 
 				When("the process group is not already excluded", func() {
@@ -140,12 +146,20 @@ var _ = Describe("operator_coordination", func() {
 							adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 							Expect(err).NotTo(HaveOccurred())
 
-							Expect(adminClient.UpdateReadyForExclusion(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-								processGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
-							})).NotTo(HaveOccurred())
-							Expect(adminClient.UpdatePendingForExclusion(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-								processGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
-							})).NotTo(HaveOccurred())
+							Expect(
+								adminClient.UpdateReadyForExclusion(
+									map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+										processGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
+									},
+								),
+							).NotTo(HaveOccurred())
+							Expect(
+								adminClient.UpdatePendingForExclusion(
+									map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+										processGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
+									},
+								),
+							).NotTo(HaveOccurred())
 						})
 
 						It("should update remove them from the exclusions set", func() {
@@ -176,7 +190,9 @@ var _ = Describe("operator_coordination", func() {
 
 			When("the synchronization mode is local", func() {
 				BeforeEach(func() {
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeLocal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeLocal),
+					)
 				})
 
 				It("shouldn't update anything", func() {
@@ -191,7 +207,9 @@ var _ = Describe("operator_coordination", func() {
 
 			When("the synchronization mode is global", func() {
 				BeforeEach(func() {
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeGlobal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeGlobal),
+					)
 				})
 
 				When("the process group is not already added", func() {
@@ -212,17 +230,27 @@ var _ = Describe("operator_coordination", func() {
 				adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(adminClient.UpdateReadyForRestart(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-					processGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
-				})).NotTo(HaveOccurred())
-				Expect(adminClient.UpdatePendingForRestart(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-					processGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
-				})).NotTo(HaveOccurred())
+				Expect(
+					adminClient.UpdateReadyForRestart(
+						map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							processGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
+						},
+					),
+				).NotTo(HaveOccurred())
+				Expect(
+					adminClient.UpdatePendingForRestart(
+						map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							processGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
+						},
+					),
+				).NotTo(HaveOccurred())
 			})
 
 			When("the synchronization mode is local", func() {
 				BeforeEach(func() {
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeLocal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeLocal),
+					)
 				})
 
 				It("shouldn't update anything", func() {
@@ -241,7 +269,9 @@ var _ = Describe("operator_coordination", func() {
 
 			When("the synchronization mode is global", func() {
 				BeforeEach(func() {
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeGlobal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeGlobal),
+					)
 				})
 
 				When("no other entry exists", func() {
@@ -263,24 +293,38 @@ var _ = Describe("operator_coordination", func() {
 					var pickedProcessGroupID fdbv1beta2.ProcessGroupID
 
 					BeforeEach(func() {
-						cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeGlobal))
+						cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+							string(fdbv1beta2.SynchronizationModeGlobal),
+						)
 
 						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 						Expect(err).NotTo(HaveOccurred())
 
-						processGroups := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStateless, 1)
+						processGroups := internal.PickProcessGroups(
+							cluster,
+							fdbv1beta2.ProcessClassStateless,
+							1,
+						)
 						Expect(processGroups).To(HaveLen(1))
 						pickedProcessGroup := processGroups[0]
 						Expect(pickedProcessGroup).NotTo(BeNil())
 						pickedProcessGroup.UpdateCondition(fdbv1beta2.IncorrectCommandLine, true)
 						pickedProcessGroupID = pickedProcessGroup.ProcessGroupID
 
-						Expect(adminClient.UpdateReadyForRestart(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-							pickedProcessGroupID: fdbv1beta2.UpdateActionAdd,
-						})).NotTo(HaveOccurred())
-						Expect(adminClient.UpdatePendingForRestart(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-							pickedProcessGroupID: fdbv1beta2.UpdateActionAdd,
-						})).NotTo(HaveOccurred())
+						Expect(
+							adminClient.UpdateReadyForRestart(
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+									pickedProcessGroupID: fdbv1beta2.UpdateActionAdd,
+								},
+							),
+						).NotTo(HaveOccurred())
+						Expect(
+							adminClient.UpdatePendingForRestart(
+								map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+									pickedProcessGroupID: fdbv1beta2.UpdateActionAdd,
+								},
+							),
+						).NotTo(HaveOccurred())
 					})
 
 					It("should only remove all the entries for the process group", func() {
@@ -306,9 +350,13 @@ var _ = Describe("operator_coordination", func() {
 				adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(adminClient.UpdatePendingForRemoval(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
-					processGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
-				})).NotTo(HaveOccurred())
+				Expect(
+					adminClient.UpdatePendingForRemoval(
+						map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							processGroup.ProcessGroupID: fdbv1beta2.UpdateActionAdd,
+						},
+					),
+				).NotTo(HaveOccurred())
 
 				beforeLen := len(cluster.Status.ProcessGroups)
 				var currentIdx int
@@ -331,7 +379,9 @@ var _ = Describe("operator_coordination", func() {
 
 			When("the synchronization mode is local", func() {
 				BeforeEach(func() {
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeLocal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeLocal),
+					)
 				})
 
 				It("shouldn't update anything", func() {
@@ -346,7 +396,9 @@ var _ = Describe("operator_coordination", func() {
 
 			When("the synchronization mode is global", func() {
 				BeforeEach(func() {
-					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(string(fdbv1beta2.SynchronizationModeGlobal))
+					cluster.Spec.AutomationOptions.SynchronizationMode = pointer.String(
+						string(fdbv1beta2.SynchronizationModeGlobal),
+					)
 				})
 
 				It("should remove the entries for the non exiting process group", func() {
@@ -361,15 +413,17 @@ var _ = Describe("operator_coordination", func() {
 		})
 	})
 
-	DescribeTable("validating if all processes are ready", func(pendingProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, readyProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, waitTime time.Duration, expectedErr string) {
-		err := AllProcessesReady(GinkgoLogr, pendingProcessGroups, readyProcessGroups, waitTime)
-		if expectedErr != "" {
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(HavePrefix(expectedErr)))
-		} else {
-			Expect(err).To(Succeed())
-		}
-	},
+	DescribeTable(
+		"validating if all processes are ready",
+		func(pendingProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, readyProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, waitTime time.Duration, expectedErr string) {
+			err := AllProcessesReady(GinkgoLogr, pendingProcessGroups, readyProcessGroups, waitTime)
+			if expectedErr != "" {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(HavePrefix(expectedErr)))
+			} else {
+				Expect(err).To(Succeed())
+			}
+		},
 		Entry("no processes provided",
 			nil,
 			nil,
@@ -428,16 +482,23 @@ var _ = Describe("operator_coordination", func() {
 		),
 	)
 
-	DescribeTable("validating if all processes are ready for exclusion", func(pendingProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, readyProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, waitTime time.Duration, expectedErr string, expectedAllowedCount int) {
-		allowed, err := AllProcessesReadyForExclusion(GinkgoLogr, pendingProcessGroups, readyProcessGroups, waitTime)
-		if expectedErr != "" {
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(HavePrefix(expectedErr)))
-		} else {
-			Expect(err).To(Succeed())
-			Expect(allowed).To(HaveLen(expectedAllowedCount))
-		}
-	},
+	DescribeTable(
+		"validating if all processes are ready for exclusion",
+		func(pendingProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, readyProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time, waitTime time.Duration, expectedErr string, expectedAllowedCount int) {
+			allowed, err := AllProcessesReadyForExclusion(
+				GinkgoLogr,
+				pendingProcessGroups,
+				readyProcessGroups,
+				waitTime,
+			)
+			if expectedErr != "" {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(HavePrefix(expectedErr)))
+			} else {
+				Expect(err).To(Succeed())
+				Expect(allowed).To(HaveLen(expectedAllowedCount))
+			}
+		},
 		Entry("no processes provided",
 			nil,
 			nil,
@@ -500,7 +561,8 @@ var _ = Describe("operator_coordination", func() {
 			"not all processes are ready:",
 			0,
 		),
-		Entry("two pending and one ready processes are provided and is ready for at least 5 minutes",
+		Entry(
+			"two pending and one ready processes are provided and is ready for at least 5 minutes",
 			map[fdbv1beta2.ProcessGroupID]time.Time{
 				"storage-1": time.Now().Add(-2 * IgnoreMissingProcessDuration),
 				"storage-2": time.Now().Add(-2 * IgnoreMissingProcessDuration),

--- a/internal/deprecations_test.go
+++ b/internal/deprecations_test.go
@@ -78,13 +78,26 @@ var _ = Describe("[internal] deprecations", func() {
 
 		When("the future defaults shouldn't be used", func() {
 			BeforeEach(func() {
-				cluster.Spec.MainContainer.ImageConfigs = append(cluster.Spec.MainContainer.ImageConfigs, fdbv1beta2.ImageConfig{BaseImage: "foundationdb/foundationdb-test"})
-				cluster.Spec.SidecarContainer.ImageConfigs = append(cluster.Spec.SidecarContainer.ImageConfigs, fdbv1beta2.ImageConfig{BaseImage: "foundationdb/foundationdb-kubernetes-sidecar-test"})
+				cluster.Spec.MainContainer.ImageConfigs = append(
+					cluster.Spec.MainContainer.ImageConfigs,
+					fdbv1beta2.ImageConfig{BaseImage: "foundationdb/foundationdb-test"},
+				)
+				cluster.Spec.SidecarContainer.ImageConfigs = append(
+					cluster.Spec.SidecarContainer.ImageConfigs,
+					fdbv1beta2.ImageConfig{
+						BaseImage: "foundationdb/foundationdb-kubernetes-sidecar-test",
+					},
+				)
 			})
 
 			Context("with the current defaults", func() {
 				JustBeforeEach(func() {
-					Expect(NormalizeClusterSpec(cluster, DeprecationOptions{UseFutureDefaults: false, OnlyShowChanges: false})).NotTo(HaveOccurred())
+					Expect(
+						NormalizeClusterSpec(
+							cluster,
+							DeprecationOptions{UseFutureDefaults: false, OnlyShowChanges: false},
+						),
+					).NotTo(HaveOccurred())
 				})
 
 				It("should have a main container defined", func() {
@@ -255,13 +268,17 @@ var _ = Describe("[internal] deprecations", func() {
 							{BaseImage: "foundationdb/foundationdb-test"},
 							{BaseImage: fdbv1beta2.FoundationDBKubernetesBaseImage},
 						}))
-						Expect(spec.SidecarContainer.ImageConfigs).To(Equal([]fdbv1beta2.ImageConfig{
+						Expect(
+							spec.SidecarContainer.ImageConfigs,
+						).To(Equal([]fdbv1beta2.ImageConfig{
 							{BaseImage: "foundationdb/foundationdb-kubernetes-sidecar-test"},
 						}))
 					})
 
 					It("should not have any init containers in the process settings", func() {
-						Expect(spec.Processes[fdbv1beta2.ProcessClassGeneral].PodTemplate.Spec.InitContainers).To(HaveLen(0))
+						Expect(
+							spec.Processes[fdbv1beta2.ProcessClassGeneral].PodTemplate.Spec.InitContainers,
+						).To(HaveLen(0))
 					})
 				})
 			})
@@ -269,13 +286,26 @@ var _ = Describe("[internal] deprecations", func() {
 
 		When("the future defaults should be used", func() {
 			BeforeEach(func() {
-				cluster.Spec.MainContainer.ImageConfigs = append(cluster.Spec.MainContainer.ImageConfigs, fdbv1beta2.ImageConfig{BaseImage: "foundationdb/foundationdb-test"})
-				cluster.Spec.SidecarContainer.ImageConfigs = append(cluster.Spec.SidecarContainer.ImageConfigs, fdbv1beta2.ImageConfig{BaseImage: "foundationdb/foundationdb-kubernetes-sidecar-test"})
+				cluster.Spec.MainContainer.ImageConfigs = append(
+					cluster.Spec.MainContainer.ImageConfigs,
+					fdbv1beta2.ImageConfig{BaseImage: "foundationdb/foundationdb-test"},
+				)
+				cluster.Spec.SidecarContainer.ImageConfigs = append(
+					cluster.Spec.SidecarContainer.ImageConfigs,
+					fdbv1beta2.ImageConfig{
+						BaseImage: "foundationdb/foundationdb-kubernetes-sidecar-test",
+					},
+				)
 			})
 
 			JustBeforeEach(func() {
 				cluster.Spec.Version = fdbv1beta2.Versions.SupportsLocalityBasedExclusions71.String()
-				Expect(NormalizeClusterSpec(cluster, DeprecationOptions{UseFutureDefaults: true, OnlyShowChanges: false})).NotTo(HaveOccurred())
+				Expect(
+					NormalizeClusterSpec(
+						cluster,
+						DeprecationOptions{UseFutureDefaults: true, OnlyShowChanges: false},
+					),
+				).NotTo(HaveOccurred())
 			})
 
 			It("should have the unified image enabled", func() {
@@ -444,7 +474,10 @@ var _ = Describe("[internal] deprecations", func() {
 			When("no image config is set", func() {
 				It("should be added", func() {
 					var imageConfigs []fdbv1beta2.ImageConfig
-					ensureImageConfigPresent(&imageConfigs, fdbv1beta2.ImageConfig{BaseImage: fdbv1beta2.FoundationDBBaseImage})
+					ensureImageConfigPresent(
+						&imageConfigs,
+						fdbv1beta2.ImageConfig{BaseImage: fdbv1beta2.FoundationDBBaseImage},
+					)
 					Expect(imageConfigs).To(HaveLen(1))
 				})
 			})
@@ -453,11 +486,16 @@ var _ = Describe("[internal] deprecations", func() {
 				var imageConfigs []fdbv1beta2.ImageConfig
 
 				BeforeEach(func() {
-					imageConfigs = []fdbv1beta2.ImageConfig{{BaseImage: fdbv1beta2.FoundationDBBaseImage}}
+					imageConfigs = []fdbv1beta2.ImageConfig{
+						{BaseImage: fdbv1beta2.FoundationDBBaseImage},
+					}
 				})
 
 				It("should not be added", func() {
-					ensureImageConfigPresent(&imageConfigs, fdbv1beta2.ImageConfig{BaseImage: fdbv1beta2.FoundationDBBaseImage})
+					ensureImageConfigPresent(
+						&imageConfigs,
+						fdbv1beta2.ImageConfig{BaseImage: fdbv1beta2.FoundationDBBaseImage},
+					)
 					Expect(imageConfigs).To(HaveLen(1))
 				})
 			})

--- a/internal/error_helper_test.go
+++ b/internal/error_helper_test.go
@@ -61,7 +61,10 @@ var _ = Describe("Internal error helper", func() {
 				}),
 			Entry("wrapped network error",
 				testCase{
-					err:      fmt.Errorf("test : %w", &net.OpError{Op: "mock", Err: fmt.Errorf("not reachable")}),
+					err: fmt.Errorf(
+						"test : %w",
+						&net.OpError{Op: "mock", Err: fmt.Errorf("not reachable")},
+					),
 					expected: true,
 				}),
 		)
@@ -79,12 +82,20 @@ var _ = Describe("Internal error helper", func() {
 			},
 			Entry("Admission error",
 				testCase{
-					err:      apierrors.NewForbidden(schema.GroupResource{}, "test", fmt.Errorf("exceeded quota: todo")),
+					err: apierrors.NewForbidden(
+						schema.GroupResource{},
+						"test",
+						fmt.Errorf("exceeded quota: todo"),
+					),
 					expected: true,
 				}),
 			Entry("Different forbidden error",
 				testCase{
-					err:      apierrors.NewForbidden(schema.GroupResource{}, "test", fmt.Errorf("not allowed")),
+					err: apierrors.NewForbidden(
+						schema.GroupResource{},
+						"test",
+						fmt.Errorf("not allowed"),
+					),
 					expected: false,
 				}),
 			Entry("simple error",
@@ -117,7 +128,10 @@ var _ = Describe("Internal error helper", func() {
 				}),
 			Entry("wrapped timeout error",
 				testCase{
-					err:      fmt.Errorf("test : %w", fdbv1beta2.TimeoutError{Err: fmt.Errorf("not reachable")}),
+					err: fmt.Errorf(
+						"test : %w",
+						fdbv1beta2.TimeoutError{Err: fmt.Errorf("not reachable")},
+					),
 					expected: true,
 				}),
 		)

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -58,7 +58,13 @@ func getRestClient(kubernetesClient client.Client, config *rest.Config) (rest.In
 		return nil, err
 	}
 
-	return apiutil.RESTClientForGVK(gvk, false, config, serializer.NewCodecFactory(kubernetesClient.Scheme()), httpClient)
+	return apiutil.RESTClientForGVK(
+		gvk,
+		false,
+		config,
+		serializer.NewCodecFactory(kubernetesClient.Scheme()),
+		httpClient,
+	)
 }
 
 // ExecuteCommandRaw will run the command without putting it into a shell.
@@ -157,7 +163,19 @@ func ExecuteCommand(
 	}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	err := ExecuteCommandRaw(ctx, kubeClient, config, namespace, name, container, cmd, nil, &stdout, &stderr, false)
+	err := ExecuteCommandRaw(
+		ctx,
+		kubeClient,
+		config,
+		namespace,
+		name,
+		container,
+		cmd,
+		nil,
+		&stdout,
+		&stderr,
+		false,
+	)
 	if printOutput {
 		log.Println("stdout:\n\n", stdout.String())
 		log.Println("stderr:\n\n", stderr.String())
@@ -176,7 +194,16 @@ func ExecuteCommandOnPod(
 	command string,
 	printOutput bool,
 ) (string, string, error) {
-	return ExecuteCommand(ctx, kubeClient, config, pod.Namespace, pod.Name, container, command, printOutput)
+	return ExecuteCommand(
+		ctx,
+		kubeClient,
+		config,
+		pod.Namespace,
+		pod.Name,
+		container,
+		command,
+		printOutput,
+	)
 }
 
 // DownloadFile will download the file from the provided Pod/container into dst.
@@ -205,7 +232,19 @@ func DownloadFile(
 		return err
 	})
 
-	err := ExecuteCommandRaw(ctx, kubeClient, config, target.Namespace, target.Name, container, []string{"/bin/cp", src, "/dev/stdout"}, nil, writer, errOut, false)
+	err := ExecuteCommandRaw(
+		ctx,
+		kubeClient,
+		config,
+		target.Namespace,
+		target.Name,
+		container,
+		[]string{"/bin/cp", src, "/dev/stdout"},
+		nil,
+		writer,
+		errOut,
+		false,
+	)
 	if err != nil {
 		log.Println(errOut.String())
 	}
@@ -249,7 +288,19 @@ func UploadFile(
 		return err
 	})
 
-	err := ExecuteCommandRaw(ctx, kubeClient, config, target.Namespace, target.Name, container, []string{"tee", "-a", dst}, reader, out, errOut, false)
+	err := ExecuteCommandRaw(
+		ctx,
+		kubeClient,
+		config,
+		target.Namespace,
+		target.Name,
+		container,
+		[]string{"tee", "-a", dst},
+		reader,
+		out,
+		errOut,
+		false,
+	)
 	if err != nil {
 		log.Println(errOut.String())
 	}
@@ -348,6 +399,9 @@ func (fakeExecutor *FakeExecutor) Stream(options remotecommand.StreamOptions) er
 
 // StreamWithContext opens a protocol streamer to the server and streams until a client closes
 // the connection or the server disconnects or the context is done.
-func (fakeExecutor *FakeExecutor) StreamWithContext(_ context.Context, options remotecommand.StreamOptions) error {
+func (fakeExecutor *FakeExecutor) StreamWithContext(
+	_ context.Context,
+	options remotecommand.StreamOptions,
+) error {
 	return fakeExecutor.Stream(options)
 }

--- a/internal/locality/locality_test.go
+++ b/internal/locality/locality_test.go
@@ -42,7 +42,12 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func generateDummyProcessInfo(id string, dcID string, port int, tls bool) fdbv1beta2.FoundationDBStatusProcessInfo {
+func generateDummyProcessInfo(
+	id string,
+	dcID string,
+	port int,
+	tls bool,
+) fdbv1beta2.FoundationDBStatusProcessInfo {
 	ipString := "1.1.1." + strings.Split(id, "-")[1]
 
 	var tlsSuffix string
@@ -207,18 +212,21 @@ var _ = Describe("Localities", func() {
 					cluster.Spec.CoordinatorSelection = []fdbv1beta2.CoordinatorSelectionSetting{}
 				})
 
-				It("should sort the localities based on the IDs but prefer transaction system Pods", func() {
-					sortLocalities("", localities)
+				It(
+					"should sort the localities based on the IDs but prefer transaction system Pods",
+					func() {
+						sortLocalities("", localities)
 
-					Expect(localities[0].Class).To(Equal(fdbv1beta2.ProcessClassLog))
-					Expect(localities[0].ID).To(Equal("log-1"))
-					Expect(localities[1].Class).To(Equal(fdbv1beta2.ProcessClassTransaction))
-					Expect(localities[1].ID).To(Equal("tlog-1"))
-					Expect(localities[2].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
-					Expect(localities[2].ID).To(Equal("storage-1"))
-					Expect(localities[3].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
-					Expect(localities[3].ID).To(Equal("storage-51"))
-				})
+						Expect(localities[0].Class).To(Equal(fdbv1beta2.ProcessClassLog))
+						Expect(localities[0].ID).To(Equal("log-1"))
+						Expect(localities[1].Class).To(Equal(fdbv1beta2.ProcessClassTransaction))
+						Expect(localities[1].ID).To(Equal("tlog-1"))
+						Expect(localities[2].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
+						Expect(localities[2].ID).To(Equal("storage-1"))
+						Expect(localities[3].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
+						Expect(localities[3].ID).To(Equal("storage-51"))
+					},
+				)
 			})
 
 			When("when the storage class is preferred", func() {
@@ -370,24 +378,45 @@ var _ = Describe("Localities", func() {
 					cluster.Spec.CoordinatorSelection = []fdbv1beta2.CoordinatorSelectionSetting{}
 				})
 
-				It("should sort the localities based on the IDs but prefer transaction system Pods", func() {
-					Expect(localities[0].Class).To(Equal(fdbv1beta2.ProcessClassLog))
-					Expect(localities[0].LocalityData).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
-					Expect(localities[1].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
-					Expect(localities[1].LocalityData).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
-					Expect(localities[2].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
-					Expect(localities[2].LocalityData).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
-					// The rest of the clusters are ordered by priority and the process ID.
-					Expect(localities[3].Class).To(Equal(fdbv1beta2.ProcessClassLog))
-					Expect(localities[3].LocalityData).To(HaveKey(fdbv1beta2.FDBLocalityDCIDKey))
-					Expect(localities[3].LocalityData[fdbv1beta2.FDBLocalityDCIDKey]).NotTo(Equal(primaryID))
-					Expect(localities[4].Class).To(Equal(fdbv1beta2.ProcessClassLog))
-					Expect(localities[4].LocalityData).To(HaveKey(fdbv1beta2.FDBLocalityDCIDKey))
-					Expect(localities[4].LocalityData[fdbv1beta2.FDBLocalityDCIDKey]).NotTo(Equal(primaryID))
-					Expect(localities[5].Class).To(Equal(fdbv1beta2.ProcessClassLog))
-					Expect(localities[5].LocalityData).To(HaveKey(fdbv1beta2.FDBLocalityDCIDKey))
-					Expect(localities[5].LocalityData[fdbv1beta2.FDBLocalityDCIDKey]).NotTo(Equal(primaryID))
-				})
+				It(
+					"should sort the localities based on the IDs but prefer transaction system Pods",
+					func() {
+						Expect(localities[0].Class).To(Equal(fdbv1beta2.ProcessClassLog))
+						Expect(
+							localities[0].LocalityData,
+						).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
+						Expect(localities[1].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
+						Expect(
+							localities[1].LocalityData,
+						).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
+						Expect(localities[2].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
+						Expect(
+							localities[2].LocalityData,
+						).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
+						// The rest of the clusters are ordered by priority and the process ID.
+						Expect(localities[3].Class).To(Equal(fdbv1beta2.ProcessClassLog))
+						Expect(
+							localities[3].LocalityData,
+						).To(HaveKey(fdbv1beta2.FDBLocalityDCIDKey))
+						Expect(
+							localities[3].LocalityData[fdbv1beta2.FDBLocalityDCIDKey],
+						).NotTo(Equal(primaryID))
+						Expect(localities[4].Class).To(Equal(fdbv1beta2.ProcessClassLog))
+						Expect(
+							localities[4].LocalityData,
+						).To(HaveKey(fdbv1beta2.FDBLocalityDCIDKey))
+						Expect(
+							localities[4].LocalityData[fdbv1beta2.FDBLocalityDCIDKey],
+						).NotTo(Equal(primaryID))
+						Expect(localities[5].Class).To(Equal(fdbv1beta2.ProcessClassLog))
+						Expect(
+							localities[5].LocalityData,
+						).To(HaveKey(fdbv1beta2.FDBLocalityDCIDKey))
+						Expect(
+							localities[5].LocalityData[fdbv1beta2.FDBLocalityDCIDKey],
+						).NotTo(Equal(primaryID))
+					},
+				)
 			})
 
 			When("when the storage class is preferred", func() {
@@ -402,21 +431,33 @@ var _ = Describe("Localities", func() {
 
 				It("should sort the localities based on the provided config", func() {
 					Expect(localities[0].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
-					Expect(localities[0].LocalityData).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
+					Expect(
+						localities[0].LocalityData,
+					).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
 					Expect(localities[1].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
-					Expect(localities[1].LocalityData).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
+					Expect(
+						localities[1].LocalityData,
+					).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
 					Expect(localities[2].Class).To(Equal(fdbv1beta2.ProcessClassLog))
-					Expect(localities[2].LocalityData).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
+					Expect(
+						localities[2].LocalityData,
+					).To(HaveKeyWithValue(fdbv1beta2.FDBLocalityDCIDKey, primaryID))
 					// The rest of the clusters are ordered by priority and the process ID.
 					Expect(localities[3].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
 					Expect(localities[3].LocalityData).To(HaveKey(fdbv1beta2.FDBLocalityDCIDKey))
-					Expect(localities[3].LocalityData[fdbv1beta2.FDBLocalityDCIDKey]).NotTo(Equal(primaryID))
+					Expect(
+						localities[3].LocalityData[fdbv1beta2.FDBLocalityDCIDKey],
+					).NotTo(Equal(primaryID))
 					Expect(localities[4].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
 					Expect(localities[4].LocalityData).To(HaveKey(fdbv1beta2.FDBLocalityDCIDKey))
-					Expect(localities[4].LocalityData[fdbv1beta2.FDBLocalityDCIDKey]).NotTo(Equal(primaryID))
+					Expect(
+						localities[4].LocalityData[fdbv1beta2.FDBLocalityDCIDKey],
+					).NotTo(Equal(primaryID))
 					Expect(localities[5].Class).To(Equal(fdbv1beta2.ProcessClassStorage))
 					Expect(localities[5].LocalityData).To(HaveKey(fdbv1beta2.FDBLocalityDCIDKey))
-					Expect(localities[5].LocalityData[fdbv1beta2.FDBLocalityDCIDKey]).NotTo(Equal(primaryID))
+					Expect(
+						localities[5].LocalityData[fdbv1beta2.FDBLocalityDCIDKey],
+					).NotTo(Equal(primaryID))
 				})
 			})
 		})
@@ -430,15 +471,41 @@ var _ = Describe("Localities", func() {
 		Context("with a flat set of processes", func() {
 			BeforeEach(func() {
 				candidates = []Info{
-					{ID: "p1", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z1"}},
-					{ID: "p2", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z1"}},
-					{ID: "p3", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z2"}},
-					{ID: "p4", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z3"}},
-					{ID: "p5", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z2"}},
-					{ID: "p6", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z4"}},
-					{ID: "p7", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z5"}},
+					{
+						ID:           "p1",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z1"},
+					},
+					{
+						ID:           "p2",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z1"},
+					},
+					{
+						ID:           "p3",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z2"},
+					},
+					{
+						ID:           "p4",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z3"},
+					},
+					{
+						ID:           "p5",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z2"},
+					},
+					{
+						ID:           "p6",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z4"},
+					},
+					{
+						ID:           "p7",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z5"},
+					},
 				}
-				result, err = ChooseDistributedProcesses(cluster, candidates, 5, ProcessSelectionConstraint{})
+				result, err = ChooseDistributedProcesses(
+					cluster,
+					candidates,
+					5,
+					ProcessSelectionConstraint{},
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -455,18 +522,41 @@ var _ = Describe("Localities", func() {
 		Context("with fewer zones than desired processes", func() {
 			BeforeEach(func() {
 				candidates = []Info{
-					{ID: "p1", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z1"}},
-					{ID: "p2", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z1"}},
-					{ID: "p3", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z2"}},
-					{ID: "p4", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z3"}},
-					{ID: "p5", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z2"}},
-					{ID: "p6", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z4"}},
+					{
+						ID:           "p1",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z1"},
+					},
+					{
+						ID:           "p2",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z1"},
+					},
+					{
+						ID:           "p3",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z2"},
+					},
+					{
+						ID:           "p4",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z3"},
+					},
+					{
+						ID:           "p5",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z2"},
+					},
+					{
+						ID:           "p6",
+						LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z4"},
+					},
 				}
 			})
 
 			Context("with no hard limit", func() {
 				It("should only re-use zones as necessary", func() {
-					result, err = ChooseDistributedProcesses(cluster, candidates, 5, ProcessSelectionConstraint{})
+					result, err = ChooseDistributedProcesses(
+						cluster,
+						candidates,
+						5,
+						ProcessSelectionConstraint{},
+					)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(len(result)).To(Equal(5))
@@ -480,11 +570,18 @@ var _ = Describe("Localities", func() {
 
 			Context("with a hard limit", func() {
 				It("should give an error", func() {
-					result, err = ChooseDistributedProcesses(cluster, candidates, 5, ProcessSelectionConstraint{
-						HardLimits: map[string]int{fdbv1beta2.FDBLocalityZoneIDKey: 1},
-					})
+					result, err = ChooseDistributedProcesses(
+						cluster,
+						candidates,
+						5,
+						ProcessSelectionConstraint{
+							HardLimits: map[string]int{fdbv1beta2.FDBLocalityZoneIDKey: 1},
+						},
+					)
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("Could only select 4 processes, but 5 are required"))
+					Expect(
+						err.Error(),
+					).To(Equal("Could only select 4 processes, but 5 are required"))
 				})
 			})
 		})
@@ -492,22 +589,87 @@ var _ = Describe("Localities", func() {
 		Context("with multiple data centers", func() {
 			BeforeEach(func() {
 				candidates = []Info{
-					{ID: "p1", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z1", fdbv1beta2.FDBLocalityDCIDKey: "dc1"}},
-					{ID: "p2", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z1", fdbv1beta2.FDBLocalityDCIDKey: "dc1"}},
-					{ID: "p3", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z2", fdbv1beta2.FDBLocalityDCIDKey: "dc1"}},
-					{ID: "p4", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z3", fdbv1beta2.FDBLocalityDCIDKey: "dc1"}},
-					{ID: "p5", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z2", fdbv1beta2.FDBLocalityDCIDKey: "dc1"}},
-					{ID: "p6", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z4", fdbv1beta2.FDBLocalityDCIDKey: "dc1"}},
-					{ID: "p7", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z5", fdbv1beta2.FDBLocalityDCIDKey: "dc1"}},
-					{ID: "p8", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z6", fdbv1beta2.FDBLocalityDCIDKey: "dc2"}},
-					{ID: "p9", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z7", fdbv1beta2.FDBLocalityDCIDKey: "dc2"}},
-					{ID: "p10", LocalityData: map[string]string{fdbv1beta2.FDBLocalityZoneIDKey: "z8", fdbv1beta2.FDBLocalityDCIDKey: "dc2"}},
+					{
+						ID: "p1",
+						LocalityData: map[string]string{
+							fdbv1beta2.FDBLocalityZoneIDKey: "z1",
+							fdbv1beta2.FDBLocalityDCIDKey:   "dc1",
+						},
+					},
+					{
+						ID: "p2",
+						LocalityData: map[string]string{
+							fdbv1beta2.FDBLocalityZoneIDKey: "z1",
+							fdbv1beta2.FDBLocalityDCIDKey:   "dc1",
+						},
+					},
+					{
+						ID: "p3",
+						LocalityData: map[string]string{
+							fdbv1beta2.FDBLocalityZoneIDKey: "z2",
+							fdbv1beta2.FDBLocalityDCIDKey:   "dc1",
+						},
+					},
+					{
+						ID: "p4",
+						LocalityData: map[string]string{
+							fdbv1beta2.FDBLocalityZoneIDKey: "z3",
+							fdbv1beta2.FDBLocalityDCIDKey:   "dc1",
+						},
+					},
+					{
+						ID: "p5",
+						LocalityData: map[string]string{
+							fdbv1beta2.FDBLocalityZoneIDKey: "z2",
+							fdbv1beta2.FDBLocalityDCIDKey:   "dc1",
+						},
+					},
+					{
+						ID: "p6",
+						LocalityData: map[string]string{
+							fdbv1beta2.FDBLocalityZoneIDKey: "z4",
+							fdbv1beta2.FDBLocalityDCIDKey:   "dc1",
+						},
+					},
+					{
+						ID: "p7",
+						LocalityData: map[string]string{
+							fdbv1beta2.FDBLocalityZoneIDKey: "z5",
+							fdbv1beta2.FDBLocalityDCIDKey:   "dc1",
+						},
+					},
+					{
+						ID: "p8",
+						LocalityData: map[string]string{
+							fdbv1beta2.FDBLocalityZoneIDKey: "z6",
+							fdbv1beta2.FDBLocalityDCIDKey:   "dc2",
+						},
+					},
+					{
+						ID: "p9",
+						LocalityData: map[string]string{
+							fdbv1beta2.FDBLocalityZoneIDKey: "z7",
+							fdbv1beta2.FDBLocalityDCIDKey:   "dc2",
+						},
+					},
+					{
+						ID: "p10",
+						LocalityData: map[string]string{
+							fdbv1beta2.FDBLocalityZoneIDKey: "z8",
+							fdbv1beta2.FDBLocalityDCIDKey:   "dc2",
+						},
+					},
 				}
 			})
 
 			Context("with the default constraints", func() {
 				BeforeEach(func() {
-					result, err = ChooseDistributedProcesses(cluster, candidates, 5, ProcessSelectionConstraint{})
+					result, err = ChooseDistributedProcesses(
+						cluster,
+						candidates,
+						5,
+						ProcessSelectionConstraint{},
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -523,9 +685,14 @@ var _ = Describe("Localities", func() {
 
 			Context("when only distributing across data centers", func() {
 				BeforeEach(func() {
-					result, err = ChooseDistributedProcesses(cluster, candidates, 5, ProcessSelectionConstraint{
-						Fields: []string{"dcid"},
-					})
+					result, err = ChooseDistributedProcesses(
+						cluster,
+						candidates,
+						5,
+						ProcessSelectionConstraint{
+							Fields: []string{"dcid"},
+						},
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -603,27 +770,35 @@ var _ = Describe("Localities", func() {
 			When("testing the correct behavior with a small set of candidates", func() {
 				BeforeEach(func() {
 					candidates = generateCandidates(dcIDs, 5, 5)
-					result, err = ChooseDistributedProcesses(cluster, candidates, cluster.DesiredCoordinatorCount(), ProcessSelectionConstraint{
-						HardLimits: GetHardLimits(cluster),
-					})
+					result, err = ChooseDistributedProcesses(
+						cluster,
+						candidates,
+						cluster.DesiredCoordinatorCount(),
+						ProcessSelectionConstraint{
+							HardLimits: GetHardLimits(cluster),
+						},
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
-				It("should recruit the processes across multiple dcs and prefer the primary", func() {
-					Expect(len(result)).To(Equal(9))
+				It(
+					"should recruit the processes across multiple dcs and prefer the primary",
+					func() {
+						Expect(len(result)).To(Equal(9))
 
-					dcCount := map[string]int{}
-					for _, process := range result {
-						dcCount[process.LocalityData[fdbv1beta2.FDBLocalityDCIDKey]]++
-					}
+						dcCount := map[string]int{}
+						for _, process := range result {
+							dcCount[process.LocalityData[fdbv1beta2.FDBLocalityDCIDKey]]++
+						}
 
-					Expect(dcCount).To(Equal(map[string]int{
-						primaryID:          3,
-						remoteID:           2,
-						remoteSatelliteID:  2,
-						primarySatelliteID: 2,
-					}))
-				})
+						Expect(dcCount).To(Equal(map[string]int{
+							primaryID:          3,
+							remoteID:           2,
+							remoteSatelliteID:  2,
+							primarySatelliteID: 2,
+						}))
+					},
+				)
 			})
 
 			// Adding a benchmark test for the ChooseDistributedProcesses. In order to print the set use FIt.
@@ -644,9 +819,14 @@ var _ = Describe("Localities", func() {
 						})
 						// Only measure the actual execution of ChooseDistributedProcesses.
 						experiment.MeasureDuration("ChooseDistributedProcesses", func() {
-							_, _ = ChooseDistributedProcesses(cluster, candidates, cluster.DesiredCoordinatorCount(), ProcessSelectionConstraint{
-								HardLimits: GetHardLimits(cluster),
-							})
+							_, _ = ChooseDistributedProcesses(
+								cluster,
+								candidates,
+								cluster.DesiredCoordinatorCount(),
+								ProcessSelectionConstraint{
+									HardLimits: GetHardLimits(cluster),
+								},
+							)
 						})
 						// We'll sample the function up to 50 times or up to a minute, whichever comes first.
 					}, gmeasure.SamplingConfig{N: 50, Duration: time.Minute})
@@ -654,144 +834,161 @@ var _ = Describe("Localities", func() {
 			})
 		})
 
-		When("a multi-region cluster is used with 4 dcs and storage processes should be preferred", func() {
-			var primaryID, remoteID, primarySatelliteID, remoteSatelliteID string
+		When(
+			"a multi-region cluster is used with 4 dcs and storage processes should be preferred",
+			func() {
+				var primaryID, remoteID, primarySatelliteID, remoteSatelliteID string
 
-			BeforeEach(func() {
-				// Generate random names to make sure we test different alphabetical orderings.
-				primaryID = internal.GenerateRandomString(10)
-				remoteID = internal.GenerateRandomString(10)
-				primarySatelliteID = internal.GenerateRandomString(10)
-				remoteSatelliteID = internal.GenerateRandomString(10)
+				BeforeEach(func() {
+					// Generate random names to make sure we test different alphabetical orderings.
+					primaryID = internal.GenerateRandomString(10)
+					remoteID = internal.GenerateRandomString(10)
+					primarySatelliteID = internal.GenerateRandomString(10)
+					remoteSatelliteID = internal.GenerateRandomString(10)
 
-				cluster.Spec.CoordinatorSelection = []fdbv1beta2.CoordinatorSelectionSetting{
-					{
-						ProcessClass: fdbv1beta2.ProcessClassStorage,
-						Priority:     math.MaxInt32,
-					},
-					{
-						ProcessClass: fdbv1beta2.ProcessClassLog,
-						Priority:     0,
-					},
-				}
-				candidates = make([]Info, 18)
-				idx := 0
-				for _, dcID := range []string{primaryID, primarySatelliteID, remoteID, remoteSatelliteID} {
-					for i := 0; i < 3; i++ {
-						candidates[idx] = Info{
-							ID:    strconv.Itoa(idx),
-							Class: fdbv1beta2.ProcessClassLog,
-							LocalityData: map[string]string{
-								fdbv1beta2.FDBLocalityZoneIDKey: dcID + "-z1" + strconv.Itoa(i),
-								fdbv1beta2.FDBLocalityDCIDKey:   dcID,
-							},
-							Priority: cluster.GetClassCandidatePriority(fdbv1beta2.ProcessClassLog),
-						}
-
-						idx++
-					}
-
-					if dcID == primarySatelliteID || dcID == remoteSatelliteID {
-						continue
-					}
-
-					for i := 0; i < 3; i++ {
-						candidates[idx] = Info{
-							ID:    strconv.Itoa(idx),
-							Class: fdbv1beta2.ProcessClassStorage,
-							LocalityData: map[string]string{
-								fdbv1beta2.FDBLocalityZoneIDKey: dcID + "-z2" + strconv.Itoa(i),
-								fdbv1beta2.FDBLocalityDCIDKey:   dcID,
-							},
-							Priority: cluster.GetClassCandidatePriority(fdbv1beta2.ProcessClassStorage),
-						}
-
-						idx++
-					}
-				}
-
-				cluster.Spec.DatabaseConfiguration = fdbv1beta2.DatabaseConfiguration{
-					UsableRegions: 2,
-					Regions: []fdbv1beta2.Region{
+					cluster.Spec.CoordinatorSelection = []fdbv1beta2.CoordinatorSelectionSetting{
 						{
-							DataCenters: []fdbv1beta2.DataCenter{
-								{
-									ID:       primaryID,
-									Priority: 1,
+							ProcessClass: fdbv1beta2.ProcessClassStorage,
+							Priority:     math.MaxInt32,
+						},
+						{
+							ProcessClass: fdbv1beta2.ProcessClassLog,
+							Priority:     0,
+						},
+					}
+					candidates = make([]Info, 18)
+					idx := 0
+					for _, dcID := range []string{primaryID, primarySatelliteID, remoteID, remoteSatelliteID} {
+						for i := 0; i < 3; i++ {
+							candidates[idx] = Info{
+								ID:    strconv.Itoa(idx),
+								Class: fdbv1beta2.ProcessClassLog,
+								LocalityData: map[string]string{
+									fdbv1beta2.FDBLocalityZoneIDKey: dcID + "-z1" + strconv.Itoa(i),
+									fdbv1beta2.FDBLocalityDCIDKey:   dcID,
 								},
-								{
-									ID:        primarySatelliteID,
-									Priority:  1,
-									Satellite: 1,
+								Priority: cluster.GetClassCandidatePriority(
+									fdbv1beta2.ProcessClassLog,
+								),
+							}
+
+							idx++
+						}
+
+						if dcID == primarySatelliteID || dcID == remoteSatelliteID {
+							continue
+						}
+
+						for i := 0; i < 3; i++ {
+							candidates[idx] = Info{
+								ID:    strconv.Itoa(idx),
+								Class: fdbv1beta2.ProcessClassStorage,
+								LocalityData: map[string]string{
+									fdbv1beta2.FDBLocalityZoneIDKey: dcID + "-z2" + strconv.Itoa(i),
+									fdbv1beta2.FDBLocalityDCIDKey:   dcID,
 								},
-								{
-									ID:        remoteSatelliteID,
-									Priority:  0,
-									Satellite: 1,
+								Priority: cluster.GetClassCandidatePriority(
+									fdbv1beta2.ProcessClassStorage,
+								),
+							}
+
+							idx++
+						}
+					}
+
+					cluster.Spec.DatabaseConfiguration = fdbv1beta2.DatabaseConfiguration{
+						UsableRegions: 2,
+						Regions: []fdbv1beta2.Region{
+							{
+								DataCenters: []fdbv1beta2.DataCenter{
+									{
+										ID:       primaryID,
+										Priority: 1,
+									},
+									{
+										ID:        primarySatelliteID,
+										Priority:  1,
+										Satellite: 1,
+									},
+									{
+										ID:        remoteSatelliteID,
+										Priority:  0,
+										Satellite: 1,
+									},
+								},
+							},
+							{
+								DataCenters: []fdbv1beta2.DataCenter{
+									{
+										ID:       remoteID,
+										Priority: 0,
+									},
+									{
+										ID:        remoteSatelliteID,
+										Priority:  1,
+										Satellite: 1,
+									},
+									{
+										ID:        primarySatelliteID,
+										Priority:  0,
+										Satellite: 1,
+									},
 								},
 							},
 						},
-						{
-							DataCenters: []fdbv1beta2.DataCenter{
-								{
-									ID:       remoteID,
-									Priority: 0,
-								},
-								{
-									ID:        remoteSatelliteID,
-									Priority:  1,
-									Satellite: 1,
-								},
-								{
-									ID:        primarySatelliteID,
-									Priority:  0,
-									Satellite: 1,
-								},
-							},
-						},
-					},
-				}
+					}
 
-				result, err = ChooseDistributedProcesses(cluster, candidates, cluster.DesiredCoordinatorCount(), ProcessSelectionConstraint{
-					HardLimits: GetHardLimits(cluster),
+					result, err = ChooseDistributedProcesses(
+						cluster,
+						candidates,
+						cluster.DesiredCoordinatorCount(),
+						ProcessSelectionConstraint{
+							HardLimits: GetHardLimits(cluster),
+						},
+					)
+					Expect(err).NotTo(HaveOccurred())
 				})
-				Expect(err).NotTo(HaveOccurred())
-			})
 
-			It("should recruit the processes across multiple dcs and prefer the primary", func() {
-				Expect(len(result)).To(Equal(9))
-				var storageCnt int
-				var logCnt int
+				It(
+					"should recruit the processes across multiple dcs and prefer the primary",
+					func() {
+						Expect(len(result)).To(Equal(9))
+						var storageCnt int
+						var logCnt int
 
-				dcCount := map[string]int{}
-				for _, process := range result {
-					dcCount[process.LocalityData[fdbv1beta2.FDBLocalityDCIDKey]]++
-					if process.Class == fdbv1beta2.ProcessClassLog {
-						logCnt++
-						continue
-					}
+						dcCount := map[string]int{}
+						for _, process := range result {
+							dcCount[process.LocalityData[fdbv1beta2.FDBLocalityDCIDKey]]++
+							if process.Class == fdbv1beta2.ProcessClassLog {
+								logCnt++
+								continue
+							}
 
-					storageCnt++
-				}
+							storageCnt++
+						}
 
-				Expect(dcCount).To(Equal(map[string]int{
-					primaryID:          3,
-					remoteID:           2,
-					remoteSatelliteID:  2,
-					primarySatelliteID: 2,
-				}))
+						Expect(dcCount).To(Equal(map[string]int{
+							primaryID:          3,
+							remoteID:           2,
+							remoteSatelliteID:  2,
+							primarySatelliteID: 2,
+						}))
 
-				// 5 storage processes should be recruited in the main and remote dc
-				Expect(storageCnt).To(BeNumerically("==", 5))
-				// the satellites only have logs, so only logs are recruited
-				Expect(logCnt).To(BeNumerically("==", 4))
-			})
-		})
+						// 5 storage processes should be recruited in the main and remote dc
+						Expect(storageCnt).To(BeNumerically("==", 5))
+						// the satellites only have logs, so only logs are recruited
+						Expect(logCnt).To(BeNumerically("==", 4))
+					},
+				)
+			},
+		)
 	})
 
-	DescribeTable("when getting the hard limits", func(cluster *fdbv1beta2.FoundationDBCluster, expected map[string]int) {
-		Expect(GetHardLimits(cluster)).To(Equal(expected))
-	},
+	DescribeTable(
+		"when getting the hard limits",
+		func(cluster *fdbv1beta2.FoundationDBCluster, expected map[string]int) {
+			Expect(GetHardLimits(cluster)).To(Equal(expected))
+		},
 		Entry("default cluster with one usable region",
 			&fdbv1beta2.FoundationDBCluster{},
 			map[string]int{
@@ -883,16 +1080,18 @@ var _ = Describe("Localities", func() {
 		),
 	)
 
-	DescribeTable("when getting the locality info from a process", func(process fdbv1beta2.FoundationDBStatusProcessInfo, mainContainerTLS bool, expected Info, expectedError bool) {
-		info, err := InfoForProcess(process, mainContainerTLS)
-		if expectedError {
-			Expect(err).To(HaveOccurred())
-			return
-		}
+	DescribeTable(
+		"when getting the locality info from a process",
+		func(process fdbv1beta2.FoundationDBStatusProcessInfo, mainContainerTLS bool, expected Info, expectedError bool) {
+			info, err := InfoForProcess(process, mainContainerTLS)
+			if expectedError {
+				Expect(err).To(HaveOccurred())
+				return
+			}
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(info).To(Equal(expected))
-	},
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info).To(Equal(expected))
+		},
 		Entry("a process info without tls",
 			fdbv1beta2.FoundationDBStatusProcessInfo{
 				CommandLine: "... --public_address=1.1.1.1:4501,1.1.1.1:4500:tls ...",
@@ -967,19 +1166,21 @@ var _ = Describe("Localities", func() {
 		),
 	)
 
-	DescribeTable("when getting the locality info from a sidecar", func(cluster *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod, expected Info, expectedError bool) {
-		client, err := mock.NewMockFdbPodClient(cluster, pod)
-		Expect(err).NotTo(HaveOccurred())
+	DescribeTable(
+		"when getting the locality info from a sidecar",
+		func(cluster *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod, expected Info, expectedError bool) {
+			client, err := mock.NewMockFdbPodClient(cluster, pod)
+			Expect(err).NotTo(HaveOccurred())
 
-		info, err := InfoFromSidecar(cluster, client)
-		if expectedError {
-			Expect(err).To(HaveOccurred())
-			return
-		}
+			info, err := InfoFromSidecar(cluster, client)
+			if expectedError {
+				Expect(err).To(HaveOccurred())
+				return
+			}
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(info).To(Equal(expected))
-	},
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info).To(Equal(expected))
+		},
 		Entry("a Pod with all fields set",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
@@ -1182,7 +1383,12 @@ var _ = Describe("Localities", func() {
 
 		Context("with the default configuration", func() {
 			It("should report the coordinators as valid", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+					logr.Discard(),
+					cluster,
+					status,
+					coordinatorStatus,
+				)
 				Expect(coordinatorsValid).To(BeTrue())
 				Expect(addressesValid).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
@@ -1191,7 +1397,12 @@ var _ = Describe("Localities", func() {
 
 		When("an empty coordinator status is passed down", func() {
 			It("should report the coordinators as invalid", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, nil)
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+					logr.Discard(),
+					cluster,
+					status,
+					nil,
+				)
 				Expect(coordinatorsValid).To(BeFalse())
 				Expect(addressesValid).To(BeFalse())
 				Expect(err).To(HaveOccurred())
@@ -1208,7 +1419,12 @@ var _ = Describe("Localities", func() {
 			})
 
 			It("should report the coordinators as invalid", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+					logr.Discard(),
+					cluster,
+					status,
+					coordinatorStatus,
+				)
 				Expect(coordinatorsValid).To(BeFalse())
 				Expect(addressesValid).To(BeTrue())
 				Expect(err).To(BeNil())
@@ -1223,7 +1439,12 @@ var _ = Describe("Localities", func() {
 			})
 
 			It("should report the coordinators as invalid", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+					logr.Discard(),
+					cluster,
+					status,
+					coordinatorStatus,
+				)
 				Expect(coordinatorsValid).To(BeFalse())
 				Expect(addressesValid).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
@@ -1236,7 +1457,12 @@ var _ = Describe("Localities", func() {
 			})
 
 			It("should ignore the process", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+					logr.Discard(),
+					cluster,
+					status,
+					coordinatorStatus,
+				)
 				Expect(coordinatorsValid).To(BeTrue())
 				Expect(addressesValid).To(BeTrue())
 				Expect(err).To(BeNil())
@@ -1249,7 +1475,12 @@ var _ = Describe("Localities", func() {
 			})
 
 			It("should report the coordinators as invalid", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+					logr.Discard(),
+					cluster,
+					status,
+					coordinatorStatus,
+				)
 				Expect(coordinatorsValid).To(BeFalse())
 				Expect(addressesValid).To(BeFalse())
 				Expect(err).NotTo(HaveOccurred())
@@ -1266,7 +1497,12 @@ var _ = Describe("Localities", func() {
 			})
 
 			It("should report that not all addresses and coordinators are valid", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+					logr.Discard(),
+					cluster,
+					status,
+					coordinatorStatus,
+				)
 				Expect(coordinatorsValid).To(BeFalse())
 				Expect(addressesValid).To(BeFalse())
 				Expect(err).To(BeNil())
@@ -1284,7 +1520,12 @@ var _ = Describe("Localities", func() {
 			})
 
 			It("should be ignored", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+					logr.Discard(),
+					cluster,
+					status,
+					coordinatorStatus,
+				)
 				Expect(coordinatorsValid).To(BeTrue())
 				Expect(addressesValid).To(BeTrue())
 				Expect(err).To(BeNil())
@@ -1304,7 +1545,12 @@ var _ = Describe("Localities", func() {
 			})
 
 			It("should ignore the test process and report the coordinators as valid", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+					logr.Discard(),
+					cluster,
+					status,
+					coordinatorStatus,
+				)
 				Expect(coordinatorsValid).To(BeTrue())
 				Expect(addressesValid).To(BeTrue())
 				Expect(err).To(BeNil())
@@ -1317,7 +1563,12 @@ var _ = Describe("Localities", func() {
 			})
 
 			It("should report the coordinators as not valid", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+					logr.Discard(),
+					cluster,
+					status,
+					coordinatorStatus,
+				)
 				Expect(coordinatorsValid).To(BeFalse())
 				Expect(addressesValid).To(BeTrue())
 				Expect(err).To(BeNil())
@@ -1340,7 +1591,12 @@ var _ = Describe("Localities", func() {
 			})
 
 			It("should report the coordinators as not valid", func() {
-				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+				coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+					logr.Discard(),
+					cluster,
+					status,
+					coordinatorStatus,
+				)
 				Expect(coordinatorsValid).To(BeFalse())
 				Expect(addressesValid).To(BeTrue())
 				Expect(err).To(BeNil())
@@ -1385,14 +1641,45 @@ var _ = Describe("Localities", func() {
 					},
 				}
 
-				status.Cluster.Processes["4"] = generateDummyProcessInfo("test-4", "dc2", 4501, false)
-				status.Cluster.Processes["5"] = generateDummyProcessInfo("test-5", "dc2", 4501, false)
-				status.Cluster.Processes["6"] = generateDummyProcessInfo("test-6", "dc2", 4501, false)
-				status.Cluster.Processes["7"] = generateDummyProcessInfo("test-7", "dc3", 4501, false)
-				status.Cluster.Processes["8"] = generateDummyProcessInfo("test-8", "dc3", 4501, false)
-				status.Cluster.Processes["9"] = generateDummyProcessInfo("test-9", "dc3", 4501, false)
+				status.Cluster.Processes["4"] = generateDummyProcessInfo(
+					"test-4",
+					"dc2",
+					4501,
+					false,
+				)
+				status.Cluster.Processes["5"] = generateDummyProcessInfo(
+					"test-5",
+					"dc2",
+					4501,
+					false,
+				)
+				status.Cluster.Processes["6"] = generateDummyProcessInfo(
+					"test-6",
+					"dc2",
+					4501,
+					false,
+				)
+				status.Cluster.Processes["7"] = generateDummyProcessInfo(
+					"test-7",
+					"dc3",
+					4501,
+					false,
+				)
+				status.Cluster.Processes["8"] = generateDummyProcessInfo(
+					"test-8",
+					"dc3",
+					4501,
+					false,
+				)
+				status.Cluster.Processes["9"] = generateDummyProcessInfo(
+					"test-9",
+					"dc3",
+					4501,
+					false,
+				)
 
-				status.Client.Coordinators.Coordinators = append(status.Client.Coordinators.Coordinators,
+				status.Client.Coordinators.Coordinators = append(
+					status.Client.Coordinators.Coordinators,
 					fdbv1beta2.FoundationDBStatusCoordinator{
 						Address: fdbv1beta2.ProcessAddress{
 							IPAddress: net.ParseIP("1.1.1.4"),
@@ -1440,7 +1727,12 @@ var _ = Describe("Localities", func() {
 
 			Context("with coordinators divided across three DCs", func() {
 				It("should report the coordinators as valid", func() {
-					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+						logr.Discard(),
+						cluster,
+						status,
+						coordinatorStatus,
+					)
 					Expect(coordinatorsValid).To(BeTrue())
 					Expect(addressesValid).To(BeTrue())
 					Expect(err).To(BeNil())
@@ -1457,7 +1749,12 @@ var _ = Describe("Localities", func() {
 				})
 
 				It("should report the coordinators as not valid", func() {
-					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+						logr.Discard(),
+						cluster,
+						status,
+						coordinatorStatus,
+					)
 					Expect(coordinatorsValid).To(BeFalse())
 					Expect(addressesValid).To(BeTrue())
 					Expect(err).To(BeNil())
@@ -1484,7 +1781,12 @@ var _ = Describe("Localities", func() {
 				})
 
 				It("should report the coordinators addresses as valid", func() {
-					_, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+					_, addressesValid, err := CheckCoordinatorValidity(
+						logr.Discard(),
+						cluster,
+						status,
+						coordinatorStatus,
+					)
 					Expect(addressesValid).To(BeTrue())
 					Expect(err).To(BeNil())
 				})
@@ -1502,7 +1804,12 @@ var _ = Describe("Localities", func() {
 					})
 
 					It("should report the coordinators addresses as valid", func() {
-						_, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+						_, addressesValid, err := CheckCoordinatorValidity(
+							logr.Discard(),
+							cluster,
+							status,
+							coordinatorStatus,
+						)
 						Expect(addressesValid).To(BeTrue())
 						Expect(err).To(BeNil())
 					})
@@ -1522,7 +1829,12 @@ var _ = Describe("Localities", func() {
 				})
 
 				It("should report the coordinators addresses as valid", func() {
-					_, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+					_, addressesValid, err := CheckCoordinatorValidity(
+						logr.Discard(),
+						cluster,
+						status,
+						coordinatorStatus,
+					)
 					Expect(addressesValid).To(BeTrue())
 					Expect(err).To(BeNil())
 				})
@@ -1541,7 +1853,12 @@ var _ = Describe("Localities", func() {
 					})
 
 					It("should report the coordinators addresses as valid", func() {
-						_, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+						_, addressesValid, err := CheckCoordinatorValidity(
+							logr.Discard(),
+							cluster,
+							status,
+							coordinatorStatus,
+						)
 						Expect(addressesValid).To(BeTrue())
 						Expect(err).To(BeNil())
 					})
@@ -1552,7 +1869,12 @@ var _ = Describe("Localities", func() {
 		When("enabling DNS names in the cluster file", func() {
 			When("the pods do not have DNS names assigned", func() {
 				It("should report valid coordinators", func() {
-					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+						logr.Discard(),
+						cluster,
+						status,
+						coordinatorStatus,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(coordinatorsValid).To(BeTrue())
 					Expect(addressesValid).To(BeTrue())
@@ -1567,7 +1889,12 @@ var _ = Describe("Localities", func() {
 				})
 
 				It("should reject coordinators based on IP addresses", func() {
-					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+						logr.Discard(),
+						cluster,
+						status,
+						coordinatorStatus,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(coordinatorsValid).To(BeFalse())
 					Expect(addressesValid).To(BeTrue())
@@ -1580,49 +1907,66 @@ var _ = Describe("Localities", func() {
 
 					for _, process := range status.Cluster.Processes {
 						process.Locality[fdbv1beta2.FDBLocalityDNSNameKey] = process.Locality[fdbv1beta2.FDBLocalityZoneIDKey]
-						status.Client.Coordinators.Coordinators = append(status.Client.Coordinators.Coordinators,
+						status.Client.Coordinators.Coordinators = append(
+							status.Client.Coordinators.Coordinators,
 							fdbv1beta2.FoundationDBStatusCoordinator{
 								Address: fdbv1beta2.ProcessAddress{
 									StringAddress: process.Locality[fdbv1beta2.FDBLocalityZoneIDKey],
 									Port:          4501,
 								},
-							})
+							},
+						)
 					}
 				})
 
 				It("should return that the coordinators are valid", func() {
-					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
+					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+						logr.Discard(),
+						cluster,
+						status,
+						coordinatorStatus,
+					)
 					Expect(coordinatorsValid).To(BeTrue())
 					Expect(addressesValid).To(BeTrue())
 					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 
-			When("the pods have DNS names assigned and the coordinator have DNS names but DNS is disabled", func() {
-				BeforeEach(func() {
-					status.Client.Coordinators.Coordinators = nil
+			When(
+				"the pods have DNS names assigned and the coordinator have DNS names but DNS is disabled",
+				func() {
+					BeforeEach(func() {
+						status.Client.Coordinators.Coordinators = nil
 
-					for _, process := range status.Cluster.Processes {
-						process.Locality[fdbv1beta2.FDBLocalityDNSNameKey] = process.Locality[fdbv1beta2.FDBLocalityZoneIDKey]
-						status.Client.Coordinators.Coordinators = append(status.Client.Coordinators.Coordinators,
-							fdbv1beta2.FoundationDBStatusCoordinator{
-								Address: fdbv1beta2.ProcessAddress{
-									StringAddress: process.Locality[fdbv1beta2.FDBLocalityZoneIDKey],
-									Port:          4501,
+						for _, process := range status.Cluster.Processes {
+							process.Locality[fdbv1beta2.FDBLocalityDNSNameKey] = process.Locality[fdbv1beta2.FDBLocalityZoneIDKey]
+							status.Client.Coordinators.Coordinators = append(
+								status.Client.Coordinators.Coordinators,
+								fdbv1beta2.FoundationDBStatusCoordinator{
+									Address: fdbv1beta2.ProcessAddress{
+										StringAddress: process.Locality[fdbv1beta2.FDBLocalityZoneIDKey],
+										Port:          4501,
+									},
 								},
-							})
-					}
+							)
+						}
 
-					cluster.Spec.Routing.UseDNSInClusterFile = pointer.Bool(false)
-				})
+						cluster.Spec.Routing.UseDNSInClusterFile = pointer.Bool(false)
+					})
 
-				It("should return that the coordinators are invalid", func() {
-					coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(logr.Discard(), cluster, status, coordinatorStatus)
-					Expect(coordinatorsValid).To(BeFalse())
-					Expect(addressesValid).To(BeTrue())
-					Expect(err).NotTo(HaveOccurred())
-				})
-			})
+					It("should return that the coordinators are invalid", func() {
+						coordinatorsValid, addressesValid, err := CheckCoordinatorValidity(
+							logr.Discard(),
+							cluster,
+							status,
+							coordinatorStatus,
+						)
+						Expect(coordinatorsValid).To(BeFalse())
+						Expect(addressesValid).To(BeTrue())
+						Expect(err).NotTo(HaveOccurred())
+					})
+				},
+			)
 		})
 	})
 })

--- a/internal/maintenance/maintenance_test.go
+++ b/internal/maintenance/maintenance_test.go
@@ -41,12 +41,21 @@ var _ = Describe("maintenance", func() {
 		processesToUpdate           []fdbv1beta2.ProcessGroupID
 	}
 
-	DescribeTable("when getting the maintenance information", func(input maintenanceTest) {
-		finishedMaintenance, staleMaintenanceInformation, processesToUpdate := GetMaintenanceInformation(logr.Discard(), input.cluster, input.status, input.processesUnderMaintenance, input.staleDuration, input.differentZoneWaitDuration)
-		Expect(finishedMaintenance).To(ConsistOf(input.finishedMaintenance))
-		Expect(staleMaintenanceInformation).To(ConsistOf(input.staleMaintenanceInformation))
-		Expect(processesToUpdate).To(ConsistOf(input.processesToUpdate))
-	},
+	DescribeTable(
+		"when getting the maintenance information",
+		func(input maintenanceTest) {
+			finishedMaintenance, staleMaintenanceInformation, processesToUpdate := GetMaintenanceInformation(
+				logr.Discard(),
+				input.cluster,
+				input.status,
+				input.processesUnderMaintenance,
+				input.staleDuration,
+				input.differentZoneWaitDuration,
+			)
+			Expect(finishedMaintenance).To(ConsistOf(input.finishedMaintenance))
+			Expect(staleMaintenanceInformation).To(ConsistOf(input.staleMaintenanceInformation))
+			Expect(processesToUpdate).To(ConsistOf(input.processesToUpdate))
+		},
 		Entry("when no process are under maintenance",
 			maintenanceTest{
 				cluster:                     &fdbv1beta2.FoundationDBCluster{},
@@ -143,7 +152,8 @@ var _ = Describe("maintenance", func() {
 				processesToUpdate:           []fdbv1beta2.ProcessGroupID{"storage-2"},
 			},
 		),
-		Entry("when one process is done with the maintenance but another one is missing in the status",
+		Entry(
+			"when one process is done with the maintenance but another one is missing in the status",
 			maintenanceTest{
 				cluster: &fdbv1beta2.FoundationDBCluster{
 					Status: fdbv1beta2.FoundationDBClusterStatus{
@@ -184,7 +194,8 @@ var _ = Describe("maintenance", func() {
 				processesToUpdate:           []fdbv1beta2.ProcessGroupID{"storage-2"},
 			},
 		),
-		Entry("when one process is done with the maintenance but another one is missing in the status and is removed from the process group list",
+		Entry(
+			"when one process is done with the maintenance but another one is missing in the status and is removed from the process group list",
 			maintenanceTest{
 				cluster: &fdbv1beta2.FoundationDBCluster{
 					Status: fdbv1beta2.FoundationDBClusterStatus{
@@ -221,7 +232,8 @@ var _ = Describe("maintenance", func() {
 				processesToUpdate:           nil,
 			},
 		),
-		Entry("when one process is done with the maintenance and another one from a different fault domain is present",
+		Entry(
+			"when one process is done with the maintenance and another one from a different fault domain is present",
 			maintenanceTest{
 				cluster: &fdbv1beta2.FoundationDBCluster{
 					Status: fdbv1beta2.FoundationDBClusterStatus{
@@ -270,7 +282,8 @@ var _ = Describe("maintenance", func() {
 				processesToUpdate:           nil,
 			},
 		),
-		Entry("when one process is done with the maintenance and another one from a different fault domain is present with an old entry",
+		Entry(
+			"when one process is done with the maintenance and another one from a different fault domain is present with an old entry",
 			maintenanceTest{
 				cluster: &fdbv1beta2.FoundationDBCluster{
 					Status: fdbv1beta2.FoundationDBClusterStatus{

--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -56,7 +56,12 @@ var _ = Describe("monitor_conf", func() {
 			It("generates conf with an no processes", func() {
 				Expect(cluster).NotTo(BeNil())
 				cluster.Status.ConnectionString = ""
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.RunServers).NotTo(BeNil())
 				Expect(*config.RunServers).To(BeFalse())
 				Expect(config.Version).To(Equal(&fdbv1beta2.Versions.Default.Version))
@@ -65,42 +70,86 @@ var _ = Describe("monitor_conf", func() {
 
 		When("running a storage instance", func() {
 			It("generates the conf", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Version).To(Equal(&fdbv1beta2.Versions.Default.Version))
 				Expect(config.BinaryPath).To(BeEmpty())
 				Expect(config.RunServers).To(BeNil())
 
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
-				Expect(config.Arguments[0]).To(Equal(monitorapi.Argument{Value: "--cluster_file=/var/fdb/data/fdb.cluster"}))
-				Expect(config.Arguments[1]).To(Equal(monitorapi.Argument{Value: "--seed_cluster_file=/var/dynamic-conf/fdb.cluster"}))
-				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[0],
+				).To(Equal(monitorapi.Argument{Value: "--cluster_file=/var/fdb/data/fdb.cluster"}))
+				Expect(
+					config.Arguments[1],
+				).To(Equal(monitorapi.Argument{Value: "--seed_cluster_file=/var/dynamic-conf/fdb.cluster"}))
+				Expect(
+					config.Arguments[2],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address=["},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNamePublicIP},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNamePublicIP,
+					},
 					{Value: "]:"},
-					{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4499, Multiplier: 2},
+					{
+						ArgumentType: monitorapi.ProcessNumberArgumentType,
+						Offset:       4499,
+						Multiplier:   2,
+					},
 				}}))
 				Expect(config.Arguments[3]).To(Equal(monitorapi.Argument{Value: "--class=storage"}))
-				Expect(config.Arguments[4]).To(Equal(monitorapi.Argument{Value: "--logdir=/var/log/fdb-trace-logs"}))
-				Expect(config.Arguments[5]).To(Equal(monitorapi.Argument{Value: "--loggroup=" + cluster.Name}))
-				Expect(config.Arguments[6]).To(Equal(monitorapi.Argument{Value: "--datadir=/var/fdb/data"}))
-				Expect(config.Arguments[7]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[4],
+				).To(Equal(monitorapi.Argument{Value: "--logdir=/var/log/fdb-trace-logs"}))
+				Expect(
+					config.Arguments[5],
+				).To(Equal(monitorapi.Argument{Value: "--loggroup=" + cluster.Name}))
+				Expect(
+					config.Arguments[6],
+				).To(Equal(monitorapi.Argument{Value: "--datadir=/var/fdb/data"}))
+				Expect(
+					config.Arguments[7],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--locality_instance_id="},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNameInstanceID},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNameInstanceID,
+					},
 				}}))
-				Expect(config.Arguments[8]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[8],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--locality_machineid="},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNameMachineID},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNameMachineID,
+					},
 				}}))
-				Expect(config.Arguments[9]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[9],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--locality_zoneid="},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNameZoneID},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNameZoneID,
+					},
 				}}))
 			})
 		})
 
 		When("running a log instance", func() {
 			It("generates the conf", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassLog, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassLog,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Version).To(Equal(&fdbv1beta2.Versions.Default.Version))
 				Expect(config.BinaryPath).To(BeEmpty())
 				Expect(config.RunServers).To(BeNil())
@@ -112,57 +161,116 @@ var _ = Describe("monitor_conf", func() {
 
 		When("using the split image type", func() {
 			It("generates the conf", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeSplit)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeSplit,
+				)
 				Expect(config.Version).To(Equal(&fdbv1beta2.Versions.Default.Version))
 				Expect(config.BinaryPath).To(BeEmpty())
 				Expect(config.RunServers).To(BeNil())
 
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
-				Expect(config.Arguments[0]).To(Equal(monitorapi.Argument{Value: "--cluster_file=/var/fdb/data/fdb.cluster"}))
-				Expect(config.Arguments[1]).To(Equal(monitorapi.Argument{Value: "--seed_cluster_file=/var/dynamic-conf/fdb.cluster"}))
-				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[0],
+				).To(Equal(monitorapi.Argument{Value: "--cluster_file=/var/fdb/data/fdb.cluster"}))
+				Expect(
+					config.Arguments[1],
+				).To(Equal(monitorapi.Argument{Value: "--seed_cluster_file=/var/dynamic-conf/fdb.cluster"}))
+				Expect(
+					config.Arguments[2],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address="},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNamePublicIP},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNamePublicIP,
+					},
 					{Value: ":"},
-					{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4499, Multiplier: 2},
+					{
+						ArgumentType: monitorapi.ProcessNumberArgumentType,
+						Offset:       4499,
+						Multiplier:   2,
+					},
 				}}))
 				Expect(config.Arguments[3]).To(Equal(monitorapi.Argument{Value: "--class=storage"}))
-				Expect(config.Arguments[4]).To(Equal(monitorapi.Argument{Value: "--logdir=/var/log/fdb-trace-logs"}))
-				Expect(config.Arguments[5]).To(Equal(monitorapi.Argument{Value: "--loggroup=" + cluster.Name}))
-				Expect(config.Arguments[6]).To(Equal(monitorapi.Argument{Value: "--datadir=/var/fdb/data"}))
-				Expect(config.Arguments[7]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[4],
+				).To(Equal(monitorapi.Argument{Value: "--logdir=/var/log/fdb-trace-logs"}))
+				Expect(
+					config.Arguments[5],
+				).To(Equal(monitorapi.Argument{Value: "--loggroup=" + cluster.Name}))
+				Expect(
+					config.Arguments[6],
+				).To(Equal(monitorapi.Argument{Value: "--datadir=/var/fdb/data"}))
+				Expect(
+					config.Arguments[7],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--locality_instance_id="},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNameInstanceID},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNameInstanceID,
+					},
 				}}))
-				Expect(config.Arguments[8]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[8],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--locality_machineid="},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNameMachineID},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNameMachineID,
+					},
 				}}))
-				Expect(config.Arguments[9]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[9],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--locality_zoneid="},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNameZoneID},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNameZoneID,
+					},
 				}}))
 			})
 		})
 
 		When("running multiple processes", func() {
 			It("adds a process ID argument", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 2, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					2,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
-				Expect(config.Arguments[7]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[7],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--locality_process_id="},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNameInstanceID},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNameInstanceID,
+					},
 					{Value: "-"},
 					{ArgumentType: monitorapi.ProcessNumberArgumentType},
 				}}))
-				Expect(config.Arguments[8]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[8],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--locality_instance_id="},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNameInstanceID},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNameInstanceID,
+					},
 				}}))
 			})
 
 			It("includes the process number in the data directory", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 2, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					2,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments[6]).To(Equal(monitorapi.Argument{
 					ArgumentType: monitorapi.ConcatenateArgumentType,
 					Values: []monitorapi.Argument{
@@ -180,13 +288,27 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("does not have a listen address", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
-				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[2],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address=["},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNamePublicIP},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNamePublicIP,
+					},
 					{Value: "]:"},
-					{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4499, Multiplier: 2},
+					{
+						ArgumentType: monitorapi.ProcessNumberArgumentType,
+						Offset:       4499,
+						Multiplier:   2,
+					},
 				}}))
 			})
 		})
@@ -199,19 +321,42 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("adds a separate listen address", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
-				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[2],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address=["},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNamePublicIP},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNamePublicIP,
+					},
 					{Value: "]:"},
-					{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4499, Multiplier: 2},
+					{
+						ArgumentType: monitorapi.ProcessNumberArgumentType,
+						Offset:       4499,
+						Multiplier:   2,
+					},
 				}}))
-				Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[10],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--listen_address=["},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNamePodIP},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNamePodIP,
+					},
 					{Value: "]:"},
-					{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4499, Multiplier: 2},
+					{
+						ArgumentType: monitorapi.ProcessNumberArgumentType,
+						Offset:       4499,
+						Multiplier:   2,
+					},
 				}}))
 			})
 
@@ -221,13 +366,27 @@ var _ = Describe("monitor_conf", func() {
 				})
 
 				It("does not have a listen address", func() {
-					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+					config := GetMonitorProcessConfiguration(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						1,
+						fdbv1beta2.ImageTypeUnified,
+					)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength))
-					Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+					Expect(
+						config.Arguments[2],
+					).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 						{Value: "--public_address=["},
-						{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNamePublicIP},
+						{
+							ArgumentType: monitorapi.EnvironmentArgumentType,
+							Source:       fdbv1beta2.EnvNamePublicIP,
+						},
 						{Value: "]:"},
-						{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4499, Multiplier: 2},
+						{
+							ArgumentType: monitorapi.ProcessNumberArgumentType,
+							Offset:       4499,
+							Multiplier:   2,
+						},
 					}}))
 				})
 			})
@@ -241,13 +400,27 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("includes the TLS flag in the address", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
-				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[2],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address=["},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNamePublicIP},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNamePublicIP,
+					},
 					{Value: "]:"},
-					{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4498, Multiplier: 2},
+					{
+						ArgumentType: monitorapi.ProcessNumberArgumentType,
+						Offset:       4498,
+						Multiplier:   2,
+					},
 					{Value: ":tls"},
 				}}))
 			})
@@ -261,18 +434,39 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("includes both addresses", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
-				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[2],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address=["},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNamePublicIP},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNamePublicIP,
+					},
 					{Value: "]:"},
-					{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4498, Multiplier: 2},
+					{
+						ArgumentType: monitorapi.ProcessNumberArgumentType,
+						Offset:       4498,
+						Multiplier:   2,
+					},
 					{Value: ":tls"},
 					{Value: ",["},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNamePublicIP},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNamePublicIP,
+					},
 					{Value: "]:"},
-					{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4499, Multiplier: 2},
+					{
+						ArgumentType: monitorapi.ProcessNumberArgumentType,
+						Offset:       4499,
+						Multiplier:   2,
+					},
 				}}))
 			})
 		})
@@ -285,18 +479,39 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("includes both addresses", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
-				Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments[2],
+				).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--public_address=["},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNamePublicIP},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNamePublicIP,
+					},
 					{Value: "]:"},
-					{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4498, Multiplier: 2},
+					{
+						ArgumentType: monitorapi.ProcessNumberArgumentType,
+						Offset:       4498,
+						Multiplier:   2,
+					},
 					{Value: ":tls"},
 					{Value: ",["},
-					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: fdbv1beta2.EnvNamePublicIP},
+					{
+						ArgumentType: monitorapi.EnvironmentArgumentType,
+						Source:       fdbv1beta2.EnvNamePublicIP,
+					},
 					{Value: "]:"},
-					{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4499, Multiplier: 2},
+					{
+						ArgumentType: monitorapi.ProcessNumberArgumentType,
+						Offset:       4499,
+						Multiplier:   2,
+					},
 				}}))
 			})
 		})
@@ -304,13 +519,22 @@ var _ = Describe("monitor_conf", func() {
 		When("the cluster has custom parameters", func() {
 			When("there are parameters in the general section", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-						"knob_disable_posix_kernel_aio = 1",
-					}}}
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_disable_posix_kernel_aio = 1",
+							},
+						},
+					}
 				})
 
 				It("includes the custom parameters", func() {
-					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+					config := GetMonitorProcessConfiguration(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						1,
+						fdbv1beta2.ImageTypeUnified,
+					)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 					Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
 						ArgumentType: monitorapi.ConcatenateArgumentType,
@@ -330,20 +554,31 @@ var _ = Describe("monitor_conf", func() {
 			When("there are parameters on different process classes", func() {
 				BeforeEach(func() {
 					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
-						fdbv1beta2.ProcessClassGeneral: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-							"knob_disable_posix_kernel_aio = 1",
-						}},
-						fdbv1beta2.ProcessClassStorage: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-							"knob_test = test1",
-						}},
-						fdbv1beta2.ProcessClassStateless: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-							"knob_test = test2",
-						}},
+						fdbv1beta2.ProcessClassGeneral: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_disable_posix_kernel_aio = 1",
+							},
+						},
+						fdbv1beta2.ProcessClassStorage: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_test = test1",
+							},
+						},
+						fdbv1beta2.ProcessClassStateless: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_test = test2",
+							},
+						},
 					}
 				})
 
 				It("includes the custom parameters for that class", func() {
-					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+					config := GetMonitorProcessConfiguration(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						1,
+						fdbv1beta2.ImageTypeUnified,
+					)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 					Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
 						ArgumentType: monitorapi.ConcatenateArgumentType,
@@ -366,13 +601,28 @@ var _ = Describe("monitor_conf", func() {
 				})
 
 				It("specifies the IP family for the public address", func() {
-					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+					config := GetMonitorProcessConfiguration(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						1,
+						fdbv1beta2.ImageTypeUnified,
+					)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength))
-					Expect(config.Arguments[2]).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+					Expect(
+						config.Arguments[2],
+					).To(Equal(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 						{Value: "--public_address=["},
-						{ArgumentType: monitorapi.IPListArgumentType, Source: fdbv1beta2.EnvNamePublicIP, IPFamily: 6},
+						{
+							ArgumentType: monitorapi.IPListArgumentType,
+							Source:       fdbv1beta2.EnvNamePublicIP,
+							IPFamily:     6,
+						},
 						{Value: "]:"},
-						{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4499, Multiplier: 2},
+						{
+							ArgumentType: monitorapi.ProcessNumberArgumentType,
+							Offset:       4499,
+							Multiplier:   2,
+						},
 					}}))
 				})
 			})
@@ -383,13 +633,28 @@ var _ = Describe("monitor_conf", func() {
 				})
 
 				It("specifies the IP family for the public address", func() {
-					config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+					config := GetMonitorProcessConfiguration(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						1,
+						fdbv1beta2.ImageTypeUnified,
+					)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength))
-					Expect(config.Arguments).To(ContainElement(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+					Expect(
+						config.Arguments,
+					).To(ContainElement(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 						{Value: "--public_address=["},
-						{ArgumentType: monitorapi.IPListArgumentType, Source: fdbv1beta2.EnvNamePublicIP, IPFamily: 4},
+						{
+							ArgumentType: monitorapi.IPListArgumentType,
+							Source:       fdbv1beta2.EnvNamePublicIP,
+							IPFamily:     4,
+						},
 						{Value: "]:"},
-						{ArgumentType: monitorapi.ProcessNumberArgumentType, Offset: 4499, Multiplier: 2},
+						{
+							ArgumentType: monitorapi.ProcessNumberArgumentType,
+							Offset:       4499,
+							Multiplier:   2,
+						},
 					}}))
 				})
 			})
@@ -404,10 +669,17 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("uses the variable as the zone ID", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 
-				Expect(config.Arguments).To(ContainElement(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
+				Expect(
+					config.Arguments,
+				).To(ContainElement(monitorapi.Argument{ArgumentType: monitorapi.ConcatenateArgumentType, Values: []monitorapi.Argument{
 					{Value: "--locality_zoneid="},
 					{ArgumentType: monitorapi.EnvironmentArgumentType, Source: "RACK"},
 				}}))
@@ -420,9 +692,16 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("includes the verification rules", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
-				Expect(config.Arguments).To(ContainElement(monitorapi.Argument{Value: "--tls_verify_peers=S.CN=foundationdb.org"}))
+				Expect(
+					config.Arguments,
+				).To(ContainElement(monitorapi.Argument{Value: "--tls_verify_peers=S.CN=foundationdb.org"}))
 			})
 		})
 
@@ -432,9 +711,16 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("includes the log group", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
-				Expect(config.Arguments).To(ContainElement(monitorapi.Argument{Value: "--loggroup=test-fdb-cluster"}))
+				Expect(
+					config.Arguments,
+				).To(ContainElement(monitorapi.Argument{Value: "--loggroup=test-fdb-cluster"}))
 			})
 		})
 
@@ -444,9 +730,16 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("adds an argument for the data center", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
-				Expect(config.Arguments).To(ContainElement(monitorapi.Argument{Value: "--locality_dcid=dc01"}))
+				Expect(
+					config.Arguments,
+				).To(ContainElement(monitorapi.Argument{Value: "--locality_dcid=dc01"}))
 			})
 		})
 
@@ -456,9 +749,16 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("adds an argument for the data hall", func() {
-				config := GetMonitorProcessConfiguration(cluster, fdbv1beta2.ProcessClassStorage, 1, fdbv1beta2.ImageTypeUnified)
+				config := GetMonitorProcessConfiguration(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					1,
+					fdbv1beta2.ImageTypeUnified,
+				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
-				Expect(config.Arguments).To(ContainElement(monitorapi.Argument{Value: "--locality_data_hall=dh01"}))
+				Expect(
+					config.Arguments,
+				).To(ContainElement(monitorapi.Argument{Value: "--locality_data_hall=dh01"}))
 			})
 		})
 	})
@@ -487,9 +787,20 @@ var _ = Describe("monitor_conf", func() {
 
 			When("no additional custom parameters are defined", func() {
 				It("should substitute the variables in the start command", func() {
-					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
+					substitutions, err := GetSubstitutionsFromClusterAndPod(
+						logr.Discard(),
+						cluster,
+						pod,
+					)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
+					command, err = GetStartCommandWithSubstitutions(
+						cluster,
+						processClass,
+						substitutions,
+						1,
+						1,
+						cluster.DesiredImageType(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(command).To(Equal(strings.Join([]string{
@@ -497,7 +808,10 @@ var _ = Describe("monitor_conf", func() {
 						"--class=storage",
 						"--cluster_file=/var/fdb/data/fdb.cluster",
 						"--datadir=/var/fdb/data",
-						fmt.Sprintf("--locality_dns_name=%s", substitutions[fdbv1beta2.EnvNameDNSName]),
+						fmt.Sprintf(
+							"--locality_dns_name=%s",
+							substitutions[fdbv1beta2.EnvNameDNSName],
+						),
 						fmt.Sprintf("--locality_instance_id=%s", processGroupID),
 						fmt.Sprintf("--locality_machineid=%s-%s", cluster.Name, processGroupID),
 						fmt.Sprintf("--locality_zoneid=%s-%s", cluster.Name, processGroupID),
@@ -512,12 +826,25 @@ var _ = Describe("monitor_conf", func() {
 			When("custom parameters with substitutions are defined", func() {
 				It("should substitute the variables in the custom parameters", func() {
 					settings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
-					settings.CustomParameters = []fdbv1beta2.FoundationDBCustomParameter{"locality_disk_id=$FDB_INSTANCE_ID"}
+					settings.CustomParameters = []fdbv1beta2.FoundationDBCustomParameter{
+						"locality_disk_id=$FDB_INSTANCE_ID",
+					}
 					cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = settings
 
-					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
+					substitutions, err := GetSubstitutionsFromClusterAndPod(
+						logr.Discard(),
+						cluster,
+						pod,
+					)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
+					command, err = GetStartCommandWithSubstitutions(
+						cluster,
+						processClass,
+						substitutions,
+						1,
+						1,
+						cluster.DesiredImageType(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(command).To(Equal(strings.Join([]string{
@@ -526,7 +853,10 @@ var _ = Describe("monitor_conf", func() {
 						"--cluster_file=/var/fdb/data/fdb.cluster",
 						"--datadir=/var/fdb/data",
 						fmt.Sprintf("--locality_disk_id=%s", processGroupID),
-						fmt.Sprintf("--locality_dns_name=%s", substitutions[fdbv1beta2.EnvNameDNSName]),
+						fmt.Sprintf(
+							"--locality_dns_name=%s",
+							substitutions[fdbv1beta2.EnvNameDNSName],
+						),
 						fmt.Sprintf("--locality_instance_id=%s", processGroupID),
 						fmt.Sprintf("--locality_machineid=%s-%s", cluster.Name, processGroupID),
 						fmt.Sprintf("--locality_zoneid=%s-%s", cluster.Name, processGroupID),
@@ -540,9 +870,20 @@ var _ = Describe("monitor_conf", func() {
 
 			When("multiple storage servers per Pod are defined", func() {
 				It("should substitute the variables in the start command", func() {
-					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
+					substitutions, err := GetSubstitutionsFromClusterAndPod(
+						logr.Discard(),
+						cluster,
+						pod,
+					)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 2, cluster.DesiredImageType())
+					command, err = GetStartCommandWithSubstitutions(
+						cluster,
+						processClass,
+						substitutions,
+						1,
+						2,
+						cluster.DesiredImageType(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 
 					id := "storage-1"
@@ -551,7 +892,10 @@ var _ = Describe("monitor_conf", func() {
 						"--class=storage",
 						"--cluster_file=/var/fdb/data/fdb.cluster",
 						"--datadir=/var/fdb/data/1",
-						fmt.Sprintf("--locality_dns_name=%s", substitutions[fdbv1beta2.EnvNameDNSName]),
+						fmt.Sprintf(
+							"--locality_dns_name=%s",
+							substitutions[fdbv1beta2.EnvNameDNSName],
+						),
 						fmt.Sprintf("--locality_instance_id=%s", id),
 						fmt.Sprintf("--locality_machineid=%s-%s", cluster.Name, id),
 						fmt.Sprintf("--locality_process_id=%s-1", id),
@@ -562,14 +906,24 @@ var _ = Describe("monitor_conf", func() {
 						"--seed_cluster_file=/var/dynamic-conf/fdb.cluster",
 					}, " ")))
 
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 2, 2, cluster.DesiredImageType())
+					command, err = GetStartCommandWithSubstitutions(
+						cluster,
+						processClass,
+						substitutions,
+						2,
+						2,
+						cluster.DesiredImageType(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
 						"/usr/bin/fdbserver",
 						"--class=storage",
 						"--cluster_file=/var/fdb/data/fdb.cluster",
 						"--datadir=/var/fdb/data/2",
-						fmt.Sprintf("--locality_dns_name=%s", substitutions[fdbv1beta2.EnvNameDNSName]),
+						fmt.Sprintf(
+							"--locality_dns_name=%s",
+							substitutions[fdbv1beta2.EnvNameDNSName],
+						),
 						fmt.Sprintf("--locality_instance_id=%s", id),
 						fmt.Sprintf("--locality_machineid=%s-%s", cluster.Name, id),
 						fmt.Sprintf("--locality_process_id=%s-2", id),
@@ -589,9 +943,20 @@ var _ = Describe("monitor_conf", func() {
 					pod.Spec.NodeName = "machine1"
 					cluster.Spec.FaultDomain = fdbv1beta2.FoundationDBClusterFaultDomain{}
 
-					substitutions, err = GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
+					substitutions, err = GetSubstitutionsFromClusterAndPod(
+						logr.Discard(),
+						cluster,
+						pod,
+					)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, fdbv1beta2.ProcessClassStorage, substitutions, 1, 1, cluster.DesiredImageType())
+					command, err = GetStartCommandWithSubstitutions(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						substitutions,
+						1,
+						1,
+						cluster.DesiredImageType(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -601,7 +966,10 @@ var _ = Describe("monitor_conf", func() {
 						"--class=storage",
 						"--cluster_file=/var/fdb/data/fdb.cluster",
 						"--datadir=/var/fdb/data",
-						fmt.Sprintf("--locality_dns_name=%s", substitutions[fdbv1beta2.EnvNameDNSName]),
+						fmt.Sprintf(
+							"--locality_dns_name=%s",
+							substitutions[fdbv1beta2.EnvNameDNSName],
+						),
 						"--locality_instance_id=storage-1",
 						"--locality_machineid=machine1",
 						"--locality_zoneid=machine1",
@@ -624,9 +992,20 @@ var _ = Describe("monitor_conf", func() {
 						Value: "kc2",
 					}
 
-					substitutions, err = GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
+					substitutions, err = GetSubstitutionsFromClusterAndPod(
+						logr.Discard(),
+						cluster,
+						pod,
+					)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, fdbv1beta2.ProcessClassStorage, substitutions, 1, 1, cluster.DesiredImageType())
+					command, err = GetStartCommandWithSubstitutions(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						substitutions,
+						1,
+						1,
+						cluster.DesiredImageType(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -636,7 +1015,10 @@ var _ = Describe("monitor_conf", func() {
 						"--class=storage",
 						"--cluster_file=/var/fdb/data/fdb.cluster",
 						"--datadir=/var/fdb/data",
-						fmt.Sprintf("--locality_dns_name=%s", substitutions[fdbv1beta2.EnvNameDNSName]),
+						fmt.Sprintf(
+							"--locality_dns_name=%s",
+							substitutions[fdbv1beta2.EnvNameDNSName],
+						),
 						"--locality_instance_id=storage-1",
 						"--locality_machineid=machine1",
 						"--locality_zoneid=kc2",
@@ -654,9 +1036,20 @@ var _ = Describe("monitor_conf", func() {
 				BeforeEach(func() {
 					cluster.Spec.Version = fdbv1beta2.Versions.Default.String()
 					cluster.Status.RunningVersion = fdbv1beta2.Versions.Default.String()
-					substitutions, err = GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
+					substitutions, err = GetSubstitutionsFromClusterAndPod(
+						logr.Discard(),
+						cluster,
+						pod,
+					)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, fdbv1beta2.ProcessClassStorage, substitutions, 1, 1, cluster.DesiredImageType())
+					command, err = GetStartCommandWithSubstitutions(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						substitutions,
+						1,
+						1,
+						cluster.DesiredImageType(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -667,7 +1060,10 @@ var _ = Describe("monitor_conf", func() {
 						"--class=storage",
 						"--cluster_file=/var/fdb/data/fdb.cluster",
 						"--datadir=/var/fdb/data",
-						fmt.Sprintf("--locality_dns_name=%s", substitutions[fdbv1beta2.EnvNameDNSName]),
+						fmt.Sprintf(
+							"--locality_dns_name=%s",
+							substitutions[fdbv1beta2.EnvNameDNSName],
+						),
 						fmt.Sprintf("--locality_instance_id=%s", id),
 						fmt.Sprintf("--locality_machineid=%s-%s", cluster.Name, id),
 						fmt.Sprintf("--locality_zoneid=%s-%s", cluster.Name, id),
@@ -687,9 +1083,20 @@ var _ = Describe("monitor_conf", func() {
 			})
 
 			It("should generate the unsorted command-line", func() {
-				substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
+				substitutions, err := GetSubstitutionsFromClusterAndPod(
+					logr.Discard(),
+					cluster,
+					pod,
+				)
 				Expect(err).NotTo(HaveOccurred())
-				command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
+				command, err = GetStartCommandWithSubstitutions(
+					cluster,
+					processClass,
+					substitutions,
+					1,
+					1,
+					cluster.DesiredImageType(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(command).To(Equal(strings.Join([]string{
@@ -711,9 +1118,20 @@ var _ = Describe("monitor_conf", func() {
 
 			When("the pod has multiple processes", func() {
 				It("should fill in the process number", func() {
-					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
+					substitutions, err := GetSubstitutionsFromClusterAndPod(
+						logr.Discard(),
+						cluster,
+						pod,
+					)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 2, 3, cluster.DesiredImageType())
+					command, err = GetStartCommandWithSubstitutions(
+						cluster,
+						processClass,
+						substitutions,
+						2,
+						3,
+						cluster.DesiredImageType(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(command).To(Equal(strings.Join([]string{
@@ -729,7 +1147,10 @@ var _ = Describe("monitor_conf", func() {
 						fmt.Sprintf("--locality_instance_id=%s", processGroupID),
 						fmt.Sprintf("--locality_machineid=%s-%s", cluster.Name, processGroupID),
 						fmt.Sprintf("--locality_zoneid=%s-%s", cluster.Name, processGroupID),
-						fmt.Sprintf("--locality_dns_name=%s", substitutions[fdbv1beta2.EnvNameDNSName]),
+						fmt.Sprintf(
+							"--locality_dns_name=%s",
+							substitutions[fdbv1beta2.EnvNameDNSName],
+						),
 					}, " ")))
 				})
 			})
@@ -745,9 +1166,20 @@ var _ = Describe("monitor_conf", func() {
 				})
 
 				It("should substitute the variables in the custom parameters", func() {
-					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
+					substitutions, err := GetSubstitutionsFromClusterAndPod(
+						logr.Discard(),
+						cluster,
+						pod,
+					)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
+					command, err = GetStartCommandWithSubstitutions(
+						cluster,
+						processClass,
+						substitutions,
+						1,
+						1,
+						cluster.DesiredImageType(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
 						"/usr/bin/fdbserver",
@@ -764,7 +1196,10 @@ var _ = Describe("monitor_conf", func() {
 						fmt.Sprintf("--locality_zoneid=%s-%s", cluster.Name, processGroupID),
 						fmt.Sprintf("--locality_disk_id=%s", processGroupID),
 						fmt.Sprintf("--test=%s-%s", cluster.Name, processGroupID),
-						fmt.Sprintf("--locality_dns_name=%s", substitutions[fdbv1beta2.EnvNameDNSName]),
+						fmt.Sprintf(
+							"--locality_dns_name=%s",
+							substitutions[fdbv1beta2.EnvNameDNSName],
+						),
 					}, " ")))
 				})
 			})
@@ -780,9 +1215,20 @@ var _ = Describe("monitor_conf", func() {
 				})
 
 				It("should substitute the variables in the custom parameters", func() {
-					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
+					substitutions, err := GetSubstitutionsFromClusterAndPod(
+						logr.Discard(),
+						cluster,
+						pod,
+					)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
+					command, err = GetStartCommandWithSubstitutions(
+						cluster,
+						processClass,
+						substitutions,
+						1,
+						1,
+						cluster.DesiredImageType(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
 						"/usr/bin/fdbserver",
@@ -798,7 +1244,10 @@ var _ = Describe("monitor_conf", func() {
 						fmt.Sprintf("--locality_machineid=%s-%s", cluster.Name, processGroupID),
 						fmt.Sprintf("--locality_zoneid=%s-%s", cluster.Name, processGroupID),
 						fmt.Sprintf("--locality_dcid=%s", processGroupID),
-						fmt.Sprintf("--locality_dns_name=%s", substitutions[fdbv1beta2.EnvNameDNSName]),
+						fmt.Sprintf(
+							"--locality_dns_name=%s",
+							substitutions[fdbv1beta2.EnvNameDNSName],
+						),
 					}, " ")))
 				})
 			})
@@ -814,9 +1263,20 @@ var _ = Describe("monitor_conf", func() {
 				})
 
 				It("should substitute the variables in the custom parameters", func() {
-					substitutions, err := GetSubstitutionsFromClusterAndPod(logr.Discard(), cluster, pod)
+					substitutions, err := GetSubstitutionsFromClusterAndPod(
+						logr.Discard(),
+						cluster,
+						pod,
+					)
 					Expect(err).NotTo(HaveOccurred())
-					command, err = GetStartCommandWithSubstitutions(cluster, processClass, substitutions, 1, 1, cluster.DesiredImageType())
+					command, err = GetStartCommandWithSubstitutions(
+						cluster,
+						processClass,
+						substitutions,
+						1,
+						1,
+						cluster.DesiredImageType(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
 						"/usr/bin/fdbserver",
@@ -832,7 +1292,10 @@ var _ = Describe("monitor_conf", func() {
 						fmt.Sprintf("--locality_machineid=%s-%s", cluster.Name, processGroupID),
 						fmt.Sprintf("--locality_zoneid=%s-%s", cluster.Name, processGroupID),
 						fmt.Sprintf("--locality_data_hall=%s", processGroupID),
-						fmt.Sprintf("--locality_dns_name=%s", substitutions[fdbv1beta2.EnvNameDNSName]),
+						fmt.Sprintf(
+							"--locality_dns_name=%s",
+							substitutions[fdbv1beta2.EnvNameDNSName],
+						),
 					}, " ")))
 				})
 			})
@@ -849,7 +1312,12 @@ var _ = Describe("monitor_conf", func() {
 
 		Context("with a basic storage instance", func() {
 			BeforeEach(func() {
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -877,7 +1345,12 @@ var _ = Describe("monitor_conf", func() {
 
 		Context("with a test instance", func() {
 			BeforeEach(func() {
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassTest, nil, cluster.GetStorageServersPerPod())
+				conf, err = GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassTest,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -906,7 +1379,12 @@ var _ = Describe("monitor_conf", func() {
 		Context("with DNS names in locality fields disabled", func() {
 			BeforeEach(func() {
 				cluster.Spec.Routing.UseDNSInClusterFile = pointer.Bool(false)
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -934,7 +1412,12 @@ var _ = Describe("monitor_conf", func() {
 		Context("with a basic storage instance with multiple storage servers per Pod", func() {
 			BeforeEach(func() {
 				cluster.Spec.StorageServersPerPod = 2
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1071,7 +1554,12 @@ var _ = Describe("monitor_conf", func() {
 				cluster.Spec.MainContainer.EnableTLS = true
 				cluster.Status.RequiredAddresses.NonTLS = false
 				cluster.Status.RequiredAddresses.TLS = true
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1103,7 +1591,12 @@ var _ = Describe("monitor_conf", func() {
 				cluster.Status.RequiredAddresses.NonTLS = true
 				cluster.Status.RequiredAddresses.TLS = true
 
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1116,7 +1609,11 @@ var _ = Describe("monitor_conf", func() {
 					fmt.Sprintf("command = $%s/fdbserver", fdbv1beta2.EnvNameBinaryDir),
 					"cluster_file = /var/fdb/data/fdb.cluster",
 					"seed_cluster_file = /var/dynamic-conf/fdb.cluster",
-					fmt.Sprintf("public_address = $%s:4500:tls,$%s:4501", fdbv1beta2.EnvNamePublicIP, fdbv1beta2.EnvNamePublicIP),
+					fmt.Sprintf(
+						"public_address = $%s:4500:tls,$%s:4501",
+						fdbv1beta2.EnvNamePublicIP,
+						fdbv1beta2.EnvNamePublicIP,
+					),
 					"class = storage",
 					"logdir = /var/log/fdb-trace-logs",
 					"loggroup = " + cluster.Name,
@@ -1135,7 +1632,12 @@ var _ = Describe("monitor_conf", func() {
 				cluster.Status.RequiredAddresses.NonTLS = true
 				cluster.Status.RequiredAddresses.TLS = true
 
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1148,7 +1650,11 @@ var _ = Describe("monitor_conf", func() {
 					fmt.Sprintf("command = $%s/fdbserver", fdbv1beta2.EnvNameBinaryDir),
 					"cluster_file = /var/fdb/data/fdb.cluster",
 					"seed_cluster_file = /var/dynamic-conf/fdb.cluster",
-					fmt.Sprintf("public_address = $%s:4500:tls,$%s:4501", fdbv1beta2.EnvNamePublicIP, fdbv1beta2.EnvNamePublicIP),
+					fmt.Sprintf(
+						"public_address = $%s:4500:tls,$%s:4501",
+						fdbv1beta2.EnvNamePublicIP,
+						fdbv1beta2.EnvNamePublicIP,
+					),
 					"class = storage",
 					"logdir = /var/log/fdb-trace-logs",
 					"loggroup = " + cluster.Name,
@@ -1164,10 +1670,19 @@ var _ = Describe("monitor_conf", func() {
 		Context("with custom parameters", func() {
 			Context("with general parameters", func() {
 				BeforeEach(func() {
-					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-						"knob_disable_posix_kernel_aio = 1",
-					}}}
-					conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_disable_posix_kernel_aio = 1",
+							},
+						},
+					}
+					conf, err = GetMonitorConf(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						nil,
+						cluster.GetStorageServersPerPod(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -1197,17 +1712,28 @@ var _ = Describe("monitor_conf", func() {
 			Context("with process-class parameters", func() {
 				BeforeEach(func() {
 					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
-						fdbv1beta2.ProcessClassGeneral: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-							"knob_disable_posix_kernel_aio = 1",
-						}},
-						fdbv1beta2.ProcessClassStorage: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-							"knob_test = test1",
-						}},
-						fdbv1beta2.ProcessClassStateless: {CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-							"knob_test = test2",
-						}},
+						fdbv1beta2.ProcessClassGeneral: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_disable_posix_kernel_aio = 1",
+							},
+						},
+						fdbv1beta2.ProcessClassStorage: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_test = test1",
+							},
+						},
+						fdbv1beta2.ProcessClassStateless: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"knob_test = test2",
+							},
+						},
 					}
-					conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+					conf, err = GetMonitorConf(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						nil,
+						cluster.GetStorageServersPerPod(),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -1241,7 +1767,12 @@ var _ = Describe("monitor_conf", func() {
 					Key:       "rack",
 					ValueFrom: "$RACK",
 				}
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1270,7 +1801,12 @@ var _ = Describe("monitor_conf", func() {
 		Context("with peer verification rules", func() {
 			BeforeEach(func() {
 				cluster.Spec.MainContainer.PeerVerificationRules = "S.CN=foundationdb.org"
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1300,7 +1836,12 @@ var _ = Describe("monitor_conf", func() {
 		Context("with a custom log group", func() {
 			BeforeEach(func() {
 				cluster.Spec.LogGroup = "test-fdb-cluster"
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1329,7 +1870,12 @@ var _ = Describe("monitor_conf", func() {
 		Context("with a data center", func() {
 			BeforeEach(func() {
 				cluster.Spec.DataCenter = "dc01"
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, cluster.GetStorageServersPerPod())
+				conf, err = GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					cluster.GetStorageServersPerPod(),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/internal/node_predicate.go
+++ b/internal/node_predicate.go
@@ -65,7 +65,8 @@ func (n NodeTaintChangedPredicate) Update(event event.UpdateEvent) bool {
 
 	taintsChanged := !equality.Semantic.DeepEqual(oldNode.Spec.Taints, newNode.Spec.Taints)
 	if taintsChanged {
-		n.Logger.V(1).Info("Node taints have changed", "node", oldNode.Name, "taintsChanged", taintsChanged, "oldTaints", oldNode.Spec.Taints, "newTaints", newNode.Spec.Taints)
+		n.Logger.V(1).
+			Info("Node taints have changed", "node", oldNode.Name, "taintsChanged", taintsChanged, "oldTaints", oldNode.Spec.Taints, "newTaints", newNode.Spec.Taints)
 	}
 
 	return taintsChanged

--- a/internal/pod_client_test.go
+++ b/internal/pod_client_test.go
@@ -81,7 +81,13 @@ var _ = Describe("pod_client", func() {
 
 		When("generating a http get request", func() {
 			It("should generate the request", func() {
-				req, err := generateRequest(retryClient, target.String(), http.MethodGet, getTimeout, postTimeout)
+				req, err := generateRequest(
+					retryClient,
+					target.String(),
+					http.MethodGet,
+					getTimeout,
+					postTimeout,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(req.Method).To(Equal(http.MethodGet))
 				Expect(retryClient.HTTPClient.Timeout).To(Equal(getTimeout))
@@ -90,17 +96,31 @@ var _ = Describe("pod_client", func() {
 
 		When("generating a http post request", func() {
 			It("should generate the request", func() {
-				req, err := generateRequest(retryClient, target.String(), http.MethodPost, getTimeout, postTimeout)
+				req, err := generateRequest(
+					retryClient,
+					target.String(),
+					http.MethodPost,
+					getTimeout,
+					postTimeout,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(req.Method).To(Equal(http.MethodPost))
 				Expect(retryClient.HTTPClient.Timeout).To(Equal(postTimeout))
-				Expect(req.Header).To(HaveKeyWithValue("Content-Type", []string{"application/json"}))
+				Expect(
+					req.Header,
+				).To(HaveKeyWithValue("Content-Type", []string{"application/json"}))
 			})
 		})
 
 		When("generating a http delete request", func() {
 			It("should generate the request", func() {
-				req, err := generateRequest(retryClient, target.String(), http.MethodDelete, getTimeout, postTimeout)
+				req, err := generateRequest(
+					retryClient,
+					target.String(),
+					http.MethodDelete,
+					getTimeout,
+					postTimeout,
+				)
 				Expect(err).To(HaveOccurred())
 				Expect(req).To(BeNil())
 			})

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -80,12 +80,19 @@ func GetPublicIPsForPod(pod *corev1.Pod, log logr.Logger) []string {
 }
 
 // GetProcessGroupIDFromMeta fetches the process group ID from an object's metadata.
-func GetProcessGroupIDFromMeta(cluster *fdbv1beta2.FoundationDBCluster, metadata metav1.ObjectMeta) fdbv1beta2.ProcessGroupID {
+func GetProcessGroupIDFromMeta(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	metadata metav1.ObjectMeta,
+) fdbv1beta2.ProcessGroupID {
 	return fdbv1beta2.ProcessGroupID(metadata.Labels[cluster.GetProcessGroupIDLabel()])
 }
 
 // GetPodSpecHash builds the hash of the expected spec for a pod.
-func GetPodSpecHash(cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus, spec *corev1.PodSpec) (string, error) {
+func GetPodSpecHash(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	processGroup *fdbv1beta2.ProcessGroupStatus,
+	spec *corev1.PodSpec,
+) (string, error) {
 	var err error
 	if spec == nil {
 		spec, err = GetPodSpec(cluster, processGroup)
@@ -111,7 +118,11 @@ func GetJSONHash(object interface{}) (string, error) {
 }
 
 // GetPodLabels creates the labels that we will apply to a Pod
-func GetPodLabels(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, id string) map[string]string {
+func GetPodLabels(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	processClass fdbv1beta2.ProcessClass,
+	id string,
+) map[string]string {
 	labels := map[string]string{}
 
 	for key, value := range cluster.GetMatchLabels() {
@@ -134,7 +145,11 @@ func GetPodLabels(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1bet
 }
 
 // GetPodMatchLabels creates the labels that we will use when filtering for a pod.
-func GetPodMatchLabels(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, id string) map[string]string {
+func GetPodMatchLabels(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	processClass fdbv1beta2.ProcessClass,
+	id string,
+) map[string]string {
 	labels := map[string]string{}
 
 	for key, value := range cluster.GetMatchLabels() {
@@ -153,7 +168,10 @@ func GetPodMatchLabels(cluster *fdbv1beta2.FoundationDBCluster, processClass fdb
 }
 
 // BuildOwnerReference returns an OwnerReference for the provided input
-func BuildOwnerReference(ownerType metav1.TypeMeta, ownerMetadata metav1.ObjectMeta) []metav1.OwnerReference {
+func BuildOwnerReference(
+	ownerType metav1.TypeMeta,
+	ownerMetadata metav1.ObjectMeta,
+) []metav1.OwnerReference {
 	return []metav1.OwnerReference{{
 		APIVersion: ownerType.APIVersion,
 		Kind:       ownerType.Kind,
@@ -164,17 +182,34 @@ func BuildOwnerReference(ownerType metav1.TypeMeta, ownerMetadata metav1.ObjectM
 }
 
 // GetSinglePodListOptions returns the listOptions to list a single Pod
-func GetSinglePodListOptions(cluster *fdbv1beta2.FoundationDBCluster, processGroupID fdbv1beta2.ProcessGroupID) []client.ListOption {
-	return []client.ListOption{client.InNamespace(cluster.ObjectMeta.Namespace), client.MatchingLabels(GetPodMatchLabels(cluster, "", string(processGroupID)))}
+func GetSinglePodListOptions(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	processGroupID fdbv1beta2.ProcessGroupID,
+) []client.ListOption {
+	return []client.ListOption{
+		client.InNamespace(cluster.ObjectMeta.Namespace),
+		client.MatchingLabels(GetPodMatchLabels(cluster, "", string(processGroupID))),
+	}
 }
 
 // GetPodListOptions returns the listOptions to list Pods
-func GetPodListOptions(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, id string) []client.ListOption {
-	return []client.ListOption{client.InNamespace(cluster.ObjectMeta.Namespace), client.MatchingLabels(GetPodMatchLabels(cluster, processClass, id))}
+func GetPodListOptions(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	processClass fdbv1beta2.ProcessClass,
+	id string,
+) []client.ListOption {
+	return []client.ListOption{
+		client.InNamespace(cluster.ObjectMeta.Namespace),
+		client.MatchingLabels(GetPodMatchLabels(cluster, processClass, id)),
+	}
 }
 
 // GetPvcMetadata returns the metadata for a PVC
-func GetPvcMetadata(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, id fdbv1beta2.ProcessGroupID) metav1.ObjectMeta {
+func GetPvcMetadata(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	processClass fdbv1beta2.ProcessClass,
+	id fdbv1beta2.ProcessGroupID,
+) metav1.ObjectMeta {
 	var customMetadata *metav1.ObjectMeta
 
 	processSettings := cluster.GetProcessSettings(processClass)
@@ -188,7 +223,10 @@ func GetPvcMetadata(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1b
 }
 
 // GetSidecarImage returns the expected sidecar image for a specific process class
-func GetSidecarImage(cluster *fdbv1beta2.FoundationDBCluster, pClass fdbv1beta2.ProcessClass) (string, error) {
+func GetSidecarImage(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	pClass fdbv1beta2.ProcessClass,
+) (string, error) {
 	settings := cluster.GetProcessSettings(pClass)
 
 	image := ""
@@ -228,13 +266,18 @@ func getIPFamilyFromPod(pod *corev1.Pod) (int, error) {
 	if GetImageType(pod) == fdbv1beta2.ImageTypeUnified {
 		currentData, present := pod.Annotations[monitorapi.CurrentConfigurationAnnotation]
 		if !present {
-			return fdbv1beta2.PodIPFamilyUnset, fmt.Errorf("could not read current launcher configuration")
+			return fdbv1beta2.PodIPFamilyUnset, fmt.Errorf(
+				"could not read current launcher configuration",
+			)
 		}
 
 		currentConfiguration := monitorapi.ProcessConfiguration{}
 		err := json.Unmarshal([]byte(currentData), &currentConfiguration)
 		if err != nil {
-			return fdbv1beta2.PodIPFamilyUnset, fmt.Errorf("could not parse current process configuration: %w", err)
+			return fdbv1beta2.PodIPFamilyUnset, fmt.Errorf(
+				"could not parse current process configuration: %w",
+				err,
+			)
 		}
 
 		for _, argument := range currentConfiguration.Arguments {
@@ -266,7 +309,8 @@ func getIPFamilyFromPod(pod *corev1.Pod) (int, error) {
 
 // validateIPFamily will validate that the IP family is valid and return a pointer.
 func validateIPFamily(ipFamily int) (int, error) {
-	if ipFamily != fdbv1beta2.PodIPFamilyIPv4 && ipFamily != fdbv1beta2.PodIPFamilyIPv6 && ipFamily != fdbv1beta2.PodIPFamilyUnset {
+	if ipFamily != fdbv1beta2.PodIPFamilyIPv4 && ipFamily != fdbv1beta2.PodIPFamilyIPv6 &&
+		ipFamily != fdbv1beta2.PodIPFamilyUnset {
 		return fdbv1beta2.PodIPFamilyUnset, fmt.Errorf("unsupported IP family %d", ipFamily)
 	}
 
@@ -316,8 +360,15 @@ func PodHasSidecarTLS(pod *corev1.Pod) bool {
 }
 
 // PodMetadataCorrect validates if the current pod metadata is correct or if the Pod metadata must be updated.
-func PodMetadataCorrect(cluster *fdbv1beta2.FoundationDBCluster, processGroup *fdbv1beta2.ProcessGroupStatus, pod *corev1.Pod) (bool, error) {
-	correct, err := podMetadataCorrect(GetPodMetadata(cluster, processGroup.ProcessClass, processGroup.ProcessGroupID, ""), pod)
+func PodMetadataCorrect(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	processGroup *fdbv1beta2.ProcessGroupStatus,
+	pod *corev1.Pod,
+) (bool, error) {
+	correct, err := podMetadataCorrect(
+		GetPodMetadata(cluster, processGroup.ProcessClass, processGroup.ProcessGroupID, ""),
+		pod,
+	)
 	if err != nil {
 		return false, err
 	}
@@ -337,7 +388,9 @@ func podMetadataCorrect(desiredMetadata metav1.ObjectMeta, pod *corev1.Pod) (boo
 	// Ignore the fdbv1beta2.LastSpecKey, this value will be updated by replacing or recreating pods.
 	desiredMetadata.Annotations[fdbv1beta2.LastSpecKey] = pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey]
 	// Don't change the annotation for the image type, this will require a pod update.
-	desiredMetadata.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(GetImageTypeFromAnnotation(pod.ObjectMeta.Annotations))
+	desiredMetadata.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(
+		GetImageTypeFromAnnotation(pod.ObjectMeta.Annotations),
+	)
 	// Don't change the IP family annotation, this will require a pod update.
 	ipFamily, err := GetIPFamily(pod)
 	if err != nil {
@@ -351,13 +404,15 @@ func podMetadataCorrect(desiredMetadata metav1.ObjectMeta, pod *corev1.Pod) (boo
 // MetadataCorrect validates if the current metadata has the desired annotations and labels.
 func MetadataCorrect(desiredMetadata metav1.ObjectMeta, currentMetadata *metav1.ObjectMeta) bool {
 	// If the annotations or labels have changed the metadata has to be updated.
-	return !MergeLabels(currentMetadata, desiredMetadata) && !MergeAnnotations(currentMetadata, desiredMetadata)
+	return !MergeLabels(currentMetadata, desiredMetadata) &&
+		!MergeAnnotations(currentMetadata, desiredMetadata)
 }
 
 // MetadataMatches determines if the current metadata on an object matches the
 // metadata specified by the cluster spec.
 func MetadataMatches(currentMetadata metav1.ObjectMeta, desiredMetadata metav1.ObjectMeta) bool {
-	return containsAll(currentMetadata.Labels, desiredMetadata.Labels) && containsAll(currentMetadata.Annotations, desiredMetadata.Annotations)
+	return containsAll(currentMetadata.Labels, desiredMetadata.Labels) &&
+		containsAll(currentMetadata.Annotations, desiredMetadata.Annotations)
 }
 
 // MergeLabels merges the labels specified by the operator into

--- a/internal/pod_helper_test.go
+++ b/internal/pod_helper_test.go
@@ -33,15 +33,17 @@ import (
 )
 
 var _ = Describe("pod_helper", func() {
-	DescribeTable("when getting the IP family from a pod", func(pod *corev1.Pod, expected int, expectedErr error) {
-		result, err := GetIPFamily(pod)
-		if expectedErr != nil {
-			Expect(err).To(MatchError(expectedErr))
-		} else {
-			Expect(err).To(Succeed())
-		}
-		Expect(result).To(Equal(expected))
-	},
+	DescribeTable(
+		"when getting the IP family from a pod",
+		func(pod *corev1.Pod, expected int, expectedErr error) {
+			result, err := GetIPFamily(pod)
+			if expectedErr != nil {
+				Expect(err).To(MatchError(expectedErr))
+			} else {
+				Expect(err).To(Succeed())
+			}
+			Expect(result).To(Equal(expected))
+		},
 		Entry("empty pod",
 			nil,
 			nil,
@@ -158,7 +160,9 @@ var _ = Describe("pod_helper", func() {
 			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.ImageTypeAnnotation:            string(fdbv1beta2.ImageTypeUnified),
+						fdbv1beta2.ImageTypeAnnotation: string(
+							fdbv1beta2.ImageTypeUnified,
+						),
 						monitorapi.CurrentConfigurationAnnotation: "{\"arguments\": [{\"type\": \"IPList\", \"ipFamily\": 4}]}",
 					},
 				},
@@ -170,7 +174,9 @@ var _ = Describe("pod_helper", func() {
 			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.ImageTypeAnnotation:            string(fdbv1beta2.ImageTypeUnified),
+						fdbv1beta2.ImageTypeAnnotation: string(
+							fdbv1beta2.ImageTypeUnified,
+						),
 						monitorapi.CurrentConfigurationAnnotation: "{\"arguments\": [{\"type\": \"IPList\", \"ipFamily\": 6}]}",
 					},
 				},
@@ -182,7 +188,9 @@ var _ = Describe("pod_helper", func() {
 			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						fdbv1beta2.ImageTypeAnnotation:            string(fdbv1beta2.ImageTypeUnified),
+						fdbv1beta2.ImageTypeAnnotation: string(
+							fdbv1beta2.ImageTypeUnified,
+						),
 						monitorapi.CurrentConfigurationAnnotation: "{\"arguments\": [{\"type\": \"IPList\", \"ipFamily\": 1337}]}",
 					},
 				},
@@ -312,31 +320,37 @@ var _ = Describe("pod_helper", func() {
 				})
 			})
 
-			Context("and the desired map is populated with a new value for an existing key", func() {
-				var desired = map[string]string{
-					"test-key": "new-value",
-				}
-
-				It("should add the new value to the target map", func() {
-					Expect(mergeMap(target, desired)).To(Equal(true))
-					Expect(target).To(Equal(map[string]string{
+			Context(
+				"and the desired map is populated with a new value for an existing key",
+				func() {
+					var desired = map[string]string{
 						"test-key": "new-value",
-					}))
-				})
-			})
+					}
 
-			Context("and the desired map is populated with the same value for an existing key", func() {
-				var desired = map[string]string{
-					"test-key": "test-value",
-				}
+					It("should add the new value to the target map", func() {
+						Expect(mergeMap(target, desired)).To(Equal(true))
+						Expect(target).To(Equal(map[string]string{
+							"test-key": "new-value",
+						}))
+					})
+				},
+			)
 
-				It("should not change the target map", func() {
-					Expect(mergeMap(target, desired)).To(Equal(false))
-					Expect(target).To(Equal(map[string]string{
+			Context(
+				"and the desired map is populated with the same value for an existing key",
+				func() {
+					var desired = map[string]string{
 						"test-key": "test-value",
-					}))
-				})
-			})
+					}
+
+					It("should not change the target map", func() {
+						Expect(mergeMap(target, desired)).To(Equal(false))
+						Expect(target).To(Equal(map[string]string{
+							"test-key": "test-value",
+						}))
+					})
+				},
+			)
 
 			Context("and the desired map is empty", func() {
 				var desired = map[string]string{}
@@ -419,7 +433,9 @@ var _ = Describe("pod_helper", func() {
 						Annotations: map[string]string{
 							fdbv1beta2.LastSpecKey:         "1",
 							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
-							fdbv1beta2.IPFamilyAnnotation:  strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+							fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+								fdbv1beta2.PodIPFamilyUnset,
+							),
 						},
 					},
 				},
@@ -447,7 +463,9 @@ var _ = Describe("pod_helper", func() {
 						Annotations: map[string]string{
 							fdbv1beta2.LastSpecKey:         "1",
 							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
-							fdbv1beta2.IPFamilyAnnotation:  strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+							fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+								fdbv1beta2.PodIPFamilyUnset,
+							),
 						},
 					},
 				},
@@ -476,7 +494,9 @@ var _ = Describe("pod_helper", func() {
 							fdbv1beta2.LastSpecKey:         "1",
 							"special":                      "43",
 							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
-							fdbv1beta2.IPFamilyAnnotation:  strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+							fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+								fdbv1beta2.PodIPFamilyUnset,
+							),
 						},
 					},
 				},
@@ -506,7 +526,9 @@ var _ = Describe("pod_helper", func() {
 						Annotations: map[string]string{
 							fdbv1beta2.LastSpecKey:         "1",
 							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
-							fdbv1beta2.IPFamilyAnnotation:  strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+							fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+								fdbv1beta2.PodIPFamilyUnset,
+							),
 						},
 					},
 				},
@@ -537,7 +559,9 @@ var _ = Describe("pod_helper", func() {
 							fdbv1beta2.LastSpecKey:         "1",
 							"controller/X":                 "wrong",
 							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
-							fdbv1beta2.IPFamilyAnnotation:  strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+							fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+								fdbv1beta2.PodIPFamilyUnset,
+							),
 						},
 					},
 				},
@@ -595,7 +619,9 @@ var _ = Describe("pod_helper", func() {
 						Annotations: map[string]string{
 							fdbv1beta2.LastSpecKey:         "1",
 							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
-							fdbv1beta2.IPFamilyAnnotation:  strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+							fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+								fdbv1beta2.PodIPFamilyUnset,
+							),
 						},
 						Labels: map[string]string{
 							"test": "test",
@@ -629,7 +655,9 @@ var _ = Describe("pod_helper", func() {
 						Annotations: map[string]string{
 							fdbv1beta2.LastSpecKey:         "1",
 							fdbv1beta2.ImageTypeAnnotation: string(fdbv1beta2.ImageTypeSplit),
-							fdbv1beta2.IPFamilyAnnotation:  strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+							fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+								fdbv1beta2.PodIPFamilyUnset,
+							),
 						},
 						Labels: map[string]string{
 							fdbv1beta2.FDBProcessClassLabel: "storage",

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -50,7 +50,10 @@ var _ = Describe("pod_models", func() {
 		When("using the split image", func() {
 			Context("with a basic storage process group", func() {
 				BeforeEach(func() {
-					pod, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					pod, err = GetPod(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -65,7 +68,10 @@ var _ = Describe("pod_models", func() {
 				})
 
 				It("should contain the process group's pod spec", func() {
-					spec, err := GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					spec, err := GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pod.Spec).To(Equal(*spec))
 				})
@@ -85,7 +91,10 @@ var _ = Describe("pod_models", func() {
 					err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 					Expect(err).NotTo(HaveOccurred())
 
-					pod, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					pod, err = GetPod(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -104,21 +113,29 @@ var _ = Describe("pod_models", func() {
 
 			Context("with a cluster controller process group", func() {
 				BeforeEach(func() {
-					pod, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassClusterController, 1))
+					pod, err = GetPod(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassClusterController, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("should contain the process group's metadata", func() {
 					Expect(pod.Name).To(Equal(fmt.Sprintf("%s-cluster-controller-1", cluster.Name)))
 					Expect(pod.ObjectMeta.Labels).To(Equal(map[string]string{
-						fdbv1beta2.FDBClusterLabel:        cluster.Name,
-						fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassClusterController),
+						fdbv1beta2.FDBClusterLabel: cluster.Name,
+						fdbv1beta2.FDBProcessClassLabel: string(
+							fdbv1beta2.ProcessClassClusterController,
+						),
 						fdbv1beta2.FDBProcessGroupIDLabel: "cluster_controller-1",
 					}))
 				})
 
 				It("should contain the process group's pod spec", func() {
-					spec, err := GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassClusterController, 1))
+					spec, err := GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassClusterController, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pod.Spec).To(Equal(*spec))
 				})
@@ -132,19 +149,28 @@ var _ = Describe("pod_models", func() {
 						},
 					}
 
-					pod, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					pod, err = GetPod(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("should add the annotations to the metadata", func() {
-					hash, err := GetPodSpecHash(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1), &pod.Spec)
+					hash, err := GetPodSpecHash(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+						&pod.Spec,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
 						"fdb-annotation":                    "value1",
 						fdbv1beta2.LastSpecKey:              hash,
 						fdbv1beta2.PublicIPSourceAnnotation: "pod",
 						fdbv1beta2.ImageTypeAnnotation:      string(fdbv1beta2.ImageTypeSplit),
-						fdbv1beta2.IPFamilyAnnotation:       strconv.Itoa(fdbv1beta2.PodIPFamilyUnset),
+						fdbv1beta2.IPFamilyAnnotation: strconv.Itoa(
+							fdbv1beta2.PodIPFamilyUnset,
+						),
 					}))
 				})
 			})
@@ -152,17 +178,22 @@ var _ = Describe("pod_models", func() {
 			Context("with custom labels", func() {
 				BeforeEach(func() {
 					cluster = CreateDefaultCluster()
-					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								"fdb-label": "value2",
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"fdb-label": "value2",
+								},
 							},
-						},
-					}}}
+						}},
+					}
 					err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 					Expect(err).NotTo(HaveOccurred())
 
-					pod, err = GetPod(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					pod, err = GetPod(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -184,18 +215,25 @@ var _ = Describe("pod_models", func() {
 		Context("with a version compatible upgrade in progress", func() {
 			BeforeEach(func() {
 				cluster.Spec.Version = fdbv1beta2.Versions.NextPatchVersion.String()
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should use the image tag defined in the desired version", func() {
 				for _, container := range spec.Containers {
 					if container.Name == fdbv1beta2.MainContainerName {
-						Expect(container.Image).To(HaveSuffix(fdbv1beta2.Versions.NextPatchVersion.String()))
+						Expect(
+							container.Image,
+						).To(HaveSuffix(fdbv1beta2.Versions.NextPatchVersion.String()))
 						continue
 					}
 
-					Expect(container.Image).To(HaveSuffix(fdbv1beta2.Versions.NextPatchVersion.String() + "-1"))
+					Expect(
+						container.Image,
+					).To(HaveSuffix(fdbv1beta2.Versions.NextPatchVersion.String() + "-1"))
 				}
 			})
 		})
@@ -203,7 +241,10 @@ var _ = Describe("pod_models", func() {
 		Context("with a version incompatible upgrade in progress", func() {
 			BeforeEach(func() {
 				cluster.Spec.Version = fdbv1beta2.Versions.NextMajorVersion.String()
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -221,7 +262,10 @@ var _ = Describe("pod_models", func() {
 
 		Context("with a basic storage process group", func() {
 			BeforeEach(func() {
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -229,7 +273,9 @@ var _ = Describe("pod_models", func() {
 				Expect(len(spec.InitContainers)).To(Equal(1))
 				initContainer := spec.InitContainers[0]
 				Expect(initContainer.Name).To(Equal(fdbv1beta2.InitContainerName))
-				Expect(initContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
+				Expect(
+					initContainer.Image,
+				).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
 				Expect(initContainer.Args).To(Equal([]string{
 					"--copy-file",
 					"fdb.cluster",
@@ -280,7 +326,9 @@ var _ = Describe("pod_models", func() {
 			It("should have the main foundationdb container", func() {
 				mainContainer := spec.Containers[0]
 				Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
-				Expect(mainContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
+				Expect(
+					mainContainer.Image,
+				).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
 				Expect(mainContainer.Command).To(Equal([]string{"sh", "-c"}))
 				Expect(mainContainer.Args).To(Equal([]string{
 					"fdbmonitor --conffile /var/dynamic-conf/fdbmonitor.conf" +
@@ -294,9 +342,13 @@ var _ = Describe("pod_models", func() {
 				}))
 
 				Expect(*mainContainer.Resources.Limits.Cpu()).To(Equal(resource.MustParse("1")))
-				Expect(*mainContainer.Resources.Limits.Memory()).To(Equal(resource.MustParse("8Gi")))
+				Expect(
+					*mainContainer.Resources.Limits.Memory(),
+				).To(Equal(resource.MustParse("8Gi")))
 				Expect(*mainContainer.Resources.Requests.Cpu()).To(Equal(resource.MustParse("1")))
-				Expect(*mainContainer.Resources.Requests.Memory()).To(Equal(resource.MustParse("8Gi")))
+				Expect(
+					*mainContainer.Resources.Requests.Memory(),
+				).To(Equal(resource.MustParse("8Gi")))
 
 				Expect(len(mainContainer.VolumeMounts)).To(Equal(3))
 
@@ -312,7 +364,9 @@ var _ = Describe("pod_models", func() {
 			It("should have the sidecar container", func() {
 				sidecarContainer := spec.Containers[1]
 				Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainerName))
-				Expect(sidecarContainer.Image).To(Equal(fmt.Sprintf("%s:%s-1", fdbv1beta2.FoundationDBSidecarBaseImage, cluster.Spec.Version)))
+				Expect(
+					sidecarContainer.Image,
+				).To(Equal(fmt.Sprintf("%s:%s-1", fdbv1beta2.FoundationDBSidecarBaseImage, cluster.Spec.Version)))
 				Expect(sidecarContainer.Args).To(Equal([]string{
 					"--copy-file",
 					"fdb.cluster",
@@ -372,9 +426,11 @@ var _ = Describe("pod_models", func() {
 				Expect(len(spec.Volumes)).To(Equal(4))
 				Expect(spec.Volumes[0]).To(Equal(corev1.Volume{
 					Name: "data",
-					VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: fmt.Sprintf("%s-storage-1-data", cluster.Name),
-					}},
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: fmt.Sprintf("%s-storage-1-data", cluster.Name),
+						},
+					},
 				}))
 				Expect(spec.Volumes[1]).To(Equal(corev1.Volume{
 					Name:         "dynamic-conf",
@@ -383,7 +439,9 @@ var _ = Describe("pod_models", func() {
 				Expect(spec.Volumes[2]).To(Equal(corev1.Volume{
 					Name: "config-map",
 					VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: fmt.Sprintf("%s-config", cluster.Name),
+						},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
 							{Key: fdbv1beta2.ClusterFileKey, Path: "fdb.cluster"},
@@ -409,9 +467,11 @@ var _ = Describe("pod_models", func() {
 									Weight: 1,
 									PodAffinityTerm: corev1.PodAffinityTerm{
 										TopologyKey: "test",
-										LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-											"test": "test",
-										}},
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"test": "test",
+											},
+										},
 									},
 								},
 							},
@@ -423,12 +483,19 @@ var _ = Describe("pod_models", func() {
 						Value: "",
 						Key:   "kubernetes.io/hostname",
 					}
-					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("should have both affinity rules", func() {
-					Expect(len(spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(BeNumerically("==", 2))
+					Expect(
+						len(
+							spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+						),
+					).To(BeNumerically("==", 2))
 				})
 			})
 
@@ -436,7 +503,10 @@ var _ = Describe("pod_models", func() {
 				BeforeEach(func() {
 					enabled := true
 					cluster.Spec.SidecarContainer.EnableLivenessProbe = &enabled
-					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -457,7 +527,10 @@ var _ = Describe("pod_models", func() {
 				BeforeEach(func() {
 					enabled := false
 					cluster.Spec.SidecarContainer.EnableReadinessProbe = &enabled
-					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -478,7 +551,10 @@ var _ = Describe("pod_models", func() {
 				BeforeEach(func() {
 					enabled := true
 					cluster.Spec.SidecarContainer.EnableReadinessProbe = &enabled
-					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -507,7 +583,10 @@ var _ = Describe("pod_models", func() {
 
 			When("running one storage server per disk", func() {
 				BeforeEach(func() {
-					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -522,7 +601,9 @@ var _ = Describe("pod_models", func() {
 				It("should have the main foundationdb container", func() {
 					mainContainer := spec.Containers[0]
 					Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
-					Expect(mainContainer.Image).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(cluster.Spec.Version)))
+					Expect(
+						mainContainer.Image,
+					).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(cluster.Spec.Version)))
 					Expect(mainContainer.Command).To(BeNil())
 					Expect(mainContainer.Args).To(Equal([]string{
 						"--input-dir", "/var/dynamic-conf",
@@ -530,7 +611,10 @@ var _ = Describe("pod_models", func() {
 					}))
 
 					Expect(mainContainer.Env).To(ConsistOf([]corev1.EnvVar{
-						{Name: fdbv1beta2.EnvNameClusterFile, Value: "/var/dynamic-conf/fdb.cluster"},
+						{
+							Name:  fdbv1beta2.EnvNameClusterFile,
+							Value: "/var/dynamic-conf/fdb.cluster",
+						},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
 						}},
@@ -555,16 +639,25 @@ var _ = Describe("pod_models", func() {
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 						}},
 						{Name: fdbv1beta2.EnvNameFDBTraceLogGroup, Value: cluster.Name},
-						{Name: fdbv1beta2.EnvNameFDBTraceLogDirPath, Value: "/var/log/fdb-trace-logs"},
+						{
+							Name:  fdbv1beta2.EnvNameFDBTraceLogDirPath,
+							Value: "/var/log/fdb-trace-logs",
+						},
 						{Name: fdbv1beta2.EnvNameNodeName, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 						}},
 					}))
 
 					Expect(*mainContainer.Resources.Limits.Cpu()).To(Equal(resource.MustParse("1")))
-					Expect(*mainContainer.Resources.Limits.Memory()).To(Equal(resource.MustParse("8Gi")))
-					Expect(*mainContainer.Resources.Requests.Cpu()).To(Equal(resource.MustParse("1")))
-					Expect(*mainContainer.Resources.Requests.Memory()).To(Equal(resource.MustParse("8Gi")))
+					Expect(
+						*mainContainer.Resources.Limits.Memory(),
+					).To(Equal(resource.MustParse("8Gi")))
+					Expect(
+						*mainContainer.Resources.Requests.Cpu(),
+					).To(Equal(resource.MustParse("1")))
+					Expect(
+						*mainContainer.Resources.Requests.Memory(),
+					).To(Equal(resource.MustParse("8Gi")))
 
 					Expect(mainContainer.VolumeMounts).To(Equal([]corev1.VolumeMount{
 						{Name: "data", MountPath: "/var/fdb/data"},
@@ -579,7 +672,9 @@ var _ = Describe("pod_models", func() {
 				It("should have the sidecar container", func() {
 					sidecarContainer := spec.Containers[1]
 					Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainerName))
-					Expect(sidecarContainer.Image).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(cluster.Spec.Version)))
+					Expect(
+						sidecarContainer.Image,
+					).To(And(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage), HaveSuffix(cluster.Spec.Version)))
 					Expect(sidecarContainer.Args).To(Equal([]string{
 						"--mode", "sidecar",
 						"--output-dir", "/var/fdb/shared-binaries",
@@ -601,9 +696,11 @@ var _ = Describe("pod_models", func() {
 					Expect(len(spec.Volumes)).To(Equal(4))
 					Expect(spec.Volumes[0]).To(Equal(corev1.Volume{
 						Name: "data",
-						VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: fmt.Sprintf("%s-storage-1-data", cluster.Name),
-						}},
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: fmt.Sprintf("%s-storage-1-data", cluster.Name),
+							},
+						},
 					}))
 					Expect(spec.Volumes[1]).To(Equal(corev1.Volume{
 						Name:         "shared-binaries",
@@ -612,7 +709,9 @@ var _ = Describe("pod_models", func() {
 					Expect(spec.Volumes[2]).To(Equal(corev1.Volume{
 						Name: "config-map",
 						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: fmt.Sprintf("%s-config", cluster.Name),
+							},
 							Items: []corev1.KeyToPath{
 								{Key: "fdbmonitor-conf-storage-json", Path: "config.json"},
 								{Key: fdbv1beta2.ClusterFileKey, Path: "fdb.cluster"},
@@ -633,7 +732,10 @@ var _ = Describe("pod_models", func() {
 			When("running multiple storage servers per disk", func() {
 				BeforeEach(func() {
 					cluster.Spec.StorageServersPerPod = 2
-					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -647,7 +749,10 @@ var _ = Describe("pod_models", func() {
 					}))
 
 					Expect(mainContainer.Env).To(ConsistOf([]corev1.EnvVar{
-						{Name: fdbv1beta2.EnvNameClusterFile, Value: "/var/dynamic-conf/fdb.cluster"},
+						{
+							Name:  fdbv1beta2.EnvNameClusterFile,
+							Value: "/var/dynamic-conf/fdb.cluster",
+						},
 						{Name: "STORAGE_SERVERS_PER_POD", Value: "2"},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
@@ -673,7 +778,10 @@ var _ = Describe("pod_models", func() {
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 						}},
 						{Name: fdbv1beta2.EnvNameFDBTraceLogGroup, Value: cluster.Name},
-						{Name: fdbv1beta2.EnvNameFDBTraceLogDirPath, Value: "/var/log/fdb-trace-logs"},
+						{
+							Name:  fdbv1beta2.EnvNameFDBTraceLogDirPath,
+							Value: "/var/log/fdb-trace-logs",
+						},
 						{Name: fdbv1beta2.EnvNameNodeName, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 						}},
@@ -684,7 +792,9 @@ var _ = Describe("pod_models", func() {
 					Expect(spec.Volumes[2]).To(Equal(corev1.Volume{
 						Name: "config-map",
 						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: fmt.Sprintf("%s-config", cluster.Name),
+							},
 							Items: []corev1.KeyToPath{
 								{Key: "fdbmonitor-conf-storage-json", Path: "config.json"},
 								{Key: fdbv1beta2.ClusterFileKey, Path: "fdb.cluster"},
@@ -697,7 +807,10 @@ var _ = Describe("pod_models", func() {
 			When("creating a log with multiple storage servers per disk", func() {
 				BeforeEach(func() {
 					cluster.Spec.StorageServersPerPod = 2
-					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassLog, 1))
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassLog, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -710,7 +823,10 @@ var _ = Describe("pod_models", func() {
 					}))
 
 					Expect(mainContainer.Env).To(ConsistOf([]corev1.EnvVar{
-						{Name: fdbv1beta2.EnvNameClusterFile, Value: "/var/dynamic-conf/fdb.cluster"},
+						{
+							Name:  fdbv1beta2.EnvNameClusterFile,
+							Value: "/var/dynamic-conf/fdb.cluster",
+						},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
 						}},
@@ -735,7 +851,10 @@ var _ = Describe("pod_models", func() {
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 						}},
 						{Name: fdbv1beta2.EnvNameFDBTraceLogGroup, Value: cluster.Name},
-						{Name: fdbv1beta2.EnvNameFDBTraceLogDirPath, Value: "/var/log/fdb-trace-logs"},
+						{
+							Name:  fdbv1beta2.EnvNameFDBTraceLogDirPath,
+							Value: "/var/log/fdb-trace-logs",
+						},
 						{Name: fdbv1beta2.EnvNameNodeName, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 						}},
@@ -746,7 +865,9 @@ var _ = Describe("pod_models", func() {
 					Expect(spec.Volumes[2]).To(Equal(corev1.Volume{
 						Name: "config-map",
 						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: fmt.Sprintf("%s-config", cluster.Name),
+							},
 							Items: []corev1.KeyToPath{
 								{Key: "fdbmonitor-conf-log-json", Path: "config.json"},
 								{Key: fdbv1beta2.ClusterFileKey, Path: "fdb.cluster"},
@@ -759,7 +880,10 @@ var _ = Describe("pod_models", func() {
 			When("running multiple log servers per disk", func() {
 				BeforeEach(func() {
 					cluster.Spec.LogServersPerPod = 2
-					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassLog, 1))
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassLog, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -773,7 +897,10 @@ var _ = Describe("pod_models", func() {
 					}))
 
 					Expect(mainContainer.Env).To(ConsistOf([]corev1.EnvVar{
-						{Name: fdbv1beta2.EnvNameClusterFile, Value: "/var/dynamic-conf/fdb.cluster"},
+						{
+							Name:  fdbv1beta2.EnvNameClusterFile,
+							Value: "/var/dynamic-conf/fdb.cluster",
+						},
 						{Name: "LOG_SERVERS_PER_POD", Value: "2"},
 						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
@@ -799,7 +926,10 @@ var _ = Describe("pod_models", func() {
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 						}},
 						{Name: fdbv1beta2.EnvNameFDBTraceLogGroup, Value: cluster.Name},
-						{Name: fdbv1beta2.EnvNameFDBTraceLogDirPath, Value: "/var/log/fdb-trace-logs"},
+						{
+							Name:  fdbv1beta2.EnvNameFDBTraceLogDirPath,
+							Value: "/var/log/fdb-trace-logs",
+						},
 						{Name: fdbv1beta2.EnvNameNodeName, ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 						}},
@@ -810,7 +940,9 @@ var _ = Describe("pod_models", func() {
 					Expect(spec.Volumes[2]).To(Equal(corev1.Volume{
 						Name: "config-map",
 						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: fmt.Sprintf("%s-config", cluster.Name),
+							},
 							Items: []corev1.KeyToPath{
 								{Key: "fdbmonitor-conf-log-json", Path: "config.json"},
 								{Key: fdbv1beta2.ClusterFileKey, Path: "fdb.cluster"},
@@ -825,7 +957,10 @@ var _ = Describe("pod_models", func() {
 					cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{"storage-1"}
 					err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 					Expect(err).NotTo(HaveOccurred())
-					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -846,7 +981,10 @@ var _ = Describe("pod_models", func() {
 					}
 					err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 					Expect(err).NotTo(HaveOccurred())
-					spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -868,7 +1006,9 @@ var _ = Describe("pod_models", func() {
 
 				BeforeEach(func() {
 					cluster.Spec.Routing.UseDNSInClusterFile = pointer.Bool(true)
-					Expect(NormalizeClusterSpec(cluster, DeprecationOptions{})).NotTo(HaveOccurred())
+					Expect(
+						NormalizeClusterSpec(cluster, DeprecationOptions{}),
+					).NotTo(HaveOccurred())
 					processGroup := GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1)
 					podName = processGroup.GetPodName(cluster)
 					spec, err = GetPodSpec(cluster, processGroup)
@@ -878,7 +1018,9 @@ var _ = Describe("pod_models", func() {
 				It("should set the FDB_DNS_NAME env variable on the main container", func() {
 					mainContainer := spec.Containers[0]
 
-					Expect(mainContainer.Env).To(ContainElements(corev1.EnvVar{Name: fdbv1beta2.EnvNameDNSName, Value: GetPodDNSName(cluster, podName)}))
+					Expect(
+						mainContainer.Env,
+					).To(ContainElements(corev1.EnvVar{Name: fdbv1beta2.EnvNameDNSName, Value: GetPodDNSName(cluster, podName)}))
 				})
 
 				It("should set the correct crash loop arg in sidecar container", func() {
@@ -888,33 +1030,41 @@ var _ = Describe("pod_models", func() {
 				})
 			})
 
-			When("a init container with the name foundationdb-kubernetes-init is specified", func() {
-				BeforeEach(func() {
-					Expect(NormalizeClusterSpec(cluster, DeprecationOptions{})).NotTo(HaveOccurred())
-					processSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
-					processSettings.PodTemplate.Spec.InitContainers = []corev1.Container{
-						{
-							Name: fdbv1beta2.InitContainerName,
-						},
-					}
-					cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = processSettings
+			When(
+				"a init container with the name foundationdb-kubernetes-init is specified",
+				func() {
+					BeforeEach(func() {
+						Expect(
+							NormalizeClusterSpec(cluster, DeprecationOptions{}),
+						).NotTo(HaveOccurred())
+						processSettings := cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]
+						processSettings.PodTemplate.Spec.InitContainers = []corev1.Container{
+							{
+								Name: fdbv1beta2.InitContainerName,
+							},
+						}
+						cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral] = processSettings
 
-					processGroup := GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1)
-					spec, err = GetPodSpec(cluster, processGroup)
-					Expect(err).NotTo(HaveOccurred())
-				})
+						processGroup := GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1)
+						spec, err = GetPodSpec(cluster, processGroup)
+						Expect(err).NotTo(HaveOccurred())
+					})
 
-				It("should not generate an init container container", func() {
-					Expect(spec.InitContainers).To(BeEmpty())
-				})
-			})
+					It("should not generate an init container container", func() {
+						Expect(spec.InitContainers).To(BeEmpty())
+					})
+				},
+			)
 		})
 
 		Context("with a pod IP family defined", func() {
 			BeforeEach(func() {
 				family := 6
 				cluster.Spec.Routing.PodIPFamily = &family
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1013,7 +1163,10 @@ var _ = Describe("pod_models", func() {
 		When("enabling DNS in the cluster file", func() {
 			BeforeEach(func() {
 				cluster.Spec.Routing.UseDNSInClusterFile = pointer.Bool(true)
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 			})
 
 			It("should set an additional environment variable on the init container", func() {
@@ -1091,7 +1244,10 @@ var _ = Describe("pod_models", func() {
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 					}},
 					{Name: fdbv1beta2.EnvNameInstanceID, Value: "storage-1"},
-					{Name: fdbv1beta2.EnvNameDNSName, Value: "operator-test-1-storage-1.operator-test-1.my-ns.svc.cluster.local"},
+					{
+						Name:  fdbv1beta2.EnvNameDNSName,
+						Value: "operator-test-1-storage-1.operator-test-1.my-ns.svc.cluster.local",
+					},
 					{Name: fdbv1beta2.EnvNameTLSVerifyPeers, Value: ""},
 				}))
 			})
@@ -1100,7 +1256,10 @@ var _ = Describe("pod_models", func() {
 		When("enabling DNS in the locality fields", func() {
 			BeforeEach(func() {
 				cluster.Spec.Routing.DefineDNSLocalityFields = pointer.Bool(true)
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 			})
 
 			It("should set an additional environment variable on the init container", func() {
@@ -1138,7 +1297,10 @@ var _ = Describe("pod_models", func() {
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 					}},
 					{Name: fdbv1beta2.EnvNameInstanceID, Value: "storage-1"},
-					{Name: fdbv1beta2.EnvNameDNSName, Value: "operator-test-1-storage-1.operator-test-1.my-ns.svc.cluster.local"},
+					{
+						Name:  fdbv1beta2.EnvNameDNSName,
+						Value: "operator-test-1-storage-1.operator-test-1.my-ns.svc.cluster.local",
+					},
 				}))
 			})
 
@@ -1175,7 +1337,10 @@ var _ = Describe("pod_models", func() {
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 					}},
 					{Name: fdbv1beta2.EnvNameInstanceID, Value: "storage-1"},
-					{Name: fdbv1beta2.EnvNameDNSName, Value: "operator-test-1-storage-1.operator-test-1.my-ns.svc.cluster.local"},
+					{
+						Name:  fdbv1beta2.EnvNameDNSName,
+						Value: "operator-test-1-storage-1.operator-test-1.my-ns.svc.cluster.local",
+					},
 					{Name: fdbv1beta2.EnvNameTLSVerifyPeers, Value: ""},
 				}))
 			})
@@ -1205,13 +1370,22 @@ var _ = Describe("pod_models", func() {
 					Value: "",
 					Key:   "kubernetes.io/hostname",
 				}
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should have both affinity rules", func() {
-				Expect(len(spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(BeNumerically("==", 1))
-				Expect(len(spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(BeNumerically("==", 1))
+				Expect(
+					len(
+						spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+					),
+				).To(BeNumerically("==", 1))
+				Expect(
+					len(spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution),
+				).To(BeNumerically("==", 1))
 			})
 		})
 
@@ -1220,7 +1394,10 @@ var _ = Describe("pod_models", func() {
 				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{"storage-1"}
 				err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1236,7 +1413,10 @@ var _ = Describe("pod_models", func() {
 				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{"*"}
 				err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1252,7 +1432,10 @@ var _ = Describe("pod_models", func() {
 				cluster.Spec.Buggify.CrashLoop = []fdbv1beta2.ProcessGroupID{"storage-2"}
 				err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1276,7 +1459,10 @@ var _ = Describe("pod_models", func() {
 						Targets:       []fdbv1beta2.ProcessGroupID{"storage-2"},
 					},
 				}
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1300,7 +1486,10 @@ var _ = Describe("pod_models", func() {
 						Targets:       []fdbv1beta2.ProcessGroupID{"storage-1"},
 					},
 				}
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1317,239 +1506,282 @@ var _ = Describe("pod_models", func() {
 			})
 		})
 
-		Context("with a process group that defines crash looping for the sidecar container", func() {
-			BeforeEach(func() {
-				cluster.Spec.Buggify.CrashLoopContainers = []fdbv1beta2.CrashLoopContainerObject{
-					{
-						ContainerName: fdbv1beta2.SidecarContainerName,
-						Targets:       []fdbv1beta2.ProcessGroupID{"storage-1"},
-					},
-				}
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
-				Expect(err).NotTo(HaveOccurred())
-			})
+		Context(
+			"with a process group that defines crash looping for the sidecar container",
+			func() {
+				BeforeEach(func() {
+					cluster.Spec.Buggify.CrashLoopContainers = []fdbv1beta2.CrashLoopContainerObject{
+						{
+							ContainerName: fdbv1beta2.SidecarContainerName,
+							Targets:       []fdbv1beta2.ProcessGroupID{"storage-1"},
+						},
+					}
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
+					Expect(err).NotTo(HaveOccurred())
+				})
 
-			It("should set the correct start command in main container", func() {
-				mainContainer := spec.Containers[0]
-				Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
-				Expect(mainContainer.Args).NotTo(Equal([]string{"crash-loop"}))
-			})
+				It("should set the correct start command in main container", func() {
+					mainContainer := spec.Containers[0]
+					Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
+					Expect(mainContainer.Args).NotTo(Equal([]string{"crash-loop"}))
+				})
 
-			It("should set the correct start command in sidecar container", func() {
-				sidecarContainer := spec.Containers[1]
-				Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainerName))
-				Expect(sidecarContainer.Args).To(Equal([]string{"crash-loop"}))
-			})
-		})
+				It("should set the correct start command in sidecar container", func() {
+					sidecarContainer := spec.Containers[1]
+					Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainerName))
+					Expect(sidecarContainer.Args).To(Equal([]string{"crash-loop"}))
+				})
+			},
+		)
 
 		Context("with an process group with scheduling broken", func() {
 			BeforeEach(func() {
 				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{"storage-1"}
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should have an affinity rule for a custom label on the node", func() {
 				Expect(spec.Affinity).NotTo(BeNil())
-				Expect(spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(Equal([]corev1.NodeSelectorTerm{
+				Expect(
+					spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+				).To(Equal([]corev1.NodeSelectorTerm{
 					{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
-							{Key: "foundationdb.org/no-schedule-allowed", Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+							{
+								Key:      "foundationdb.org/no-schedule-allowed",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"true"},
+							},
 						},
 					},
 				}))
 			})
 		})
 
-		Context("with a basic storage process group with multiple storage servers per disk", func() {
-			BeforeEach(func() {
-				cluster.Spec.StorageServersPerPod = 2
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
-				Expect(err).NotTo(HaveOccurred())
-			})
+		Context(
+			"with a basic storage process group with multiple storage servers per disk",
+			func() {
+				BeforeEach(func() {
+					cluster.Spec.StorageServersPerPod = 2
+					spec, err = GetPodSpec(
+						cluster,
+						GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+					)
+					Expect(err).NotTo(HaveOccurred())
+				})
 
-			It("should have the built-in init container", func() {
-				Expect(len(spec.InitContainers)).To(Equal(1))
-				initContainer := spec.InitContainers[0]
-				Expect(initContainer.Name).To(Equal(fdbv1beta2.InitContainerName))
-				Expect(initContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
-				Expect(initContainer.Args).To(Equal([]string{
-					"--copy-file",
-					"fdb.cluster",
-					"--input-monitor-conf",
-					"fdbmonitor.conf",
-					"--copy-binary",
-					"fdbserver",
-					"--copy-binary",
-					"fdbcli",
-					"--main-container-version",
-					cluster.Spec.Version,
-					"--substitute-variable",
-					fdbv1beta2.EnvNamePodIP,
-					"--substitute-variable",
-					fdbv1beta2.EnvNameDNSName,
-					"--init-mode",
-				}))
-				Expect(initContainer.Env).To(Equal([]corev1.EnvVar{
-					{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-					}},
-					{Name: fdbv1beta2.EnvNamePodIP, ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-					}},
-					{Name: fdbv1beta2.EnvNameMachineID, ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					}},
-					{Name: fdbv1beta2.EnvNameZoneID, ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					}},
-					{Name: fdbv1beta2.EnvNameInstanceID, Value: "storage-1"},
-					{
-						Name:  fdbv1beta2.EnvNameDNSName,
-						Value: "operator-test-1-storage-1.operator-test-1.my-ns.svc.cluster.local",
-					},
-				}))
-				Expect(initContainer.VolumeMounts).To(Equal([]corev1.VolumeMount{
-					{Name: "config-map", MountPath: "/var/input-files"},
-					{Name: "dynamic-conf", MountPath: "/var/output-files"},
-				}))
-				Expect(initContainer.ReadinessProbe).To(BeNil())
-			})
-
-			It("should have two containers", func() {
-				Expect(len(spec.Containers)).To(Equal(2))
-			})
-
-			It("should have the main foundationdb container", func() {
-				mainContainer := spec.Containers[0]
-				Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
-				Expect(mainContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
-				Expect(mainContainer.Command).To(Equal([]string{"sh", "-c"}))
-				Expect(mainContainer.Args).To(Equal([]string{
-					"fdbmonitor --conffile /var/dynamic-conf/fdbmonitor.conf" +
-						" --lockfile /var/dynamic-conf/fdbmonitor.lockfile" +
-						" --loggroup operator-test-1" +
-						" >> /var/log/fdb-trace-logs/fdbmonitor-$(date '+%Y-%m-%d').log 2>&1",
-				}))
-
-				Expect(mainContainer.Env).To(Equal([]corev1.EnvVar{
-					{Name: fdbv1beta2.EnvNameClusterFile, Value: "/var/dynamic-conf/fdb.cluster"},
-				}))
-
-				Expect(*mainContainer.Resources.Limits.Cpu()).To(Equal(resource.MustParse("1")))
-				Expect(*mainContainer.Resources.Limits.Memory()).To(Equal(resource.MustParse("8Gi")))
-				Expect(*mainContainer.Resources.Requests.Cpu()).To(Equal(resource.MustParse("1")))
-				Expect(*mainContainer.Resources.Requests.Memory()).To(Equal(resource.MustParse("8Gi")))
-
-				Expect(len(mainContainer.VolumeMounts)).To(Equal(3))
-
-				Expect(mainContainer.VolumeMounts).To(Equal([]corev1.VolumeMount{
-					{Name: "data", MountPath: "/var/fdb/data"},
-					{Name: "dynamic-conf", MountPath: "/var/dynamic-conf"},
-					{Name: "fdb-trace-logs", MountPath: "/var/log/fdb-trace-logs"},
-				}))
-
-				Expect(*mainContainer.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
-			})
-
-			It("should have the sidecar container", func() {
-				sidecarContainer := spec.Containers[1]
-				Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainerName))
-				Expect(sidecarContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
-				Expect(sidecarContainer.Args).To(Equal([]string{
-					"--copy-file",
-					"fdb.cluster",
-					"--input-monitor-conf",
-					"fdbmonitor.conf",
-					"--copy-binary",
-					"fdbserver",
-					"--copy-binary",
-					"fdbcli",
-					"--main-container-version",
-					cluster.Spec.Version,
-					"--substitute-variable",
-					fdbv1beta2.EnvNamePodIP,
-					"--substitute-variable",
-					fdbv1beta2.EnvNameDNSName,
-				}))
-				Expect(sidecarContainer.Env).To(Equal([]corev1.EnvVar{
-					{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-					}},
-					{Name: fdbv1beta2.EnvNamePodIP, ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-					}},
-					{Name: fdbv1beta2.EnvNameMachineID, ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					}},
-					{Name: fdbv1beta2.EnvNameZoneID, ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-					}},
-					{Name: fdbv1beta2.EnvNameInstanceID, Value: "storage-1"},
-					{
-						Name:  fdbv1beta2.EnvNameDNSName,
-						Value: "operator-test-1-storage-1.operator-test-1.my-ns.svc.cluster.local",
-					},
-					{Name: fdbv1beta2.EnvNameTLSVerifyPeers, Value: ""},
-					{Name: "STORAGE_SERVERS_PER_POD", Value: "2"},
-				}))
-				Expect(sidecarContainer.VolumeMounts).To(Equal([]corev1.VolumeMount{
-					{Name: "config-map", MountPath: "/var/input-files"},
-					{Name: "dynamic-conf", MountPath: "/var/output-files"},
-				}))
-				Expect(sidecarContainer.LivenessProbe).To(Equal(&corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						TCPSocket: &corev1.TCPSocketAction{
-							Port: intstr.IntOrString{IntVal: 8080},
+				It("should have the built-in init container", func() {
+					Expect(len(spec.InitContainers)).To(Equal(1))
+					initContainer := spec.InitContainers[0]
+					Expect(initContainer.Name).To(Equal(fdbv1beta2.InitContainerName))
+					Expect(
+						initContainer.Image,
+					).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
+					Expect(initContainer.Args).To(Equal([]string{
+						"--copy-file",
+						"fdb.cluster",
+						"--input-monitor-conf",
+						"fdbmonitor.conf",
+						"--copy-binary",
+						"fdbserver",
+						"--copy-binary",
+						"fdbcli",
+						"--main-container-version",
+						cluster.Spec.Version,
+						"--substitute-variable",
+						fdbv1beta2.EnvNamePodIP,
+						"--substitute-variable",
+						fdbv1beta2.EnvNameDNSName,
+						"--init-mode",
+					}))
+					Expect(initContainer.Env).To(Equal([]corev1.EnvVar{
+						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+						}},
+						{Name: fdbv1beta2.EnvNamePodIP, ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+						}},
+						{Name: fdbv1beta2.EnvNameMachineID, ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+						}},
+						{Name: fdbv1beta2.EnvNameZoneID, ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+						}},
+						{Name: fdbv1beta2.EnvNameInstanceID, Value: "storage-1"},
+						{
+							Name:  fdbv1beta2.EnvNameDNSName,
+							Value: "operator-test-1-storage-1.operator-test-1.my-ns.svc.cluster.local",
 						},
-					},
-					PeriodSeconds:    30,
-					FailureThreshold: 5,
-					TimeoutSeconds:   1,
-				}))
-				Expect(sidecarContainer.ReadinessProbe).To(BeNil())
+					}))
+					Expect(initContainer.VolumeMounts).To(Equal([]corev1.VolumeMount{
+						{Name: "config-map", MountPath: "/var/input-files"},
+						{Name: "dynamic-conf", MountPath: "/var/output-files"},
+					}))
+					Expect(initContainer.ReadinessProbe).To(BeNil())
+				})
 
-				Expect(*sidecarContainer.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
-			})
+				It("should have two containers", func() {
+					Expect(len(spec.Containers)).To(Equal(2))
+				})
 
-			It("should have the built-in volumes", func() {
-				Expect(len(spec.Volumes)).To(Equal(4))
-				Expect(spec.Volumes[0]).To(Equal(corev1.Volume{
-					Name: "data",
-					VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: fmt.Sprintf("%s-storage-1-data", cluster.Name),
-					}},
-				}))
-				Expect(spec.Volumes[1]).To(Equal(corev1.Volume{
-					Name:         "dynamic-conf",
-					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-				}))
-				Expect(spec.Volumes[2]).To(Equal(corev1.Volume{
-					Name: "config-map",
-					VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
-						Items: []corev1.KeyToPath{
-							{Key: "fdbmonitor-conf-storage-density-2", Path: "fdbmonitor.conf"},
-							{Key: fdbv1beta2.ClusterFileKey, Path: "fdb.cluster"},
+				It("should have the main foundationdb container", func() {
+					mainContainer := spec.Containers[0]
+					Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
+					Expect(
+						mainContainer.Image,
+					).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
+					Expect(mainContainer.Command).To(Equal([]string{"sh", "-c"}))
+					Expect(mainContainer.Args).To(Equal([]string{
+						"fdbmonitor --conffile /var/dynamic-conf/fdbmonitor.conf" +
+							" --lockfile /var/dynamic-conf/fdbmonitor.lockfile" +
+							" --loggroup operator-test-1" +
+							" >> /var/log/fdb-trace-logs/fdbmonitor-$(date '+%Y-%m-%d').log 2>&1",
+					}))
+
+					Expect(mainContainer.Env).To(Equal([]corev1.EnvVar{
+						{
+							Name:  fdbv1beta2.EnvNameClusterFile,
+							Value: "/var/dynamic-conf/fdb.cluster",
 						},
-					}},
-				}))
-				Expect(spec.Volumes[3]).To(Equal(corev1.Volume{
-					Name:         "fdb-trace-logs",
-					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-				}))
-			})
+					}))
 
-			It("should have no affinity rules", func() {
-				Expect(spec.Affinity).To(BeNil())
-			})
-		})
+					Expect(*mainContainer.Resources.Limits.Cpu()).To(Equal(resource.MustParse("1")))
+					Expect(
+						*mainContainer.Resources.Limits.Memory(),
+					).To(Equal(resource.MustParse("8Gi")))
+					Expect(
+						*mainContainer.Resources.Requests.Cpu(),
+					).To(Equal(resource.MustParse("1")))
+					Expect(
+						*mainContainer.Resources.Requests.Memory(),
+					).To(Equal(resource.MustParse("8Gi")))
+
+					Expect(len(mainContainer.VolumeMounts)).To(Equal(3))
+
+					Expect(mainContainer.VolumeMounts).To(Equal([]corev1.VolumeMount{
+						{Name: "data", MountPath: "/var/fdb/data"},
+						{Name: "dynamic-conf", MountPath: "/var/dynamic-conf"},
+						{Name: "fdb-trace-logs", MountPath: "/var/log/fdb-trace-logs"},
+					}))
+
+					Expect(*mainContainer.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
+				})
+
+				It("should have the sidecar container", func() {
+					sidecarContainer := spec.Containers[1]
+					Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainerName))
+					Expect(
+						sidecarContainer.Image,
+					).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
+					Expect(sidecarContainer.Args).To(Equal([]string{
+						"--copy-file",
+						"fdb.cluster",
+						"--input-monitor-conf",
+						"fdbmonitor.conf",
+						"--copy-binary",
+						"fdbserver",
+						"--copy-binary",
+						"fdbcli",
+						"--main-container-version",
+						cluster.Spec.Version,
+						"--substitute-variable",
+						fdbv1beta2.EnvNamePodIP,
+						"--substitute-variable",
+						fdbv1beta2.EnvNameDNSName,
+					}))
+					Expect(sidecarContainer.Env).To(Equal([]corev1.EnvVar{
+						{Name: fdbv1beta2.EnvNamePublicIP, ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+						}},
+						{Name: fdbv1beta2.EnvNamePodIP, ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+						}},
+						{Name: fdbv1beta2.EnvNameMachineID, ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+						}},
+						{Name: fdbv1beta2.EnvNameZoneID, ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+						}},
+						{Name: fdbv1beta2.EnvNameInstanceID, Value: "storage-1"},
+						{
+							Name:  fdbv1beta2.EnvNameDNSName,
+							Value: "operator-test-1-storage-1.operator-test-1.my-ns.svc.cluster.local",
+						},
+						{Name: fdbv1beta2.EnvNameTLSVerifyPeers, Value: ""},
+						{Name: "STORAGE_SERVERS_PER_POD", Value: "2"},
+					}))
+					Expect(sidecarContainer.VolumeMounts).To(Equal([]corev1.VolumeMount{
+						{Name: "config-map", MountPath: "/var/input-files"},
+						{Name: "dynamic-conf", MountPath: "/var/output-files"},
+					}))
+					Expect(sidecarContainer.LivenessProbe).To(Equal(&corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							TCPSocket: &corev1.TCPSocketAction{
+								Port: intstr.IntOrString{IntVal: 8080},
+							},
+						},
+						PeriodSeconds:    30,
+						FailureThreshold: 5,
+						TimeoutSeconds:   1,
+					}))
+					Expect(sidecarContainer.ReadinessProbe).To(BeNil())
+
+					Expect(*sidecarContainer.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
+				})
+
+				It("should have the built-in volumes", func() {
+					Expect(len(spec.Volumes)).To(Equal(4))
+					Expect(spec.Volumes[0]).To(Equal(corev1.Volume{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: fmt.Sprintf("%s-storage-1-data", cluster.Name),
+							},
+						},
+					}))
+					Expect(spec.Volumes[1]).To(Equal(corev1.Volume{
+						Name:         "dynamic-conf",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+					}))
+					Expect(spec.Volumes[2]).To(Equal(corev1.Volume{
+						Name: "config-map",
+						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: fmt.Sprintf("%s-config", cluster.Name),
+							},
+							Items: []corev1.KeyToPath{
+								{Key: "fdbmonitor-conf-storage-density-2", Path: "fdbmonitor.conf"},
+								{Key: fdbv1beta2.ClusterFileKey, Path: "fdb.cluster"},
+							},
+						}},
+					}))
+					Expect(spec.Volumes[3]).To(Equal(corev1.Volume{
+						Name:         "fdb-trace-logs",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+					}))
+				})
+
+				It("should have no affinity rules", func() {
+					Expect(spec.Affinity).To(BeNil())
+				})
+			},
+		)
 
 		Context("with a the public IP from the pod", func() {
 			BeforeEach(func() {
 				var source = fdbv1beta2.PublicIPSourcePod
 				cluster.Spec.Routing.PublicIPSource = &source
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1598,19 +1830,26 @@ var _ = Describe("pod_models", func() {
 				}))
 			})
 
-			It("should have the environment variables for the IPs in the sidecar container", func() {
-				sidecarEnv := GetEnvVars(spec.Containers[1])
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP]).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath).To(Equal("status.podIP"))
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP]).NotTo(BeNil())
-			})
+			It(
+				"should have the environment variables for the IPs in the sidecar container",
+				func() {
+					sidecarEnv := GetEnvVars(spec.Containers[1])
+					Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP]).NotTo(BeNil())
+					Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom).NotTo(BeNil())
+					Expect(
+						sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath,
+					).To(Equal("status.podIP"))
+					Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP]).NotTo(BeNil())
+				},
+			)
 
 			It("should have the environment variables for the IPs in the init container", func() {
 				sidecarEnv := GetEnvVars(spec.InitContainers[0])
 				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP]).NotTo(BeNil())
 				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath).To(Equal("status.podIP"))
+				Expect(
+					sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath,
+				).To(Equal("status.podIP"))
 				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP]).NotTo(BeNil())
 			})
 		})
@@ -1621,7 +1860,10 @@ var _ = Describe("pod_models", func() {
 				cluster.Spec.Routing.PublicIPSource = &source
 				enabled := true
 				cluster.Spec.UseExplicitListenAddress = &enabled
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1670,24 +1912,35 @@ var _ = Describe("pod_models", func() {
 				}))
 			})
 
-			It("should have the environment variables for the IPs in the sidecar container", func() {
-				sidecarEnv := GetEnvVars(spec.Containers[1])
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP]).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath).To(Equal("status.podIP"))
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP]).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom.FieldRef.FieldPath).To(Equal("status.podIP"))
-			})
+			It(
+				"should have the environment variables for the IPs in the sidecar container",
+				func() {
+					sidecarEnv := GetEnvVars(spec.Containers[1])
+					Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP]).NotTo(BeNil())
+					Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom).NotTo(BeNil())
+					Expect(
+						sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath,
+					).To(Equal("status.podIP"))
+					Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP]).NotTo(BeNil())
+					Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom).NotTo(BeNil())
+					Expect(
+						sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom.FieldRef.FieldPath,
+					).To(Equal("status.podIP"))
+				},
+			)
 
 			It("should have the environment variables for the IPs in the init container", func() {
 				sidecarEnv := GetEnvVars(spec.InitContainers[0])
 				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP]).NotTo(BeNil())
 				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath).To(Equal("status.podIP"))
+				Expect(
+					sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath,
+				).To(Equal("status.podIP"))
 				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP]).NotTo(BeNil())
 				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom.FieldRef.FieldPath).To(Equal("status.podIP"))
+				Expect(
+					sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom.FieldRef.FieldPath,
+				).To(Equal("status.podIP"))
 			})
 		})
 
@@ -1695,28 +1948,42 @@ var _ = Describe("pod_models", func() {
 			BeforeEach(func() {
 				var source = fdbv1beta2.PublicIPSourceService
 				cluster.Spec.Routing.PublicIPSource = &source
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should have the environment variables for the IPs in the sidecar container", func() {
-				sidecarEnv := GetEnvVars(spec.Containers[1])
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP]).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath).To(Equal("metadata.annotations['foundationdb.org/public-ip']"))
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP]).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom.FieldRef.FieldPath).To(Equal("status.podIP"))
-			})
+			It(
+				"should have the environment variables for the IPs in the sidecar container",
+				func() {
+					sidecarEnv := GetEnvVars(spec.Containers[1])
+					Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP]).NotTo(BeNil())
+					Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom).NotTo(BeNil())
+					Expect(
+						sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath,
+					).To(Equal("metadata.annotations['foundationdb.org/public-ip']"))
+					Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP]).NotTo(BeNil())
+					Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom).NotTo(BeNil())
+					Expect(
+						sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom.FieldRef.FieldPath,
+					).To(Equal("status.podIP"))
+				},
+			)
 
 			It("should have the environment variables for the IPs in the init container", func() {
 				sidecarEnv := GetEnvVars(spec.InitContainers[0])
 				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP]).NotTo(BeNil())
 				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath).To(Equal("metadata.annotations['foundationdb.org/public-ip']"))
+				Expect(
+					sidecarEnv[fdbv1beta2.EnvNamePublicIP].ValueFrom.FieldRef.FieldPath,
+				).To(Equal("metadata.annotations['foundationdb.org/public-ip']"))
 				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP]).NotTo(BeNil())
 				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom).NotTo(BeNil())
-				Expect(sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom.FieldRef.FieldPath).To(Equal("status.podIP"))
+				Expect(
+					sidecarEnv[fdbv1beta2.EnvNamePodIP].ValueFrom.FieldRef.FieldPath,
+				).To(Equal("status.podIP"))
 			})
 
 			It("should have the pod IP in the init container args", func() {
@@ -1767,7 +2034,10 @@ var _ = Describe("pod_models", func() {
 
 		Context("with a headless service", func() {
 			BeforeEach(func() {
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1781,7 +2051,10 @@ var _ = Describe("pod_models", func() {
 			BeforeEach(func() {
 				cluster.Spec.Routing.UseDNSInClusterFile = pointer.Bool(false)
 				cluster.Spec.Routing.HeadlessService = pointer.Bool(false)
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1794,29 +2067,34 @@ var _ = Describe("pod_models", func() {
 		Context("with custom resources", func() {
 			BeforeEach(func() {
 				cluster = CreateDefaultCluster()
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name: fdbv1beta2.MainContainerName,
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										"cpu":    resource.MustParse("2"),
-										"memory": resource.MustParse("8Gi"),
-									},
-									Limits: corev1.ResourceList{
-										"cpu":    resource.MustParse("4"),
-										"memory": resource.MustParse("16Gi"),
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: fdbv1beta2.MainContainerName,
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"cpu":    resource.MustParse("2"),
+											"memory": resource.MustParse("8Gi"),
+										},
+										Limits: corev1.ResourceList{
+											"cpu":    resource.MustParse("4"),
+											"memory": resource.MustParse("16Gi"),
+										},
 									},
 								},
 							},
 						},
-					},
-				}}}
+					}},
+				}
 				err := NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1824,16 +2102,23 @@ var _ = Describe("pod_models", func() {
 				mainContainer := spec.Containers[0]
 				Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
 				Expect(*mainContainer.Resources.Limits.Cpu()).To(Equal(resource.MustParse("4")))
-				Expect(*mainContainer.Resources.Limits.Memory()).To(Equal(resource.MustParse("16Gi")))
+				Expect(
+					*mainContainer.Resources.Limits.Memory(),
+				).To(Equal(resource.MustParse("16Gi")))
 				Expect(*mainContainer.Resources.Requests.Cpu()).To(Equal(resource.MustParse("2")))
-				Expect(*mainContainer.Resources.Requests.Memory()).To(Equal(resource.MustParse("8Gi")))
+				Expect(
+					*mainContainer.Resources.Requests.Memory(),
+				).To(Equal(resource.MustParse("8Gi")))
 			})
 		})
 
 		Context("with a host-based fault domain", func() {
 			BeforeEach(func() {
 				cluster.Spec.FaultDomain = fdbv1beta2.FoundationDBClusterFaultDomain{}
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 			})
 
 			It("should set the fault domain information in the sidecar environment", func() {
@@ -1871,8 +2156,10 @@ var _ = Describe("pod_models", func() {
 									TopologyKey: "kubernetes.io/hostname",
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											fdbv1beta2.FDBClusterLabel:      cluster.Name,
-											fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+											fdbv1beta2.FDBClusterLabel: cluster.Name,
+											fdbv1beta2.FDBProcessClassLabel: string(
+												fdbv1beta2.ProcessClassStorage,
+											),
 										},
 									},
 								},
@@ -1886,14 +2173,20 @@ var _ = Describe("pod_models", func() {
 		Context("with custom resource labels", func() {
 			BeforeEach(func() {
 				cluster.Spec.LabelConfig = fdbv1beta2.LabelConfig{
-					MatchLabels:    map[string]string{"fdb-custom-name": cluster.Name, "fdb-managed-by-operator": "true"},
+					MatchLabels: map[string]string{
+						"fdb-custom-name":         cluster.Name,
+						"fdb-managed-by-operator": "true",
+					},
 					ResourceLabels: map[string]string{"fdb-new-custom-name": cluster.Name},
 				}
 				cluster.Spec.FaultDomain = fdbv1beta2.FoundationDBClusterFaultDomain{}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1907,9 +2200,11 @@ var _ = Describe("pod_models", func() {
 									TopologyKey: "kubernetes.io/hostname",
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"fdb-custom-name":               cluster.Name,
-											fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
-											"fdb-managed-by-operator":       "true",
+											"fdb-custom-name": cluster.Name,
+											fdbv1beta2.FDBProcessClassLabel: string(
+												fdbv1beta2.ProcessClassStorage,
+											),
+											"fdb-managed-by-operator": "true",
 										},
 									},
 								},
@@ -1927,7 +2222,10 @@ var _ = Describe("pod_models", func() {
 					Key:       "rack",
 					ValueFrom: "$RACK",
 				}
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1963,8 +2261,10 @@ var _ = Describe("pod_models", func() {
 									TopologyKey: "rack",
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											fdbv1beta2.FDBClusterLabel:      cluster.Name,
-											fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+											fdbv1beta2.FDBClusterLabel: cluster.Name,
+											fdbv1beta2.FDBProcessClassLabel: string(
+												fdbv1beta2.ProcessClassStorage,
+											),
 										},
 									},
 								},
@@ -1981,7 +2281,10 @@ var _ = Describe("pod_models", func() {
 					Key:   "foundationdb.org/kubernetes-cluster",
 					Value: "kc2",
 				}
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2018,24 +2321,29 @@ var _ = Describe("pod_models", func() {
 		Context("with custom containers", func() {
 			BeforeEach(func() {
 				cluster = CreateDefaultCluster()
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{{
-							Name:    "test-container",
-							Image:   "foundationdb/" + cluster.Name,
-							Command: []string{"echo", "test1"},
-						}},
-						Containers: []corev1.Container{{
-							Name:    "test-container",
-							Image:   "foundationdb/" + cluster.Name,
-							Command: []string{"echo", "test2"},
-						}},
-					},
-				}}}
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{{
+								Name:    "test-container",
+								Image:   "foundationdb/" + cluster.Name,
+								Command: []string{"echo", "test1"},
+							}},
+							Containers: []corev1.Container{{
+								Name:    "test-container",
+								Image:   "foundationdb/" + cluster.Name,
+								Command: []string{"echo", "test2"},
+							}},
+						},
+					}},
+				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2049,7 +2357,9 @@ var _ = Describe("pod_models", func() {
 
 				initContainer := spec.InitContainers[1]
 				Expect(initContainer.Name).To(Equal(fdbv1beta2.InitContainerName))
-				Expect(initContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
+				Expect(
+					initContainer.Image,
+				).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
 			})
 
 			It("should have all three containers", func() {
@@ -2057,7 +2367,9 @@ var _ = Describe("pod_models", func() {
 
 				mainContainer := spec.Containers[0]
 				Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
-				Expect(mainContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
+				Expect(
+					mainContainer.Image,
+				).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
 
 				testContainer := spec.Containers[1]
 				Expect(testContainer.Name).To(Equal("test-container"))
@@ -2066,70 +2378,97 @@ var _ = Describe("pod_models", func() {
 
 				sidecarContainer := spec.Containers[2]
 				Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainerName))
-				Expect(sidecarContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
+				Expect(
+					sidecarContainer.Image,
+				).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
 			})
 		})
 
 		Context("with custom container images with tag", func() {
 			BeforeEach(func() {
 				cluster = CreateDefaultCluster()
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{{
-							Name:  fdbv1beta2.InitContainerName,
-							Image: "test/foundationdb-kubernetes-sidecar:dummy",
-						}},
-						Containers: []corev1.Container{{
-							Name:  fdbv1beta2.MainContainerName,
-							Image: "test/foundationdb:dummy",
-						}, {
-							Name:  fdbv1beta2.SidecarContainerName,
-							Image: "test/foundationdb-kubernetes-sidecar:dummy",
-						}},
-					},
-				}}}
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{{
+								Name:  fdbv1beta2.InitContainerName,
+								Image: "test/foundationdb-kubernetes-sidecar:dummy",
+							}},
+							Containers: []corev1.Container{{
+								Name:  fdbv1beta2.MainContainerName,
+								Image: "test/foundationdb:dummy",
+							}, {
+								Name:  fdbv1beta2.SidecarContainerName,
+								Image: "test/foundationdb-kubernetes-sidecar:dummy",
+							}},
+						},
+					}},
+				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should return an error since a tag is specified", func() {
-				_, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				_, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		Context("with custom environment", func() {
 			BeforeEach(func() {
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name: fdbv1beta2.MainContainerName,
-								Env: []corev1.EnvVar{
-									{Name: fdbv1beta2.EnvNameTLSCert, Value: "/var/secrets/cert.pem"},
-									{Name: fdbv1beta2.EnvNameTLSCaFile, Value: "/var/secrets/cert.pem"},
-									{Name: fdbv1beta2.EnvNameTLSKeyFile, Value: "/var/secrets/cert.pem"},
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: fdbv1beta2.MainContainerName,
+									Env: []corev1.EnvVar{
+										{
+											Name:  fdbv1beta2.EnvNameTLSCert,
+											Value: "/var/secrets/cert.pem",
+										},
+										{
+											Name:  fdbv1beta2.EnvNameTLSCaFile,
+											Value: "/var/secrets/cert.pem",
+										},
+										{
+											Name:  fdbv1beta2.EnvNameTLSKeyFile,
+											Value: "/var/secrets/cert.pem",
+										},
+									},
+								},
+								{
+									Name: fdbv1beta2.SidecarContainerName,
+									Env: []corev1.EnvVar{
+										{
+											Name:  fdbv1beta2.EnvNameAdditionalEnvFile,
+											Value: "/var/custom-env",
+										},
+									},
 								},
 							},
-							{
-								Name: fdbv1beta2.SidecarContainerName,
-								Env: []corev1.EnvVar{
-									{Name: fdbv1beta2.EnvNameAdditionalEnvFile, Value: "/var/custom-env"},
+							InitContainers: []corev1.Container{
+								{
+									Name: fdbv1beta2.InitContainerName,
+									Env: []corev1.EnvVar{
+										{
+											Name:  fdbv1beta2.EnvNameAdditionalEnvFile,
+											Value: "/var/custom-env-init",
+										},
+									},
 								},
 							},
 						},
-						InitContainers: []corev1.Container{
-							{
-								Name: fdbv1beta2.InitContainerName,
-								Env: []corev1.EnvVar{
-									{Name: fdbv1beta2.EnvNameAdditionalEnvFile, Value: "/var/custom-env-init"},
-								},
-							},
-						},
-					},
-				}}}
+					}},
+				}
 
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2197,7 +2536,10 @@ var _ = Describe("pod_models", func() {
 				cluster.Spec.SidecarContainer.EnableTLS = true
 				cluster.Spec.SidecarContainer.PeerVerificationRules = "S.CN=foundationdb.org"
 
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2290,29 +2632,36 @@ var _ = Describe("pod_models", func() {
 		Context("with custom volumes", func() {
 			BeforeEach(func() {
 				cluster = CreateDefaultCluster()
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Volumes: []corev1.Volume{{
-							Name: "test-secrets",
-							VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
-								SecretName: "test-secrets",
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{{
+								Name: "test-secrets",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "test-secrets",
+									},
+								},
 							}},
-						}},
-						Containers: []corev1.Container{
-							{
-								Name: fdbv1beta2.MainContainerName,
-								VolumeMounts: []corev1.VolumeMount{{
-									Name:      "test-secrets",
-									MountPath: "/var/secrets",
-								}},
+							Containers: []corev1.Container{
+								{
+									Name: fdbv1beta2.MainContainerName,
+									VolumeMounts: []corev1.VolumeMount{{
+										Name:      "test-secrets",
+										MountPath: "/var/secrets",
+									}},
+								},
 							},
 						},
-					},
-				}}}
+					}},
+				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2347,9 +2696,11 @@ var _ = Describe("pod_models", func() {
 					}},
 				}))
 				Expect(spec.Volumes[1]).To(Equal(corev1.Volume{
-					VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: fmt.Sprintf("%s-storage-1-data", cluster.Name),
-					}},
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: fmt.Sprintf("%s-storage-1-data", cluster.Name),
+						},
+					},
 					Name: "data",
 				}))
 				Expect(spec.Volumes[2]).To(Equal(corev1.Volume{
@@ -2359,7 +2710,9 @@ var _ = Describe("pod_models", func() {
 				Expect(spec.Volumes[3]).To(Equal(corev1.Volume{
 					Name: "config-map",
 					VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: fmt.Sprintf("%s-config", cluster.Name),
+						},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
 							{Key: fdbv1beta2.ClusterFileKey, Path: "fdb.cluster"},
@@ -2381,18 +2734,25 @@ var _ = Describe("pod_models", func() {
 				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("sets the images on the containers", func() {
 				initContainer := spec.InitContainers[0]
 				Expect(initContainer.Name).To(Equal(fdbv1beta2.InitContainerName))
-				Expect(initContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-2", cluster.Spec.Version)))
+				Expect(
+					initContainer.Image,
+				).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-2", cluster.Spec.Version)))
 
 				mainContainer := spec.Containers[0]
 				Expect(mainContainer.Name).To(Equal(fdbv1beta2.MainContainerName))
-				Expect(mainContainer.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
+				Expect(
+					mainContainer.Image,
+				).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
 
 				sidecarContainer := spec.Containers[1]
 				Expect(sidecarContainer.Name).To(Equal(fdbv1beta2.SidecarContainerName))
@@ -2405,36 +2765,47 @@ var _ = Describe("pod_models", func() {
 
 				podSecurityContext := &corev1.PodSecurityContext{FSGroup: new(int64)}
 				*podSecurityContext.FSGroup = 5000
-				mainSecurityContext := &corev1.SecurityContext{RunAsGroup: new(int64), RunAsUser: new(int64)}
+				mainSecurityContext := &corev1.SecurityContext{
+					RunAsGroup: new(int64),
+					RunAsUser:  new(int64),
+				}
 				*mainSecurityContext.RunAsGroup = 3000
 				*mainSecurityContext.RunAsUser = 4000
-				sidecarSecurityContext := &corev1.SecurityContext{RunAsGroup: new(int64), RunAsUser: new(int64)}
+				sidecarSecurityContext := &corev1.SecurityContext{
+					RunAsGroup: new(int64),
+					RunAsUser:  new(int64),
+				}
 				*sidecarSecurityContext.RunAsGroup = 1000
 				*sidecarSecurityContext.RunAsUser = 2000
 
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						SecurityContext: podSecurityContext,
-						Containers: []corev1.Container{
-							{
-								Name:            fdbv1beta2.MainContainerName,
-								SecurityContext: mainSecurityContext,
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {PodTemplate: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							SecurityContext: podSecurityContext,
+							Containers: []corev1.Container{
+								{
+									Name:            fdbv1beta2.MainContainerName,
+									SecurityContext: mainSecurityContext,
+								},
+								{
+									Name:            fdbv1beta2.SidecarContainerName,
+									SecurityContext: sidecarSecurityContext,
+								},
 							},
-							{
-								Name:            fdbv1beta2.SidecarContainerName,
-								SecurityContext: sidecarSecurityContext,
+							InitContainers: []corev1.Container{
+								{
+									Name:            fdbv1beta2.InitContainerName,
+									SecurityContext: sidecarSecurityContext,
+								},
 							},
 						},
-						InitContainers: []corev1.Container{
-							{
-								Name:            fdbv1beta2.InitContainerName,
-								SecurityContext: sidecarSecurityContext,
-							},
-						},
-					},
-				}}}
+					}},
+				}
 
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2460,7 +2831,10 @@ var _ = Describe("pod_models", func() {
 		Context("with an process group ID prefix", func() {
 			BeforeEach(func() {
 				cluster.Spec.ProcessGroupIDPrefix = "dc1"
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2490,28 +2864,41 @@ var _ = Describe("pod_models", func() {
 
 		Context("with no custom map", func() {
 			BeforeEach(func() {
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("adds config-map volume that refers to custom map", func() {
-				Expect(spec.Volumes[2].VolumeSource.ConfigMap.LocalObjectReference.Name).To(Equal(fmt.Sprintf("%s-%s", cluster.Name, "config")))
+				Expect(
+					spec.Volumes[2].VolumeSource.ConfigMap.LocalObjectReference.Name,
+				).To(Equal(fmt.Sprintf("%s-%s", cluster.Name, "config")))
 			})
 		})
 
 		Context("with no custom pvc", func() {
 			BeforeEach(func() {
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("adds data volume that refers to default pvc", func() {
-				Expect(spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ClaimName).To(Equal(fmt.Sprintf("%s-storage-1-data", cluster.Name)))
+				Expect(
+					spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ClaimName,
+				).To(Equal(fmt.Sprintf("%s-storage-1-data", cluster.Name)))
 			})
 		})
 
 		Context("with a custom CA", func() {
 			BeforeEach(func() {
 				cluster.Spec.TrustedCAs = []string{"Test"}
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 			})
 
 			It("should pass the CA file to the main container", func() {
@@ -2612,7 +2999,9 @@ var _ = Describe("pod_models", func() {
 				Expect(spec.Volumes[2]).To(Equal(corev1.Volume{
 					Name: "config-map",
 					VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: fmt.Sprintf("%s-config", cluster.Name),
+						},
 						Items: []corev1.KeyToPath{
 							{Key: "fdbmonitor-conf-storage", Path: "fdbmonitor.conf"},
 							{Key: fdbv1beta2.ClusterFileKey, Path: "fdb.cluster"},
@@ -2642,7 +3031,10 @@ var _ = Describe("pod_models", func() {
 				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -2677,7 +3069,10 @@ var _ = Describe("pod_models", func() {
 				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				spec, err = GetPodSpec(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				spec, err = GetPodSpec(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -2703,7 +3098,10 @@ var _ = Describe("pod_models", func() {
 
 		Context("with a basic storage process group", func() {
 			BeforeEach(func() {
-				service, err = GetService(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				service, err = GetService(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2738,7 +3136,10 @@ var _ = Describe("pod_models", func() {
 		Context("with podIPFamily 6", func() {
 			BeforeEach(func() {
 				cluster.Spec.Routing.PodIPFamily = pointer.Int(6)
-				service, err = GetService(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				service, err = GetService(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2768,13 +3169,19 @@ var _ = Describe("pod_models", func() {
 		Context("with custom resource labels", func() {
 			BeforeEach(func() {
 				cluster.Spec.LabelConfig = fdbv1beta2.LabelConfig{
-					MatchLabels:    map[string]string{"fdb-custom-name": cluster.Name, "fdb-managed-by-operator": "true"},
+					MatchLabels: map[string]string{
+						"fdb-custom-name":         cluster.Name,
+						"fdb-managed-by-operator": "true",
+					},
 					ResourceLabels: map[string]string{"fdb-new-custom-name": cluster.Name},
 				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				service, err = GetService(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				service, err = GetService(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2813,7 +3220,10 @@ var _ = Describe("pod_models", func() {
 
 		Context("with a basic storage process group", func() {
 			BeforeEach(func() {
-				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				pvc, err = GetPvc(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2842,13 +3252,19 @@ var _ = Describe("pod_models", func() {
 		Context("with custom resource labels", func() {
 			BeforeEach(func() {
 				cluster.Spec.LabelConfig = fdbv1beta2.LabelConfig{
-					MatchLabels:    map[string]string{"fdb-custom-name": cluster.Name, "fdb-managed-by-operator": "true"},
+					MatchLabels: map[string]string{
+						"fdb-custom-name":         cluster.Name,
+						"fdb-managed-by-operator": "true",
+					},
 					ResourceLabels: map[string]string{"fdb-new-custom-name": cluster.Name},
 				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				pvc, err = GetPvc(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2867,16 +3283,23 @@ var _ = Describe("pod_models", func() {
 
 		Context("with a custom storage size", func() {
 			BeforeEach(func() {
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
-					Spec: corev1.PersistentVolumeClaimSpec{
-						Resources: corev1.VolumeResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceStorage: resource.MustParse("64G"),
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.VolumeResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("64G"),
+									},
+								},
 							},
 						},
 					},
-				}}}
-				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				}
+				pvc, err = GetPvc(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2891,17 +3314,24 @@ var _ = Describe("pod_models", func() {
 
 		Context("with custom metadata", func() {
 			BeforeEach(func() {
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							"fdb-annotation": "value1",
-						},
-						Labels: map[string]string{
-							"fdb-label": "value2",
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"fdb-annotation": "value1",
+								},
+								Labels: map[string]string{
+									"fdb-label": "value2",
+								},
+							},
 						},
 					},
-				}}}
-				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				}
+				pvc, err = GetPvc(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2923,7 +3353,10 @@ var _ = Describe("pod_models", func() {
 
 		Context("for a stateless process group", func() {
 			BeforeEach(func() {
-				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStateless, 1))
+				pvc, err = GetPvc(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStateless, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2935,7 +3368,10 @@ var _ = Describe("pod_models", func() {
 		Context("with an process group ID prefix", func() {
 			BeforeEach(func() {
 				cluster.Spec.ProcessGroupIDPrefix = "dc1"
-				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				pvc, err = GetPvc(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2953,12 +3389,19 @@ var _ = Describe("pod_models", func() {
 			var class string
 			BeforeEach(func() {
 				class = "local"
-				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{fdbv1beta2.ProcessClassGeneral: {VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
-					Spec: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &class,
+				cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+					fdbv1beta2.ProcessClassGeneral: {
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+							Spec: corev1.PersistentVolumeClaimSpec{
+								StorageClassName: &class,
+							},
+						},
 					},
-				}}}
-				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				}
+				pvc, err = GetPvc(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2970,7 +3413,10 @@ var _ = Describe("pod_models", func() {
 		Context("with an process group ID prefix", func() {
 			BeforeEach(func() {
 				cluster.Spec.ProcessGroupIDPrefix = "dc1"
-				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				pvc, err = GetPvc(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2986,7 +3432,10 @@ var _ = Describe("pod_models", func() {
 
 		Context("with default name in the suffix", func() {
 			BeforeEach(func() {
-				pvc, err = GetPvc(cluster, GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1))
+				pvc, err = GetPvc(
+					cluster,
+					GetProcessGroup(cluster, fdbv1beta2.ProcessClassStorage, 1),
+				)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -3046,7 +3495,10 @@ var _ = Describe("pod_models", func() {
 		Context("with custom resource labels", func() {
 			BeforeEach(func() {
 				cluster.Spec.LabelConfig = fdbv1beta2.LabelConfig{
-					MatchLabels:    map[string]string{"fdb-custom-name": cluster.Name, "fdb-managed-by-operator": "true"},
+					MatchLabels: map[string]string{
+						"fdb-custom-name":         cluster.Name,
+						"fdb-managed-by-operator": "true",
+					},
 					ResourceLabels: map[string]string{"fdb-new-custom-name": cluster.Name},
 				}
 				err = NormalizeClusterSpec(cluster, DeprecationOptions{})
@@ -3116,7 +3568,9 @@ var _ = Describe("pod_models", func() {
 			It("should set the metadata for the deployment", func() {
 				Expect(deployment.ObjectMeta.Name).To(Equal("operator-test-1-backup-agents"))
 				Expect(len(deployment.ObjectMeta.OwnerReferences)).To(Equal(1))
-				Expect(deployment.ObjectMeta.OwnerReferences[0].UID).To(Equal(cluster.ObjectMeta.UID))
+				Expect(
+					deployment.ObjectMeta.OwnerReferences[0].UID,
+				).To(Equal(cluster.ObjectMeta.UID))
 				Expect(deployment.ObjectMeta.Labels).To(Equal(map[string]string{
 					fdbv1beta2.BackupDeploymentLabel: string(cluster.ObjectMeta.UID),
 				}))
@@ -3131,7 +3585,9 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("should set the labels for the pod selector", func() {
-				Expect(*deployment.Spec.Selector).To(Equal(metav1.LabelSelector{MatchLabels: map[string]string{
+				Expect(
+					*deployment.Spec.Selector,
+				).To(Equal(metav1.LabelSelector{MatchLabels: map[string]string{
 					fdbv1beta2.BackupDeploymentPodLabel: "operator-test-1-backup-agents",
 				}}))
 				Expect(deployment.Spec.Template.ObjectMeta.Labels).To(Equal(map[string]string{
@@ -3146,12 +3602,20 @@ var _ = Describe("pod_models", func() {
 
 			It("should have the default volumes", func() {
 				Expect(deployment.Spec.Template.Spec.Volumes).To(Equal([]corev1.Volume{
-					{Name: "logs", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-					{Name: "dynamic-conf", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+					{
+						Name:         "logs",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+					},
+					{
+						Name:         "dynamic-conf",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+					},
 					{
 						Name: "config-map",
 						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: fmt.Sprintf("%s-config", cluster.Name),
+							},
 							Items: []corev1.KeyToPath{
 								{Key: fdbv1beta2.ClusterFileKey, Path: "fdb.cluster"},
 							},
@@ -3172,7 +3636,9 @@ var _ = Describe("pod_models", func() {
 				})
 
 				It("should set the image and command for the backup agent", func() {
-					Expect(container.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
+					Expect(
+						container.Image,
+					).To(Equal(fmt.Sprintf("foundationdb/foundationdb:%s", cluster.Spec.Version)))
 					Expect(container.Command).To(Equal([]string{"backup_agent"}))
 					Expect(container.Args).To(Equal([]string{
 						"--log",
@@ -3183,7 +3649,10 @@ var _ = Describe("pod_models", func() {
 
 				It("should set the basic environment", func() {
 					Expect(container.Env).To(Equal([]corev1.EnvVar{
-						{Name: fdbv1beta2.EnvNameClusterFile, Value: "/var/dynamic-conf/fdb.cluster"},
+						{
+							Name:  fdbv1beta2.EnvNameClusterFile,
+							Value: "/var/dynamic-conf/fdb.cluster",
+						},
 					}))
 				})
 
@@ -3196,9 +3665,13 @@ var _ = Describe("pod_models", func() {
 
 				It("should set default resource limits", func() {
 					Expect(*container.Resources.Limits.Cpu()).To(Equal(resource.MustParse("1")))
-					Expect(*container.Resources.Limits.Memory()).To(Equal(resource.MustParse("1Gi")))
+					Expect(
+						*container.Resources.Limits.Memory(),
+					).To(Equal(resource.MustParse("1Gi")))
 					Expect(*container.Resources.Requests.Cpu()).To(Equal(resource.MustParse("1")))
-					Expect(*container.Resources.Requests.Memory()).To(Equal(resource.MustParse("1Gi")))
+					Expect(
+						*container.Resources.Requests.Memory(),
+					).To(Equal(resource.MustParse("1Gi")))
 				})
 			})
 
@@ -3214,7 +3687,9 @@ var _ = Describe("pod_models", func() {
 				})
 
 				It("should set the image and command for the container", func() {
-					Expect(container.Image).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
+					Expect(
+						container.Image,
+					).To(Equal(fmt.Sprintf("foundationdb/foundationdb-kubernetes-sidecar:%s-1", cluster.Spec.Version)))
 					Expect(container.Args).To(Equal([]string{
 						"--copy-file",
 						"fdb.cluster",
@@ -3238,13 +3713,23 @@ var _ = Describe("pod_models", func() {
 				backup.Spec.PodTemplateSpec = &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
-							{Name: "secrets", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "backup-secrets"}}},
+							{
+								Name: "secrets",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "backup-secrets",
+									},
+								},
+							},
 						},
 						Containers: []corev1.Container{
 							{
 								Name: fdbv1beta2.MainContainerName,
 								Env: []corev1.EnvVar{
-									{Name: "FDB_BLOB_CREDENTIALS", Value: "/var/secrets/blob_credentials.json"},
+									{
+										Name:  "FDB_BLOB_CREDENTIALS",
+										Value: "/var/secrets/blob_credentials.json",
+									},
 								},
 								VolumeMounts: []corev1.VolumeMount{
 									{Name: "secrets", MountPath: "/var/secrets"},
@@ -3260,13 +3745,26 @@ var _ = Describe("pod_models", func() {
 
 			It("should customize the volumes", func() {
 				Expect(deployment.Spec.Template.Spec.Volumes).To(Equal([]corev1.Volume{
-					{Name: "secrets", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "backup-secrets"}}},
-					{Name: "logs", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-					{Name: "dynamic-conf", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+					{
+						Name: "secrets",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{SecretName: "backup-secrets"},
+						},
+					},
+					{
+						Name:         "logs",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+					},
+					{
+						Name:         "dynamic-conf",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+					},
 					{
 						Name: "config-map",
 						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-config", cluster.Name)},
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: fmt.Sprintf("%s-config", cluster.Name),
+							},
 							Items: []corev1.KeyToPath{
 								{Key: fdbv1beta2.ClusterFileKey, Path: "fdb.cluster"},
 							},
@@ -3289,7 +3787,10 @@ var _ = Describe("pod_models", func() {
 				It("should customize the environment", func() {
 					Expect(container.Env).To(Equal([]corev1.EnvVar{
 						{Name: "FDB_BLOB_CREDENTIALS", Value: "/var/secrets/blob_credentials.json"},
-						{Name: fdbv1beta2.EnvNameClusterFile, Value: "/var/dynamic-conf/fdb.cluster"},
+						{
+							Name:  fdbv1beta2.EnvNameClusterFile,
+							Value: "/var/dynamic-conf/fdb.cluster",
+						},
 					}))
 				})
 
@@ -3377,7 +3878,9 @@ var _ = Describe("pod_models", func() {
 
 		Context("with customParameters", func() {
 			BeforeEach(func() {
-				backup.Spec.CustomParameters = []fdbv1beta2.FoundationDBCustomParameter{"customParameter=1337"}
+				backup.Spec.CustomParameters = []fdbv1beta2.FoundationDBCustomParameter{
+					"customParameter=1337",
+				}
 				deployment, err = GetBackupDeployment(backup)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(deployment).NotTo(BeNil())
@@ -3386,7 +3889,9 @@ var _ = Describe("pod_models", func() {
 			It("should set custom parameter in the args", func() {
 				Expect(deployment.ObjectMeta.Name).To(Equal("operator-test-1-backup-agents"))
 				Expect(len(deployment.ObjectMeta.OwnerReferences)).To(Equal(1))
-				Expect(deployment.ObjectMeta.OwnerReferences[0].UID).To(Equal(cluster.ObjectMeta.UID))
+				Expect(
+					deployment.ObjectMeta.OwnerReferences[0].UID,
+				).To(Equal(cluster.ObjectMeta.UID))
 				Expect(deployment.ObjectMeta.Labels).To(Equal(map[string]string{
 					"foundationdb.org/backup-for": string(cluster.ObjectMeta.UID),
 				}))
@@ -3394,7 +3899,9 @@ var _ = Describe("pod_models", func() {
 					"foundationdb.org/last-applied-spec": "879780b88956de7a05e245cdbf16c565b95fe5c956e3a89e7ea259cd9b209d97",
 				}))
 
-				Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--customParameter=1337"))
+				Expect(
+					deployment.Spec.Template.Spec.Containers[0].Args,
+				).To(ContainElement("--customParameter=1337"))
 			})
 		})
 
@@ -3412,8 +3919,12 @@ var _ = Describe("pod_models", func() {
 			})
 
 			It("should set the image based on the image configs", func() {
-				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("foundationdb/foundationdb:dev"))
-				Expect(deployment.Spec.Template.Spec.InitContainers[0].Image).To(Equal("foundationdb/foundationdb-kubernetes-sidecar:dev-1"))
+				Expect(
+					deployment.Spec.Template.Spec.Containers[0].Image,
+				).To(Equal("foundationdb/foundationdb:dev"))
+				Expect(
+					deployment.Spec.Template.Spec.InitContainers[0].Image,
+				).To(Equal("foundationdb/foundationdb-kubernetes-sidecar:dev-1"))
 			})
 		})
 
@@ -3445,7 +3956,9 @@ var _ = Describe("pod_models", func() {
 
 			It("should set the image without validating the tag", func() {
 				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("test:main"))
-				Expect(deployment.Spec.Template.Spec.InitContainers[0].Image).To(Equal("test:sidecar"))
+				Expect(
+					deployment.Spec.Template.Spec.InitContainers[0].Image,
+				).To(Equal("test:sidecar"))
 			})
 		})
 
@@ -3462,7 +3975,9 @@ var _ = Describe("pod_models", func() {
 				Expect(deployment.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 				Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 
-				Expect(deployment.Spec.Template.Spec.InitContainers[0].Image).To(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage))
+				Expect(
+					deployment.Spec.Template.Spec.InitContainers[0].Image,
+				).To(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage))
 				Expect(deployment.Spec.Template.Spec.InitContainers[0].Args).To(ConsistOf(
 					"--copy-file",
 					"fdb.cluster",
@@ -3474,7 +3989,9 @@ var _ = Describe("pod_models", func() {
 					"/var/output-files",
 					"--input-dir",
 					"/var/input-files"))
-				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage))
+				Expect(
+					deployment.Spec.Template.Spec.Containers[0].Image,
+				).To(HavePrefix(fdbv1beta2.FoundationDBKubernetesBaseImage))
 			})
 		})
 	})
@@ -3488,7 +4005,12 @@ var _ = Describe("pod_models", func() {
 
 		DescribeTable("should return the correct image",
 			func(input testCase, allowTagOverride bool, expected string) {
-				image, _ := GetImage(input.imageName, input.imageConfigs, input.versionString, allowTagOverride)
+				image, _ := GetImage(
+					input.imageName,
+					input.imageConfigs,
+					input.versionString,
+					allowTagOverride,
+				)
 				Expect(image).To(Equal(expected))
 			},
 			Entry("only defaults used",
@@ -3535,7 +4057,14 @@ var _ = Describe("pod_models", func() {
 
 			DescribeTable("should return the correct image",
 				func(input testCase, expected string) {
-					err = configureSidecarContainerForCluster(cluster, "operator-test-storage-1", input.container, input.initMode, input.processGroupID, "6.2.21")
+					err = configureSidecarContainerForCluster(
+						cluster,
+						"operator-test-storage-1",
+						input.container,
+						input.initMode,
+						input.processGroupID,
+						"6.2.21",
+					)
 					if input.hasError {
 						Expect(err).To(HaveOccurred())
 					} else {
@@ -3580,7 +4109,10 @@ var _ = Describe("pod_models", func() {
 					},
 				}
 
-				storageServersPerPod, err := GetServersPerPodForPod(pod, fdbv1beta2.ProcessClassStorage)
+				storageServersPerPod, err := GetServersPerPodForPod(
+					pod,
+					fdbv1beta2.ProcessClassStorage,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(storageServersPerPod).To(Equal(1))
 			})
@@ -3601,7 +4133,10 @@ var _ = Describe("pod_models", func() {
 					},
 				}
 
-				storageServersPerPod, err := GetServersPerPodForPod(pod, fdbv1beta2.ProcessClassStorage)
+				storageServersPerPod, err := GetServersPerPodForPod(
+					pod,
+					fdbv1beta2.ProcessClassStorage,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(storageServersPerPod).To(Equal(2))
 			})
@@ -3617,7 +4152,10 @@ var _ = Describe("pod_models", func() {
 					},
 				}
 
-				storageServersPerPod, err := GetServersPerPodForPod(pod, fdbv1beta2.ProcessClassStorage)
+				storageServersPerPod, err := GetServersPerPodForPod(
+					pod,
+					fdbv1beta2.ProcessClassStorage,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(storageServersPerPod).To(Equal(1))
 			})
@@ -3625,7 +4163,10 @@ var _ = Describe("pod_models", func() {
 
 		Context("when pod is nil", func() {
 			It("should return 1", func() {
-				storageServersPerPod, err := GetServersPerPodForPod(nil, fdbv1beta2.ProcessClassStorage)
+				storageServersPerPod, err := GetServersPerPodForPod(
+					nil,
+					fdbv1beta2.ProcessClassStorage,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(storageServersPerPod).To(Equal(1))
 			})
@@ -3635,7 +4176,10 @@ var _ = Describe("pod_models", func() {
 			It("should return 1", func() {
 				pod := &corev1.Pod{}
 
-				storageServersPerPod, err := GetServersPerPodForPod(pod, fdbv1beta2.ProcessClassStorage)
+				storageServersPerPod, err := GetServersPerPodForPod(
+					pod,
+					fdbv1beta2.ProcessClassStorage,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(storageServersPerPod).To(Equal(1))
 			})
@@ -3647,7 +4191,10 @@ var _ = Describe("pod_models", func() {
 					Spec: corev1.PodSpec{},
 				}
 
-				storageServersPerPod, err := GetServersPerPodForPod(pod, fdbv1beta2.ProcessClassStorage)
+				storageServersPerPod, err := GetServersPerPodForPod(
+					pod,
+					fdbv1beta2.ProcessClassStorage,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(storageServersPerPod).To(Equal(1))
 			})
@@ -3657,13 +4204,17 @@ var _ = Describe("pod_models", func() {
 	Describe("GetPodDNSName", func() {
 		It("builds the DNS name based on the cluster spec", func() {
 			cluster.Spec.Routing.DNSDomain = pointer.String("cluster.example")
-			Expect(GetPodDNSName(cluster, "operator-test-storage-1")).To(Equal("operator-test-storage-1.operator-test-1.my-ns.svc.cluster.example"))
+			Expect(
+				GetPodDNSName(cluster, "operator-test-storage-1"),
+			).To(Equal("operator-test-storage-1.operator-test-1.my-ns.svc.cluster.example"))
 		})
 	})
 
-	DescribeTable("getting the process group ID from the Pod name", func(cluster *fdbv1beta2.FoundationDBCluster, podName string, expected fdbv1beta2.ProcessGroupID) {
-		Expect(GetProcessGroupIDFromPodName(cluster, podName)).To(Equal(expected))
-	},
+	DescribeTable(
+		"getting the process group ID from the Pod name",
+		func(cluster *fdbv1beta2.FoundationDBCluster, podName string, expected fdbv1beta2.ProcessGroupID) {
+			Expect(GetProcessGroupIDFromPodName(cluster, podName)).To(Equal(expected))
+		},
 		Entry("cluster without prefix", &fdbv1beta2.FoundationDBCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
@@ -3676,7 +4227,8 @@ var _ = Describe("pod_models", func() {
 			Spec: fdbv1beta2.FoundationDBClusterSpec{
 				ProcessGroupIDPrefix: "prefix",
 			},
-		}, "test-storage-1", fdbv1beta2.ProcessGroupID("prefix-storage-1")))
+		}, "test-storage-1", fdbv1beta2.ProcessGroupID("prefix-storage-1")),
+	)
 
 	Describe("ContainsPod", func() {
 		var pod1, pod2 *corev1.Pod

--- a/internal/process_class.go
+++ b/internal/process_class.go
@@ -26,11 +26,17 @@ import (
 )
 
 // ProcessClassFromLabels extracts the ProcessClass label from the metav1.ObjectMeta.Labels map
-func ProcessClassFromLabels(cluster *fdbv1beta2.FoundationDBCluster, labels map[string]string) fdbv1beta2.ProcessClass {
+func ProcessClassFromLabels(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	labels map[string]string,
+) fdbv1beta2.ProcessClass {
 	return fdbv1beta2.ProcessClass(labels[cluster.GetProcessClassLabel()])
 }
 
 // GetProcessClassFromMeta fetches the process class from an object's metadata.
-func GetProcessClassFromMeta(cluster *fdbv1beta2.FoundationDBCluster, metadata v1.ObjectMeta) fdbv1beta2.ProcessClass {
+func GetProcessClassFromMeta(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	metadata v1.ObjectMeta,
+) fdbv1beta2.ProcessClass {
 	return ProcessClassFromLabels(cluster, metadata.Labels)
 }

--- a/internal/removals/remove_test.go
+++ b/internal/removals/remove_test.go
@@ -162,7 +162,8 @@ var _ = Describe("remove", func() {
 			},
 		}
 
-		DescribeTable("should delete the Pods based on the deletion mode",
+		DescribeTable(
+			"should delete the Pods based on the deletion mode",
 			func(removalMode fdbv1beta2.PodUpdateMode, zones map[fdbv1beta2.FaultDomain][]*fdbv1beta2.ProcessGroupStatus, expected int, expectedErr error) {
 				_, removals, err := GetProcessGroupsToRemove(removalMode, zones)
 				if expectedErr != nil {
@@ -216,7 +217,8 @@ var _ = Describe("remove", func() {
 	})
 
 	When("checking if a removal is allowed", func() {
-		DescribeTable("should return if a removal is allowed and the wait time",
+		DescribeTable(
+			"should return if a removal is allowed and the wait time",
 			func(lastDeletion int64, currentTimestamp int64, waitBetween int, expectedRes bool, expectedWaitTime int64) {
 				waitTime, ok := RemovalAllowed(lastDeletion, currentTimestamp, waitBetween)
 				Expect(ok).To(Equal(expectedRes))
@@ -261,14 +263,16 @@ var _ = Describe("remove", func() {
 		)
 	})
 
-	DescribeTable("when getting the addresses to validate before removal", func(cluster *fdbv1beta2.FoundationDBCluster, expected []fdbv1beta2.ProcessAddress) {
-		remainingMap, addresses := getAddressesToValidateBeforeRemoval(logr.Discard(), cluster)
-		Expect(addresses).To(ConsistOf(expected))
-		for _, address := range addresses {
-			Expect(remainingMap).To(HaveKeyWithValue(address.String(), false))
-		}
-		Expect(remainingMap).To(HaveLen(len(expected)))
-	},
+	DescribeTable(
+		"when getting the addresses to validate before removal",
+		func(cluster *fdbv1beta2.FoundationDBCluster, expected []fdbv1beta2.ProcessAddress) {
+			remainingMap, addresses := getAddressesToValidateBeforeRemoval(logr.Discard(), cluster)
+			Expect(addresses).To(ConsistOf(expected))
+			for _, address := range addresses {
+				Expect(remainingMap).To(HaveKeyWithValue(address.String(), false))
+			}
+			Expect(remainingMap).To(HaveLen(len(expected)))
+		},
 		Entry("when no process groups must be removed",
 			&fdbv1beta2.FoundationDBCluster{},
 			nil,

--- a/internal/replacements/replace_failed_process_groups_test.go
+++ b/internal/replacements/replace_failed_process_groups_test.go
@@ -28,9 +28,13 @@ import (
 )
 
 var _ = Describe("replace_failed_process_groups", func() {
-	DescribeTable("check if removal is allowed", func(cluster *fdbv1beta2.FoundationDBCluster, maxReplacements int, faultDomainsWithReplacements map[fdbv1beta2.FaultDomain]fdbv1beta2.None, faultDomain fdbv1beta2.FaultDomain, expected bool) {
-		Expect(removalAllowed(cluster, maxReplacements, faultDomainsWithReplacements, faultDomain)).To(Equal(expected))
-	},
+	DescribeTable(
+		"check if removal is allowed",
+		func(cluster *fdbv1beta2.FoundationDBCluster, maxReplacements int, faultDomainsWithReplacements map[fdbv1beta2.FaultDomain]fdbv1beta2.None, faultDomain fdbv1beta2.FaultDomain, expected bool) {
+			Expect(
+				removalAllowed(cluster, maxReplacements, faultDomainsWithReplacements, faultDomain),
+			).To(Equal(expected))
+		},
 		Entry("process group based replacement: with 1 replacement allowed",
 			&fdbv1beta2.FoundationDBCluster{},
 			1,
@@ -114,9 +118,11 @@ var _ = Describe("replace_failed_process_groups", func() {
 		),
 	)
 
-	DescribeTable("when checking if process group replacements because of node taints is allowed", func(cluster *fdbv1beta2.FoundationDBCluster, expected bool) {
-		Expect(nodeTaintReplacementsAllowed(GinkgoLogr, cluster)).To(Equal(expected))
-	},
+	DescribeTable(
+		"when checking if process group replacements because of node taints is allowed",
+		func(cluster *fdbv1beta2.FoundationDBCluster, expected bool) {
+			Expect(nodeTaintReplacementsAllowed(GinkgoLogr, cluster)).To(Equal(expected))
+		},
 		Entry("no process groups with taint condition is present and taint feature is disabled",
 			&fdbv1beta2.FoundationDBCluster{},
 			false,
@@ -173,7 +179,8 @@ var _ = Describe("replace_failed_process_groups", func() {
 			},
 			true,
 		),
-		Entry("two process groups with taint condition in different fault domains are present and taint feature is enabled",
+		Entry(
+			"two process groups with taint condition in different fault domains are present and taint feature is enabled",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
 					AutomationOptions: fdbv1beta2.FoundationDBClusterAutomationOptions{
@@ -216,7 +223,8 @@ var _ = Describe("replace_failed_process_groups", func() {
 			},
 			false,
 		),
-		Entry("two process groups with taint condition in the same fault domain are present and taint feature is enabled",
+		Entry(
+			"two process groups with taint condition in the same fault domain are present and taint feature is enabled",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
 					AutomationOptions: fdbv1beta2.FoundationDBClusterAutomationOptions{

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -63,7 +63,13 @@ var _ = Describe("replace_misconfigured_pods", func() {
 		replaceOnSecurityContextChange := true
 
 		JustBeforeEach(func() {
-			needsRemoval, err = processGroupNeedsRemovalForPod(cluster, pod, processGroup, log, replaceOnSecurityContextChange)
+			needsRemoval, err = processGroupNeedsRemovalForPod(
+				cluster,
+				pod,
+				processGroup,
+				log,
+				replaceOnSecurityContextChange,
+			)
 		})
 
 		When("a storage Pod is checked", func() {
@@ -87,11 +93,17 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				spec, err := internal.GetPodSpec(cluster, processGroup)
 				Expect(err).NotTo(HaveOccurred())
 
-				pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey], err = internal.GetPodSpecHash(cluster, processGroup, spec)
+				pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey], err = internal.GetPodSpecHash(
+					cluster,
+					processGroup,
+					spec,
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				pod.Spec = *spec
-				Expect(internal.NormalizeClusterSpec(cluster, deprecationOptions)).NotTo(HaveOccurred())
+				Expect(
+					internal.NormalizeClusterSpec(cluster, deprecationOptions),
+				).NotTo(HaveOccurred())
 			})
 
 			When("process group has no Pod", func() {
@@ -139,7 +151,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			When("the public IP source is removed", func() {
 				BeforeEach(func() {
 					pod.ObjectMeta.Annotations = map[string]string{
-						fdbv1beta2.PublicIPSourceAnnotation: string(fdbv1beta2.PublicIPSourceService),
+						fdbv1beta2.PublicIPSourceAnnotation: string(
+							fdbv1beta2.PublicIPSourceService,
+						),
 					}
 					cluster.Spec.Routing.PublicIPSource = nil
 				})
@@ -188,7 +202,11 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 			When("the nodeSelector doesn't match but the PodSpecHash matches", func() {
 				BeforeEach(func() {
-					pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey], err = internal.GetPodSpecHash(cluster, processGroup, nil)
+					pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey], err = internal.GetPodSpecHash(
+						cluster,
+						processGroup,
+						nil,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					pod.Spec.NodeSelector = map[string]string{
 						"dummy": "test",
@@ -226,11 +244,17 @@ var _ = Describe("replace_misconfigured_pods", func() {
 						spec, err := internal.GetPodSpec(cluster, processGroup)
 						Expect(err).NotTo(HaveOccurred())
 
-						pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey], err = internal.GetPodSpecHash(cluster, processGroup, spec)
+						pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey], err = internal.GetPodSpecHash(
+							cluster,
+							processGroup,
+							spec,
+						)
 						Expect(err).NotTo(HaveOccurred())
 
 						pod.Spec = *spec
-						Expect(internal.NormalizeClusterSpec(cluster, deprecationOptions)).NotTo(HaveOccurred())
+						Expect(
+							internal.NormalizeClusterSpec(cluster, deprecationOptions),
+						).NotTo(HaveOccurred())
 					})
 
 					It("should not need a removal", func() {
@@ -265,17 +289,20 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 			})
 
-			When("PodUpdateStrategyTransactionReplacement is set and the PodSpecHash doesn't match", func() {
-				BeforeEach(func() {
-					pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = "-1"
-					cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyTransactionReplacement
-				})
+			When(
+				"PodUpdateStrategyTransactionReplacement is set and the PodSpecHash doesn't match",
+				func() {
+					BeforeEach(func() {
+						pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = "-1"
+						cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyTransactionReplacement
+					})
 
-				It("should not need a removal", func() {
-					Expect(needsRemoval).To(BeFalse())
-					Expect(err).NotTo(HaveOccurred())
-				})
-			})
+					It("should not need a removal", func() {
+						Expect(needsRemoval).To(BeFalse())
+						Expect(err).NotTo(HaveOccurred())
+					})
+				},
+			)
 
 			When("checking if the PVC requires a replacement", func() {
 				var pvc *corev1.PersistentVolumeClaim
@@ -286,7 +313,12 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				JustBeforeEach(func() {
-					needsRemoval, err = processGroupNeedsRemovalForPVC(cluster, pvc, log, processGroup)
+					needsRemoval, err = processGroupNeedsRemovalForPVC(
+						cluster,
+						pvc,
+						log,
+						processGroup,
+					)
 				})
 
 				When("PVC name doesn't match", func() {
@@ -396,14 +428,16 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					BeforeEach(func() {
 						newCPU, err := resource.ParseQuantity("1000")
 						Expect(err).NotTo(HaveOccurred())
-						cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral].PodTemplate.Spec.Containers = append(cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral].PodTemplate.Spec.Containers,
+						cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral].PodTemplate.Spec.Containers = append(
+							cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral].PodTemplate.Spec.Containers,
 							corev1.Container{
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU: newCPU,
 									},
 								},
-							})
+							},
+						)
 					})
 
 					It("should need a removal", func() {
@@ -495,7 +529,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 					When("FSGroup is changed", func() {
 						BeforeEach(func() {
-							pod.Spec.SecurityContext = &corev1.PodSecurityContext{FSGroup: pointer.Int64(1234)}
+							pod.Spec.SecurityContext = &corev1.PodSecurityContext{
+								FSGroup: pointer.Int64(1234),
+							}
 						})
 
 						When("replaceOnSecurityContextChange is true", func() {
@@ -521,13 +557,18 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				When("the last applied spec hash is not different from desired spec hash", func() {
 					When("FSGroup is changed", func() {
 						BeforeEach(func() {
-							pod.Spec.SecurityContext = &corev1.PodSecurityContext{FSGroup: pointer.Int64(1234)}
+							pod.Spec.SecurityContext = &corev1.PodSecurityContext{
+								FSGroup: pointer.Int64(1234),
+							}
 						})
 
-						It("should not need a removal (guard against server-side defaults)", func() {
-							Expect(needsRemoval).To(BeFalse())
-							Expect(err).NotTo(HaveOccurred())
-						})
+						It(
+							"should not need a removal (guard against server-side defaults)",
+							func() {
+								Expect(needsRemoval).To(BeFalse())
+								Expect(err).NotTo(HaveOccurred())
+							},
+						)
 					})
 				})
 			})
@@ -543,7 +584,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 					When("the pod ip family is v4", func() {
 						BeforeEach(func() {
-							cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
+							cluster.Spec.Routing.PodIPFamily = pointer.Int(
+								fdbv1beta2.PodIPFamilyIPv4,
+							)
 						})
 
 						When("the image type is split", func() {
@@ -553,7 +596,11 @@ var _ = Describe("replace_misconfigured_pods", func() {
 										continue
 									}
 
-									pod.Spec.Containers[idx].Args = append(pod.Spec.Containers[idx].Args, "--public-ip-family", "4")
+									pod.Spec.Containers[idx].Args = append(
+										pod.Spec.Containers[idx].Args,
+										"--public-ip-family",
+										"4",
+									)
 								}
 							})
 
@@ -567,7 +614,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 							BeforeEach(func() {
 								unified := fdbv1beta2.ImageTypeUnified
 								cluster.Spec.ImageType = &unified
-								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(fdbv1beta2.ImageTypeUnified)
+								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(
+									fdbv1beta2.ImageTypeUnified,
+								)
 
 								currentConfiguration := monitorapi.ProcessConfiguration{
 									Arguments: []monitorapi.Argument{
@@ -581,7 +630,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 								currentConfig, err := json.Marshal(currentConfiguration)
 								Expect(err).NotTo(HaveOccurred())
 
-								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(currentConfig)
+								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(
+									currentConfig,
+								)
 							})
 
 							It("should *not* need a removal", func() {
@@ -593,7 +644,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 					When("the pod ip family is v6", func() {
 						BeforeEach(func() {
-							cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv6)
+							cluster.Spec.Routing.PodIPFamily = pointer.Int(
+								fdbv1beta2.PodIPFamilyIPv6,
+							)
 						})
 
 						When("the image type is split", func() {
@@ -603,7 +656,11 @@ var _ = Describe("replace_misconfigured_pods", func() {
 										continue
 									}
 
-									pod.Spec.Containers[idx].Args = append(pod.Spec.Containers[idx].Args, "--public-ip-family", "6")
+									pod.Spec.Containers[idx].Args = append(
+										pod.Spec.Containers[idx].Args,
+										"--public-ip-family",
+										"6",
+									)
 								}
 							})
 
@@ -617,7 +674,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 							BeforeEach(func() {
 								unified := fdbv1beta2.ImageTypeUnified
 								cluster.Spec.ImageType = &unified
-								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(fdbv1beta2.ImageTypeUnified)
+								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(
+									fdbv1beta2.ImageTypeUnified,
+								)
 
 								currentConfiguration := monitorapi.ProcessConfiguration{
 									Arguments: []monitorapi.Argument{
@@ -631,7 +690,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 								currentConfig, err := json.Marshal(currentConfiguration)
 								Expect(err).NotTo(HaveOccurred())
 
-								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(currentConfig)
+								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(
+									currentConfig,
+								)
 							})
 
 							It("should *not* need a removal", func() {
@@ -646,7 +707,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 					When("the pod ip family at the pod is nil", func() {
 						When("the pod ip family at cluster level is v4", func() {
 							BeforeEach(func() {
-								cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
+								cluster.Spec.Routing.PodIPFamily = pointer.Int(
+									fdbv1beta2.PodIPFamilyIPv4,
+								)
 							})
 
 							It("should need a removal", func() {
@@ -657,7 +720,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 						When("the pod ip family at cluster level is v6", func() {
 							BeforeEach(func() {
-								cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
+								cluster.Spec.Routing.PodIPFamily = pointer.Int(
+									fdbv1beta2.PodIPFamilyIPv4,
+								)
 							})
 
 							It("should need a removal", func() {
@@ -675,7 +740,11 @@ var _ = Describe("replace_misconfigured_pods", func() {
 										continue
 									}
 
-									pod.Spec.Containers[idx].Args = append(pod.Spec.Containers[idx].Args, "--public-ip-family", "4")
+									pod.Spec.Containers[idx].Args = append(
+										pod.Spec.Containers[idx].Args,
+										"--public-ip-family",
+										"4",
+									)
 								}
 
 								pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = ""
@@ -694,7 +763,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 							When("the pod ip family at cluster level is v6", func() {
 								BeforeEach(func() {
-									cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv6)
+									cluster.Spec.Routing.PodIPFamily = pointer.Int(
+										fdbv1beta2.PodIPFamilyIPv6,
+									)
 								})
 
 								It("should need a removal", func() {
@@ -708,7 +779,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 							BeforeEach(func() {
 								unified := fdbv1beta2.ImageTypeUnified
 								cluster.Spec.ImageType = &unified
-								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(fdbv1beta2.ImageTypeUnified)
+								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(
+									fdbv1beta2.ImageTypeUnified,
+								)
 
 								currentConfiguration := monitorapi.ProcessConfiguration{
 									Arguments: []monitorapi.Argument{
@@ -722,7 +795,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 								currentConfig, err := json.Marshal(currentConfiguration)
 								Expect(err).NotTo(HaveOccurred())
 
-								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(currentConfig)
+								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(
+									currentConfig,
+								)
 								pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = ""
 							})
 
@@ -739,7 +814,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 							When("the pod ip family at cluster level is v6", func() {
 								BeforeEach(func() {
-									cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv6)
+									cluster.Spec.Routing.PodIPFamily = pointer.Int(
+										fdbv1beta2.PodIPFamilyIPv6,
+									)
 								})
 
 								It("should need a removal", func() {
@@ -758,7 +835,11 @@ var _ = Describe("replace_misconfigured_pods", func() {
 										continue
 									}
 
-									pod.Spec.Containers[idx].Args = append(pod.Spec.Containers[idx].Args, "--public-ip-family", "6")
+									pod.Spec.Containers[idx].Args = append(
+										pod.Spec.Containers[idx].Args,
+										"--public-ip-family",
+										"6",
+									)
 								}
 
 								pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = ""
@@ -777,7 +858,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 							When("the pod ip family at cluster level is v4", func() {
 								BeforeEach(func() {
-									cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
+									cluster.Spec.Routing.PodIPFamily = pointer.Int(
+										fdbv1beta2.PodIPFamilyIPv4,
+									)
 								})
 
 								It("should need a removal", func() {
@@ -791,7 +874,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 							BeforeEach(func() {
 								unified := fdbv1beta2.ImageTypeUnified
 								cluster.Spec.ImageType = &unified
-								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(fdbv1beta2.ImageTypeUnified)
+								pod.Annotations[fdbv1beta2.ImageTypeAnnotation] = string(
+									fdbv1beta2.ImageTypeUnified,
+								)
 
 								currentConfiguration := monitorapi.ProcessConfiguration{
 									Arguments: []monitorapi.Argument{
@@ -805,7 +890,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 								currentConfig, err := json.Marshal(currentConfiguration)
 								Expect(err).NotTo(HaveOccurred())
 
-								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(currentConfig)
+								pod.Annotations[monitorapi.CurrentConfigurationAnnotation] = string(
+									currentConfig,
+								)
 								pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = ""
 							})
 
@@ -822,7 +909,9 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 							When("the pod ip family at cluster level is v4", func() {
 								BeforeEach(func() {
-									cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
+									cluster.Spec.Routing.PodIPFamily = pointer.Int(
+										fdbv1beta2.PodIPFamilyIPv4,
+									)
 								})
 
 								It("should need a removal", func() {
@@ -857,35 +946,47 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				spec, err := internal.GetPodSpec(cluster, processGroup)
 				Expect(err).NotTo(HaveOccurred())
 
-				pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey], err = internal.GetPodSpecHash(cluster, processGroup, spec)
+				pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey], err = internal.GetPodSpecHash(
+					cluster,
+					processGroup,
+					spec,
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				pod.Spec = *spec
-				Expect(internal.NormalizeClusterSpec(cluster, deprecationOptions)).NotTo(HaveOccurred())
+				Expect(
+					internal.NormalizeClusterSpec(cluster, deprecationOptions),
+				).NotTo(HaveOccurred())
 			})
 
-			When("the storageServersPerPod is changed for a non storage class process group", func() {
-				BeforeEach(func() {
-					cluster.Spec.StorageServersPerPod = 2
-				})
+			When(
+				"the storageServersPerPod is changed for a non storage class process group",
+				func() {
+					BeforeEach(func() {
+						cluster.Spec.StorageServersPerPod = 2
+					})
 
-				It("should not need a removal", func() {
-					Expect(needsRemoval).To(BeFalse())
-					Expect(err).NotTo(HaveOccurred())
-				})
-			})
+					It("should not need a removal", func() {
+						Expect(needsRemoval).To(BeFalse())
+						Expect(err).NotTo(HaveOccurred())
+					})
+				},
+			)
 
-			When("PodUpdateStrategyTransactionReplacement is set and the PodSpecHash doesn't match for transaction", func() {
-				BeforeEach(func() {
-					pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = "-1"
-					cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyTransactionReplacement
-				})
+			When(
+				"PodUpdateStrategyTransactionReplacement is set and the PodSpecHash doesn't match for transaction",
+				func() {
+					BeforeEach(func() {
+						pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] = "-1"
+						cluster.Spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyTransactionReplacement
+					})
 
-				It("should need a removal", func() {
-					Expect(needsRemoval).To(BeTrue())
-					Expect(err).NotTo(HaveOccurred())
-				})
-			})
+					It("should need a removal", func() {
+						Expect(needsRemoval).To(BeTrue())
+						Expect(err).NotTo(HaveOccurred())
+					})
+				},
+			)
 
 			When("process group ID prefix changes", func() {
 				BeforeEach(func() {
@@ -919,7 +1020,10 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				Expect(k8sClient.Create(context.Background(), newPod)).To(Succeed())
 
 				// Populate process groups
-				cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(id, fdbv1beta2.ProcessClassStorage, nil))
+				cluster.Status.ProcessGroups = append(
+					cluster.Status.ProcessGroups,
+					fdbv1beta2.NewProcessGroupStatus(id, fdbv1beta2.ProcessClassStorage, nil),
+				)
 			}
 
 			for i := 0; i < 1; i++ {
@@ -937,7 +1041,10 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(k8sClient.Create(context.Background(), newPod)).To(Succeed())
 				// Populate process groups
-				cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus(id, fdbv1beta2.ProcessClassTransaction, nil))
+				cluster.Status.ProcessGroups = append(
+					cluster.Status.ProcessGroups,
+					fdbv1beta2.NewProcessGroupStatus(id, fdbv1beta2.ProcessClassTransaction, nil),
+				)
 			}
 
 			// Force a replacement of all processes
@@ -952,7 +1059,14 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			})
 
 			It("should not have a replacements", func() {
-				hasReplacement, err := ReplaceMisconfiguredProcessGroups(context.Background(), &podmanager.StandardPodLifecycleManager{}, k8sClient, log, cluster, true)
+				hasReplacement, err := ReplaceMisconfiguredProcessGroups(
+					context.Background(),
+					&podmanager.StandardPodLifecycleManager{},
+					k8sClient,
+					log,
+					cluster,
+					true,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(hasReplacement).To(BeFalse())
 
@@ -975,7 +1089,14 @@ var _ = Describe("replace_misconfigured_pods", func() {
 			})
 
 			It("should have two replacements", func() {
-				hasReplacement, err := ReplaceMisconfiguredProcessGroups(context.Background(), &podmanager.StandardPodLifecycleManager{}, k8sClient, log, cluster, true)
+				hasReplacement, err := ReplaceMisconfiguredProcessGroups(
+					context.Background(),
+					&podmanager.StandardPodLifecycleManager{},
+					k8sClient,
+					log,
+					cluster,
+					true,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(hasReplacement).To(BeTrue())
 
@@ -994,7 +1115,14 @@ var _ = Describe("replace_misconfigured_pods", func() {
 
 		When("Setting is unset", func() {
 			It("should replace all process groups", func() {
-				hasReplacement, err := ReplaceMisconfiguredProcessGroups(context.Background(), &podmanager.StandardPodLifecycleManager{}, k8sClient, log, cluster, true)
+				hasReplacement, err := ReplaceMisconfiguredProcessGroups(
+					context.Background(),
+					&podmanager.StandardPodLifecycleManager{},
+					k8sClient,
+					log,
+					cluster,
+					true,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(hasReplacement).To(BeTrue())
 
@@ -1020,7 +1148,13 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				BeforeEach(func() {
 					podName, _ := cluster.GetProcessGroupID(fdbv1beta2.ProcessClassStorage, 0)
 					currentPod := &corev1.Pod{}
-					Expect(k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Name: podName, Namespace: cluster.Namespace}, currentPod)).NotTo(HaveOccurred())
+					Expect(
+						k8sClient.Get(
+							context.Background(),
+							ctrlClient.ObjectKey{Name: podName, Namespace: cluster.Namespace},
+							currentPod,
+						),
+					).NotTo(HaveOccurred())
 
 					spec := currentPod.Spec.DeepCopy()
 					var cIdx int
@@ -1039,7 +1173,14 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				})
 
 				It("should not have any replacements", func() {
-					hasReplacement, err := ReplaceMisconfiguredProcessGroups(context.Background(), &podmanager.StandardPodLifecycleManager{}, k8sClient, log, cluster, true)
+					hasReplacement, err := ReplaceMisconfiguredProcessGroups(
+						context.Background(),
+						&podmanager.StandardPodLifecycleManager{},
+						k8sClient,
+						log,
+						cluster,
+						true,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(hasReplacement).To(BeFalse())
 
@@ -1116,7 +1257,13 @@ var _ = DescribeTable("file_security_context_changed",
 		&corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{},
 			Containers: []corev1.Container{
-				{SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: new(bool)}}},
+				{
+					SecurityContext: &corev1.SecurityContext{
+						WindowsOptions: &corev1.WindowsSecurityContextOptions{
+							HostProcess: new(bool),
+						},
+					},
+				},
 			}},
 		&corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{},
@@ -1129,7 +1276,13 @@ var _ = DescribeTable("file_security_context_changed",
 		&corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{},
 			Containers: []corev1.Container{
-				{SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: new(bool)}}},
+				{
+					SecurityContext: &corev1.SecurityContext{
+						WindowsOptions: &corev1.WindowsSecurityContextOptions{
+							HostProcess: new(bool),
+						},
+					},
+				},
 			}},
 		&corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{},
@@ -1147,7 +1300,13 @@ var _ = DescribeTable("file_security_context_changed",
 		&corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{},
 			Containers: []corev1.Container{
-				{SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: new(bool)}}},
+				{
+					SecurityContext: &corev1.SecurityContext{
+						WindowsOptions: &corev1.WindowsSecurityContextOptions{
+							HostProcess: new(bool),
+						},
+					},
+				},
 			}},
 		false,
 	),
@@ -1193,7 +1352,9 @@ var _ = DescribeTable("file_security_context_changed",
 	Entry("RunAsUser is added to the pod spec",
 		&corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{RunAsUser: pointer.Int64(42)},
-			Containers:      []corev1.Container{{}}}, // needs a "matching" container to compare effective settings
+			Containers: []corev1.Container{
+				{},
+			}}, // needs a "matching" container to compare effective settings
 		&corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{},
 			Containers:      []corev1.Container{{}}},

--- a/internal/restarts/restarts_test.go
+++ b/internal/restarts/restarts_test.go
@@ -27,9 +27,11 @@ import (
 )
 
 var _ = Describe("restarts", func() {
-	DescribeTable("when getting the filter conditions for a cluster", func(cluster *fdbv1beta2.FoundationDBCluster, expected map[fdbv1beta2.ProcessGroupConditionType]bool) {
-		Expect(GetFilterConditions(cluster)).To(Equal(expected))
-	},
+	DescribeTable(
+		"when getting the filter conditions for a cluster",
+		func(cluster *fdbv1beta2.FoundationDBCluster, expected map[fdbv1beta2.ProcessGroupConditionType]bool) {
+			Expect(GetFilterConditions(cluster)).To(Equal(expected))
+		},
 		Entry("when no upgrade is performed",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -106,7 +106,11 @@ func CreateDefaultBackup(cluster *fdbv1beta2.FoundationDBCluster) *fdbv1beta2.Fo
 }
 
 // GetProcessGroup is a helper method that creates a ProcessGroup based on the provided process class and id number.
-func GetProcessGroup(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, idNum int) *fdbv1beta2.ProcessGroupStatus {
+func GetProcessGroup(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	processClass fdbv1beta2.ProcessClass,
+	idNum int,
+) *fdbv1beta2.ProcessGroupStatus {
 	_, processGroupID := cluster.GetProcessGroupID(processClass, idNum)
 
 	return &fdbv1beta2.ProcessGroupStatus{
@@ -128,7 +132,11 @@ func GenerateRandomString(n int) string {
 }
 
 // PickProcessGroups will pick a number of process groups for the specified process class.
-func PickProcessGroups(cluster *fdbv1beta2.FoundationDBCluster, processClass fdbv1beta2.ProcessClass, count int) []*fdbv1beta2.ProcessGroupStatus {
+func PickProcessGroups(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	processClass fdbv1beta2.ProcessClass,
+	count int,
+) []*fdbv1beta2.ProcessGroupStatus {
 	pickedProcessGroups := make([]*fdbv1beta2.ProcessGroupStatus, 0, count)
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
@@ -146,7 +154,10 @@ func PickProcessGroups(cluster *fdbv1beta2.FoundationDBCluster, processClass fdb
 }
 
 // SetupClusterForTest will generate all required resources like Pods for test cases.
-func SetupClusterForTest(cluster *fdbv1beta2.FoundationDBCluster, k8sClient ctrlClient.Client) error {
+func SetupClusterForTest(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	k8sClient ctrlClient.Client,
+) error {
 	counts, err := cluster.GetProcessCountsWithDefaults()
 	if err != nil {
 		return err
@@ -166,7 +177,10 @@ func SetupClusterForTest(cluster *fdbv1beta2.FoundationDBCluster, k8sClient ctrl
 
 		processGroupIDs[processClass] = map[int]bool{}
 		for count > 0 {
-			processGroupID := cluster.GetNextRandomProcessGroupID(processClass, processGroupIDs[processClass])
+			processGroupID := cluster.GetNextRandomProcessGroupID(
+				processClass,
+				processGroupIDs[processClass],
+			)
 			newProcessGroup := fdbv1beta2.NewProcessGroupStatus(processGroupID, processClass, nil)
 			newProcessGroup.ProcessGroupConditions = nil
 

--- a/kubectl-fdb/cmd/buggify_crash_loop_test.go
+++ b/kubectl-fdb/cmd/buggify_crash_loop_test.go
@@ -65,7 +65,9 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							clean:         false,
 						}
 						tc.ProcessGroupOpts.namespace = namespace
-						Expect(updateCrashLoopContainerList(cmd, k8sClient, opts, tc.ProcessGroupOpts)).NotTo(HaveOccurred())
+						Expect(
+							updateCrashLoopContainerList(cmd, k8sClient, opts, tc.ProcessGroupOpts),
+						).NotTo(HaveOccurred())
 
 						for cluster, processGroupsInCrashLoop := range tc.ExpectedProcessGroupsInCrashLoop {
 							var resCluster fdbv1beta2.FoundationDBCluster
@@ -78,9 +80,15 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 								if crashLoopContainerObj.ContainerName != fdbv1beta2.MainContainerName {
 									continue
 								}
-								Expect(processGroupsInCrashLoop).To(ContainElements(crashLoopContainerObj.Targets))
-								Expect(crashLoopContainerObj.Targets).To(ContainElements(processGroupsInCrashLoop))
-								Expect(processGroupsInCrashLoop).To(HaveLen(len(crashLoopContainerObj.Targets)))
+								Expect(
+									processGroupsInCrashLoop,
+								).To(ContainElements(crashLoopContainerObj.Targets))
+								Expect(
+									crashLoopContainerObj.Targets,
+								).To(ContainElements(processGroupsInCrashLoop))
+								Expect(
+									processGroupsInCrashLoop,
+								).To(HaveLen(len(crashLoopContainerObj.Targets)))
 							}
 						}
 					},
@@ -109,19 +117,49 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							ProcessGroupOpts: processGroupSelectionOptions{
 								ids: []string{
 									// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
-									fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
-									fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
-									fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage),
+									fmt.Sprintf(
+										"%s-%s-1",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+									fmt.Sprintf(
+										"%s-%s-2",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+									fmt.Sprintf(
+										"%s-%s-2",
+										secondClusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
 								},
 								clusterLabel: fdbv1beta2.FDBClusterLabel,
 							},
 							ExpectedProcessGroupsInCrashLoop: map[string][]fdbv1beta2.ProcessGroupID{
 								clusterName: {
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+									fdbv1beta2.ProcessGroupID(
+										fmt.Sprintf(
+											"%s-%s-1",
+											clusterName,
+											fdbv1beta2.ProcessClassStorage,
+										),
+									),
+									fdbv1beta2.ProcessGroupID(
+										fmt.Sprintf(
+											"%s-%s-2",
+											clusterName,
+											fdbv1beta2.ProcessClassStorage,
+										),
+									),
 								},
 								secondClusterName: {
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+									fdbv1beta2.ProcessGroupID(
+										fmt.Sprintf(
+											"%s-%s-2",
+											secondClusterName,
+											fdbv1beta2.ProcessClassStorage,
+										),
+									),
 								},
 							},
 						}),
@@ -134,8 +172,20 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							ExpectedProcessGroupsInCrashLoop: map[string][]fdbv1beta2.ProcessGroupID{
 								clusterName: {
 									// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+									fdbv1beta2.ProcessGroupID(
+										fmt.Sprintf(
+											"%s-%s-1",
+											clusterName,
+											fdbv1beta2.ProcessClassStorage,
+										),
+									),
+									fdbv1beta2.ProcessGroupID(
+										fmt.Sprintf(
+											"%s-%s-2",
+											clusterName,
+											fdbv1beta2.ProcessClassStorage,
+										),
+									),
 								},
 							},
 						}),
@@ -143,12 +193,20 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 						processGroupOptionsTestCase{
 							ProcessGroupOpts: processGroupSelectionOptions{
 								clusterName: clusterName,
-								conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses},
+								conditions: []fdbv1beta2.ProcessGroupConditionType{
+									fdbv1beta2.MissingProcesses,
+								},
 							},
 							ExpectedProcessGroupsInCrashLoop: map[string][]fdbv1beta2.ProcessGroupID{
 								clusterName: {
 									// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
-									fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+									fdbv1beta2.ProcessGroupID(
+										fmt.Sprintf(
+											"%s-%s-2",
+											clusterName,
+											fdbv1beta2.ProcessClassStorage,
+										),
+									),
 								},
 							},
 						}),
@@ -162,7 +220,10 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 						ContainerName: fdbv1beta2.MainContainerName,
 						Targets:       []fdbv1beta2.ProcessGroupID{"test-storage-1"},
 					}
-					cluster.Spec.Buggify.CrashLoopContainers = append(cluster.Spec.Buggify.CrashLoopContainers, crashLoopContainerObj)
+					cluster.Spec.Buggify.CrashLoopContainers = append(
+						cluster.Spec.Buggify.CrashLoopContainers,
+						crashLoopContainerObj,
+					)
 				})
 
 				DescribeTable("should add all targeted process groups to crash-loop container list",
@@ -180,7 +241,9 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							clusterName: clusterName,
 							namespace:   namespace,
 						}
-						Expect(updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts)).NotTo(HaveOccurred())
+						Expect(
+							updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts),
+						).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster
 						Expect(k8sClient.Get(context.Background(), client.ObjectKey{
@@ -192,23 +255,38 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							if crashLoopContainerObj.ContainerName != fdbv1beta2.MainContainerName {
 								continue
 							}
-							Expect(tc.ExpectedProcessGroupsInCrashLoop).To(ConsistOf(crashLoopContainerObj.Targets))
+							Expect(
+								tc.ExpectedProcessGroupsInCrashLoop,
+							).To(ConsistOf(crashLoopContainerObj.Targets))
 						}
 					},
 					Entry("Adding same process group.",
 						testCase{
-							ProcessGroups:                    []string{"test-storage-1"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
+							ProcessGroups: []string{"test-storage-1"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{
+								"test-storage-1",
+							},
 						}),
 					Entry("Adding single but different process group.",
 						testCase{
-							ProcessGroups:                    []string{"test-storage-2"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2"},
+							ProcessGroups: []string{"test-storage-2"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{
+								"test-storage-1",
+								"test-storage-2",
+							},
 						}),
 					Entry("Adding multiple process groups.",
 						testCase{
-							ProcessGroups:                    []string{"test-storage-1", "test-storage-2", "test-stateless-3"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-stateless-3"},
+							ProcessGroups: []string{
+								"test-storage-1",
+								"test-storage-2",
+								"test-stateless-3",
+							},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{
+								"test-storage-1",
+								"test-storage-2",
+								"test-stateless-3",
+							},
 						}),
 				)
 			})
@@ -219,8 +297,14 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 						ContainerName: fdbv1beta2.SidecarContainerName,
 						Targets:       []fdbv1beta2.ProcessGroupID{"should-be-ignored-storage-1"},
 					}
-					cluster.Spec.Buggify.CrashLoopContainers = append(cluster.Spec.Buggify.CrashLoopContainers, crashLoopContainerObj)
-					secondCluster.Spec.Buggify.CrashLoopContainers = append(cluster.Spec.Buggify.CrashLoopContainers, crashLoopContainerObj)
+					cluster.Spec.Buggify.CrashLoopContainers = append(
+						cluster.Spec.Buggify.CrashLoopContainers,
+						crashLoopContainerObj,
+					)
+					secondCluster.Spec.Buggify.CrashLoopContainers = append(
+						cluster.Spec.Buggify.CrashLoopContainers,
+						crashLoopContainerObj,
+					)
 				})
 
 				DescribeTable("should add all targeted processes to crash-loop container list",
@@ -238,7 +322,9 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							clusterName: clusterName,
 							namespace:   namespace,
 						}
-						Expect(updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts)).NotTo(HaveOccurred())
+						Expect(
+							updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts),
+						).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster
 						Expect(k8sClient.Get(context.Background(), client.ObjectKey{
@@ -250,18 +336,30 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 							if crashLoopContainerObj.ContainerName != fdbv1beta2.MainContainerName {
 								continue
 							}
-							Expect(tc.ExpectedProcessGroupsInCrashLoop).To(ConsistOf(crashLoopContainerObj.Targets))
+							Expect(
+								tc.ExpectedProcessGroupsInCrashLoop,
+							).To(ConsistOf(crashLoopContainerObj.Targets))
 						}
 					},
 					Entry("Adding single process group.",
 						testCase{
-							ProcessGroups:                    []string{"test-storage-1"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
+							ProcessGroups: []string{"test-storage-1"},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{
+								"test-storage-1",
+							},
 						}),
 					Entry("Adding multiple process group.",
 						testCase{
-							ProcessGroups:                    []string{"test-storage-1", "test-storage-2", "test-stateless-3"},
-							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-stateless-3"},
+							ProcessGroups: []string{
+								"test-storage-1",
+								"test-storage-2",
+								"test-stateless-3",
+							},
+							ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{
+								"test-storage-1",
+								"test-storage-2",
+								"test-stateless-3",
+							},
 						}),
 				)
 
@@ -277,12 +375,20 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 			BeforeEach(func() {
 				crashLoopContainerObj := fdbv1beta2.CrashLoopContainerObject{
 					ContainerName: fdbv1beta2.MainContainerName,
-					Targets:       []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-stateless-3"},
+					Targets: []fdbv1beta2.ProcessGroupID{
+						"test-storage-1",
+						"test-storage-2",
+						"test-stateless-3",
+					},
 				}
-				cluster.Spec.Buggify.CrashLoopContainers = append(cluster.Spec.Buggify.CrashLoopContainers, crashLoopContainerObj)
+				cluster.Spec.Buggify.CrashLoopContainers = append(
+					cluster.Spec.Buggify.CrashLoopContainers,
+					crashLoopContainerObj,
+				)
 			})
 
-			DescribeTable("should remove all targeted process groups from crash-loop container list",
+			DescribeTable(
+				"should remove all targeted process groups from crash-loop container list",
 				func(tc testCase) {
 					Expect(cluster.Spec.Buggify.CrashLoopContainers).To(HaveLen(1))
 					cmd := newBuggifyCrashLoop(genericclioptions.IOStreams{})
@@ -297,7 +403,9 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 						clusterName: clusterName,
 						namespace:   namespace,
 					}
-					Expect(updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts)).NotTo(HaveOccurred())
+					Expect(
+						updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts),
+					).NotTo(HaveOccurred())
 
 					var resCluster fdbv1beta2.FoundationDBCluster
 					Expect(k8sClient.Get(context.Background(), client.ObjectKey{
@@ -309,22 +417,36 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 						if crashLoopContainerObj.ContainerName != fdbv1beta2.MainContainerName {
 							continue
 						}
-						Expect(tc.ExpectedProcessGroupsInCrashLoop).To(ConsistOf(crashLoopContainerObj.Targets))
+						Expect(
+							tc.ExpectedProcessGroupsInCrashLoop,
+						).To(ConsistOf(crashLoopContainerObj.Targets))
 					}
 				},
 				Entry("Removing single process group.",
 					testCase{
-						ProcessGroups:                    []string{"test-storage-1"},
-						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-storage-2", "test-stateless-3"},
+						ProcessGroups: []string{"test-storage-1"},
+						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{
+							"test-storage-2",
+							"test-stateless-3",
+						},
 					}),
 				Entry("Removing multiple process groups.",
 					testCase{
-						ProcessGroups:                    []string{"test-storage-1", "test-storage-2"},
-						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{"test-stateless-3"},
+						ProcessGroups: []string{
+							"test-storage-1",
+							"test-storage-2",
+						},
+						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{
+							"test-stateless-3",
+						},
 					}),
 				Entry("Removing all process groups.",
 					testCase{
-						ProcessGroups:                    []string{"test-storage-1", "test-storage-2", "test-stateless-3"},
+						ProcessGroups: []string{
+							"test-storage-1",
+							"test-storage-2",
+							"test-stateless-3",
+						},
 						ExpectedProcessGroupsInCrashLoop: []fdbv1beta2.ProcessGroupID{},
 					}),
 			)
@@ -334,9 +456,16 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 			BeforeEach(func() {
 				crashLoopContainerObj := fdbv1beta2.CrashLoopContainerObject{
 					ContainerName: fdbv1beta2.MainContainerName,
-					Targets:       []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2", "storage-3"},
+					Targets: []fdbv1beta2.ProcessGroupID{
+						"storage-1",
+						"storage-2",
+						"storage-3",
+					},
 				}
-				cluster.Spec.Buggify.CrashLoopContainers = append(cluster.Spec.Buggify.CrashLoopContainers, crashLoopContainerObj)
+				cluster.Spec.Buggify.CrashLoopContainers = append(
+					cluster.Spec.Buggify.CrashLoopContainers,
+					crashLoopContainerObj,
+				)
 			})
 
 			It("should clear everything from the crash-loop container-list", func() {
@@ -352,7 +481,9 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 					clusterName: clusterName,
 					namespace:   namespace,
 				}
-				Expect(updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts)).NotTo(HaveOccurred())
+				Expect(
+					updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts),
+				).NotTo(HaveOccurred())
 
 				var resCluster fdbv1beta2.FoundationDBCluster
 				Expect(k8sClient.Get(context.Background(), client.ObjectKey{
@@ -383,7 +514,9 @@ var _ = Describe("[plugin] buggify crash-loop process groups command", func() {
 				}
 				err := updateCrashLoopContainerList(cmd, k8sClient, opts, processGroupOpts)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("clean option requires cluster-name argument"))
+				Expect(
+					err.Error(),
+				).To(ContainSubstring("clean option requires cluster-name argument"))
 			})
 		})
 	})

--- a/kubectl-fdb/cmd/buggify_empty_monitor_conf.go
+++ b/kubectl-fdb/cmd/buggify_empty_monitor_conf.go
@@ -89,7 +89,13 @@ kubectl fdb buggify empty-monitor-conf --set-value=false -c cluster
 }
 
 // updateMonitorConf updates the monitor conf of the cluster
-func updateMonitorConf(kubeClient client.Client, clusterName string, namespace string, wait bool, set bool) error {
+func updateMonitorConf(
+	kubeClient client.Client,
+	clusterName string,
+	namespace string,
+	wait bool,
+	set bool,
+) error {
 	cluster, err := loadCluster(kubeClient, namespace, clusterName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -105,7 +111,14 @@ func updateMonitorConf(kubeClient client.Client, clusterName string, namespace s
 	patch := client.MergeFrom(cluster.DeepCopy())
 
 	if wait {
-		if !confirmAction(fmt.Sprintf("Setting empty-monitor-conf to %v for cluster %s/%s", set, namespace, clusterName)) {
+		if !confirmAction(
+			fmt.Sprintf(
+				"Setting empty-monitor-conf to %v for cluster %s/%s",
+				set,
+				namespace,
+				clusterName,
+			),
+		) {
 			return fmt.Errorf("user aborted the removal")
 		}
 	}

--- a/kubectl-fdb/cmd/buggify_no_schedule.go
+++ b/kubectl-fdb/cmd/buggify_no_schedule.go
@@ -100,21 +100,40 @@ See help for even more process group selection options, such as by processClass,
 }
 
 // updateNoScheduleList updates the removal list of the cluster
-func updateNoScheduleList(cmd *cobra.Command, kubeClient client.Client, opts buggifyProcessGroupOptions, processGroupOpts processGroupSelectionOptions) error {
+func updateNoScheduleList(
+	cmd *cobra.Command,
+	kubeClient client.Client,
+	opts buggifyProcessGroupOptions,
+	processGroupOpts processGroupSelectionOptions,
+) error {
 	if opts.clean {
 		if processGroupOpts.clusterName == "" {
 			return fmt.Errorf("clean option requires cluster-name argument")
 		}
-		cluster, err := loadCluster(kubeClient, processGroupOpts.namespace, processGroupOpts.clusterName)
+		cluster, err := loadCluster(
+			kubeClient,
+			processGroupOpts.namespace,
+			processGroupOpts.clusterName,
+		)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
-				return fmt.Errorf("could not get cluster: %s/%s", processGroupOpts.namespace, processGroupOpts.clusterName)
+				return fmt.Errorf(
+					"could not get cluster: %s/%s",
+					processGroupOpts.namespace,
+					processGroupOpts.clusterName,
+				)
 			}
 			return err
 		}
 		patch := client.MergeFrom(cluster.DeepCopy())
 		if opts.wait {
-			if !confirmAction(fmt.Sprintf("Clearing no-schedule list from cluster %s/%s", processGroupOpts.namespace, processGroupOpts.clusterName)) {
+			if !confirmAction(
+				fmt.Sprintf(
+					"Clearing no-schedule list from cluster %s/%s",
+					processGroupOpts.namespace,
+					processGroupOpts.clusterName,
+				),
+			) {
 				return fmt.Errorf("user aborted the removal")
 			}
 		}
@@ -134,7 +153,15 @@ func updateNoScheduleList(cmd *cobra.Command, kubeClient client.Client, opts bug
 		}
 
 		if opts.clear {
-			if opts.wait && !confirmAction(fmt.Sprintf("Removing %v from no-schedule from cluster %s/%s", processGroupIDs, processGroupOpts.namespace, processGroupOpts.clusterName)) {
+			if opts.wait &&
+				!confirmAction(
+					fmt.Sprintf(
+						"Removing %v from no-schedule from cluster %s/%s",
+						processGroupIDs,
+						processGroupOpts.namespace,
+						processGroupOpts.clusterName,
+					),
+				) {
 				return fmt.Errorf("user aborted the removal")
 			}
 			cluster.RemoveProcessGroupsFromNoScheduleList(processGroupIDs)

--- a/kubectl-fdb/cmd/buggify_no_schedule_test.go
+++ b/kubectl-fdb/cmd/buggify_no_schedule_test.go
@@ -51,7 +51,12 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 				func(tc processGroupOptionsTestCase) {
 					cmd := newBuggifyNoSchedule(genericclioptions.IOStreams{})
 					tc.ProcessGroupOpts.namespace = namespace
-					err := updateNoScheduleList(cmd, k8sClient, buggifyProcessGroupOptions{}, tc.ProcessGroupOpts)
+					err := updateNoScheduleList(
+						cmd,
+						k8sClient,
+						buggifyProcessGroupOptions{},
+						tc.ProcessGroupOpts,
+					)
 					Expect(err).NotTo(HaveOccurred())
 
 					for cluster, processGroupsInNoSchedule := range tc.ExpectedProcessGroupsInNoSchedule {
@@ -61,9 +66,15 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 							Name:      cluster,
 						}, &resCluster)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(processGroupsInNoSchedule).To(ContainElements(resCluster.Spec.Buggify.NoSchedule))
-						Expect(resCluster.Spec.Buggify.NoSchedule).To(ContainElements(processGroupsInNoSchedule))
-						Expect(len(processGroupsInNoSchedule)).To(BeNumerically("==", len(resCluster.Spec.Buggify.NoSchedule)))
+						Expect(
+							processGroupsInNoSchedule,
+						).To(ContainElements(resCluster.Spec.Buggify.NoSchedule))
+						Expect(
+							resCluster.Spec.Buggify.NoSchedule,
+						).To(ContainElements(processGroupsInNoSchedule))
+						Expect(
+							len(processGroupsInNoSchedule),
+						).To(BeNumerically("==", len(resCluster.Spec.Buggify.NoSchedule)))
 					}
 				},
 				Entry("Adding single instance.",
@@ -93,17 +104,39 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 								// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
 								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
 								fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
-								fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage),
+								fmt.Sprintf(
+									"%s-%s-2",
+									secondClusterName,
+									fdbv1beta2.ProcessClassStorage,
+								),
 							},
 							clusterLabel: fdbv1beta2.FDBClusterLabel,
 						},
 						ExpectedProcessGroupsInNoSchedule: map[string][]fdbv1beta2.ProcessGroupID{
 							clusterName: {
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-1",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+								),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-2",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+								),
 							},
 							secondClusterName: {
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-2",
+										secondClusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+								),
 							},
 						},
 					}),
@@ -116,8 +149,20 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 						ExpectedProcessGroupsInNoSchedule: map[string][]fdbv1beta2.ProcessGroupID{
 							clusterName: {
 								// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-1",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+								),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-2",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+								),
 							},
 						},
 					}),
@@ -125,12 +170,20 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 					processGroupOptionsTestCase{
 						ProcessGroupOpts: processGroupSelectionOptions{
 							clusterName: clusterName,
-							conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses},
+							conditions: []fdbv1beta2.ProcessGroupConditionType{
+								fdbv1beta2.MissingProcesses,
+							},
 						},
 						ExpectedProcessGroupsInNoSchedule: map[string][]fdbv1beta2.ProcessGroupID{
 							clusterName: {
 								// the helper function to create pods for the k8s client uses "instance" not "storage" processGroup names
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-2",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+								),
 							},
 						},
 					}),
@@ -154,7 +207,12 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 							clusterName: clusterName,
 							namespace:   namespace,
 						}
-						err := updateNoScheduleList(cmd, k8sClient, buggifyProcessGroupOptions{}, processGroupOpts)
+						err := updateNoScheduleList(
+							cmd,
+							k8sClient,
+							buggifyProcessGroupOptions{},
+							processGroupOpts,
+						)
 						Expect(err).NotTo(HaveOccurred())
 
 						var resCluster fdbv1beta2.FoundationDBCluster
@@ -163,22 +221,36 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 							Name:      clusterName,
 						}, &resCluster)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(tc.ExpectedInstancesInNoSchedule).To(ConsistOf(resCluster.Spec.Buggify.NoSchedule))
+						Expect(
+							tc.ExpectedInstancesInNoSchedule,
+						).To(ConsistOf(resCluster.Spec.Buggify.NoSchedule))
 					},
 					Entry("Adding the same instance.",
 						testCase{
-							Instances:                     []string{"test-storage-1"},
-							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
+							Instances: []string{"test-storage-1"},
+							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{
+								"test-storage-1",
+							},
 						}),
 					Entry("Adding different instance.",
 						testCase{
-							Instances:                     []string{"test-storage-2"},
-							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2"},
+							Instances: []string{"test-storage-2"},
+							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{
+								"test-storage-1",
+								"test-storage-2",
+							},
 						}),
 					Entry("Adding multiple instances.",
 						testCase{
-							Instances:                     []string{"test-storage-2", "test-stateless-3"},
-							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-stateless-3"},
+							Instances: []string{
+								"test-storage-2",
+								"test-stateless-3",
+							},
+							ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{
+								"test-storage-1",
+								"test-storage-2",
+								"test-stateless-3",
+							},
 						}),
 				)
 			})
@@ -186,7 +258,11 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 
 		When("removing process group from no-schedule list from a cluster", func() {
 			BeforeEach(func() {
-				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{"test-storage-1", "test-storage-2", "test-stateless-3"}
+				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{
+					"test-storage-1",
+					"test-storage-2",
+					"test-stateless-3",
+				}
 			})
 
 			type testCase struct {
@@ -216,17 +292,27 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 						Name:      clusterName,
 					}, &resCluster)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(tc.ExpectedInstancesInNoSchedule).To(ConsistOf(resCluster.Spec.Buggify.NoSchedule))
+					Expect(
+						tc.ExpectedInstancesInNoSchedule,
+					).To(ConsistOf(resCluster.Spec.Buggify.NoSchedule))
 				},
 				Entry("Removing single instance.",
 					testCase{
-						Instances:                     []string{"test-storage-1"},
-						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-2", "test-stateless-3"},
+						Instances: []string{"test-storage-1"},
+						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{
+							"test-storage-2",
+							"test-stateless-3",
+						},
 					}),
 				Entry("Removing multiple instances.",
 					testCase{
-						Instances:                     []string{"test-storage-2", "test-stateless-3"},
-						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{"test-storage-1"},
+						Instances: []string{
+							"test-storage-2",
+							"test-stateless-3",
+						},
+						ExpectedInstancesInNoSchedule: []fdbv1beta2.ProcessGroupID{
+							"test-storage-1",
+						},
 					}),
 			)
 
@@ -234,7 +320,11 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 
 		When("clearing no-schedule list", func() {
 			BeforeEach(func() {
-				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2", "storage-3"}
+				cluster.Spec.Buggify.NoSchedule = []fdbv1beta2.ProcessGroupID{
+					"storage-1",
+					"storage-2",
+					"storage-3",
+				}
 			})
 
 			It("should clear the no-schedule list", func() {
@@ -274,7 +364,9 @@ var _ = Describe("[plugin] buggify no-schedule instances command", func() {
 				}
 				err := updateNoScheduleList(cmd, k8sClient, opts, processGroupOpts)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("clean option requires cluster-name argument"))
+				Expect(
+					err.Error(),
+				).To(ContainSubstring("clean option requires cluster-name argument"))
 			})
 		})
 	})

--- a/kubectl-fdb/cmd/configuration.go
+++ b/kubectl-fdb/cmd/configuration.go
@@ -67,7 +67,12 @@ func newConfigurationCmd(streams genericclioptions.IOStreams) *cobra.Command {
 					return updateConfig(kubeClient, clusterName, namespace, failOver, wait)
 				}
 
-				configuration, err := getConfigurationString(kubeClient, clusterName, namespace, failOver)
+				configuration, err := getConfigurationString(
+					kubeClient,
+					clusterName,
+					namespace,
+					failOver,
+				)
 				if err != nil {
 					return err
 				}
@@ -99,14 +104,22 @@ kubectl fdb get configuration --fail-over --update c1
 	cmd.SetErr(o.ErrOut)
 	cmd.SetIn(o.In)
 
-	cmd.Flags().Bool("fail-over", false, "defines if the configuration should be changed to issue a fail over")
-	cmd.Flags().Bool("update", false, "defines if the configuration should be updated in the cluster spec")
+	cmd.Flags().
+		Bool("fail-over", false, "defines if the configuration should be changed to issue a fail over")
+	cmd.Flags().
+		Bool("update", false, "defines if the configuration should be updated in the cluster spec")
 	o.configFlags.AddFlags(cmd.Flags())
 
 	return cmd
 }
 
-func updateConfig(kubeClient client.Client, clusterName string, namespace string, failOver bool, wait bool) error {
+func updateConfig(
+	kubeClient client.Client,
+	clusterName string,
+	namespace string,
+	failOver bool,
+	wait bool,
+) error {
 	cluster, err := loadCluster(kubeClient, namespace, clusterName)
 	if err != nil {
 		return err
@@ -135,7 +148,12 @@ func updateConfig(kubeClient client.Client, clusterName string, namespace string
 }
 
 // getConfigurationString returns the configuration string
-func getConfigurationString(kubeClient client.Client, clusterName string, namespace string, failOver bool) (string, error) {
+func getConfigurationString(
+	kubeClient client.Client,
+	clusterName string,
+	namespace string,
+	failOver bool,
+) (string, error) {
 	cluster, err := loadCluster(kubeClient, namespace, clusterName)
 	if err != nil {
 		return "", err

--- a/kubectl-fdb/cmd/configuration_test.go
+++ b/kubectl-fdb/cmd/configuration_test.go
@@ -60,13 +60,17 @@ var _ = Describe("[plugin] configuration command", func() {
 			It("should return the configuration string", func() {
 				configuration, err := getConfigurationString(k8sClient, "test", "test", false)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(configuration).To(Equal("  usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"test\\\",\\\"priority\\\":1}]}]"))
+				Expect(
+					configuration,
+				).To(Equal("  usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"test\\\",\\\"priority\\\":1}]}]"))
 			})
 
 			It("should return the same configuration string with fail-over", func() {
 				configuration, err := getConfigurationString(k8sClient, "test", "test", true)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(configuration).To(Equal("  usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"test\\\",\\\"priority\\\":1}]}]"))
+				Expect(
+					configuration,
+				).To(Equal("  usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"test\\\",\\\"priority\\\":1}]}]"))
 			})
 		})
 
@@ -131,13 +135,17 @@ var _ = Describe("[plugin] configuration command", func() {
 			It("should return the configuration string", func() {
 				configuration, err := getConfigurationString(k8sClient, "test", "test", false)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(configuration).To(Equal("  usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_single\\\"},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\"},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_double\\\"}]"))
+				Expect(
+					configuration,
+				).To(Equal("  usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_single\\\"},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\"},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_double\\\"}]"))
 			})
 
 			It("should return the configuration string with the modified priority", func() {
 				configuration, err := getConfigurationString(k8sClient, "test", "test", true)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(configuration).To(Equal("  usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\"},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_single\\\"},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_double\\\"}]"))
+				Expect(
+					configuration,
+				).To(Equal("  usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\"},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_single\\\"},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_double\\\"}]"))
 			})
 
 			When("Updating the config for the cluster", func() {
@@ -155,7 +163,9 @@ var _ = Describe("[plugin] configuration command", func() {
 					config := resCluster.Spec.DatabaseConfiguration
 					Expect(len(config.Regions)).To(BeNumerically("==", 2))
 
-					Expect(config.Regions[0].SatelliteRedundancyMode).To(Equal(fdbv1beta2.RedundancyModeOneSatelliteSingle))
+					Expect(
+						config.Regions[0].SatelliteRedundancyMode,
+					).To(Equal(fdbv1beta2.RedundancyModeOneSatelliteSingle))
 					Expect(config.Regions[0].SatelliteLogs).To(Equal(3))
 
 					Expect(config.Regions[0].DataCenters[0].ID).To(Equal("primary"))
@@ -178,7 +188,9 @@ var _ = Describe("[plugin] configuration command", func() {
 					Expect(config.Regions[1].DataCenters[2].Satellite).To(Equal(1))
 					Expect(config.Regions[1].DataCenters[2].Priority).To(Equal(0))
 
-					Expect(config.GetConfigurationString()).To(Equal("  usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\"},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_single\\\"},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_double\\\"}]"))
+					Expect(
+						config.GetConfigurationString(),
+					).To(Equal("  usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[{\\\"datacenters\\\":[{\\\"id\\\":\\\"primary\\\"},{\\\"id\\\":\\\"primary-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_single\\\"},{\\\"datacenters\\\":[{\\\"id\\\":\\\"remote\\\",\\\"priority\\\":1},{\\\"id\\\":\\\"remote-sat\\\",\\\"priority\\\":1,\\\"satellite\\\":1},{\\\"id\\\":\\\"primary-sat\\\",\\\"satellite\\\":1}],\\\"satellite_logs\\\":3,\\\"satellite_redundancy_mode\\\":\\\"one_satellite_double\\\"}]"))
 				})
 			})
 		})

--- a/kubectl-fdb/cmd/cordon.go
+++ b/kubectl-fdb/cmd/cordon.go
@@ -81,10 +81,28 @@ func newCordonCmd(streams genericclioptions.IOStreams) *cobra.Command {
 					return err
 				}
 
-				return cordonNode(cmd, kubeClient, clusterName, nodes, namespace, withExclusion, wait, clusterLabel)
+				return cordonNode(
+					cmd,
+					kubeClient,
+					clusterName,
+					nodes,
+					namespace,
+					withExclusion,
+					wait,
+					clusterLabel,
+				)
 			}
 
-			return cordonNode(cmd, kubeClient, clusterName, args, namespace, withExclusion, wait, clusterLabel)
+			return cordonNode(
+				cmd,
+				kubeClient,
+				clusterName,
+				args,
+				namespace,
+				withExclusion,
+				wait,
+				clusterLabel,
+			)
 		},
 		Example: `
 # Evacuate all process groups for a cluster in the current namespace that are hosted on node-1
@@ -113,17 +131,30 @@ kubectl fdb cordon --node-selector machine=a,disk=fast -l fdb-cluster-label
 	cmd.SetErr(o.ErrOut)
 	cmd.SetIn(o.In)
 
-	cmd.Flags().StringP("fdb-cluster", "c", "", "evacuate process group(s) from the provided cluster.")
-	cmd.Flags().StringToStringVarP(&nodeSelectors, "node-selector", "", nil, "node-selector to select all nodes that should be cordoned. Can't be used with specific nodes.")
-	cmd.Flags().BoolP("exclusion", "e", true, "define if the process groups should be removed with exclusion.")
-	cmd.Flags().StringP("cluster-label", "l", fdbv1beta2.FDBClusterLabel, "cluster label to fetch the appropriate Pods and identify the according cluster.")
+	cmd.Flags().
+		StringP("fdb-cluster", "c", "", "evacuate process group(s) from the provided cluster.")
+	cmd.Flags().
+		StringToStringVarP(&nodeSelectors, "node-selector", "", nil, "node-selector to select all nodes that should be cordoned. Can't be used with specific nodes.")
+	cmd.Flags().
+		BoolP("exclusion", "e", true, "define if the process groups should be removed with exclusion.")
+	cmd.Flags().
+		StringP("cluster-label", "l", fdbv1beta2.FDBClusterLabel, "cluster label to fetch the appropriate Pods and identify the according cluster.")
 	o.configFlags.AddFlags(cmd.Flags())
 
 	return cmd
 }
 
 // cordonNode gets all process groups of this cluster that run on the given nodes and add them to the remove list
-func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName string, nodes []string, namespace string, withExclusion bool, wait bool, clusterLabel string) error {
+func cordonNode(
+	cmd *cobra.Command,
+	kubeClient client.Client,
+	inputClusterName string,
+	nodes []string,
+	namespace string,
+	withExclusion bool,
+	wait bool,
+	clusterLabel string,
+) error {
 	cmd.Printf("Starting to cordon %d nodes\n", len(nodes))
 	if len(nodes) == 0 {
 		return errors.New("no nodes were provided for cordoning")
@@ -134,7 +165,10 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 	for _, node := range nodes {
 		pods, err := fetchPodsOnNode(kubeClient, inputClusterName, namespace, node, clusterLabel)
 		if err != nil {
-			observedErrors = append(observedErrors, fmt.Errorf("error fetching Pods from node: %s", node))
+			observedErrors = append(
+				observedErrors,
+				fmt.Errorf("error fetching Pods from node: %s", node),
+			)
 			continue
 		}
 
@@ -163,7 +197,10 @@ func cordonNode(cmd *cobra.Command, kubeClient client.Client, inputClusterName s
 				removeAllFailed: false,
 			})
 		if err != nil {
-			observedErrors = append(observedErrors, fmt.Errorf("unable to cordon all Pods on node %s", node))
+			observedErrors = append(
+				observedErrors,
+				fmt.Errorf("unable to cordon all Pods on node %s", node),
+			)
 			continue
 		}
 

--- a/kubectl-fdb/cmd/cordon_test.go
+++ b/kubectl-fdb/cmd/cordon_test.go
@@ -58,7 +58,16 @@ var _ = Describe("[plugin] cordon command", func() {
 		DescribeTable("should cordon all targeted processes",
 			func(input testCase) {
 				cmd := newCordonCmd(genericclioptions.IOStreams{})
-				err := cordonNode(cmd, k8sClient, input.clusterName, input.nodes, namespace, input.WithExclusion, false, input.clusterLabel)
+				err := cordonNode(
+					cmd,
+					k8sClient,
+					input.clusterName,
+					input.nodes,
+					namespace,
+					input.WithExclusion,
+					false,
+					input.clusterLabel,
+				)
 				if input.wantErrorContains != "" {
 					Expect(err).To(Not(BeNil()))
 					Expect(err.Error()).To(ContainSubstring(input.wantErrorContains))
@@ -76,18 +85,28 @@ var _ = Describe("[plugin] cordon command", func() {
 						Name:      clusterName,
 					}, &resCluster)
 					Expect(err).NotTo(HaveOccurred())
-					instancesToRemove = append(instancesToRemove, resCluster.Spec.ProcessGroupsToRemove...)
-					instancesToRemoveWithoutExclusion = append(instancesToRemoveWithoutExclusion, resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion...)
+					instancesToRemove = append(
+						instancesToRemove,
+						resCluster.Spec.ProcessGroupsToRemove...)
+					instancesToRemoveWithoutExclusion = append(
+						instancesToRemoveWithoutExclusion,
+						resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion...)
 				}
 
 				Expect(input.ExpectedInstancesToRemove).To(ConsistOf(instancesToRemove))
-				Expect(input.ExpectedInstancesToRemoveWithoutExclusion).To(ConsistOf(instancesToRemoveWithoutExclusion))
+				Expect(
+					input.ExpectedInstancesToRemoveWithoutExclusion,
+				).To(ConsistOf(instancesToRemoveWithoutExclusion))
 			},
 			Entry("Cordon node with exclusion",
 				testCase{
-					nodes:                     []string{"node-1"},
-					WithExclusion:             true,
-					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage))},
+					nodes:         []string{"node-1"},
+					WithExclusion: true,
+					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+						),
+					},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:  clusterName,
 					clusterLabel: "",
@@ -97,7 +116,11 @@ var _ = Describe("[plugin] cordon command", func() {
 					nodes:                     []string{"node-1"},
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
-					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage))},
+					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+						),
+					},
 					clusterName:  clusterName,
 					clusterLabel: "",
 				}),
@@ -126,8 +149,12 @@ var _ = Describe("[plugin] cordon command", func() {
 					nodes:         []string{"node-1", "node-2"},
 					WithExclusion: true,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+						),
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+						),
 					},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:  clusterName,
@@ -139,26 +166,46 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+						),
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+						),
 					},
 					clusterName:  clusterName,
 					clusterLabel: "",
 				}),
 			Entry("Cordon node from second cluster without exclusion",
 				testCase{
-					nodes:                     []string{"node-1"},
-					WithExclusion:             true,
-					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage))},
+					nodes:         []string{"node-1"},
+					WithExclusion: true,
+					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf(
+								"%s-%s-1",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
+						),
+					},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:  secondClusterName,
 					clusterLabel: "",
 				}),
 			Entry("Cordon node from second cluster without exclusion with cluster label",
 				testCase{
-					nodes:                     []string{"node-1"},
-					WithExclusion:             true,
-					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage))},
+					nodes:         []string{"node-1"},
+					WithExclusion: true,
+					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf(
+								"%s-%s-1",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
+						),
+					},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:  secondClusterName,
 					clusterLabel: fdbv1beta2.FDBClusterLabel,
@@ -168,8 +215,16 @@ var _ = Describe("[plugin] cordon command", func() {
 					nodes:         []string{"node-1"},
 					WithExclusion: true,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+						),
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf(
+								"%s-%s-1",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
+						),
 					},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{},
 					clusterName:  "",
@@ -181,10 +236,26 @@ var _ = Describe("[plugin] cordon command", func() {
 					WithExclusion:             false,
 					ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
 					ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
-						fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+						),
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+						),
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf(
+								"%s-%s-1",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
+						),
+						fdbv1beta2.ProcessGroupID(
+							fmt.Sprintf(
+								"%s-%s-2",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
+						),
 					},
 					clusterName:  "",
 					clusterLabel: fdbv1beta2.FDBClusterLabel,
@@ -210,9 +281,13 @@ func createPods(clusterName string, namespace string) error {
 				Name:      fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
 				Namespace: namespace,
 				Labels: map[string]string{
-					fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStorage),
-					fdbv1beta2.FDBClusterLabel:        clusterName,
-					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+					fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+					fdbv1beta2.FDBClusterLabel:      clusterName,
+					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf(
+						"%s-%s-1",
+						clusterName,
+						fdbv1beta2.ProcessClassStorage,
+					),
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -224,9 +299,13 @@ func createPods(clusterName string, namespace string) error {
 				Name:      fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
 				Namespace: namespace,
 				Labels: map[string]string{
-					fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStorage),
-					fdbv1beta2.FDBClusterLabel:        clusterName,
-					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+					fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+					fdbv1beta2.FDBClusterLabel:      clusterName,
+					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf(
+						"%s-%s-2",
+						clusterName,
+						fdbv1beta2.ProcessClassStorage,
+					),
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -238,9 +317,13 @@ func createPods(clusterName string, namespace string) error {
 				Name:      fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
 				Namespace: namespace,
 				Labels: map[string]string{
-					fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStateless),
-					fdbv1beta2.FDBClusterLabel:        clusterName,
-					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
+					fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStateless),
+					fdbv1beta2.FDBClusterLabel:      clusterName,
+					fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf(
+						"%s-%s-3",
+						clusterName,
+						fdbv1beta2.ProcessClassStateless,
+					),
 				},
 			},
 			Spec: corev1.PodSpec{

--- a/kubectl-fdb/cmd/deprecation.go
+++ b/kubectl-fdb/cmd/deprecation.go
@@ -23,8 +23,9 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"strings"
+
+	"github.com/google/go-cmp/cmp"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
@@ -110,7 +111,14 @@ kubectl fdb deprecation --show-cluster-spec`,
 	return cmd
 }
 
-func checkDeprecation(cmd *cobra.Command, kubeClient client.Client, inputClusters []string, namespace string, deprecationOptions internal.DeprecationOptions, showClusterSpec bool) error {
+func checkDeprecation(
+	cmd *cobra.Command,
+	kubeClient client.Client,
+	inputClusters []string,
+	namespace string,
+	deprecationOptions internal.DeprecationOptions,
+	showClusterSpec bool,
+) error {
 	clusters := &fdbv1beta2.FoundationDBClusterList{}
 
 	err := kubeClient.List(context.Background(), clusters, client.InNamespace(namespace))

--- a/kubectl-fdb/cmd/deprecation_test.go
+++ b/kubectl-fdb/cmd/deprecation_test.go
@@ -62,15 +62,26 @@ var _ = Describe("[plugin] deprecation command", func() {
 				Expect(k8sClient.Delete(context.TODO(), &tc.cluster)).NotTo(HaveOccurred())
 				Expect(k8sClient.Create(context.TODO(), &tc.cluster)).NotTo(HaveOccurred())
 
-				cmd := newDeprecationCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer})
-				err := checkDeprecation(cmd, k8sClient, tc.inputClusters, namespace, tc.deprecationOptions, tc.showClusterSpec)
+				cmd := newDeprecationCmd(
+					genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer},
+				)
+				err := checkDeprecation(
+					cmd,
+					k8sClient,
+					tc.inputClusters,
+					namespace,
+					tc.deprecationOptions,
+					tc.showClusterSpec,
+				)
 				if tc.expectedError != "" {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal(tc.expectedError))
 					// We don't compare the diff output since it includes some special
 					// whitespace characters
 					if tc.checkOutput {
-						Expect(strings.TrimSpace(outBuffer.String())).To(Equal(strings.TrimSpace(tc.expectedOutput)))
+						Expect(
+							strings.TrimSpace(outBuffer.String()),
+						).To(Equal(strings.TrimSpace(tc.expectedOutput)))
 					}
 					return
 				}
@@ -209,7 +220,10 @@ var _ = Describe("[plugin] deprecation command", func() {
 			errBuffer := bytes.Buffer{}
 			inBuffer := bytes.Buffer{}
 
-			cmd = NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer}, &MockVersionChecker{})
+			cmd = NewRootCmd(
+				genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer},
+				&MockVersionChecker{},
+			)
 		})
 
 		It("should print out the help information", func() {

--- a/kubectl-fdb/cmd/exec.go
+++ b/kubectl-fdb/cmd/exec.go
@@ -89,7 +89,13 @@ func newExecCmd(streams genericclioptions.IOStreams) *cobra.Command {
 	return cmd
 }
 
-func runExec(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluster, config *rest.Config, commandArgs []string) error {
+func runExec(
+	cmd *cobra.Command,
+	kubeClient client.Client,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	config *rest.Config,
+	commandArgs []string,
+) error {
 	pods, err := getRunningPodsForCluster(cmd.Context(), kubeClient, cluster)
 	if err != nil {
 		return err
@@ -100,5 +106,17 @@ func runExec(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1beta2.F
 		return err
 	}
 
-	return kubeHelper.ExecuteCommandRaw(cmd.Context(), kubeClient, config, clientPod.Namespace, clientPod.Name, fdbv1beta2.MainContainerName, commandArgs, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.OutOrStderr(), true)
+	return kubeHelper.ExecuteCommandRaw(
+		cmd.Context(),
+		kubeClient,
+		config,
+		clientPod.Namespace,
+		clientPod.Name,
+		fdbv1beta2.MainContainerName,
+		commandArgs,
+		cmd.InOrStdin(),
+		cmd.OutOrStdout(),
+		cmd.OutOrStderr(),
+		true,
+	)
 }

--- a/kubectl-fdb/cmd/exec_test.go
+++ b/kubectl-fdb/cmd/exec_test.go
@@ -63,17 +63,40 @@ var _ = Describe("[plugin] exec command", func() {
 				errBuffer := bytes.Buffer{}
 				inBuffer := bytes.Buffer{}
 
-				rootCmd := NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer}, &MockVersionChecker{})
-				Expect(runExec(rootCmd, k8sClient, cluster, &rest.Config{}, input.Command)).NotTo(HaveOccurred())
+				rootCmd := NewRootCmd(
+					genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer},
+					&MockVersionChecker{},
+				)
+				Expect(
+					runExec(rootCmd, k8sClient, cluster, &rest.Config{}, input.Command),
+				).NotTo(HaveOccurred())
 			},
 			Entry("Exec into instance with valid pod",
 				testCase{
-					ExpectedArgs: []string{"--namespace", "test", "exec", "-it", "storage-1", "--", "bash"},
+					ExpectedArgs: []string{
+						"--namespace",
+						"test",
+						"exec",
+						"-it",
+						"storage-1",
+						"--",
+						"bash",
+					},
 				}),
 			Entry("Exec into instance with explicit context",
 				testCase{
-					Context:      "remote-kc",
-					ExpectedArgs: []string{"--context", "remote-kc", "--namespace", "test", "exec", "-it", "storage-1", "--", "bash"},
+					Context: "remote-kc",
+					ExpectedArgs: []string{
+						"--context",
+						"remote-kc",
+						"--namespace",
+						"test",
+						"exec",
+						"-it",
+						"storage-1",
+						"--",
+						"bash",
+					},
 				}),
 		)
 	})

--- a/kubectl-fdb/cmd/fix_coordinator_ips_test.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips_test.go
@@ -83,7 +83,10 @@ var _ = Describe("[plugin] fix-coordinator-ips command", func() {
 				errBuffer := bytes.Buffer{}
 				inBuffer := bytes.Buffer{}
 
-				rootCmd := NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer}, &MockVersionChecker{})
+				rootCmd := NewRootCmd(
+					genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer},
+					&MockVersionChecker{},
+				)
 				err := updateIPsInConnectionString(rootCmd, cluster, k8sClient)
 
 				if input.ExpectedError != "" {

--- a/kubectl-fdb/cmd/k8s_client_test.go
+++ b/kubectl-fdb/cmd/k8s_client_test.go
@@ -63,7 +63,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 							ProcessGroupID: "storage-2",
 							Addresses:      []string{"1.2.3.5"},
 							ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
-								fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.IncorrectCommandLine),
+								fdbv1beta2.NewProcessGroupCondition(
+									fdbv1beta2.IncorrectCommandLine,
+								),
 							},
 						},
 						{
@@ -78,7 +80,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 							Addresses:        []string{"1.2.3.7"},
 							RemovalTimestamp: &metav1.Time{Time: time.Now()},
 							ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
-								fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.IncorrectCommandLine),
+								fdbv1beta2.NewProcessGroupCondition(
+									fdbv1beta2.IncorrectCommandLine,
+								),
 							},
 						},
 						{
@@ -98,7 +102,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 						Name:      "storage-1",
 						Namespace: namespace,
 						Labels: map[string]string{
-							fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStorage),
+							fdbv1beta2.FDBProcessClassLabel: string(
+								fdbv1beta2.ProcessClassStorage,
+							),
 							fdbv1beta2.FDBClusterLabel:        clusterName,
 							fdbv1beta2.FDBProcessGroupIDLabel: "storage-1",
 						},
@@ -112,7 +118,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 						Name:      "storage-2",
 						Namespace: namespace,
 						Labels: map[string]string{
-							fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStorage),
+							fdbv1beta2.FDBProcessClassLabel: string(
+								fdbv1beta2.ProcessClassStorage,
+							),
 							fdbv1beta2.FDBClusterLabel:        clusterName,
 							fdbv1beta2.FDBProcessGroupIDLabel: "storage-2",
 						},
@@ -126,7 +134,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 						Name:      "stateless-3",
 						Namespace: namespace,
 						Labels: map[string]string{
-							fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStorage),
+							fdbv1beta2.FDBProcessClassLabel: string(
+								fdbv1beta2.ProcessClassStorage,
+							),
 							fdbv1beta2.FDBClusterLabel:        clusterName,
 							fdbv1beta2.FDBProcessGroupIDLabel: "stateless-3",
 						},
@@ -140,7 +150,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 						Name:      "instance-4",
 						Namespace: namespace,
 						Labels: map[string]string{
-							fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStorage),
+							fdbv1beta2.FDBProcessClassLabel: string(
+								fdbv1beta2.ProcessClassStorage,
+							),
 							fdbv1beta2.FDBClusterLabel:        clusterName,
 							fdbv1beta2.FDBProcessGroupIDLabel: "instance-4",
 						},
@@ -170,10 +182,19 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 		DescribeTable("should show all deprecations",
 			func(tc testCase) {
 				outBuffer := bytes.Buffer{}
-				pods, err := getAllPodsFromClusterWithCondition(context.Background(), &outBuffer, k8sClient, clusterName, namespace, tc.conditions)
+				pods, err := getAllPodsFromClusterWithCondition(
+					context.Background(),
+					&outBuffer,
+					k8sClient,
+					clusterName,
+					namespace,
+					tc.conditions,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pods).Should(ConsistOf(tc.expected))
-				Expect(strings.Split(outBuffer.String(), "\n")).Should(ConsistOf(strings.Split(tc.expectedOutputBuffer, "\n")))
+				Expect(
+					strings.Split(outBuffer.String(), "\n"),
+				).Should(ConsistOf(strings.Split(tc.expectedOutputBuffer, "\n")))
 			},
 			Entry("No conditions",
 				testCase{
@@ -183,26 +204,43 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				}),
 			Entry("Single condition",
 				testCase{
-					conditions:           []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses},
+					conditions: []fdbv1beta2.ProcessGroupConditionType{
+						fdbv1beta2.MissingProcesses,
+					},
 					expected:             []string{"storage-1"},
 					expectedOutputBuffer: "Skipping Process Group: stateless-3, Pod is not running, current phase: Failed\n",
 				}),
 			Entry("Multiple conditions",
 				testCase{
-					conditions:           []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses, fdbv1beta2.IncorrectCommandLine},
-					expected:             append(expectedPodNamesMultipleConditions, "storage-1", "storage-2"),
+					conditions: []fdbv1beta2.ProcessGroupConditionType{
+						fdbv1beta2.MissingProcesses,
+						fdbv1beta2.IncorrectCommandLine,
+					},
+					expected: append(
+						expectedPodNamesMultipleConditions,
+						"storage-1",
+						"storage-2",
+					),
 					expectedOutputBuffer: "Skipping Process Group: stateless-3, Pod is not running, current phase: Failed\n",
 				}),
 			Entry("Single condition and missing pod",
 				testCase{
-					conditions:           []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.SidecarUnreachable},
+					conditions: []fdbv1beta2.ProcessGroupConditionType{
+						fdbv1beta2.SidecarUnreachable,
+					},
 					expected:             []string{},
 					expectedOutputBuffer: "Skipping Process Group: instance-5, because it does not have a corresponding Pod.\n",
 				}),
 			Entry("Multiple conditions and missing pod",
 				testCase{
-					conditions:           []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses, fdbv1beta2.SidecarUnreachable},
-					expected:             append(expectedPodNamesMultipleConditionsMissingPods, "storage-1"),
+					conditions: []fdbv1beta2.ProcessGroupConditionType{
+						fdbv1beta2.MissingProcesses,
+						fdbv1beta2.SidecarUnreachable,
+					},
+					expected: append(
+						expectedPodNamesMultipleConditionsMissingPods,
+						"storage-1",
+					),
 					expectedOutputBuffer: "Skipping Process Group: instance-5, because it does not have a corresponding Pod.\nSkipping Process Group: stateless-3, Pod is not running, current phase: Failed\n",
 				}),
 		)
@@ -217,7 +255,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				// Remove the process group prefix from the ID.
 				for idx, processGroup := range cluster.Status.ProcessGroups {
 					newID := strings.TrimPrefix(string(processGroup.ProcessGroupID), previousPrefix)
-					cluster.Status.ProcessGroups[idx].ProcessGroupID = fdbv1beta2.ProcessGroupID(newID)
+					cluster.Status.ProcessGroups[idx].ProcessGroupID = fdbv1beta2.ProcessGroupID(
+						newID,
+					)
 				}
 			})
 
@@ -293,7 +333,10 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 	When("calling getProcessGroupsByCluster", func() {
 		BeforeEach(func() {
 			// creating Pods for first cluster.
-			cluster = generateClusterStruct(clusterName, namespace) // the status is overwritten by prior tests
+			cluster = generateClusterStruct(
+				clusterName,
+				namespace,
+			) // the status is overwritten by prior tests
 			Expect(createPods(clusterName, namespace)).NotTo(HaveOccurred())
 
 			// creating a second cluster
@@ -341,7 +384,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 			Entry("errors when ids are passed along with processClass selector",
 				testCase{
 					opts: processGroupSelectionOptions{
-						ids:          []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)},
+						ids: []string{
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+						},
 						processClass: string(fdbv1beta2.ProcessClassStateless),
 						clusterName:  clusterName,
 					},
@@ -371,12 +416,23 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				testCase{
 					opts: processGroupSelectionOptions{
 						clusterLabel: fdbv1beta2.FDBClusterLabel,
-						ids:          []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)},
+						ids: []string{
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
+						},
 					},
 					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
 						clusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf(
+									"%s-%s-3",
+									clusterName,
+									fdbv1beta2.ProcessClassStateless,
+								),
+							),
 						},
 					},
 				},
@@ -387,17 +443,39 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 						clusterLabel: fdbv1beta2.FDBClusterLabel,
 						ids: []string{
 							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
-							fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage),
-							fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage),
+							fmt.Sprintf(
+								"%s-%s-1",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
+							fmt.Sprintf(
+								"%s-%s-2",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
 						},
 					},
 					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
 						clusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							),
 						},
 						secondClusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf(
+									"%s-%s-1",
+									secondClusterName,
+									fdbv1beta2.ProcessClassStorage,
+								),
+							),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf(
+									"%s-%s-2",
+									secondClusterName,
+									fdbv1beta2.ProcessClassStorage,
+								),
+							),
 						},
 					},
 				},
@@ -405,13 +483,20 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 			Entry("gets processGroups from podNames and cluster name",
 				testCase{
 					opts: processGroupSelectionOptions{
-						ids:         []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)},
+						ids: []string{
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+						},
 						clusterName: clusterName,
 					},
 					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
 						clusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+							),
 						},
 					},
 				},
@@ -424,8 +509,12 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 					},
 					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
 						clusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+							),
 						},
 					},
 				},
@@ -438,7 +527,13 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 					},
 					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
 						clusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf(
+									"%s-%s-3",
+									clusterName,
+									fdbv1beta2.ProcessClassStateless,
+								),
+							),
 						},
 					},
 				},
@@ -451,8 +546,12 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 					},
 					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
 						clusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+							),
 						},
 					},
 				},
@@ -461,11 +560,15 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				testCase{
 					opts: processGroupSelectionOptions{
 						clusterName: clusterName,
-						conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses},
+						conditions: []fdbv1beta2.ProcessGroupConditionType{
+							fdbv1beta2.MissingProcesses,
+						},
 					},
 					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
 						clusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+							),
 						},
 					},
 				},
@@ -474,7 +577,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				testCase{
 					opts: processGroupSelectionOptions{
 						clusterName: clusterName,
-						conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.IncorrectPodSpec},
+						conditions: []fdbv1beta2.ProcessGroupConditionType{
+							fdbv1beta2.IncorrectPodSpec,
+						},
 					},
 					wantResult:      nil,
 					wantErrContains: "found no processGroups meeting the selection criteria",
@@ -488,9 +593,19 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 					},
 					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
 						clusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+							),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf(
+									"%s-%s-3",
+									clusterName,
+									fdbv1beta2.ProcessClassStateless,
+								),
+							),
 						},
 					},
 				},
@@ -500,12 +615,20 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 					opts: processGroupSelectionOptions{
 						clusterName: clusterName,
 						matchLabels: map[string]string{
-							fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStateless),
+							fdbv1beta2.FDBProcessClassLabel: string(
+								fdbv1beta2.ProcessClassStateless,
+							),
 						},
 					},
 					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
 						clusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf(
+									"%s-%s-3",
+									clusterName,
+									fdbv1beta2.ProcessClassStateless,
+								),
+							),
 						},
 					},
 				},
@@ -515,13 +638,25 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 					opts: processGroupSelectionOptions{
 						clusterName: clusterName,
 						matchLabels: map[string]string{
-							fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStateless),
-							fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
+							fdbv1beta2.FDBProcessClassLabel: string(
+								fdbv1beta2.ProcessClassStateless,
+							),
+							fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf(
+								"%s-%s-3",
+								clusterName,
+								fdbv1beta2.ProcessClassStateless,
+							),
 						},
 					},
 					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
 						clusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf(
+									"%s-%s-3",
+									clusterName,
+									fdbv1beta2.ProcessClassStateless,
+								),
+							),
 						},
 					},
 				},
@@ -530,12 +665,26 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				testCase{
 					opts: processGroupSelectionOptions{
 						clusterName: secondClusterName,
-						matchLabels: map[string]string{fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage)},
+						matchLabels: map[string]string{
+							fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+						},
 					},
 					wantResult: map[string][]fdbv1beta2.ProcessGroupID{
 						secondClusterName: {
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
-							fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf(
+									"%s-%s-1",
+									secondClusterName,
+									fdbv1beta2.ProcessClassStorage,
+								),
+							),
+							fdbv1beta2.ProcessGroupID(
+								fmt.Sprintf(
+									"%s-%s-2",
+									secondClusterName,
+									fdbv1beta2.ProcessClassStorage,
+								),
+							),
 						},
 					},
 				},
@@ -544,7 +693,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				testCase{
 					opts: processGroupSelectionOptions{
 						clusterName: clusterName,
-						matchLabels: map[string]string{fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassProxy)},
+						matchLabels: map[string]string{
+							fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassProxy),
+						},
 					},
 					wantErrContains: "found no processGroups meeting the selection criteria",
 				},
@@ -554,7 +705,10 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 	When("calling getPodNamesByCluster", func() {
 		BeforeEach(func() {
 			// creating Pods for first cluster.
-			cluster = generateClusterStruct(clusterName, namespace) // the status is overwritten by prior tests
+			cluster = generateClusterStruct(
+				clusterName,
+				namespace,
+			) // the status is overwritten by prior tests
 			Expect(createPods(clusterName, namespace)).NotTo(HaveOccurred())
 
 			// creating a second cluster
@@ -602,7 +756,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 			Entry("errors when ids are passed along with processClass selector",
 				testCase{
 					opts: processGroupSelectionOptions{
-						ids:          []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)},
+						ids: []string{
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+						},
 						processClass: string(fdbv1beta2.ProcessClassStateless),
 						clusterName:  clusterName,
 					},
@@ -632,7 +788,10 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				testCase{
 					opts: processGroupSelectionOptions{
 						clusterLabel: fdbv1beta2.FDBClusterLabel,
-						ids:          []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)},
+						ids: []string{
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
+						},
 					},
 					wantResult: map[string][]string{
 						clusterName: {
@@ -648,8 +807,16 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 						clusterLabel: fdbv1beta2.FDBClusterLabel,
 						ids: []string{
 							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
-							fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage),
-							fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage),
+							fmt.Sprintf(
+								"%s-%s-1",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
+							fmt.Sprintf(
+								"%s-%s-2",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
 						},
 					},
 					wantResult: map[string][]string{
@@ -657,8 +824,16 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
 						},
 						secondClusterName: {
-							fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage),
-							fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage),
+							fmt.Sprintf(
+								"%s-%s-1",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
+							fmt.Sprintf(
+								"%s-%s-2",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
 						},
 					},
 				},
@@ -666,7 +841,10 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 			Entry("gets pods from podNames and cluster name",
 				testCase{
 					opts: processGroupSelectionOptions{
-						ids:         []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)},
+						ids: []string{
+							fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+						},
 						clusterName: clusterName,
 					},
 					wantResult: map[string][]string{
@@ -722,7 +900,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				testCase{
 					opts: processGroupSelectionOptions{
 						clusterName: clusterName,
-						conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses},
+						conditions: []fdbv1beta2.ProcessGroupConditionType{
+							fdbv1beta2.MissingProcesses,
+						},
 					},
 					wantResult: map[string][]string{
 						clusterName: {
@@ -735,7 +915,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				testCase{
 					opts: processGroupSelectionOptions{
 						clusterName: clusterName,
-						conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.IncorrectPodSpec},
+						conditions: []fdbv1beta2.ProcessGroupConditionType{
+							fdbv1beta2.IncorrectPodSpec,
+						},
 					},
 					wantResult:      nil,
 					wantErrContains: "found no pods meeting the selection criteria",
@@ -761,7 +943,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 					opts: processGroupSelectionOptions{
 						clusterName: clusterName,
 						matchLabels: map[string]string{
-							fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStateless),
+							fdbv1beta2.FDBProcessClassLabel: string(
+								fdbv1beta2.ProcessClassStateless,
+							),
 						},
 					},
 					wantResult: map[string][]string{
@@ -776,8 +960,14 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 					opts: processGroupSelectionOptions{
 						clusterName: clusterName,
 						matchLabels: map[string]string{
-							fdbv1beta2.FDBProcessClassLabel:   string(fdbv1beta2.ProcessClassStateless),
-							fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless),
+							fdbv1beta2.FDBProcessClassLabel: string(
+								fdbv1beta2.ProcessClassStateless,
+							),
+							fdbv1beta2.FDBProcessGroupIDLabel: fmt.Sprintf(
+								"%s-%s-3",
+								clusterName,
+								fdbv1beta2.ProcessClassStateless,
+							),
 						},
 					},
 					wantResult: map[string][]string{
@@ -791,12 +981,22 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				testCase{
 					opts: processGroupSelectionOptions{
 						clusterName: secondClusterName,
-						matchLabels: map[string]string{fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage)},
+						matchLabels: map[string]string{
+							fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassStorage),
+						},
 					},
 					wantResult: map[string][]string{
 						secondClusterName: {
-							fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage),
-							fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage),
+							fmt.Sprintf(
+								"%s-%s-1",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
+							fmt.Sprintf(
+								"%s-%s-2",
+								secondClusterName,
+								fdbv1beta2.ProcessClassStorage,
+							),
 						},
 					},
 				},
@@ -805,7 +1005,9 @@ var _ = Describe("[plugin] using the Kubernetes client", func() {
 				testCase{
 					opts: processGroupSelectionOptions{
 						clusterName: clusterName,
-						matchLabels: map[string]string{fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassProxy)},
+						matchLabels: map[string]string{
+							fdbv1beta2.FDBProcessClassLabel: string(fdbv1beta2.ProcessClassProxy),
+						},
 					},
 					wantErrContains: "found no pods meeting the selection criteria",
 				},

--- a/kubectl-fdb/cmd/recover_multi_region_cluster.go
+++ b/kubectl-fdb/cmd/recover_multi_region_cluster.go
@@ -72,7 +72,10 @@ func newRecoverMultiRegionClusterCmd(streams genericclioptions.IOStreams) *cobra
 			}
 
 			if len(args) != 1 {
-				return fmt.Errorf("exactly one cluster name must be specified, provided args: %v", args)
+				return fmt.Errorf(
+					"exactly one cluster name must be specified, provided args: %v",
+					args,
+				)
 			}
 
 			clusterName := args[0]
@@ -93,13 +96,20 @@ func newRecoverMultiRegionClusterCmd(streams genericclioptions.IOStreams) *cobra
 			}
 
 			if wait {
-				confirmed := confirmAction(fmt.Sprintf("WARNING:\nThe cluster: %s/%s will be force recovered.\nOnly perform those steps if you are unable to recover the coordinator state.\nPerforming this action can lead to data loss.",
-					namespace, clusterName))
+				confirmed := confirmAction(
+					fmt.Sprintf(
+						"WARNING:\nThe cluster: %s/%s will be force recovered.\nOnly perform those steps if you are unable to recover the coordinator state.\nPerforming this action can lead to data loss.",
+						namespace,
+						clusterName,
+					),
+				)
 				if !confirmed {
 					return fmt.Errorf("aborted recover multi-region aciton")
 				}
 
-				confirmed = confirmAction("WARNING:\nIf this is a multi-region cluster, or is spread across different namespaces/Kubernetes clusters.\nEnsure that all Pods of this FDB cluster: %s in the other namespaces/Kubernetes clusters are deleted and shutdown.")
+				confirmed = confirmAction(
+					"WARNING:\nIf this is a multi-region cluster, or is spread across different namespaces/Kubernetes clusters.\nEnsure that all Pods of this FDB cluster: %s in the other namespaces/Kubernetes clusters are deleted and shutdown.",
+				)
 				if !confirmed {
 					return fmt.Errorf("aborted recover multi-region aciton")
 				}
@@ -136,12 +146,21 @@ kubectl fdb recover-multi-region-cluster -n testing sample-cluster-1
 // Performing this action can result in data loss.
 func RecoverMultiRegionCluster(ctx context.Context, opts RecoverMultiRegionClusterOpts) error {
 	cluster := &fdbv1beta2.FoundationDBCluster{}
-	err := opts.Client.Get(ctx, client.ObjectKey{Name: opts.ClusterName, Namespace: opts.Namespace}, cluster)
+	err := opts.Client.Get(
+		ctx,
+		client.ObjectKey{Name: opts.ClusterName, Namespace: opts.Namespace},
+		cluster,
+	)
 	if err != nil {
 		return err
 	}
 
-	err = checkIfClusterIsUnavailableAndMajorityOfCoordinatorsAreUnreachable(ctx, opts.Client, opts.Config, cluster)
+	err = checkIfClusterIsUnavailableAndMajorityOfCoordinatorsAreUnreachable(
+		ctx,
+		opts.Client,
+		opts.Config,
+		cluster,
+	)
 	if err != nil {
 		return err
 	}
@@ -158,7 +177,12 @@ func RecoverMultiRegionCluster(ctx context.Context, opts RecoverMultiRegionClust
 	addresses := strings.Split(lastConnectionStringParts[1], ",")
 	usesDNSInClusterFile := cluster.UseDNSInClusterFile()
 
-	log.Println("current connection string", lastConnectionString, "cluster uses DNS:", usesDNSInClusterFile)
+	log.Println(
+		"current connection string",
+		lastConnectionString,
+		"cluster uses DNS:",
+		usesDNSInClusterFile,
+	)
 	var useTLS bool
 	coordinators := map[string]fdbv1beta2.ProcessAddress{}
 	for _, addr := range addresses {
@@ -291,8 +315,21 @@ func RecoverMultiRegionCluster(ctx context.Context, opts RecoverMultiRegionClust
 			tmpCoordinatorFiles[idx] = path.Join(tmpDir, coordinatorFile)
 		}
 
-		log.Println("tmpCoordinatorFiles", tmpCoordinatorFiles, "checking the location of the coordination-0.fdq in Pod", runningCoordinator.Name)
-		stdout, stderr, err := kubeHelper.ExecuteCommandOnPod(context.Background(), opts.Client, opts.Config, runningCoordinator, fdbv1beta2.MainContainerName, "find /var/fdb/data/ -type f -name 'coordination-0.fdq' -print -quit | head -n 1", false)
+		log.Println(
+			"tmpCoordinatorFiles",
+			tmpCoordinatorFiles,
+			"checking the location of the coordination-0.fdq in Pod",
+			runningCoordinator.Name,
+		)
+		stdout, stderr, err := kubeHelper.ExecuteCommandOnPod(
+			context.Background(),
+			opts.Client,
+			opts.Config,
+			runningCoordinator,
+			fdbv1beta2.MainContainerName,
+			"find /var/fdb/data/ -type f -name 'coordination-0.fdq' -print -quit | head -n 1",
+			false,
+		)
 		if err != nil {
 			log.Println(stderr)
 			return err
@@ -306,7 +343,14 @@ func RecoverMultiRegionCluster(ctx context.Context, opts RecoverMultiRegionClust
 		dataDir := path.Dir(strings.TrimSpace(lines[0]))
 		log.Println("dataDir:", dataDir)
 		for idx, coordinatorFile := range coordinatorFiles {
-			err = downloadCoordinatorFile(ctx, opts.Client, opts.Config, runningCoordinator, path.Join(dataDir, coordinatorFile), tmpCoordinatorFiles[idx])
+			err = downloadCoordinatorFile(
+				ctx,
+				opts.Client,
+				opts.Config,
+				runningCoordinator,
+				path.Join(dataDir, coordinatorFile),
+				tmpCoordinatorFiles[idx],
+			)
 			if err != nil {
 				return err
 			}
@@ -316,7 +360,14 @@ func RecoverMultiRegionCluster(ctx context.Context, opts RecoverMultiRegionClust
 			targetDataDir := getDataDir(dataDir, target, cluster)
 
 			for idx, coordinatorFile := range coordinatorFiles {
-				err = uploadCoordinatorFile(ctx, opts.Client, opts.Config, target, tmpCoordinatorFiles[idx], path.Join(targetDataDir, coordinatorFile))
+				err = uploadCoordinatorFile(
+					ctx,
+					opts.Client,
+					opts.Config,
+					target,
+					tmpCoordinatorFiles[idx],
+					path.Join(targetDataDir, coordinatorFile),
+				)
 				if err != nil {
 					return err
 				}
@@ -361,7 +412,9 @@ func RecoverMultiRegionCluster(ctx context.Context, opts RecoverMultiRegionClust
 			var curlStr strings.Builder
 			curlStr.WriteString("curl -X POST")
 			if internal.PodHasSidecarTLS(&loopPod) {
-				curlStr.WriteString(" --cacert ${FDB_TLS_CA_FILE} --cert ${FDB_TLS_CERTIFICATE_FILE} --key ${FDB_TLS_KEY_FILE} -k https://")
+				curlStr.WriteString(
+					" --cacert ${FDB_TLS_CA_FILE} --cert ${FDB_TLS_CERTIFICATE_FILE} --key ${FDB_TLS_KEY_FILE} -k https://",
+				)
 			} else {
 				curlStr.WriteString(" http://")
 			}
@@ -371,7 +424,19 @@ func RecoverMultiRegionCluster(ctx context.Context, opts RecoverMultiRegionClust
 
 			command = append(command, curlStr.String())
 
-			err = kubeHelper.ExecuteCommandRaw(ctx, opts.Client, opts.Config, runningCoordinator.Namespace, runningCoordinator.Name, fdbv1beta2.MainContainerName, command, nil, opts.Stdout, opts.Stderr, false)
+			err = kubeHelper.ExecuteCommandRaw(
+				ctx,
+				opts.Client,
+				opts.Config,
+				runningCoordinator.Namespace,
+				runningCoordinator.Name,
+				fdbv1beta2.MainContainerName,
+				command,
+				nil,
+				opts.Stdout,
+				opts.Stderr,
+				false,
+			)
 			if err != nil {
 				return err
 			}
@@ -388,11 +453,27 @@ func RecoverMultiRegionCluster(ctx context.Context, opts RecoverMultiRegionClust
 	// Wait until all fdbservers have started again.
 	time.Sleep(1 * time.Minute)
 
-	command := []string{"fdbcli", "--exec", fmt.Sprintf("force_recovery_with_data_loss %s", cluster.Spec.DataCenter)}
+	command := []string{
+		"fdbcli",
+		"--exec",
+		fmt.Sprintf("force_recovery_with_data_loss %s", cluster.Spec.DataCenter),
+	}
 	// Now you can exec into a container and use `fdbcli` to connect to the cluster.
 	// If you use a multi-region cluster you have to issue `force_recovery_with_data_loss`
 	log.Println("Triggering force recovery with command:", command)
-	err = kubeHelper.ExecuteCommandRaw(ctx, opts.Client, opts.Config, runningCoordinator.Namespace, runningCoordinator.Name, fdbv1beta2.MainContainerName, command, nil, opts.Stdout, opts.Stderr, false)
+	err = kubeHelper.ExecuteCommandRaw(
+		ctx,
+		opts.Client,
+		opts.Config,
+		runningCoordinator.Namespace,
+		runningCoordinator.Name,
+		fdbv1beta2.MainContainerName,
+		command,
+		nil,
+		opts.Stdout,
+		opts.Stderr,
+		false,
+	)
 	if err != nil {
 		return err
 	}
@@ -437,7 +518,14 @@ func getDataDir(dataDir string, pod *corev1.Pod, cluster *fdbv1beta2.FoundationD
 	return baseDir
 }
 
-func downloadCoordinatorFile(ctx context.Context, kubeClient client.Client, config *rest.Config, pod *corev1.Pod, src string, dst string) error {
+func downloadCoordinatorFile(
+	ctx context.Context,
+	kubeClient client.Client,
+	config *rest.Config,
+	pod *corev1.Pod,
+	src string,
+	dst string,
+) error {
 	tmpCoordinatorFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 	if err != nil {
 		return err
@@ -447,8 +535,25 @@ func downloadCoordinatorFile(ctx context.Context, kubeClient client.Client, conf
 		_ = tmpCoordinatorFile.Close()
 	}()
 
-	log.Println("Download files, target:", dst, "source", src, "pod", pod.Name, "Namespace", pod.Namespace)
-	err = kubeHelper.DownloadFile(ctx, kubeClient, config, pod, fdbv1beta2.MainContainerName, src, tmpCoordinatorFile)
+	log.Println(
+		"Download files, target:",
+		dst,
+		"source",
+		src,
+		"pod",
+		pod.Name,
+		"Namespace",
+		pod.Namespace,
+	)
+	err = kubeHelper.DownloadFile(
+		ctx,
+		kubeClient,
+		config,
+		pod,
+		fdbv1beta2.MainContainerName,
+		src,
+		tmpCoordinatorFile,
+	)
 	if err != nil {
 		return err
 	}
@@ -465,7 +570,14 @@ func downloadCoordinatorFile(ctx context.Context, kubeClient client.Client, conf
 	return nil
 }
 
-func uploadCoordinatorFile(ctx context.Context, kubeClient client.Client, config *rest.Config, pod *corev1.Pod, src string, dst string) error {
+func uploadCoordinatorFile(
+	ctx context.Context,
+	kubeClient client.Client,
+	config *rest.Config,
+	pod *corev1.Pod,
+	src string,
+	dst string,
+) error {
 	tmpCoordinatorFile, err := os.OpenFile(src, os.O_RDONLY, 0600)
 	if err != nil {
 		return err
@@ -475,13 +587,35 @@ func uploadCoordinatorFile(ctx context.Context, kubeClient client.Client, config
 		_ = tmpCoordinatorFile.Close()
 	}()
 
-	log.Println("Upload files, target:", dst, "source", src, "pod", pod.Name, "Namespace", pod.Namespace)
+	log.Println(
+		"Upload files, target:",
+		dst,
+		"source",
+		src,
+		"pod",
+		pod.Name,
+		"Namespace",
+		pod.Namespace,
+	)
 
-	return kubeHelper.UploadFile(ctx, kubeClient, config, pod, fdbv1beta2.MainContainerName, tmpCoordinatorFile, dst)
+	return kubeHelper.UploadFile(
+		ctx,
+		kubeClient,
+		config,
+		pod,
+		fdbv1beta2.MainContainerName,
+		tmpCoordinatorFile,
+		dst,
+	)
 }
 
 // restartFdbserverInCluster will try to restart all fdbserver processes inside all the pods of the cluster. If the restart fails, it will be retried again two more times.
-func restartFdbserverInCluster(ctx context.Context, kubeClient client.Client, config *rest.Config, cluster *fdbv1beta2.FoundationDBCluster) error {
+func restartFdbserverInCluster(
+	ctx context.Context,
+	kubeClient client.Client,
+	config *rest.Config,
+	cluster *fdbv1beta2.FoundationDBCluster,
+) error {
 	pods, err := getRunningPodsForCluster(ctx, kubeClient, cluster)
 	if err != nil {
 		return err
@@ -491,7 +625,16 @@ func restartFdbserverInCluster(ctx context.Context, kubeClient client.Client, co
 	retryRestart := make([]corev1.Pod, 0, len(pods.Items))
 	for _, pod := range pods.Items {
 		var stderr string
-		_, _, err = kubeHelper.ExecuteCommand(context.Background(), kubeClient, config, pod.Namespace, pod.Name, fdbv1beta2.MainContainerName, "pkill fdbserver && rm -f /var/fdb/data/fdb.cluster && pkill fdbserver || true", false)
+		_, _, err = kubeHelper.ExecuteCommand(
+			context.Background(),
+			kubeClient,
+			config,
+			pod.Namespace,
+			pod.Name,
+			fdbv1beta2.MainContainerName,
+			"pkill fdbserver && rm -f /var/fdb/data/fdb.cluster && pkill fdbserver || true",
+			false,
+		)
 		if err != nil {
 			// If the pod doesn't exist anymore ignore the error. The pod will have the new configuration when recreated again.
 			if k8serrors.IsNotFound(err) {
@@ -499,10 +642,33 @@ func restartFdbserverInCluster(ctx context.Context, kubeClient client.Client, co
 			}
 
 			time.Sleep(1 * time.Second)
-			log.Println("error restarting process in pod", pod.Name, "got error", err.Error(), "will be directly retried, stderr:", stderr)
-			_, stderr, err = kubeHelper.ExecuteCommand(context.Background(), kubeClient, config, pod.Namespace, pod.Name, fdbv1beta2.MainContainerName, "pkill fdbserver && rm -f /var/fdb/data/fdb.cluster && pkill fdbserver || true", false)
+			log.Println(
+				"error restarting process in pod",
+				pod.Name,
+				"got error",
+				err.Error(),
+				"will be directly retried, stderr:",
+				stderr,
+			)
+			_, stderr, err = kubeHelper.ExecuteCommand(
+				context.Background(),
+				kubeClient,
+				config,
+				pod.Namespace,
+				pod.Name,
+				fdbv1beta2.MainContainerName,
+				"pkill fdbserver && rm -f /var/fdb/data/fdb.cluster && pkill fdbserver || true",
+				false,
+			)
 			if err != nil {
-				log.Println("error restarting process in pod", pod.Name, "got error", err.Error(), "will be retried later, stderr:", stderr)
+				log.Println(
+					"error restarting process in pod",
+					pod.Name,
+					"got error",
+					err.Error(),
+					"will be retried later, stderr:",
+					stderr,
+				)
 				retryRestart = append(retryRestart, pod)
 			}
 		}
@@ -514,7 +680,11 @@ func restartFdbserverInCluster(ctx context.Context, kubeClient client.Client, co
 
 	// If we have more than one pod where we failed to restart the fdbserver processes, wait ten seconds before trying again.
 	time.Sleep(10 * time.Second)
-	log.Println("Failed to restart the fdbserver processes in", len(retryRestart), "pods, will be retried now.")
+	log.Println(
+		"Failed to restart the fdbserver processes in",
+		len(retryRestart),
+		"pods, will be retried now.",
+	)
 
 	for _, pod := range retryRestart {
 		// Pod is marked for deletion, so we can skip it here.
@@ -522,7 +692,16 @@ func restartFdbserverInCluster(ctx context.Context, kubeClient client.Client, co
 			continue
 		}
 
-		_, _, err = kubeHelper.ExecuteCommand(context.Background(), kubeClient, config, pod.Namespace, pod.Name, fdbv1beta2.MainContainerName, "pkill fdbserver && rm -f /var/fdb/data/fdb.cluster && pkill fdbserver || true", false)
+		_, _, err = kubeHelper.ExecuteCommand(
+			context.Background(),
+			kubeClient,
+			config,
+			pod.Namespace,
+			pod.Name,
+			fdbv1beta2.MainContainerName,
+			"pkill fdbserver && rm -f /var/fdb/data/fdb.cluster && pkill fdbserver || true",
+			false,
+		)
 		if err != nil {
 			// If the pod doesn't exist anymore ignore the error. The pod will have the new configuration when recreated again.
 			if k8serrors.IsNotFound(err) {
@@ -536,7 +715,12 @@ func restartFdbserverInCluster(ctx context.Context, kubeClient client.Client, co
 	return nil
 }
 
-func checkIfClusterIsUnavailableAndMajorityOfCoordinatorsAreUnreachable(ctx context.Context, kubeClient client.Client, config *rest.Config, cluster *fdbv1beta2.FoundationDBCluster) error {
+func checkIfClusterIsUnavailableAndMajorityOfCoordinatorsAreUnreachable(
+	ctx context.Context,
+	kubeClient client.Client,
+	config *rest.Config,
+	cluster *fdbv1beta2.FoundationDBCluster,
+) error {
 	pods, err := getRunningPodsForCluster(ctx, kubeClient, cluster)
 	if err != nil {
 		return err

--- a/kubectl-fdb/cmd/recover_multi_region_cluster_test.go
+++ b/kubectl-fdb/cmd/recover_multi_region_cluster_test.go
@@ -38,9 +38,11 @@ var _ = Describe("[plugin] running the recover multi-region cluster command", fu
 		expected string
 	}
 
-	DescribeTable("when getting the data dir for uploading files", func(test dataDirTest) {
-		Expect(getDataDir(test.input, test.pod, test.cluster)).To(Equal(test.expected))
-	},
+	DescribeTable(
+		"when getting the data dir for uploading files",
+		func(test dataDirTest) {
+			Expect(getDataDir(test.input, test.pod, test.cluster)).To(Equal(test.expected))
+		},
 		Entry("data dir is already correct",
 			dataDirTest{
 				input: "/var/fdb/data",
@@ -114,7 +116,8 @@ var _ = Describe("[plugin] running the recover multi-region cluster command", fu
 				expected: "/var/fdb/data/1",
 			},
 		),
-		Entry("data dir has process directory and target pod has multiple processes with unified image",
+		Entry(
+			"data dir has process directory and target pod has multiple processes with unified image",
 			dataDirTest{
 				input: "/var/fdb/data/2",
 				pod: &corev1.Pod{

--- a/kubectl-fdb/cmd/remove_process_group.go
+++ b/kubectl-fdb/cmd/remove_process_group.go
@@ -93,8 +93,10 @@ kubectl fdb remove process-groups --match-labels="label-key=label-value,other-ke
 	}
 
 	addProcessSelectionFlags(cmd)
-	cmd.Flags().BoolP("exclusion", "e", true, "define if the process groups should be removed with exclusion.")
-	cmd.Flags().Bool("remove-all-failed", false, "define if all failed processes should be replaced.")
+	cmd.Flags().
+		BoolP("exclusion", "e", true, "define if the process groups should be removed with exclusion.")
+	cmd.Flags().
+		Bool("remove-all-failed", false, "define if all failed processes should be replaced.")
 
 	cmd.SetOut(o.Out)
 	cmd.SetErr(o.ErrOut)
@@ -116,9 +118,17 @@ type replaceProcessGroupsOptions struct {
 // If clusterName is specified, it will ONLY do so for the specified cluster.
 // If processClass is specified, it will ignore the given ids and remove all processes in the given cluster whose pods
 // have a processClassLabel matching the processClass.
-func replaceProcessGroups(cmd *cobra.Command, kubeClient client.Client, processGroupOpts processGroupSelectionOptions, opts replaceProcessGroupsOptions) (int, error) {
+func replaceProcessGroups(
+	cmd *cobra.Command,
+	kubeClient client.Client,
+	processGroupOpts processGroupSelectionOptions,
+	opts replaceProcessGroupsOptions,
+) (int, error) {
 	// TODO(nic): consider putting "allProcesses" into the process selection functions to avoid having these checks outside for more sensitive commands
-	if len(processGroupOpts.ids) == 0 && !opts.removeAllFailed && processGroupOpts.processClass == "" && len(processGroupOpts.conditions) == 0 && len(processGroupOpts.matchLabels) == 0 {
+	if len(processGroupOpts.ids) == 0 && !opts.removeAllFailed &&
+		processGroupOpts.processClass == "" &&
+		len(processGroupOpts.conditions) == 0 &&
+		len(processGroupOpts.matchLabels) == 0 {
 		return 0, errors.New("no processGroups could be selected with the provided options")
 	}
 
@@ -127,13 +137,24 @@ func replaceProcessGroups(cmd *cobra.Command, kubeClient client.Client, processG
 		return 0, err
 	}
 
-	return replaceProcessGroupsFromCluster(cmd, kubeClient, processGroupsByCluster, processGroupOpts.namespace, opts)
+	return replaceProcessGroupsFromCluster(
+		cmd,
+		kubeClient,
+		processGroupsByCluster,
+		processGroupOpts.namespace,
+		opts,
+	)
 }
 
 // replaceProcessGroupsFromCluster removes the process groups ONLY from the specified cluster.
 // It also returns the list of processGroupIDs that it removed from the cluster.
-func replaceProcessGroupsFromCluster(cmd *cobra.Command, kubeClient client.Client, processGroupsByCluster map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID,
-	namespace string, opts replaceProcessGroupsOptions) (int, error) {
+func replaceProcessGroupsFromCluster(
+	cmd *cobra.Command,
+	kubeClient client.Client,
+	processGroupsByCluster map[*fdbv1beta2.FoundationDBCluster][]fdbv1beta2.ProcessGroupID,
+	namespace string,
+	opts replaceProcessGroupsOptions,
+) (int, error) {
 	totalRemoved := 0
 	for cluster, processGroupIDs := range processGroupsByCluster {
 		cmd.Printf("Cluster %v/%v:\n", namespace, cluster.Name)
@@ -159,7 +180,15 @@ func replaceProcessGroupsFromCluster(cmd *cobra.Command, kubeClient client.Clien
 		}
 
 		if opts.wait {
-			if !confirmAction(fmt.Sprintf("Remove %v from cluster %s/%s with exclude: %t", processGroupIDs, namespace, cluster.Name, opts.withExclusion)) {
+			if !confirmAction(
+				fmt.Sprintf(
+					"Remove %v from cluster %s/%s with exclude: %t",
+					processGroupIDs,
+					namespace,
+					cluster.Name,
+					opts.withExclusion,
+				),
+			) {
 				return totalRemoved, fmt.Errorf("user aborted the removal")
 			}
 		}

--- a/kubectl-fdb/cmd/remove_process_group_test.go
+++ b/kubectl-fdb/cmd/remove_process_group_test.go
@@ -85,11 +85,21 @@ var _ = Describe("[plugin] remove process groups command", func() {
 						Name:      clusterName,
 					}, &resCluster)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(tc.ExpectedInstancesToRemove).To(ContainElements(resCluster.Spec.ProcessGroupsToRemove))
-					Expect(len(tc.ExpectedInstancesToRemove)).To(BeNumerically("==", len(resCluster.Spec.ProcessGroupsToRemove)))
-					Expect(tc.ExpectedInstancesToRemoveWithoutExclusion).To(ContainElements(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion))
-					Expect(len(tc.ExpectedInstancesToRemoveWithoutExclusion)).To(BeNumerically("==", len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion)))
-					Expect(tc.ExpectedProcessCounts.Storage).To(Equal(resCluster.Spec.ProcessCounts.Storage))
+					Expect(
+						tc.ExpectedInstancesToRemove,
+					).To(ContainElements(resCluster.Spec.ProcessGroupsToRemove))
+					Expect(
+						len(tc.ExpectedInstancesToRemove),
+					).To(BeNumerically("==", len(resCluster.Spec.ProcessGroupsToRemove)))
+					Expect(
+						tc.ExpectedInstancesToRemoveWithoutExclusion,
+					).To(ContainElements(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion))
+					Expect(
+						len(tc.ExpectedInstancesToRemoveWithoutExclusion),
+					).To(BeNumerically("==", len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion)))
+					Expect(
+						tc.ExpectedProcessCounts.Storage,
+					).To(Equal(resCluster.Spec.ProcessCounts.Storage))
 				},
 				Entry("Remove process group with exclusion",
 					testCase{
@@ -107,7 +117,9 @@ var _ = Describe("[plugin] remove process groups command", func() {
 						Instances:                 []string{"test-storage-1"},
 						WithExclusion:             false,
 						ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
-						ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{"storage-1"},
+						ExpectedInstancesToRemoveWithoutExclusion: []fdbv1beta2.ProcessGroupID{
+							"storage-1",
+						},
 						ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 							Storage: 1,
 						},
@@ -131,75 +143,98 @@ var _ = Describe("[plugin] remove process groups command", func() {
 				})
 
 				When("adding the same process group to the removal list without exclusion", func() {
-					It("should add the process group to the removal without exclusion list", func() {
-						removals := []string{"test-storage-1"}
-						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-						_, err := replaceProcessGroups(cmd, k8sClient,
-							processGroupSelectionOptions{
-								ids:          removals,
-								namespace:    namespace,
-								clusterName:  clusterName,
-								clusterLabel: "",
-								processClass: "",
-							},
-							replaceProcessGroupsOptions{
-								withExclusion:   false,
-								wait:            false,
-								removeAllFailed: false,
-							})
-						Expect(err).NotTo(HaveOccurred())
+					It(
+						"should add the process group to the removal without exclusion list",
+						func() {
+							removals := []string{"test-storage-1"}
+							cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
+							_, err := replaceProcessGroups(cmd, k8sClient,
+								processGroupSelectionOptions{
+									ids:          removals,
+									namespace:    namespace,
+									clusterName:  clusterName,
+									clusterLabel: "",
+									processClass: "",
+								},
+								replaceProcessGroupsOptions{
+									withExclusion:   false,
+									wait:            false,
+									removeAllFailed: false,
+								})
+							Expect(err).NotTo(HaveOccurred())
 
-						var resCluster fdbv1beta2.FoundationDBCluster
-						err = k8sClient.Get(context.Background(), client.ObjectKey{
-							Namespace: namespace,
-							Name:      clusterName,
-						}, &resCluster)
+							var resCluster fdbv1beta2.FoundationDBCluster
+							err = k8sClient.Get(context.Background(), client.ObjectKey{
+								Namespace: namespace,
+								Name:      clusterName,
+							}, &resCluster)
 
-						Expect(err).NotTo(HaveOccurred())
-						Expect(resCluster.Spec.ProcessGroupsToRemove).To(ContainElements(fdbv1beta2.ProcessGroupID("storage-1")))
-						Expect(len(resCluster.Spec.ProcessGroupsToRemove)).To(BeNumerically("==", len(removals)))
-						Expect(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion).To(ContainElements(fdbv1beta2.ProcessGroupID("storage-1")))
-						Expect(len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion)).To(BeNumerically("==", len(removals)))
-					})
+							Expect(err).NotTo(HaveOccurred())
+							Expect(
+								resCluster.Spec.ProcessGroupsToRemove,
+							).To(ContainElements(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								len(resCluster.Spec.ProcessGroupsToRemove),
+							).To(BeNumerically("==", len(removals)))
+							Expect(
+								resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion,
+							).To(ContainElements(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion),
+							).To(BeNumerically("==", len(removals)))
+						},
+					)
 				})
 
 				When("adding the same process group to the removal list", func() {
-					It("should add the process group to the removal without exclusion list", func() {
-						removals := []string{"test-storage-1"}
-						cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
-						_, err := replaceProcessGroups(cmd, k8sClient,
-							processGroupSelectionOptions{
-								ids:          removals,
-								namespace:    namespace,
-								clusterName:  clusterName,
-								clusterLabel: "",
-								processClass: "",
-							},
-							replaceProcessGroupsOptions{
-								withExclusion:   true,
-								wait:            false,
-								removeAllFailed: false,
-							})
-						Expect(err).NotTo(HaveOccurred())
+					It(
+						"should add the process group to the removal without exclusion list",
+						func() {
+							removals := []string{"test-storage-1"}
+							cmd := newRemoveProcessGroupCmd(genericclioptions.IOStreams{})
+							_, err := replaceProcessGroups(cmd, k8sClient,
+								processGroupSelectionOptions{
+									ids:          removals,
+									namespace:    namespace,
+									clusterName:  clusterName,
+									clusterLabel: "",
+									processClass: "",
+								},
+								replaceProcessGroupsOptions{
+									withExclusion:   true,
+									wait:            false,
+									removeAllFailed: false,
+								})
+							Expect(err).NotTo(HaveOccurred())
 
-						var resCluster fdbv1beta2.FoundationDBCluster
-						err = k8sClient.Get(context.Background(), client.ObjectKey{
-							Namespace: namespace,
-							Name:      clusterName,
-						}, &resCluster)
+							var resCluster fdbv1beta2.FoundationDBCluster
+							err = k8sClient.Get(context.Background(), client.ObjectKey{
+								Namespace: namespace,
+								Name:      clusterName,
+							}, &resCluster)
 
-						Expect(err).NotTo(HaveOccurred())
-						Expect(resCluster.Spec.ProcessGroupsToRemove).To(ContainElements(fdbv1beta2.ProcessGroupID("storage-1")))
-						Expect(len(resCluster.Spec.ProcessGroupsToRemove)).To(BeNumerically("==", len(removals)))
-						Expect(len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion)).To(BeNumerically("==", 0))
-					})
+							Expect(err).NotTo(HaveOccurred())
+							Expect(
+								resCluster.Spec.ProcessGroupsToRemove,
+							).To(ContainElements(fdbv1beta2.ProcessGroupID("storage-1")))
+							Expect(
+								len(resCluster.Spec.ProcessGroupsToRemove),
+							).To(BeNumerically("==", len(removals)))
+							Expect(
+								len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion),
+							).To(BeNumerically("==", 0))
+						},
+					)
 				})
 			})
 
 			When("processes are removed by pod and clusterLabel criteria", func() {
 				BeforeEach(func() {
 					// creating Pods for first cluster.
-					cluster = generateClusterStruct(clusterName, namespace) // the status is overwritten by prior tests
+					cluster = generateClusterStruct(
+						clusterName,
+						namespace,
+					) // the status is overwritten by prior tests
 					Expect(createPods(clusterName, namespace)).NotTo(HaveOccurred())
 
 					// creating a second cluster
@@ -252,10 +287,18 @@ var _ = Describe("[plugin] remove process groups command", func() {
 								Name:      clusterName,
 							}, &resCluster)
 							Expect(err).NotTo(HaveOccurred())
-							Expect(clusterData.ExpectedInstancesToRemove).To(ContainElements(resCluster.Spec.ProcessGroupsToRemove))
-							Expect(len(clusterData.ExpectedInstancesToRemove)).To(BeNumerically("==", len(resCluster.Spec.ProcessGroupsToRemove)))
-							Expect(len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion)).To(BeNumerically("==", 0))
-							Expect(clusterData.ExpectedProcessCounts.Storage).To(Equal(resCluster.Spec.ProcessCounts.Storage))
+							Expect(
+								clusterData.ExpectedInstancesToRemove,
+							).To(ContainElements(resCluster.Spec.ProcessGroupsToRemove))
+							Expect(
+								len(clusterData.ExpectedInstancesToRemove),
+							).To(BeNumerically("==", len(resCluster.Spec.ProcessGroupsToRemove)))
+							Expect(
+								len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion),
+							).To(BeNumerically("==", 0))
+							Expect(
+								clusterData.ExpectedProcessCounts.Storage,
+							).To(Equal(resCluster.Spec.ProcessCounts.Storage))
 						}
 					},
 					Entry("errors when process group IDs are provided instead of pod names",
@@ -275,9 +318,14 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					),
 					Entry("errors when no cluster found with given label",
 						testCase{
-							podNames:          []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)},
-							clusterLabel:      "invalid-cluster-label",
-							wantErrorContains: fmt.Sprintf("no cluster-label 'invalid-cluster-label' found for pod '%s-storage-1'", clusterName),
+							podNames: []string{
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							},
+							clusterLabel: "invalid-cluster-label",
+							wantErrorContains: fmt.Sprintf(
+								"no cluster-label 'invalid-cluster-label' found for pod '%s-storage-1'",
+								clusterName,
+							),
 							clusterDataMap: map[string]clusterData{
 								clusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{},
@@ -290,12 +338,20 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					),
 					Entry("removes valid 1 process group referred to by pod name and cluster-label",
 						testCase{
-							podNames:     []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)},
+							podNames: []string{
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+							},
 							clusterLabel: fdbv1beta2.FDBClusterLabel,
 							clusterDataMap: map[string]clusterData{
 								clusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+										fdbv1beta2.ProcessGroupID(
+											fmt.Sprintf(
+												"%s-%s-1",
+												clusterName,
+												fdbv1beta2.ProcessClassStorage,
+											),
+										),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -312,12 +368,25 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					),
 					Entry("removes two process groups, each on a different cluster",
 						testCase{
-							podNames:     []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)},
+							podNames: []string{
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+								fmt.Sprintf(
+									"%s-%s-1",
+									secondClusterName,
+									fdbv1beta2.ProcessClassStorage,
+								),
+							},
 							clusterLabel: fdbv1beta2.FDBClusterLabel,
 							clusterDataMap: map[string]clusterData{
 								clusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+										fdbv1beta2.ProcessGroupID(
+											fmt.Sprintf(
+												"%s-%s-1",
+												clusterName,
+												fdbv1beta2.ProcessClassStorage,
+											),
+										),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -325,7 +394,13 @@ var _ = Describe("[plugin] remove process groups command", func() {
 								},
 								secondClusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+										fdbv1beta2.ProcessGroupID(
+											fmt.Sprintf(
+												"%s-%s-1",
+												secondClusterName,
+												fdbv1beta2.ProcessClassStorage,
+											),
+										),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -336,12 +411,30 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					),
 					Entry("removes 3 process groups, on 2 different clusters",
 						testCase{
-							podNames:     []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)},
+							podNames: []string{
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+								fmt.Sprintf(
+									"%s-%s-1",
+									secondClusterName,
+									fdbv1beta2.ProcessClassStorage,
+								),
+								fmt.Sprintf(
+									"%s-%s-2",
+									secondClusterName,
+									fdbv1beta2.ProcessClassStorage,
+								),
+							},
 							clusterLabel: fdbv1beta2.FDBClusterLabel,
 							clusterDataMap: map[string]clusterData{
 								clusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
+										fdbv1beta2.ProcessGroupID(
+											fmt.Sprintf(
+												"%s-%s-1",
+												clusterName,
+												fdbv1beta2.ProcessClassStorage,
+											),
+										),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -349,8 +442,20 @@ var _ = Describe("[plugin] remove process groups command", func() {
 								},
 								secondClusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+										fdbv1beta2.ProcessGroupID(
+											fmt.Sprintf(
+												"%s-%s-1",
+												secondClusterName,
+												fdbv1beta2.ProcessClassStorage,
+											),
+										),
+										fdbv1beta2.ProcessGroupID(
+											fmt.Sprintf(
+												"%s-%s-2",
+												secondClusterName,
+												fdbv1beta2.ProcessClassStorage,
+											),
+										),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -361,14 +466,38 @@ var _ = Describe("[plugin] remove process groups command", func() {
 					),
 					Entry("removes 4 process groups, on 2 different clusters",
 						testCase{
-							podNames: []string{fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
-								fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage), fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)},
+							podNames: []string{
+								fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage),
+								fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage),
+								fmt.Sprintf(
+									"%s-%s-1",
+									secondClusterName,
+									fdbv1beta2.ProcessClassStorage,
+								),
+								fmt.Sprintf(
+									"%s-%s-2",
+									secondClusterName,
+									fdbv1beta2.ProcessClassStorage,
+								),
+							},
 							clusterLabel: fdbv1beta2.FDBClusterLabel,
 							clusterDataMap: map[string]clusterData{
 								clusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+										fdbv1beta2.ProcessGroupID(
+											fmt.Sprintf(
+												"%s-%s-1",
+												clusterName,
+												fdbv1beta2.ProcessClassStorage,
+											),
+										),
+										fdbv1beta2.ProcessGroupID(
+											fmt.Sprintf(
+												"%s-%s-2",
+												clusterName,
+												fdbv1beta2.ProcessClassStorage,
+											),
+										),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -376,8 +505,20 @@ var _ = Describe("[plugin] remove process groups command", func() {
 								},
 								secondClusterName: {
 									ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", secondClusterName, fdbv1beta2.ProcessClassStorage)),
-										fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", secondClusterName, fdbv1beta2.ProcessClassStorage)),
+										fdbv1beta2.ProcessGroupID(
+											fmt.Sprintf(
+												"%s-%s-1",
+												secondClusterName,
+												fdbv1beta2.ProcessClassStorage,
+											),
+										),
+										fdbv1beta2.ProcessGroupID(
+											fmt.Sprintf(
+												"%s-%s-2",
+												secondClusterName,
+												fdbv1beta2.ProcessClassStorage,
+											),
+										),
 									},
 									ExpectedProcessCounts: fdbv1beta2.ProcessCounts{
 										Storage: 1,
@@ -390,7 +531,10 @@ var _ = Describe("[plugin] remove process groups command", func() {
 			})
 			When("processes are specified via processClass or condition", func() {
 				BeforeEach(func() {
-					cluster = generateClusterStruct(clusterName, namespace) // the status is overwritten by prior tests
+					cluster = generateClusterStruct(
+						clusterName,
+						namespace,
+					) // the status is overwritten by prior tests
 					Expect(createPods(clusterName, namespace)).NotTo(HaveOccurred())
 
 				})
@@ -432,9 +576,15 @@ var _ = Describe("[plugin] remove process groups command", func() {
 							Name:      clusterName,
 						}, &resCluster)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(tc.ExpectedInstancesToRemove).To(ContainElements(resCluster.Spec.ProcessGroupsToRemove))
-						Expect(len(tc.ExpectedInstancesToRemove)).To(BeNumerically("==", len(resCluster.Spec.ProcessGroupsToRemove)))
-						Expect(len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion)).To(BeNumerically("==", 0))
+						Expect(
+							tc.ExpectedInstancesToRemove,
+						).To(ContainElements(resCluster.Spec.ProcessGroupsToRemove))
+						Expect(
+							len(tc.ExpectedInstancesToRemove),
+						).To(BeNumerically("==", len(resCluster.Spec.ProcessGroupsToRemove)))
+						Expect(
+							len(resCluster.Spec.ProcessGroupsToRemoveWithoutExclusion),
+						).To(BeNumerically("==", 0))
 					},
 					Entry("errors when no process groups are found of the given class",
 						testCase{
@@ -457,7 +607,13 @@ var _ = Describe("[plugin] remove process groups command", func() {
 							processClass: string(fdbv1beta2.ProcessClassStateless),
 							clusterName:  clusterName,
 							ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-3", clusterName, fdbv1beta2.ProcessClassStateless)),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-3",
+										clusterName,
+										fdbv1beta2.ProcessClassStateless,
+									),
+								),
 							},
 						},
 					),
@@ -466,41 +622,79 @@ var _ = Describe("[plugin] remove process groups command", func() {
 							processClass: string(fdbv1beta2.ProcessClassStorage),
 							clusterName:  clusterName,
 							ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-1",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+								),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-2",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+								),
 							},
 						},
 					),
 					Entry("errors when both processClass and condition are specified",
 						testCase{
-							processClass:      string(fdbv1beta2.ProcessClassStorage),
-							conditions:        []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.PodFailing},
+							processClass: string(fdbv1beta2.ProcessClassStorage),
+							conditions: []fdbv1beta2.ProcessGroupConditionType{
+								fdbv1beta2.PodFailing,
+							},
 							clusterName:       clusterName,
 							wantErrorContains: "selection of processes by both processClass and conditions is not supported",
 						},
 					),
 					Entry("selects all 2 processes with PodFailing",
 						testCase{
-							conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.PodFailing},
+							conditions: []fdbv1beta2.ProcessGroupConditionType{
+								fdbv1beta2.PodFailing,
+							},
 							clusterName: clusterName,
 							ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-1", clusterName, fdbv1beta2.ProcessClassStorage)),
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-1",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+								),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-2",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+								),
 							},
 						},
 					),
 					Entry("selects the 1 process with MissingProcesses",
 						testCase{
-							conditions:  []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.MissingProcesses},
+							conditions: []fdbv1beta2.ProcessGroupConditionType{
+								fdbv1beta2.MissingProcesses,
+							},
 							clusterName: clusterName,
 							ExpectedInstancesToRemove: []fdbv1beta2.ProcessGroupID{
-								fdbv1beta2.ProcessGroupID(fmt.Sprintf("%s-%s-2", clusterName, fdbv1beta2.ProcessClassStorage)),
+								fdbv1beta2.ProcessGroupID(
+									fmt.Sprintf(
+										"%s-%s-2",
+										clusterName,
+										fdbv1beta2.ProcessClassStorage,
+									),
+								),
 							},
 						},
 					),
 					Entry("selects all 0 processes in IncorrectPodSpec",
 						testCase{
-							conditions:        []fdbv1beta2.ProcessGroupConditionType{fdbv1beta2.IncorrectPodSpec},
+							conditions: []fdbv1beta2.ProcessGroupConditionType{
+								fdbv1beta2.IncorrectPodSpec,
+							},
 							clusterName:       clusterName,
 							wantErrorContains: "found no processGroups meeting the selection criteria",
 						},

--- a/kubectl-fdb/cmd/restart_test.go
+++ b/kubectl-fdb/cmd/restart_test.go
@@ -42,7 +42,10 @@ var _ = Describe("[plugin] root command", func() {
 		})
 
 		It("should not throw an error", func() {
-			cmd := NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer}, &MockVersionChecker{})
+			cmd := NewRootCmd(
+				genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer},
+				&MockVersionChecker{},
+			)
 
 			args := []string{"restart", "-c", "sample"}
 			cmd.SetArgs(args)

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -50,7 +50,10 @@ func newFDBOptions(streams genericclioptions.IOStreams) *fdbBOptions {
 }
 
 // NewRootCmd provides a cobra command wrapping FDB actions
-func NewRootCmd(streams genericclioptions.IOStreams, pluginVersionChecker VersionChecker) *cobra.Command {
+func NewRootCmd(
+	streams genericclioptions.IOStreams,
+	pluginVersionChecker VersionChecker,
+) *cobra.Command {
 	o := newFDBOptions(streams)
 
 	cmd := &cobra.Command{
@@ -75,10 +78,14 @@ func NewRootCmd(streams genericclioptions.IOStreams, pluginVersionChecker Versio
 	cmd.SetIn(o.In)
 
 	viper.SetDefault("license", "apache 2")
-	cmd.PersistentFlags().StringP("operator-name", "o", "fdb-kubernetes-operator-controller-manager", "Name of the Deployment for the operator.")
-	cmd.PersistentFlags().Bool("version-check", true, "If the plugin should check if a newer release of the plugin exists. If so the command will not be executed.")
-	cmd.PersistentFlags().BoolP("wait", "w", true, "If the plugin should wait for confirmation before executing any action")
-	cmd.PersistentFlags().Uint16P("sleep", "z", 0, "The plugin should sleep between sequential operations for the defined time in seconds (default 0)")
+	cmd.PersistentFlags().
+		StringP("operator-name", "o", "fdb-kubernetes-operator-controller-manager", "Name of the Deployment for the operator.")
+	cmd.PersistentFlags().
+		Bool("version-check", true, "If the plugin should check if a newer release of the plugin exists. If so the command will not be executed.")
+	cmd.PersistentFlags().
+		BoolP("wait", "w", true, "If the plugin should wait for confirmation before executing any action")
+	cmd.PersistentFlags().
+		Uint16P("sleep", "z", 0, "The plugin should sleep between sequential operations for the defined time in seconds (default 0)")
 	o.configFlags.AddFlags(cmd.Flags())
 
 	cmd.AddCommand(
@@ -184,16 +191,25 @@ type processGroupSelectionOptions struct {
 }
 
 func addProcessSelectionFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP("fdb-cluster", "c", "", "Selects process groups from the provided cluster. "+
-		"Required if not passing cluster-label.")
-	cmd.Flags().String("process-class", "", "Selects process groups matching the provided value in the provided cluster.  Using this option ignores provided ids.")
-	cmd.Flags().StringP("cluster-label", "l", fdbv1beta2.FDBClusterLabel, "cluster label used to identify the cluster for a requested pod. "+
-		"It is incompatible with process-class, and process-condition.")
-	cmd.Flags().StringArray("process-condition", []string{}, "Selects process groups that are in any of the given FDB process group conditions.")
-	cmd.Flags().StringToString("match-labels", map[string]string{}, "Selects process groups running on pods matching the given labels and are in the provided cluster.  Using this option ignores provided ids.")
+	cmd.Flags().
+		StringP("fdb-cluster", "c", "", "Selects process groups from the provided cluster. "+
+			"Required if not passing cluster-label.")
+	cmd.Flags().
+		String("process-class", "", "Selects process groups matching the provided value in the provided cluster.  Using this option ignores provided ids.")
+	cmd.Flags().
+		StringP("cluster-label", "l", fdbv1beta2.FDBClusterLabel, "cluster label used to identify the cluster for a requested pod. "+
+			"It is incompatible with process-class, and process-condition.")
+	cmd.Flags().
+		StringArray("process-condition", []string{}, "Selects process groups that are in any of the given FDB process group conditions.")
+	cmd.Flags().
+		StringToString("match-labels", map[string]string{}, "Selects process groups running on pods matching the given labels and are in the provided cluster.  Using this option ignores provided ids.")
 }
 
-func getProcessSelectionOptsFromFlags(cmd *cobra.Command, o *fdbBOptions, ids []string) (processGroupSelectionOptions, error) {
+func getProcessSelectionOptsFromFlags(
+	cmd *cobra.Command,
+	o *fdbBOptions,
+	ids []string,
+) (processGroupSelectionOptions, error) {
 	opts := processGroupSelectionOptions{}
 	cluster, err := cmd.Flags().GetString("fdb-cluster")
 	if err != nil {

--- a/kubectl-fdb/cmd/root_test.go
+++ b/kubectl-fdb/cmd/root_test.go
@@ -42,7 +42,10 @@ var _ = Describe("[plugin] root command", func() {
 		})
 
 		It("should not throw an error", func() {
-			cmd := NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer}, &MockVersionChecker{})
+			cmd := NewRootCmd(
+				genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer},
+				&MockVersionChecker{},
+			)
 			cmd.SetArgs([]string{})
 			Expect(cmd.Execute()).NotTo(HaveOccurred())
 		})

--- a/kubectl-fdb/cmd/suite_test.go
+++ b/kubectl-fdb/cmd/suite_test.go
@@ -80,23 +80,29 @@ func generateClusterStruct(name string, namespace string) *fdbv1beta2.Foundation
 			ConnectionString: "test:id1234@127.0.0.1:4500",
 			ProcessGroups: []*fdbv1beta2.ProcessGroupStatus{
 				{
-					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-" + string(fdbv1beta2.ProcessClassStorage) + "-1"),
-					ProcessClass:   fdbv1beta2.ProcessClassStorage,
+					ProcessGroupID: fdbv1beta2.ProcessGroupID(
+						name + "-" + string(fdbv1beta2.ProcessClassStorage) + "-1",
+					),
+					ProcessClass: fdbv1beta2.ProcessClassStorage,
 					ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
 						fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.PodFailing),
 					},
 				},
 				{
-					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-" + string(fdbv1beta2.ProcessClassStorage) + "-2"),
-					ProcessClass:   fdbv1beta2.ProcessClassStorage,
+					ProcessGroupID: fdbv1beta2.ProcessGroupID(
+						name + "-" + string(fdbv1beta2.ProcessClassStorage) + "-2",
+					),
+					ProcessClass: fdbv1beta2.ProcessClassStorage,
 					ProcessGroupConditions: []*fdbv1beta2.ProcessGroupCondition{
 						fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.PodFailing),
 						fdbv1beta2.NewProcessGroupCondition(fdbv1beta2.MissingProcesses),
 					},
 				},
 				{
-					ProcessGroupID: fdbv1beta2.ProcessGroupID(name + "-" + string(fdbv1beta2.ProcessClassStateless) + "-3"),
-					ProcessClass:   fdbv1beta2.ProcessClassStateless,
+					ProcessGroupID: fdbv1beta2.ProcessGroupID(
+						name + "-" + string(fdbv1beta2.ProcessClassStateless) + "-3",
+					),
+					ProcessClass: fdbv1beta2.ProcessClassStateless,
 				},
 			},
 		},

--- a/kubectl-fdb/cmd/update_connection_string.go
+++ b/kubectl-fdb/cmd/update_connection_string.go
@@ -51,7 +51,11 @@ func newUpdateConnectionStringCmd(streams genericclioptions.IOStreams) *cobra.Co
 			}
 
 			cluster := &fdbv1beta2.FoundationDBCluster{}
-			err = kubeClient.Get(cmd.Context(), client.ObjectKey{Name: clusterName, Namespace: namespace}, cluster)
+			err = kubeClient.Get(
+				cmd.Context(),
+				client.ObjectKey{Name: clusterName, Namespace: namespace},
+				cluster,
+			)
 			if err != nil {
 				return err
 			}
@@ -66,8 +70,9 @@ kubectl fdb update connection-string -c cluster test:cluster@192.168.0.1:4500
 kubectl fdb -n default update connection-string -c cluster test:cluster@192.168.0.1:4500`,
 	}
 
-	cmd.Flags().StringP("fdb-cluster", "c", "", "Selects process groups from the provided cluster. "+
-		"Required if not passing cluster-label.")
+	cmd.Flags().
+		StringP("fdb-cluster", "c", "", "Selects process groups from the provided cluster. "+
+			"Required if not passing cluster-label.")
 	cmd.SetOut(o.Out)
 	cmd.SetErr(o.ErrOut)
 	cmd.SetIn(o.In)
@@ -77,9 +82,19 @@ kubectl fdb -n default update connection-string -c cluster test:cluster@192.168.
 }
 
 // updateConnectionStringCmd will update the connection string if the current connection string is outdated in the fdbv1beta2.FoundationDBCluster status.
-func updateConnectionStringCmd(cmd *cobra.Command, kubeClient client.Client, cluster *fdbv1beta2.FoundationDBCluster, connectionString string) error {
+func updateConnectionStringCmd(
+	cmd *cobra.Command,
+	kubeClient client.Client,
+	cluster *fdbv1beta2.FoundationDBCluster,
+	connectionString string,
+) error {
 	if cluster.Status.ConnectionString == connectionString {
-		cmd.Printf("cluster %s/%s already has connections string \"%s\" set\n", cluster.Namespace, cluster.Name, connectionString)
+		cmd.Printf(
+			"cluster %s/%s already has connections string \"%s\" set\n",
+			cluster.Namespace,
+			cluster.Name,
+			connectionString,
+		)
 		return nil
 	}
 

--- a/kubectl-fdb/cmd/update_connection_string_test.go
+++ b/kubectl-fdb/cmd/update_connection_string_test.go
@@ -49,7 +49,10 @@ var _ = Describe("[plugin] update connection string command", func() {
 		outBuffer = bytes.Buffer{}
 		errBuffer = bytes.Buffer{}
 		inBuffer = bytes.Buffer{}
-		cmd = NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer}, &MockVersionChecker{})
+		cmd = NewRootCmd(
+			genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer},
+			&MockVersionChecker{},
+		)
 		initialConnectionString = cluster.Status.ConnectionString
 	})
 
@@ -89,15 +92,32 @@ var _ = Describe("[plugin] update connection string command", func() {
 				Expect(outBuffer.String()).To(BeEmpty())
 
 				fetchedCluster := &fdbv1beta2.FoundationDBCluster{}
-				Expect(k8sClient.Get(context.Background(), ctrlClient.ObjectKeyFromObject(cluster), fetchedCluster)).To(Succeed())
+				Expect(
+					k8sClient.Get(
+						context.Background(),
+						ctrlClient.ObjectKeyFromObject(cluster),
+						fetchedCluster,
+					),
+				).To(Succeed())
 
 				Expect(fetchedCluster.Status.ConnectionString).To(Equal(connectionString))
 				Expect(fetchedCluster.Status.ConnectionString).NotTo(Equal(initialConnectionString))
 
 				fetchedConfigMap := &corev1.ConfigMap{}
-				Expect(k8sClient.Get(context.Background(), ctrlClient.ObjectKey{Namespace: cluster.Namespace, Name: fmt.Sprintf("%s-config", cluster.Name)}, fetchedConfigMap)).To(Succeed())
+				Expect(
+					k8sClient.Get(
+						context.Background(),
+						ctrlClient.ObjectKey{
+							Namespace: cluster.Namespace,
+							Name:      fmt.Sprintf("%s-config", cluster.Name),
+						},
+						fetchedConfigMap,
+					),
+				).To(Succeed())
 				Expect(fetchedConfigMap.Data).To(HaveLen(1))
-				Expect(fetchedConfigMap.Data).To(HaveKeyWithValue(fdbv1beta2.ClusterFileKey, connectionString))
+				Expect(
+					fetchedConfigMap.Data,
+				).To(HaveKeyWithValue(fdbv1beta2.ClusterFileKey, connectionString))
 			})
 		})
 
@@ -106,9 +126,12 @@ var _ = Describe("[plugin] update connection string command", func() {
 				connectionString = "test-invalid@127.0.0.1:4500"
 			})
 
-			It("should return an error with the information that the connection string is invalid", func() {
-				Expect(err).To(MatchError(ContainSubstring("invalid connection string")))
-			})
+			It(
+				"should return an error with the information that the connection string is invalid",
+				func() {
+					Expect(err).To(MatchError(ContainSubstring("invalid connection string")))
+				},
+			)
 		})
 	})
 })

--- a/kubectl-fdb/cmd/version.go
+++ b/kubectl-fdb/cmd/version.go
@@ -99,13 +99,19 @@ kubectl fdb version --client-only
 	cmd.SetIn(o.In)
 
 	o.configFlags.AddFlags(cmd.Flags())
-	cmd.Flags().Bool("client-only", false, "Prints out the plugin version only without checking the operator version.")
+	cmd.Flags().
+		Bool("client-only", false, "Prints out the plugin version only without checking the operator version.")
 	cmd.Flags().String("container-name", "manager", "The container name of Kubernetes Deployment.")
 
 	return cmd
 }
 
-func version(kubeClient client.Client, operatorName string, namespace string, containerName string) (string, error) {
+func version(
+	kubeClient client.Client,
+	operatorName string,
+	namespace string,
+	containerName string,
+) (string, error) {
 	operatorDeployment, err := getOperator(kubeClient, operatorName, namespace)
 	if err != nil {
 		return "", err
@@ -120,5 +126,10 @@ func version(kubeClient client.Client, operatorName string, namespace string, co
 		return imageName[len(imageName)-1], nil
 	}
 
-	return "", fmt.Errorf("could not find container: %s in %s/%s", containerName, namespace, operatorName)
+	return "", fmt.Errorf(
+		"could not find container: %s in %s/%s",
+		containerName,
+		namespace,
+		operatorName,
+	)
 }

--- a/kubectl-fdb/cmd/version_test.go
+++ b/kubectl-fdb/cmd/version_test.go
@@ -46,7 +46,10 @@ var _ = Describe("[plugin] version command", func() {
 			errBuffer = bytes.Buffer{}
 			inBuffer = bytes.Buffer{}
 
-			rootCmd := NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer}, &MockVersionChecker{})
+			rootCmd := NewRootCmd(
+				genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer},
+				&MockVersionChecker{},
+			)
 
 			args := []string{"version", "--client-only"}
 			rootCmd.SetArgs(args)
@@ -157,8 +160,10 @@ var _ = Describe("[plugin] version command", func() {
 							},
 						},
 					},
-					expectedError: fmt.Errorf("could not find container: manager in default/fdb-operator"),
-					hasError:      true,
+					expectedError: fmt.Errorf(
+						"could not find container: manager in default/fdb-operator",
+					),
+					hasError: true,
 				}),
 		)
 	})
@@ -178,7 +183,10 @@ var _ = Describe("[plugin] version command", func() {
 			errBuffer = bytes.Buffer{}
 			inBuffer = bytes.Buffer{}
 
-			rootCmd := NewRootCmd(genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer}, &MockVersionChecker{MockedVersion: "2.0.0"})
+			rootCmd := NewRootCmd(
+				genericclioptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer},
+				&MockVersionChecker{MockedVersion: "2.0.0"},
+			)
 
 			args := []string{"version", "--client-only"}
 			rootCmd.SetArgs(args)
@@ -189,7 +197,8 @@ var _ = Describe("[plugin] version command", func() {
 
 		It("should print out the client version", func() {
 			Expect(outBuffer.String()).To(ContainSubstring(
-				"kubectl-fdb plugin is not up-to-date, please install the latest version and try again!"))
+				"kubectl-fdb plugin is not up-to-date, please install the latest version and try again!",
+			))
 		})
 	})
 })

--- a/kubectl-fdb/main.go
+++ b/kubectl-fdb/main.go
@@ -32,7 +32,10 @@ import (
 func main() {
 	flags := pflag.NewFlagSet("kubectl-fdb", pflag.ExitOnError)
 	pflag.CommandLine = flags
-	root := cmd.NewRootCmd(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}, &cmd.RealVersionChecker{})
+	root := cmd.NewRootCmd(
+		genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
+		&cmd.RealVersionChecker{},
+	)
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/mock-kubernetes-client/client/client_test.go
+++ b/mock-kubernetes-client/client/client_test.go
@@ -76,7 +76,11 @@ var _ = Describe("[mock client]", func() {
 			Expect(pod.ObjectMeta.Generation).To(Equal(int64(1)))
 
 			podCopy := &corev1.Pod{}
-			err = mockClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, podCopy)
+			err = mockClient.Get(
+				context.TODO(),
+				types.NamespacedName{Namespace: "default", Name: "pod1"},
+				podCopy,
+			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podCopy.Name).To(Equal("pod1"))
 			Expect(len(podCopy.Spec.Containers)).To(Equal(1))
@@ -94,12 +98,20 @@ var _ = Describe("[mock client]", func() {
 			Expect(pod.ObjectMeta.Generation).To(Equal(int64(1)))
 
 			podCopy := &corev1.Pod{}
-			Expect(mockClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, podCopy)).NotTo(HaveOccurred())
+			Expect(
+				mockClient.Get(
+					context.TODO(),
+					types.NamespacedName{Namespace: "default", Name: "pod1"},
+					podCopy,
+				),
+			).NotTo(HaveOccurred())
 			Expect(podCopy.Name).To(Equal("pod1"))
 			Expect(len(podCopy.Spec.Containers)).To(Equal(1))
 			Expect(podCopy.Spec.Containers[0].Name).To(Equal("test-container"))
 			Expect(podCopy.ObjectMeta.Generation).To(Equal(int64(1)))
-			Expect(podCopy.ObjectMeta.CreationTimestamp.Time.Minute()).To(Equal(expectedCreationTime.Minute()))
+			Expect(
+				podCopy.ObjectMeta.CreationTimestamp.Time.Minute(),
+			).To(Equal(expectedCreationTime.Minute()))
 		})
 	})
 
@@ -114,7 +126,11 @@ var _ = Describe("[mock client]", func() {
 
 		It("should create a mock IP", func() {
 			pod := &corev1.Pod{}
-			err := mockClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, pod)
+			err := mockClient.Get(
+				context.TODO(),
+				types.NamespacedName{Namespace: "default", Name: "pod1"},
+				pod,
+			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pod.Name).To(Equal("pod1"))
 			Expect(len(pod.Spec.Containers)).To(Equal(1))
@@ -131,7 +147,11 @@ var _ = Describe("[mock client]", func() {
 
 			It("should return an empty Pod IP", func() {
 				pod := &corev1.Pod{}
-				err := mockClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, pod)
+				err := mockClient.Get(
+					context.TODO(),
+					types.NamespacedName{Namespace: "default", Name: "pod1"},
+					pod,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pod.Name).To(Equal("pod1"))
 				Expect(len(pod.Spec.Containers)).To(Equal(1))
@@ -188,12 +208,20 @@ var _ = Describe("[mock client]", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			pod := &corev1.Pod{}
-			err = mockClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod2"}, pod)
+			err = mockClient.Get(
+				context.TODO(),
+				types.NamespacedName{Namespace: "default", Name: "pod2"},
+				pod,
+			)
 			Expect(err).To(HaveOccurred())
 			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 
 			deployment := &appsv1.Deployment{}
-			err = mockClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, deployment)
+			err = mockClient.Get(
+				context.TODO(),
+				types.NamespacedName{Namespace: "default", Name: "pod1"},
+				deployment,
+			)
 			Expect(err).To(HaveOccurred())
 			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 		})
@@ -238,13 +266,21 @@ var _ = Describe("[mock client]", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			podCopy := &corev1.Pod{}
-			err = mockClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, podCopy)
+			err = mockClient.Get(
+				context.TODO(),
+				types.NamespacedName{Namespace: "default", Name: "pod1"},
+				podCopy,
+			)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = mockClient.Delete(context.TODO(), pod2)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = mockClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod2"}, podCopy)
+			err = mockClient.Get(
+				context.TODO(),
+				types.NamespacedName{Namespace: "default", Name: "pod2"},
+				podCopy,
+			)
 			Expect(err).To(HaveOccurred())
 			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 		})
@@ -264,7 +300,11 @@ var _ = Describe("[mock client]", func() {
 			Expect(pod.ObjectMeta.Generation).To(Equal(int64(2)))
 
 			podCopy := &corev1.Pod{}
-			err = mockClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, podCopy)
+			err = mockClient.Get(
+				context.TODO(),
+				types.NamespacedName{Namespace: "default", Name: "pod1"},
+				podCopy,
+			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(podCopy.Spec.Containers)).To(Equal(1))
 			Expect(len(podCopy.Spec.Containers[0].Env)).To(Equal(1))
@@ -290,7 +330,11 @@ var _ = Describe("[mock client]", func() {
 			Expect(pod.ObjectMeta.Generation).To(Equal(int64(1)))
 
 			podCopy := &corev1.Pod{}
-			err = mockClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "pod1"}, podCopy)
+			err = mockClient.Get(
+				context.TODO(),
+				types.NamespacedName{Namespace: "default", Name: "pod1"},
+				podCopy,
+			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podCopy.Status.HostIP).To(Equal("foo"))
 			Expect(podCopy.ObjectMeta.Generation).To(Equal(int64(1)))
@@ -359,7 +403,11 @@ var _ = Describe("[mock client]", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			pods := &corev1.PodList{}
-			err = mockClient.List(context.TODO(), pods, ctrlClient.MatchingLabels(map[string]string{"app": "app2"}))
+			err = mockClient.List(
+				context.TODO(),
+				pods,
+				ctrlClient.MatchingLabels(map[string]string{"app": "app2"}),
+			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(pods.Items)).To(Equal(1))
 			Expect(pods.Items[0].Name).To(Equal("pod2"))
@@ -367,7 +415,13 @@ var _ = Describe("[mock client]", func() {
 			appRequirement, err := labels.NewRequirement("app", selection.Exists, nil)
 			Expect(err).NotTo(HaveOccurred())
 			pods = &corev1.PodList{}
-			err = mockClient.List(context.TODO(), pods, ctrlClient.MatchingLabelsSelector{Selector: labels.NewSelector().Add(*appRequirement)})
+			err = mockClient.List(
+				context.TODO(),
+				pods,
+				ctrlClient.MatchingLabelsSelector{
+					Selector: labels.NewSelector().Add(*appRequirement),
+				},
+			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(pods.Items)).To(Equal(2))
 			sortPodsByName(pods)
@@ -439,7 +493,14 @@ var _ = Describe("[mock client]", func() {
 	When("creating an event with in the past", func() {
 		It("should create the event", func() {
 			timestamp := metav1.Time{Time: time.Now().Add(-1 * time.Minute)}
-			mockClient.PastEventf(createDummyPod(), timestamp, "Testing", "This is a test", "Test message: %d", 5)
+			mockClient.PastEventf(
+				createDummyPod(),
+				timestamp,
+				"Testing",
+				"This is a test",
+				"Test message: %d",
+				5,
+			)
 			events := &corev1.EventList{}
 			err := mockClient.List(context.TODO(), events)
 			Expect(err).NotTo(HaveOccurred())
@@ -457,7 +518,14 @@ var _ = Describe("[mock client]", func() {
 
 	When("creating an event with annotations", func() {
 		It("should create the event", func() {
-			mockClient.AnnotatedEventf(createDummyPod(), map[string]string{"anno": "value"}, "Testing", "This is a test", "Test message: %d", 5)
+			mockClient.AnnotatedEventf(
+				createDummyPod(),
+				map[string]string{"anno": "value"},
+				"Testing",
+				"This is a test",
+				"Test message: %d",
+				5,
+			)
 			events := &corev1.EventList{}
 			err := mockClient.List(context.TODO(), events)
 			Expect(err).NotTo(HaveOccurred())
@@ -469,7 +537,9 @@ var _ = Describe("[mock client]", func() {
 			Expect(events.Items[0].Type).To(Equal("Testing"))
 			Expect(events.Items[0].Reason).To(Equal("This is a test"))
 			Expect(events.Items[0].Message).To(Equal("Test message: 5"))
-			Expect(events.Items[0].ObjectMeta.Annotations).To(Equal(map[string]string{"anno": "value"}))
+			Expect(
+				events.Items[0].ObjectMeta.Annotations,
+			).To(Equal(map[string]string{"anno": "value"}))
 		})
 	})
 
@@ -477,30 +547,33 @@ var _ = Describe("[mock client]", func() {
 		var expectedPods = int32(4)
 
 		BeforeEach(func() {
-			mockClient = NewMockClient(scheme.Scheme, func(ctx context.Context, client *MockClient, object ctrlClient.Object) error {
-				replicaSet, isReplicaSet := object.(*appsv1.ReplicaSet)
-				if !isReplicaSet {
+			mockClient = NewMockClient(
+				scheme.Scheme,
+				func(ctx context.Context, client *MockClient, object ctrlClient.Object) error {
+					replicaSet, isReplicaSet := object.(*appsv1.ReplicaSet)
+					if !isReplicaSet {
+						return nil
+					}
+
+					expectedReplicas := pointer.Int32Deref(replicaSet.Spec.Replicas, 1)
+
+					for i := int32(0); i < expectedReplicas; i++ {
+						err := client.Create(ctx, &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: replicaSet.Namespace,
+								Name:      fmt.Sprintf("%s-%d", replicaSet.Name, i),
+							},
+						})
+						_ = err
+					}
+
+					replicaSet.Labels = map[string]string{
+						"test": "success",
+					}
+
 					return nil
-				}
-
-				expectedReplicas := pointer.Int32Deref(replicaSet.Spec.Replicas, 1)
-
-				for i := int32(0); i < expectedReplicas; i++ {
-					err := client.Create(ctx, &corev1.Pod{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: replicaSet.Namespace,
-							Name:      fmt.Sprintf("%s-%d", replicaSet.Name, i),
-						},
-					})
-					_ = err
-				}
-
-				replicaSet.Labels = map[string]string{
-					"test": "success",
-				}
-
-				return nil
-			})
+				},
+			)
 
 			Expect(mockClient.Create(context.TODO(), &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -519,8 +592,12 @@ var _ = Describe("[mock client]", func() {
 
 			// Ensure the label is update
 			replicaSet := &appsv1.ReplicaSet{}
-			Expect(mockClient.Get(context.TODO(), ctrlClient.ObjectKey{Name: "unicorn"}, replicaSet)).NotTo(HaveOccurred())
-			Expect(pointer.Int32Deref(replicaSet.Spec.Replicas, -1)).To(BeNumerically("==", expectedPods))
+			Expect(
+				mockClient.Get(context.TODO(), ctrlClient.ObjectKey{Name: "unicorn"}, replicaSet),
+			).NotTo(HaveOccurred())
+			Expect(
+				pointer.Int32Deref(replicaSet.Spec.Replicas, -1),
+			).To(BeNumerically("==", expectedPods))
 			Expect(replicaSet.Labels).To(HaveKeyWithValue("test", "success"))
 		})
 	})
@@ -582,11 +659,15 @@ var _ = Describe("[mock client]", func() {
 				return nil
 			}
 
-			mockClient = NewMockClientWithHooks(scheme.Scheme, []func(ctx context.Context, client *MockClient, object ctrlClient.Object) error{
-				createHook,
-			}, []func(ctx context.Context, client *MockClient, object ctrlClient.Object) error{
-				updateHook,
-			})
+			mockClient = NewMockClientWithHooks(
+				scheme.Scheme,
+				[]func(ctx context.Context, client *MockClient, object ctrlClient.Object) error{
+					createHook,
+				},
+				[]func(ctx context.Context, client *MockClient, object ctrlClient.Object) error{
+					updateHook,
+				},
+			)
 
 			replicaSet := &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -609,8 +690,12 @@ var _ = Describe("[mock client]", func() {
 
 			// Ensure the label is update
 			replicaSet := &appsv1.ReplicaSet{}
-			Expect(mockClient.Get(context.TODO(), ctrlClient.ObjectKey{Name: "unicorn"}, replicaSet)).NotTo(HaveOccurred())
-			Expect(pointer.Int32Deref(replicaSet.Spec.Replicas, -1)).To(BeNumerically("==", expectedPods+additionalPods))
+			Expect(
+				mockClient.Get(context.TODO(), ctrlClient.ObjectKey{Name: "unicorn"}, replicaSet),
+			).NotTo(HaveOccurred())
+			Expect(
+				pointer.Int32Deref(replicaSet.Spec.Replicas, -1),
+			).To(BeNumerically("==", expectedPods+additionalPods))
 			Expect(replicaSet.Labels).To(HaveKeyWithValue("test", "success"))
 		})
 	})

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -88,7 +88,11 @@ type AdminClient interface {
 	GetBackupStatus() (*fdbv1beta2.FoundationDBLiveBackupStatus, error)
 
 	// StartRestore starts a new restore.
-	StartRestore(url string, keyRanges []fdbv1beta2.FoundationDBKeyRange, encyptionKeyPath string) error
+	StartRestore(
+		url string,
+		keyRanges []fdbv1beta2.FoundationDBKeyRange,
+		encyptionKeyPath string,
+	) error
 
 	// GetRestoreStatus gets the status of the current restore.
 	GetRestoreStatus() (string, error)

--- a/pkg/fdbadminclient/database_provider.go
+++ b/pkg/fdbadminclient/database_provider.go
@@ -34,13 +34,23 @@ type DatabaseClientProvider interface {
 
 	// GetLockClientWithLogger generates a client for working with locks through the database.
 	// The provided logger will be used as logger for the LockClient.
-	GetLockClientWithLogger(cluster *fdbv1beta2.FoundationDBCluster, logger logr.Logger) (LockClient, error)
+	GetLockClientWithLogger(
+		cluster *fdbv1beta2.FoundationDBCluster,
+		logger logr.Logger,
+	) (LockClient, error)
 
 	// GetAdminClient generates a client for performing administrative actions
 	// against the database.
-	GetAdminClient(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client) (AdminClient, error)
+	GetAdminClient(
+		cluster *fdbv1beta2.FoundationDBCluster,
+		kubernetesClient client.Client,
+	) (AdminClient, error)
 
 	// GetAdminClientWithLogger generates a client for performing administrative actions
 	// against the database. The provided logger will be used as logger for the AdminClient.
-	GetAdminClientWithLogger(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client, logger logr.Logger) (AdminClient, error)
+	GetAdminClientWithLogger(
+		cluster *fdbv1beta2.FoundationDBCluster,
+		kubernetesClient client.Client,
+		logger logr.Logger,
+	) (AdminClient, error)
 }

--- a/pkg/fdbadminclient/lock_client.go
+++ b/pkg/fdbadminclient/lock_client.go
@@ -38,7 +38,10 @@ type LockClient interface {
 
 	// AddPendingUpgrades registers information about which process groups are
 	// pending an upgrade to a new version.
-	AddPendingUpgrades(version fdbv1beta2.Version, processGroupIDs []fdbv1beta2.ProcessGroupID) error
+	AddPendingUpgrades(
+		version fdbv1beta2.Version,
+		processGroupIDs []fdbv1beta2.ProcessGroupID,
+	) error
 
 	// GetPendingUpgrades returns the stored information about which process
 	// groups are pending an upgrade to a new version.

--- a/pkg/fdbadminclient/mock/admin_client_mock_test.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock_test.go
@@ -56,9 +56,13 @@ var _ = Describe("mock_client", func() {
 							Name:      processGroup.GetPodName(input.cluster),
 							Namespace: input.cluster.GetNamespace(),
 							Labels: map[string]string{
-								fdbv1beta2.FDBClusterLabel:        input.cluster.Name,
-								fdbv1beta2.FDBProcessGroupIDLabel: string(processGroup.ProcessGroupID),
-								fdbv1beta2.FDBProcessClassLabel:   string(processGroup.ProcessClass),
+								fdbv1beta2.FDBClusterLabel: input.cluster.Name,
+								fdbv1beta2.FDBProcessGroupIDLabel: string(
+									processGroup.ProcessGroupID,
+								),
+								fdbv1beta2.FDBProcessClassLabel: string(
+									processGroup.ProcessClass,
+								),
 							},
 						},
 						Status: corev1.PodStatus{
@@ -74,7 +78,13 @@ var _ = Describe("mock_client", func() {
 				status, err := admin.GetStatus()
 				Expect(err).NotTo(HaveOccurred())
 
-				remaining, err := removals.GetRemainingMap(GinkgoLogr, admin, input.cluster, status, 0)
+				remaining, err := removals.GetRemainingMap(
+					GinkgoLogr,
+					admin,
+					input.cluster,
+					status,
+					0,
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(remaining).To(Equal(input.remaining))
@@ -230,7 +240,10 @@ var _ = Describe("mock_client", func() {
 				processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{}
 			}
 			config := processes[fdbv1beta2.ProcessClassGeneral]
-			config.CustomParameters = append(config.CustomParameters, fdbv1beta2.FoundationDBCustomParameter(newKnob))
+			config.CustomParameters = append(
+				config.CustomParameters,
+				fdbv1beta2.FoundationDBCustomParameter(newKnob),
+			)
 			processes[fdbv1beta2.ProcessClassGeneral] = config
 			cluster.Spec.Processes = processes
 			adminClient.Cluster = cluster
@@ -248,7 +261,9 @@ var _ = Describe("mock_client", func() {
 
 		When("the process is restarted", func() {
 			It("should update the command line arguments", func() {
-				Expect(adminClient.KillProcesses([]fdbv1beta2.ProcessAddress{processAddress})).NotTo(HaveOccurred())
+				Expect(
+					adminClient.KillProcesses([]fdbv1beta2.ProcessAddress{processAddress}),
+				).NotTo(HaveOccurred())
 				Expect(adminClient.KilledAddresses).To(HaveLen(1))
 				status, err := adminClient.GetStatus()
 				Expect(err).NotTo(HaveOccurred())
@@ -355,27 +370,42 @@ var _ = Describe("mock_client", func() {
 			When("adding a pending for removal", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					It("should add the process group to the map", func() {
-						Expect(adminClient.pendingForRemoval).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
+						Expect(
+							adminClient.pendingForRemoval,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
 					})
 				})
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					BeforeEach(func() {
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
 					It("should add the process group to the map", func() {
 						Expect(adminClient.pendingForRemoval).To(HaveLen(1))
-						Expect(adminClient.pendingForRemoval).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							adminClient.pendingForRemoval,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
 					})
 				})
 			})
@@ -383,7 +413,9 @@ var _ = Describe("mock_client", func() {
 			When("removing a pending for removal", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionDelete}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionDelete,
+						}
 					})
 
 					It("shouldn't change the map", func() {
@@ -393,8 +425,17 @@ var _ = Describe("mock_client", func() {
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionDelete}
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionDelete,
+						}
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
@@ -406,7 +447,9 @@ var _ = Describe("mock_client", func() {
 
 					When("the process group is in the map", func() {
 						BeforeEach(func() {
-							adminClient.pendingForRemoval = map[fdbv1beta2.ProcessGroupID]time.Time{"storage-1": {}}
+							adminClient.pendingForRemoval = map[fdbv1beta2.ProcessGroupID]time.Time{
+								"storage-1": {},
+							}
 						})
 
 						It("should not remove the process group from the map", func() {
@@ -427,27 +470,42 @@ var _ = Describe("mock_client", func() {
 			When("adding a pending for exclusion", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					It("should add the process group to the map", func() {
-						Expect(adminClient.pendingForExclusion).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
+						Expect(
+							adminClient.pendingForExclusion,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
 					})
 				})
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					BeforeEach(func() {
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
 					It("should add the process group to the map", func() {
 						Expect(adminClient.pendingForExclusion).To(HaveLen(1))
-						Expect(adminClient.pendingForExclusion).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							adminClient.pendingForExclusion,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
 					})
 				})
 			})
@@ -455,7 +513,9 @@ var _ = Describe("mock_client", func() {
 			When("removing a pending for exclusion", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionDelete}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionDelete,
+						}
 					})
 
 					It("shouldn't change the map", func() {
@@ -465,8 +525,17 @@ var _ = Describe("mock_client", func() {
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionDelete}
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionDelete,
+						}
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
@@ -478,7 +547,9 @@ var _ = Describe("mock_client", func() {
 
 					When("the process group is in the map", func() {
 						BeforeEach(func() {
-							adminClient.pendingForExclusion = map[fdbv1beta2.ProcessGroupID]time.Time{"storage-1": {}}
+							adminClient.pendingForExclusion = map[fdbv1beta2.ProcessGroupID]time.Time{
+								"storage-1": {},
+							}
 						})
 
 						It("should not remove the process group from the map", func() {
@@ -499,27 +570,42 @@ var _ = Describe("mock_client", func() {
 			When("adding a pending for inclusion", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					It("should add the process group to the map", func() {
-						Expect(adminClient.pendingForInclusion).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
+						Expect(
+							adminClient.pendingForInclusion,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
 					})
 				})
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					BeforeEach(func() {
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
 					It("should add the process group to the map", func() {
 						Expect(adminClient.pendingForInclusion).To(HaveLen(1))
-						Expect(adminClient.pendingForInclusion).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							adminClient.pendingForInclusion,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
 					})
 				})
 			})
@@ -527,7 +613,9 @@ var _ = Describe("mock_client", func() {
 			When("removing a pending for inclusion", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionDelete}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionDelete,
+						}
 					})
 
 					It("shouldn't change the map", func() {
@@ -537,8 +625,17 @@ var _ = Describe("mock_client", func() {
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionDelete}
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionDelete,
+						}
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
@@ -550,7 +647,9 @@ var _ = Describe("mock_client", func() {
 
 					When("the process group is in the map", func() {
 						BeforeEach(func() {
-							adminClient.pendingForInclusion = map[fdbv1beta2.ProcessGroupID]time.Time{"storage-1": {}}
+							adminClient.pendingForInclusion = map[fdbv1beta2.ProcessGroupID]time.Time{
+								"storage-1": {},
+							}
 						})
 
 						It("should not remove the process group from the map", func() {
@@ -571,27 +670,42 @@ var _ = Describe("mock_client", func() {
 			When("adding a pending for restart", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					It("should add the process group to the map", func() {
-						Expect(adminClient.pendingForRestart).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
+						Expect(
+							adminClient.pendingForRestart,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
 					})
 				})
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					BeforeEach(func() {
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
 					It("should add the process group to the map", func() {
 						Expect(adminClient.pendingForRestart).To(HaveLen(1))
-						Expect(adminClient.pendingForRestart).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							adminClient.pendingForRestart,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
 					})
 				})
 			})
@@ -599,7 +713,9 @@ var _ = Describe("mock_client", func() {
 			When("removing a pending for restart", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionDelete}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionDelete,
+						}
 					})
 
 					It("shouldn't change the map", func() {
@@ -609,8 +725,17 @@ var _ = Describe("mock_client", func() {
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionDelete}
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionDelete,
+						}
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
@@ -622,7 +747,9 @@ var _ = Describe("mock_client", func() {
 
 					When("the process group is in the map", func() {
 						BeforeEach(func() {
-							adminClient.pendingForRestart = map[fdbv1beta2.ProcessGroupID]time.Time{"storage-1": {}}
+							adminClient.pendingForRestart = map[fdbv1beta2.ProcessGroupID]time.Time{
+								"storage-1": {},
+							}
 						})
 
 						It("should not remove the process group from the map", func() {
@@ -643,27 +770,42 @@ var _ = Describe("mock_client", func() {
 			When("adding a ready for exclusion", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					It("should add the process group to the map", func() {
-						Expect(adminClient.readyForExclusion).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
+						Expect(
+							adminClient.readyForExclusion,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
 					})
 				})
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					BeforeEach(func() {
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
 					It("should add the process group to the map", func() {
 						Expect(adminClient.readyForExclusion).To(HaveLen(1))
-						Expect(adminClient.readyForExclusion).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							adminClient.readyForExclusion,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
 					})
 				})
 			})
@@ -671,7 +813,9 @@ var _ = Describe("mock_client", func() {
 			When("removing a ready for exclusion", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionDelete}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionDelete,
+						}
 					})
 
 					It("shouldn't change the map", func() {
@@ -681,8 +825,17 @@ var _ = Describe("mock_client", func() {
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionDelete}
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionDelete,
+						}
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
@@ -694,7 +847,9 @@ var _ = Describe("mock_client", func() {
 
 					When("the process group is in the map", func() {
 						BeforeEach(func() {
-							adminClient.readyForExclusion = map[fdbv1beta2.ProcessGroupID]time.Time{"storage-1": {}}
+							adminClient.readyForExclusion = map[fdbv1beta2.ProcessGroupID]time.Time{
+								"storage-1": {},
+							}
 						})
 
 						It("should remove the process group from the map", func() {
@@ -715,27 +870,42 @@ var _ = Describe("mock_client", func() {
 			When("adding a ready for inclusion", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					It("should add the process group to the map", func() {
-						Expect(adminClient.readyForInclusion).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
+						Expect(
+							adminClient.readyForInclusion,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
 					})
 				})
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					BeforeEach(func() {
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
 					It("should add the process group to the map", func() {
 						Expect(adminClient.readyForInclusion).To(HaveLen(1))
-						Expect(adminClient.readyForInclusion).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							adminClient.readyForInclusion,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
 					})
 				})
 			})
@@ -743,7 +913,9 @@ var _ = Describe("mock_client", func() {
 			When("removing a ready for inclusion", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionDelete}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionDelete,
+						}
 					})
 
 					It("shouldn't change map", func() {
@@ -753,8 +925,17 @@ var _ = Describe("mock_client", func() {
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionDelete}
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionDelete,
+						}
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
@@ -766,7 +947,9 @@ var _ = Describe("mock_client", func() {
 
 					When("the process group is in the map", func() {
 						BeforeEach(func() {
-							adminClient.readyForInclusion = map[fdbv1beta2.ProcessGroupID]time.Time{"storage-1": {}}
+							adminClient.readyForInclusion = map[fdbv1beta2.ProcessGroupID]time.Time{
+								"storage-1": {},
+							}
 						})
 
 						It("should not remove the process group from the map", func() {
@@ -787,27 +970,42 @@ var _ = Describe("mock_client", func() {
 			When("adding a ready for restart", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					It("should add the process group to the map", func() {
-						Expect(adminClient.readyForRestart).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
+						Expect(
+							adminClient.readyForRestart,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("doesntExist")))
 					})
 				})
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionAdd}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionAdd,
+						}
 					})
 
 					BeforeEach(func() {
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
 					It("should add the process group to the map", func() {
 						Expect(adminClient.readyForRestart).To(HaveLen(1))
-						Expect(adminClient.readyForRestart).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
+						Expect(
+							adminClient.readyForRestart,
+						).To(HaveKey(fdbv1beta2.ProcessGroupID("storage-1")))
 					})
 				})
 			})
@@ -815,7 +1013,9 @@ var _ = Describe("mock_client", func() {
 			When("removing a ready for restart", func() {
 				When("the process group doesn't exist", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"doesntExist": fdbv1beta2.UpdateActionDelete}
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"doesntExist": fdbv1beta2.UpdateActionDelete,
+						}
 					})
 
 					It("should not add the process group to the map", func() {
@@ -825,8 +1025,17 @@ var _ = Describe("mock_client", func() {
 
 				When("the process group exists", func() {
 					BeforeEach(func() {
-						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{"storage-1": fdbv1beta2.UpdateActionDelete}
-						cluster.Status.ProcessGroups = append(cluster.Status.ProcessGroups, fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}))
+						updates = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction{
+							"storage-1": fdbv1beta2.UpdateActionDelete,
+						}
+						cluster.Status.ProcessGroups = append(
+							cluster.Status.ProcessGroups,
+							fdbv1beta2.NewProcessGroupStatus(
+								"storage-1",
+								fdbv1beta2.ProcessClassStorage,
+								[]string{"192.168.0.2"},
+							),
+						)
 						adminClient.Cluster = cluster
 					})
 
@@ -838,7 +1047,9 @@ var _ = Describe("mock_client", func() {
 
 					When("the process group is in the map", func() {
 						BeforeEach(func() {
-							adminClient.readyForRestart = map[fdbv1beta2.ProcessGroupID]time.Time{"storage-1": {}}
+							adminClient.readyForRestart = map[fdbv1beta2.ProcessGroupID]time.Time{
+								"storage-1": {},
+							}
 						})
 
 						It("should not remove the process group from the map", func() {
@@ -1043,9 +1254,18 @@ var _ = Describe("mock_client", func() {
 						"storage-1":        {},
 						"prefix-storage-1": {},
 					}
-					adminClient.Cluster.Status.ProcessGroups = append(adminClient.Cluster.Status.ProcessGroups,
-						fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}),
-						fdbv1beta2.NewProcessGroupStatus("prefix-storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.3"}),
+					adminClient.Cluster.Status.ProcessGroups = append(
+						adminClient.Cluster.Status.ProcessGroups,
+						fdbv1beta2.NewProcessGroupStatus(
+							"storage-1",
+							fdbv1beta2.ProcessClassStorage,
+							[]string{"192.168.0.2"},
+						),
+						fdbv1beta2.NewProcessGroupStatus(
+							"prefix-storage-1",
+							fdbv1beta2.ProcessClassStorage,
+							[]string{"192.168.0.3"},
+						),
 					)
 				})
 
@@ -1090,9 +1310,18 @@ var _ = Describe("mock_client", func() {
 						"storage-1":        {},
 						"prefix-storage-1": {},
 					}
-					adminClient.Cluster.Status.ProcessGroups = append(adminClient.Cluster.Status.ProcessGroups,
-						fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}),
-						fdbv1beta2.NewProcessGroupStatus("prefix-storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.3"}),
+					adminClient.Cluster.Status.ProcessGroups = append(
+						adminClient.Cluster.Status.ProcessGroups,
+						fdbv1beta2.NewProcessGroupStatus(
+							"storage-1",
+							fdbv1beta2.ProcessClassStorage,
+							[]string{"192.168.0.2"},
+						),
+						fdbv1beta2.NewProcessGroupStatus(
+							"prefix-storage-1",
+							fdbv1beta2.ProcessClassStorage,
+							[]string{"192.168.0.3"},
+						),
 					)
 				})
 
@@ -1137,9 +1366,18 @@ var _ = Describe("mock_client", func() {
 						"storage-1":        {},
 						"prefix-storage-1": {},
 					}
-					adminClient.Cluster.Status.ProcessGroups = append(adminClient.Cluster.Status.ProcessGroups,
-						fdbv1beta2.NewProcessGroupStatus("storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.2"}),
-						fdbv1beta2.NewProcessGroupStatus("prefix-storage-1", fdbv1beta2.ProcessClassStorage, []string{"192.168.0.3"}),
+					adminClient.Cluster.Status.ProcessGroups = append(
+						adminClient.Cluster.Status.ProcessGroups,
+						fdbv1beta2.NewProcessGroupStatus(
+							"storage-1",
+							fdbv1beta2.ProcessClassStorage,
+							[]string{"192.168.0.2"},
+						),
+						fdbv1beta2.NewProcessGroupStatus(
+							"prefix-storage-1",
+							fdbv1beta2.ProcessClassStorage,
+							[]string{"192.168.0.3"},
+						),
 					)
 				})
 
@@ -1164,7 +1402,10 @@ var _ = Describe("mock_client", func() {
 	})
 })
 
-func getCommandlineForProcessFromStatus(status *fdbv1beta2.FoundationDBStatus, targetProcess string) string {
+func getCommandlineForProcessFromStatus(
+	status *fdbv1beta2.FoundationDBStatus,
+	targetProcess string,
+) string {
 	for _, process := range status.Cluster.Processes {
 		if process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey] != targetProcess {
 			continue

--- a/pkg/fdbadminclient/mock/database_provider.go
+++ b/pkg/fdbadminclient/mock/database_provider.go
@@ -31,24 +31,36 @@ import (
 type DatabaseClientProvider struct{}
 
 // GetLockClient generates a client for working with locks through the database.
-func (p DatabaseClientProvider) GetLockClient(cluster *fdbv1beta2.FoundationDBCluster) (fdbadminclient.LockClient, error) {
+func (p DatabaseClientProvider) GetLockClient(
+	cluster *fdbv1beta2.FoundationDBCluster,
+) (fdbadminclient.LockClient, error) {
 	return NewMockLockClient(cluster)
 }
 
 // GetLockClientWithLogger generates a client for working with locks through the database.
 // The provided logger will be used as logger for the LockClient.
-func (p DatabaseClientProvider) GetLockClientWithLogger(cluster *fdbv1beta2.FoundationDBCluster, _ logr.Logger) (fdbadminclient.LockClient, error) {
+func (p DatabaseClientProvider) GetLockClientWithLogger(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	_ logr.Logger,
+) (fdbadminclient.LockClient, error) {
 	return NewMockLockClient(cluster)
 }
 
 // GetAdminClient generates a client for performing administrative actions
 // against the database.
-func (p DatabaseClientProvider) GetAdminClient(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client) (fdbadminclient.AdminClient, error) {
+func (p DatabaseClientProvider) GetAdminClient(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	kubernetesClient client.Client,
+) (fdbadminclient.AdminClient, error) {
 	return NewMockAdminClient(cluster, kubernetesClient)
 }
 
 // GetAdminClientWithLogger generates a client for performing administrative actions
 // against the database.
-func (p DatabaseClientProvider) GetAdminClientWithLogger(cluster *fdbv1beta2.FoundationDBCluster, kubernetesClient client.Client, _ logr.Logger) (fdbadminclient.AdminClient, error) {
+func (p DatabaseClientProvider) GetAdminClientWithLogger(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	kubernetesClient client.Client,
+	_ logr.Logger,
+) (fdbadminclient.AdminClient, error) {
 	return NewMockAdminClient(cluster, kubernetesClient)
 }

--- a/pkg/fdbadminclient/mock/lock_client.go
+++ b/pkg/fdbadminclient/mock/lock_client.go
@@ -56,7 +56,10 @@ func (client *LockClient) Disabled() bool {
 
 // AddPendingUpgrades registers information about which process groups are
 // pending an upgrade to a new version.
-func (client *LockClient) AddPendingUpgrades(version fdbv1beta2.Version, processGroupIDs []fdbv1beta2.ProcessGroupID) error {
+func (client *LockClient) AddPendingUpgrades(
+	version fdbv1beta2.Version,
+	processGroupIDs []fdbv1beta2.ProcessGroupID,
+) error {
 	if client.pendingUpgrades[version] == nil {
 		client.pendingUpgrades[version] = make(map[fdbv1beta2.ProcessGroupID]bool)
 	}
@@ -68,7 +71,9 @@ func (client *LockClient) AddPendingUpgrades(version fdbv1beta2.Version, process
 
 // GetPendingUpgrades returns the stored information about which process
 // groups are pending an upgrade to a new version.
-func (client *LockClient) GetPendingUpgrades(version fdbv1beta2.Version) (map[fdbv1beta2.ProcessGroupID]bool, error) {
+func (client *LockClient) GetPendingUpgrades(
+	version fdbv1beta2.Version,
+) (map[fdbv1beta2.ProcessGroupID]bool, error) {
 	upgrades := client.pendingUpgrades[version]
 	if upgrades == nil {
 		return make(map[fdbv1beta2.ProcessGroupID]bool), nil
@@ -131,7 +136,10 @@ func NewMockLockClientUncast(cluster *fdbv1beta2.FoundationDBCluster) *LockClien
 
 	client := lockClientCache[cluster.Name]
 	if client == nil {
-		client = &LockClient{cluster: cluster, pendingUpgrades: make(map[fdbv1beta2.Version]map[fdbv1beta2.ProcessGroupID]bool)}
+		client = &LockClient{
+			cluster:         cluster,
+			pendingUpgrades: make(map[fdbv1beta2.Version]map[fdbv1beta2.ProcessGroupID]bool),
+		}
 		lockClientCache[cluster.Name] = client
 	}
 	return client

--- a/pkg/fdbadminclient/mock/lock_client_test.go
+++ b/pkg/fdbadminclient/mock/lock_client_test.go
@@ -46,16 +46,27 @@ var _ = Describe("lock_client_test", func() {
 
 	Describe("AddPendingUpgrades", func() {
 		It("adds the upgrades to the map", func() {
-			err = lockClient.AddPendingUpgrades(fdbv1beta2.Versions.Default, []fdbv1beta2.ProcessGroupID{"storage-1", "storage-2"})
+			err = lockClient.AddPendingUpgrades(
+				fdbv1beta2.Versions.Default,
+				[]fdbv1beta2.ProcessGroupID{"storage-1", "storage-2"},
+			)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = lockClient.AddPendingUpgrades(fdbv1beta2.Versions.Default, []fdbv1beta2.ProcessGroupID{"storage-3"})
+			err = lockClient.AddPendingUpgrades(
+				fdbv1beta2.Versions.Default,
+				[]fdbv1beta2.ProcessGroupID{"storage-3"},
+			)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = lockClient.AddPendingUpgrades(fdbv1beta2.Versions.NextMajorVersion, []fdbv1beta2.ProcessGroupID{"storage-3", "storage-4"})
+			err = lockClient.AddPendingUpgrades(
+				fdbv1beta2.Versions.NextMajorVersion,
+				[]fdbv1beta2.ProcessGroupID{"storage-3", "storage-4"},
+			)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(lockClient.pendingUpgrades).To(Equal(map[fdbv1beta2.Version]map[fdbv1beta2.ProcessGroupID]bool{
+			Expect(
+				lockClient.pendingUpgrades,
+			).To(Equal(map[fdbv1beta2.Version]map[fdbv1beta2.ProcessGroupID]bool{
 				fdbv1beta2.Versions.Default: {
 					"storage-1": true,
 					"storage-2": true,

--- a/pkg/fdbstatus/status_checks_test.go
+++ b/pkg/fdbstatus/status_checks_test.go
@@ -82,7 +82,8 @@ var _ = Describe("status_checks", func() {
 				},
 			},
 		}
-		DescribeTable("fetching the excluded and remaining processes from the status",
+		DescribeTable(
+			"fetching the excluded and remaining processes from the status",
 			func(status *fdbv1beta2.FoundationDBStatus,
 				addresses []fdbv1beta2.ProcessAddress,
 				expectedInProgress []fdbv1beta2.ProcessAddress,
@@ -432,7 +433,8 @@ var _ = Describe("status_checks", func() {
 				nil,
 				nil,
 			),
-			Entry("when the machine-readable status contains the \"unreadable_configuration\" message",
+			Entry(
+				"when the machine-readable status contains the \"unreadable_configuration\" message",
 				&fdbv1beta2.FoundationDBStatus{
 					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
 						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
@@ -478,7 +480,8 @@ var _ = Describe("status_checks", func() {
 				nil,
 				nil,
 			),
-			Entry("when the machine-readable status contains the \"full_replication_timeout\" message",
+			Entry(
+				"when the machine-readable status contains the \"full_replication_timeout\" message",
 				&fdbv1beta2.FoundationDBStatus{
 					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
 						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
@@ -570,44 +573,80 @@ var _ = Describe("status_checks", func() {
 				nil,
 				nil,
 			),
-			Entry("when the process is excluded and locality based exclusions are used",
+			Entry(
+				"when the process is excluded and locality based exclusions are used",
 				status,
-				[]fdbv1beta2.ProcessAddress{fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil)},
-				[]fdbv1beta2.ProcessAddress{fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil)},
+				[]fdbv1beta2.ProcessAddress{
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil),
+				},
+				[]fdbv1beta2.ProcessAddress{
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil),
+				},
 				nil,
 				nil,
 				nil,
 			),
-			Entry("when the process is not excluded and locality based exclusions are used",
+			Entry(
+				"when the process is not excluded and locality based exclusions are used",
 				status,
-				[]fdbv1beta2.ProcessAddress{fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil)},
+				[]fdbv1beta2.ProcessAddress{
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil),
+				},
 				nil,
-				[]fdbv1beta2.ProcessAddress{fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil)},
+				[]fdbv1beta2.ProcessAddress{
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil),
+				},
 				nil,
 				nil,
 			),
-			Entry("when the process is excluded and locality based exclusions are used and an IP address is provided",
+			Entry(
+				"when the process is excluded and locality based exclusions are used and an IP address is provided",
 				status,
-				[]fdbv1beta2.ProcessAddress{fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil), addr4},
-				[]fdbv1beta2.ProcessAddress{fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil), addr4},
+				[]fdbv1beta2.ProcessAddress{
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil),
+					addr4,
+				},
+				[]fdbv1beta2.ProcessAddress{
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil),
+					addr4,
+				},
 				nil,
 				nil,
 				nil,
 			),
-			Entry("when the process is not excluded and locality based exclusions are use and an IP address is provided",
+			Entry(
+				"when the process is not excluded and locality based exclusions are use and an IP address is provided",
 				status,
-				[]fdbv1beta2.ProcessAddress{fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil), addr3},
+				[]fdbv1beta2.ProcessAddress{
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil),
+					addr3,
+				},
 				nil,
-				[]fdbv1beta2.ProcessAddress{fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil), addr3},
+				[]fdbv1beta2.ProcessAddress{
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil),
+					addr3,
+				},
 				nil,
 				nil,
 			),
 
-			Entry("when one process is not excluded, one process is excluded and locality based exclusions are use and an IP address is provided",
+			Entry(
+				"when one process is not excluded, one process is excluded and locality based exclusions are use and an IP address is provided",
 				status,
-				[]fdbv1beta2.ProcessAddress{fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil), addr3, fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil), addr4},
-				[]fdbv1beta2.ProcessAddress{fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil), addr4},
-				[]fdbv1beta2.ProcessAddress{fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil), addr3},
+				[]fdbv1beta2.ProcessAddress{
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil),
+					addr3,
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil),
+					addr4,
+				},
+				[]fdbv1beta2.ProcessAddress{
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:4", 0, nil),
+					addr4,
+				},
+				[]fdbv1beta2.ProcessAddress{
+					fdbv1beta2.NewProcessAddress(net.IP{}, "locality_instance_id:3", 0, nil),
+					addr3,
+				},
 				nil,
 				nil,
 			),
@@ -801,15 +840,22 @@ var _ = Describe("status_checks", func() {
 		)
 	})
 
-	DescribeTable("when getting the minimum uptime and the address map", func(cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, useRecoveryState bool, expectedMinimumUptime float64, expectedAddressMap map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.ProcessAddress) {
-		minimumUptime, addressMap, err := GetMinimumUptimeAndAddressMap(logr.Discard(), cluster, status, useRecoveryState)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(minimumUptime).To(BeNumerically("==", expectedMinimumUptime))
-		Expect(len(addressMap)).To(BeNumerically("==", len(expectedAddressMap)))
-		for key, value := range expectedAddressMap {
-			Expect(addressMap).To(HaveKeyWithValue(key, value))
-		}
-	},
+	DescribeTable(
+		"when getting the minimum uptime and the address map",
+		func(cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, useRecoveryState bool, expectedMinimumUptime float64, expectedAddressMap map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.ProcessAddress) {
+			minimumUptime, addressMap, err := GetMinimumUptimeAndAddressMap(
+				logr.Discard(),
+				cluster,
+				status,
+				useRecoveryState,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(minimumUptime).To(BeNumerically("==", expectedMinimumUptime))
+			Expect(len(addressMap)).To(BeNumerically("==", len(expectedAddressMap)))
+			for key, value := range expectedAddressMap {
+				Expect(addressMap).To(HaveKeyWithValue(key, value))
+			}
+		},
 		Entry("when recovered since is not available",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
@@ -842,12 +888,14 @@ var _ = Describe("status_checks", func() {
 					},
 				},
 			}),
-		Entry("when recovered since is enabled and version supports it, it should use the minimum of recovered since or process uptime",
+		Entry(
+			"when recovered since is enabled and version supports it, it should use the minimum of recovered since or process uptime",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
 					Version: fdbv1beta2.Versions.SupportsRecoveryState.String(),
 				},
-			}, &fdbv1beta2.FoundationDBStatus{
+			},
+			&fdbv1beta2.FoundationDBStatus{
 				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 					Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 						"test": {
@@ -873,7 +921,8 @@ var _ = Describe("status_checks", func() {
 						IPAddress: net.ParseIP("127.0.0.1"),
 					},
 				},
-			}),
+			},
+		),
 		Entry("when recovered since is disabled and version supports it",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
@@ -903,12 +952,14 @@ var _ = Describe("status_checks", func() {
 					},
 				},
 			}),
-		Entry("when recovered since is not available and multiple processes are reporting but one is missing localities",
+		Entry(
+			"when recovered since is not available and multiple processes are reporting but one is missing localities",
 			&fdbv1beta2.FoundationDBCluster{
 				Spec: fdbv1beta2.FoundationDBClusterSpec{
 					Version: fdbv1beta2.Versions.Default.String(),
 				},
-			}, &fdbv1beta2.FoundationDBStatus{
+			},
+			&fdbv1beta2.FoundationDBStatus{
 				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 					Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
 						"test": {
@@ -940,7 +991,8 @@ var _ = Describe("status_checks", func() {
 						IPAddress: net.ParseIP("127.0.0.1"),
 					},
 				},
-			}),
+			},
+		),
 	)
 
 	Context("fault domain checks on status object", func() {
@@ -967,7 +1019,12 @@ var _ = Describe("status_checks", func() {
 							TeamTrackers: []fdbv1beta2.FoundationDBStatusTeamTracker{
 								{
 									Primary: true,
-									State:   fdbv1beta2.FoundationDBStatusDataState{Description: "", Healthy: true, Name: "healthy", MinReplicasRemaining: 4},
+									State: fdbv1beta2.FoundationDBStatusDataState{
+										Description:          "",
+										Healthy:              true,
+										Name:                 "healthy",
+										MinReplicasRemaining: 4,
+									},
 								},
 							},
 						},
@@ -983,11 +1040,21 @@ var _ = Describe("status_checks", func() {
 							TeamTrackers: []fdbv1beta2.FoundationDBStatusTeamTracker{
 								{
 									Primary: true,
-									State:   fdbv1beta2.FoundationDBStatusDataState{Description: "", Healthy: false, Name: "healthy", MinReplicasRemaining: 4},
+									State: fdbv1beta2.FoundationDBStatusDataState{
+										Description:          "",
+										Healthy:              false,
+										Name:                 "healthy",
+										MinReplicasRemaining: 4,
+									},
 								},
 								{
 									Primary: false,
-									State:   fdbv1beta2.FoundationDBStatusDataState{Description: "", Healthy: true, Name: "healthy", MinReplicasRemaining: 0},
+									State: fdbv1beta2.FoundationDBStatusDataState{
+										Description:          "",
+										Healthy:              true,
+										Name:                 "healthy",
+										MinReplicasRemaining: 0,
+									},
 								},
 							},
 						},
@@ -1005,11 +1072,21 @@ var _ = Describe("status_checks", func() {
 							TeamTrackers: []fdbv1beta2.FoundationDBStatusTeamTracker{
 								{
 									Primary: true,
-									State:   fdbv1beta2.FoundationDBStatusDataState{Description: "", Healthy: true, Name: "healthy", MinReplicasRemaining: 4},
+									State: fdbv1beta2.FoundationDBStatusDataState{
+										Description:          "",
+										Healthy:              true,
+										Name:                 "healthy",
+										MinReplicasRemaining: 4,
+									},
 								},
 								{
 									Primary: false,
-									State:   fdbv1beta2.FoundationDBStatusDataState{Description: "", Healthy: false, Name: "healthy", MinReplicasRemaining: 0},
+									State: fdbv1beta2.FoundationDBStatusDataState{
+										Description:          "",
+										Healthy:              false,
+										Name:                 "healthy",
+										MinReplicasRemaining: 0,
+									},
 								},
 							},
 						},
@@ -1073,7 +1150,9 @@ var _ = Describe("status_checks", func() {
 
 				err := DoLogServerFaultDomainCheckOnStatus(status)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("primary log fault tolerance is not satisfied, replication factor: 2, current fault tolerance: 0"))
+				Expect(
+					err.Error(),
+				).To(Equal("primary log fault tolerance is not satisfied, replication factor: 2, current fault tolerance: 0"))
 			})
 
 			It("not enough replicas in remote", func() {
@@ -1095,7 +1174,9 @@ var _ = Describe("status_checks", func() {
 
 				err := DoLogServerFaultDomainCheckOnStatus(status)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("remote log fault tolerance is not satisfied, replication factor: 4, current fault tolerance: 1"))
+				Expect(
+					err.Error(),
+				).To(Equal("remote log fault tolerance is not satisfied, replication factor: 4, current fault tolerance: 1"))
 			})
 
 			It("not enough replicas in the satellite", func() {
@@ -1117,7 +1198,9 @@ var _ = Describe("status_checks", func() {
 
 				err := DoLogServerFaultDomainCheckOnStatus(status)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("satellite log fault tolerance is not satisfied, replication factor: 4, current fault tolerance: 1"))
+				Expect(
+					err.Error(),
+				).To(Equal("satellite log fault tolerance is not satisfied, replication factor: 4, current fault tolerance: 1"))
 			})
 
 			It("multiple log server sets", func() {
@@ -1212,7 +1295,9 @@ var _ = Describe("status_checks", func() {
 				It("should report an error", func() {
 					err := DoCoordinatorFaultDomainCheckOnStatus(status)
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring(status.Client.Coordinators.Coordinators[0].Address.String()))
+					Expect(
+						err.Error(),
+					).To(ContainSubstring(status.Client.Coordinators.Coordinators[0].Address.String()))
 				})
 			})
 
@@ -1225,7 +1310,9 @@ var _ = Describe("status_checks", func() {
 				It("should report an error", func() {
 					err := DoCoordinatorFaultDomainCheckOnStatus(status)
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(And(ContainSubstring(status.Client.Coordinators.Coordinators[0].Address.String()), ContainSubstring(status.Client.Coordinators.Coordinators[1].Address.String())))
+					Expect(
+						err.Error(),
+					).To(And(ContainSubstring(status.Client.Coordinators.Coordinators[0].Address.String()), ContainSubstring(status.Client.Coordinators.Coordinators[1].Address.String())))
 				})
 			})
 
@@ -1295,11 +1382,21 @@ var _ = Describe("status_checks", func() {
 							TeamTrackers: []fdbv1beta2.FoundationDBStatusTeamTracker{
 								{
 									Primary: true,
-									State:   fdbv1beta2.FoundationDBStatusDataState{Description: "", Healthy: true, Name: "healthy", MinReplicasRemaining: 4},
+									State: fdbv1beta2.FoundationDBStatusDataState{
+										Description:          "",
+										Healthy:              true,
+										Name:                 "healthy",
+										MinReplicasRemaining: 4,
+									},
 								},
 								{
 									Primary: false,
-									State:   fdbv1beta2.FoundationDBStatusDataState{Description: "", Healthy: false, Name: "healthy", MinReplicasRemaining: 0},
+									State: fdbv1beta2.FoundationDBStatusDataState{
+										Description:          "",
+										Healthy:              false,
+										Name:                 "healthy",
+										MinReplicasRemaining: 0,
+									},
 								},
 							},
 						},
@@ -1334,11 +1431,15 @@ var _ = Describe("status_checks", func() {
 			})
 
 			It("do log server fault domain check", func() {
-				Expect(DoFaultDomainChecksOnStatus(status, false, true, false)).NotTo(HaveOccurred())
+				Expect(
+					DoFaultDomainChecksOnStatus(status, false, true, false),
+				).NotTo(HaveOccurred())
 			})
 
 			It("do coordinator fault domain check", func() {
-				Expect(DoFaultDomainChecksOnStatus(status, false, false, true)).NotTo(HaveOccurred())
+				Expect(
+					DoFaultDomainChecksOnStatus(status, false, false, true),
+				).NotTo(HaveOccurred())
 			})
 
 			It("do storage server and log server fault domain checks", func() {
@@ -1358,7 +1459,8 @@ var _ = Describe("status_checks", func() {
 	When("checking if the cluster has the desired fault tolerance from the status", func() {
 		log := logr.New(logf.NullLogSink{})
 
-		DescribeTable("should return if the cluster has the desired fault tolerance",
+		DescribeTable(
+			"should return if the cluster has the desired fault tolerance",
 			func(status *fdbv1beta2.FoundationDBStatus, cluster *fdbv1beta2.FoundationDBCluster, expected bool) {
 				Expect(HasDesiredFaultToleranceFromStatus(log, status, cluster)).To(Equal(expected))
 			},
@@ -1735,7 +1837,8 @@ var _ = Describe("status_checks", func() {
 	})
 
 	When("performing the default safety check.", func() {
-		DescribeTable("should return if the safety check is satisfied or not",
+		DescribeTable(
+			"should return if the safety check is satisfied or not",
 			func(status *fdbv1beta2.FoundationDBStatus, maximumActiveGeneration int, expected error) {
 				err := DefaultSafetyChecks(status, maximumActiveGeneration, "test")
 				if expected == nil {
@@ -1777,7 +1880,8 @@ var _ = Describe("status_checks", func() {
 				1,
 				fmt.Errorf("cluster is unavailable, cannot test"),
 			),
-			Entry("cluster has too many active generations",
+			Entry(
+				"cluster has too many active generations",
 				&fdbv1beta2.FoundationDBStatus{
 					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
 						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
@@ -1791,7 +1895,9 @@ var _ = Describe("status_checks", func() {
 					},
 				},
 				1,
-				fmt.Errorf("cluster has 10 active generations, but only 1 active generations are allowed to safely test"),
+				fmt.Errorf(
+					"cluster has 10 active generations, but only 1 active generations are allowed to safely test",
+				),
 			),
 			Entry("cluster has more than one active generations",
 				&fdbv1beta2.FoundationDBStatus{
@@ -1813,7 +1919,8 @@ var _ = Describe("status_checks", func() {
 	})
 
 	When("performing the exclude safety check.", func() {
-		DescribeTable("should return if the safety check is satisfied or not",
+		DescribeTable(
+			"should return if the safety check is satisfied or not",
 			func(cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, expected error) {
 				err := CanSafelyExcludeProcessesWithRecoveryState(cluster, status, 120.0)
 				if expected == nil {
@@ -1883,7 +1990,8 @@ var _ = Describe("status_checks", func() {
 				},
 				nil,
 			),
-			Entry("cluster has more than one active generations",
+			Entry(
+				"cluster has more than one active generations",
 				&fdbv1beta2.FoundationDBCluster{
 					Status: fdbv1beta2.FoundationDBClusterStatus{
 						RunningVersion: "7.1.20",
@@ -1901,9 +2009,12 @@ var _ = Describe("status_checks", func() {
 						},
 					},
 				},
-				fmt.Errorf("cluster has 11 active generations, but only 10 active generations are allowed to safely exclude processes"),
+				fmt.Errorf(
+					"cluster has 11 active generations, but only 10 active generations are allowed to safely exclude processes",
+				),
 			),
-			Entry("cluster's last recovery is 10 seconds ago",
+			Entry(
+				"cluster's last recovery is 10 seconds ago",
 				&fdbv1beta2.FoundationDBCluster{
 					Status: fdbv1beta2.FoundationDBClusterStatus{
 						RunningVersion: "7.1.57",
@@ -1922,7 +2033,9 @@ var _ = Describe("status_checks", func() {
 						},
 					},
 				},
-				fmt.Errorf("cannot: exclude processes, clusters last recovery was 10.00 seconds ago, wait until the last recovery was 120 seconds ago"),
+				fmt.Errorf(
+					"cannot: exclude processes, clusters last recovery was 10.00 seconds ago, wait until the last recovery was 120 seconds ago",
+				),
 			),
 			Entry("cluster's last recovery is 120 seconds ago",
 				&fdbv1beta2.FoundationDBCluster{
@@ -1949,7 +2062,8 @@ var _ = Describe("status_checks", func() {
 	})
 
 	When("performing the include safety check.", func() {
-		DescribeTable("should return if the safety check is satisfied or not",
+		DescribeTable(
+			"should return if the safety check is satisfied or not",
 			func(cluster *fdbv1beta2.FoundationDBCluster, status *fdbv1beta2.FoundationDBStatus, expected error) {
 				err := CanSafelyIncludeProcesses(cluster, status, 300.0)
 				if expected == nil {
@@ -1980,7 +2094,8 @@ var _ = Describe("status_checks", func() {
 				},
 				nil,
 			),
-			Entry("cluster is not fully reconciled",
+			Entry(
+				"cluster is not fully reconciled",
 				&fdbv1beta2.FoundationDBCluster{
 					Status: fdbv1beta2.FoundationDBClusterStatus{
 						RunningVersion: "7.1.20",
@@ -1999,7 +2114,9 @@ var _ = Describe("status_checks", func() {
 						},
 					},
 				},
-				fmt.Errorf("cannot: include processes, cluster recovery state is recovery_transaction, but it must be \"fully_recovered\" or \"all_logs_recruited\""),
+				fmt.Errorf(
+					"cannot: include processes, cluster recovery state is recovery_transaction, but it must be \"fully_recovered\" or \"all_logs_recruited\"",
+				),
 			),
 			Entry("cluster is unavailable",
 				&fdbv1beta2.FoundationDBCluster{
@@ -2043,7 +2160,8 @@ var _ = Describe("status_checks", func() {
 				},
 				nil,
 			),
-			Entry("cluster has more than ten active generations",
+			Entry(
+				"cluster has more than ten active generations",
 				&fdbv1beta2.FoundationDBCluster{
 					Status: fdbv1beta2.FoundationDBClusterStatus{
 						RunningVersion: "7.1.20",
@@ -2062,9 +2180,12 @@ var _ = Describe("status_checks", func() {
 						},
 					},
 				},
-				fmt.Errorf("cluster has 11 active generations, but only 10 active generations are allowed to safely include processes"),
+				fmt.Errorf(
+					"cluster has 11 active generations, but only 10 active generations are allowed to safely include processes",
+				),
 			),
-			Entry("cluster's last recovery is 10 seconds ago",
+			Entry(
+				"cluster's last recovery is 10 seconds ago",
 				&fdbv1beta2.FoundationDBCluster{
 					Status: fdbv1beta2.FoundationDBClusterStatus{
 						RunningVersion: "7.1.57",
@@ -2084,7 +2205,9 @@ var _ = Describe("status_checks", func() {
 						},
 					},
 				},
-				fmt.Errorf("cannot: include processes, clusters last recovery was 10.00 seconds ago, wait until the last recovery was 300 seconds ago"),
+				fmt.Errorf(
+					"cannot: include processes, clusters last recovery was 10.00 seconds ago, wait until the last recovery was 300 seconds ago",
+				),
 			),
 			Entry("cluster's last recovery is 320 seconds ago",
 				&fdbv1beta2.FoundationDBCluster{
@@ -2112,7 +2235,8 @@ var _ = Describe("status_checks", func() {
 	})
 
 	When("performing the bounce safety check.", func() {
-		DescribeTable("should return if the safety check is satisfied or not",
+		DescribeTable(
+			"should return if the safety check is satisfied or not",
 			func(status *fdbv1beta2.FoundationDBStatus, currentUptime float64, minimumUptime float64, expected error) {
 				err := CanSafelyBounceProcesses(currentUptime, minimumUptime, status)
 				if expected == nil {
@@ -2176,7 +2300,8 @@ var _ = Describe("status_checks", func() {
 				10.0,
 				nil,
 			),
-			Entry("cluster has more than one active generations",
+			Entry(
+				"cluster has more than one active generations",
 				&fdbv1beta2.FoundationDBStatus{
 					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
 						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
@@ -2191,9 +2316,12 @@ var _ = Describe("status_checks", func() {
 				},
 				42.0,
 				10.0,
-				fmt.Errorf("cluster has 11 active generations, but only 10 active generations are allowed to safely bounce processes"),
+				fmt.Errorf(
+					"cluster has 11 active generations, but only 10 active generations are allowed to safely bounce processes",
+				),
 			),
-			Entry("cluster is not up for long enough",
+			Entry(
+				"cluster is not up for long enough",
 				&fdbv1beta2.FoundationDBStatus{
 					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
 						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
@@ -2208,9 +2336,12 @@ var _ = Describe("status_checks", func() {
 				},
 				42.0,
 				60.0,
-				fmt.Errorf("cluster has only been up for 42.00 seconds, but must be up for 60.00 seconds to safely bounce"),
+				fmt.Errorf(
+					"cluster has only been up for 42.00 seconds, but must be up for 60.00 seconds to safely bounce",
+				),
 			),
-			Entry("cluster cannot clean bounce",
+			Entry(
+				"cluster cannot clean bounce",
 				&fdbv1beta2.FoundationDBStatus{
 					Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
 						DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
@@ -2229,21 +2360,25 @@ var _ = Describe("status_checks", func() {
 				},
 				42.0,
 				10.0,
-				fmt.Errorf("cannot perform a clean bounce based on cluster status, current recovery state: exploding"),
+				fmt.Errorf(
+					"cannot perform a clean bounce based on cluster status, current recovery state: exploding",
+				),
 			),
 		)
 	})
 
-	DescribeTable("when testing if a configuration change is allowed", func(status *fdbv1beta2.FoundationDBStatus, useRecoveryState bool, expected error) {
-		err := ConfigurationChangeAllowed(status, useRecoveryState)
-		if expected == nil {
-			Expect(err).NotTo(HaveOccurred())
-			return
-		}
+	DescribeTable(
+		"when testing if a configuration change is allowed",
+		func(status *fdbv1beta2.FoundationDBStatus, useRecoveryState bool, expected error) {
+			err := ConfigurationChangeAllowed(status, useRecoveryState)
+			if expected == nil {
+				Expect(err).NotTo(HaveOccurred())
+				return
+			}
 
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(Equal(expected))
-	},
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(expected))
+		},
 		Entry(
 			"status is healthy",
 			&fdbv1beta2.FoundationDBStatus{
@@ -2310,7 +2445,9 @@ var _ = Describe("status_checks", func() {
 				},
 			},
 			true,
-			fmt.Errorf("clusters last recovery was 5.00 seconds ago, wait until the last recovery was 60 seconds ago"),
+			fmt.Errorf(
+				"clusters last recovery was 5.00 seconds ago, wait until the last recovery was 60 seconds ago",
+			),
 		),
 		Entry(
 			"status contains error message",
@@ -2364,7 +2501,9 @@ var _ = Describe("status_checks", func() {
 				},
 			},
 			true,
-			fmt.Errorf("worst data lag is too high, current worst data lag in seconds: 61.00, maximum allowed lag:  60.00"),
+			fmt.Errorf(
+				"worst data lag is too high, current worst data lag in seconds: 61.00, maximum allowed lag:  60.00",
+			),
 		),
 	)
 
@@ -2380,14 +2519,16 @@ var _ = Describe("status_checks", func() {
 		Entry("six Pib", int64(6*1024*1024*1024*1024*1024), "6.00Pi"),
 	)
 
-	DescribeTable("checking the QoS status", func(input *fdbv1beta2.FoundationDBStatus, expected error) {
-		result := CheckQosStatus(input)
-		if expected == nil {
-			Expect(result).To(Succeed())
-		} else {
-			Expect(result).To(MatchError(expected))
-		}
-	},
+	DescribeTable(
+		"checking the QoS status",
+		func(input *fdbv1beta2.FoundationDBStatus, expected error) {
+			result := CheckQosStatus(input)
+			if expected == nil {
+				Expect(result).To(Succeed())
+			} else {
+				Expect(result).To(MatchError(expected))
+			}
+		},
 		Entry("all values are below threshold",
 			&fdbv1beta2.FoundationDBStatus{
 				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
@@ -2396,7 +2537,8 @@ var _ = Describe("status_checks", func() {
 			},
 			nil,
 		),
-		Entry("worst data lag storage server is too high",
+		Entry(
+			"worst data lag storage server is too high",
 			&fdbv1beta2.FoundationDBStatus{
 				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 					Qos: fdbv1beta2.FoundationDBStatusQosInfo{
@@ -2406,9 +2548,12 @@ var _ = Describe("status_checks", func() {
 					},
 				},
 			},
-			fmt.Errorf("worst data lag is too high, current worst data lag in seconds: 61.00, maximum allowed lag:  60.00"),
+			fmt.Errorf(
+				"worst data lag is too high, current worst data lag in seconds: 61.00, maximum allowed lag:  60.00",
+			),
 		),
-		Entry("worst durability lag storage server is too high",
+		Entry(
+			"worst durability lag storage server is too high",
 			&fdbv1beta2.FoundationDBStatus{
 				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 					Qos: fdbv1beta2.FoundationDBStatusQosInfo{
@@ -2418,9 +2563,12 @@ var _ = Describe("status_checks", func() {
 					},
 				},
 			},
-			fmt.Errorf("worst durability lag is too high, current worst durability lag in seconds: 61.00, maximum allowed lag:  60.00"),
+			fmt.Errorf(
+				"worst durability lag is too high, current worst durability lag in seconds: 61.00, maximum allowed lag:  60.00",
+			),
 		),
-		Entry("worst queue bytes for log server is too high",
+		Entry(
+			"worst queue bytes for log server is too high",
 			&fdbv1beta2.FoundationDBStatus{
 				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 					Qos: fdbv1beta2.FoundationDBStatusQosInfo{
@@ -2428,9 +2576,12 @@ var _ = Describe("status_checks", func() {
 					},
 				},
 			},
-			fmt.Errorf("worst queue bytes for log server is too high, current worst queue bytes: 500.00Mi, maximum allowed queue bytes: 250.00Mi"),
+			fmt.Errorf(
+				"worst queue bytes for log server is too high, current worst queue bytes: 500.00Mi, maximum allowed queue bytes: 250.00Mi",
+			),
 		),
-		Entry("worst queue bytes for storage server is too high",
+		Entry(
+			"worst queue bytes for storage server is too high",
 			&fdbv1beta2.FoundationDBStatus{
 				Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
 					Qos: fdbv1beta2.FoundationDBStatusQosInfo{
@@ -2438,7 +2589,9 @@ var _ = Describe("status_checks", func() {
 					},
 				},
 			},
-			fmt.Errorf("worst queue bytes for storage server is too high, current worst queue bytes: 500.00Mi, maximum allowed queue bytes: 250.00Mi"),
+			fmt.Errorf(
+				"worst queue bytes for storage server is too high, current worst queue bytes: 500.00Mi, maximum allowed queue bytes: 250.00Mi",
+			),
 		),
 	)
 })

--- a/pkg/podclient/mock/pod_client.go
+++ b/pkg/podclient/mock/pod_client.go
@@ -37,7 +37,10 @@ type FdbPodClient struct {
 }
 
 // NewMockFdbPodClient builds a mock client for working with an FDB pod
-func NewMockFdbPodClient(cluster *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod) (podclient.FdbPodClient, error) {
+func NewMockFdbPodClient(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	pod *corev1.Pod,
+) (podclient.FdbPodClient, error) {
 	return &FdbPodClient{Cluster: cluster, Pod: pod, logger: logr.New(log.NullLogSink{})}, nil
 }
 

--- a/pkg/podmanager/fdb_process_group.go
+++ b/pkg/podmanager/fdb_process_group.go
@@ -45,7 +45,10 @@ func GetProcessGroupIDFromProcessID(id string) string {
 }
 
 // GetProcessGroupID returns the process group ID from the Pods metadata
-func GetProcessGroupID(cluster *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod) fdbv1beta2.ProcessGroupID {
+func GetProcessGroupID(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	pod *corev1.Pod,
+) fdbv1beta2.ProcessGroupID {
 	if pod == nil {
 		return ""
 	}
@@ -54,7 +57,10 @@ func GetProcessGroupID(cluster *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod)
 }
 
 // GetProcessClass fetches the process class from a Pod's metadata.
-func GetProcessClass(cluster *fdbv1beta2.FoundationDBCluster, pod *corev1.Pod) (fdbv1beta2.ProcessClass, error) {
+func GetProcessClass(
+	cluster *fdbv1beta2.FoundationDBCluster,
+	pod *corev1.Pod,
+) (fdbv1beta2.ProcessClass, error) {
 	if pod == nil {
 		return "", fmt.Errorf("failed to fetch process class from nil Pod")
 	}

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -109,51 +109,211 @@ type Options struct {
 
 // BindFlags will parse the given flagset for the operator option flags
 func (o *Options) BindFlags(fs *flag.FlagSet) {
-	fs.StringVar(&o.MetricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	fs.BoolVar(&o.EnableLeaderElection, "enable-leader-election", true,
-		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	fs.StringVar(&o.LeaderElectionID, "leader-election-id", "fdb-kubernetes-operator",
-		"LeaderElectionID determines the name of the resource that leader election will use for holding the leader lock.")
-	fs.BoolVar(&o.DeprecationOptions.UseFutureDefaults, "use-future-defaults", false,
+	fs.StringVar(
+		&o.MetricsAddr,
+		"metrics-addr",
+		":8080",
+		"The address the metric endpoint binds to.",
+	)
+	fs.BoolVar(
+		&o.EnableLeaderElection,
+		"enable-leader-election",
+		true,
+		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.",
+	)
+	fs.StringVar(
+		&o.LeaderElectionID,
+		"leader-election-id",
+		"fdb-kubernetes-operator",
+		"LeaderElectionID determines the name of the resource that leader election will use for holding the leader lock.",
+	)
+	fs.BoolVar(
+		&o.DeprecationOptions.UseFutureDefaults,
+		"use-future-defaults",
+		false,
 		"Apply defaults from the next major version of the operator. This is only intended for use in development.",
 	)
 	fs.StringVar(&o.LogFile, "log-file", "", "The path to a file to write logs to.")
 	fs.IntVar(&o.CliTimeout, "cli-timeout", 10, "The timeout to use for CLI commands in seconds.")
-	fs.IntVar(&o.MaxCliTimeout, "max-cli-timeout", 40, "The maximum timeout to use for CLI commands in seconds. This timeout is used for CLI requests that are known to be potentially slow like get status or exclude.")
-	fs.IntVar(&o.MaxConcurrentReconciles, "max-concurrent-reconciles", 1, "Defines the maximum number of concurrent reconciles for all controllers.")
-	fs.BoolVar(&o.CleanUpOldLogFile, "cleanup-old-cli-logs", true, "Defines if the operator should delete old fdbcli log files.")
-	fs.DurationVar(&o.LogFileMinAge, "log-file-min-age", 5*time.Minute, "Defines the minimum age of fdbcli log files before removing when \"--cleanup-old-cli-logs\" is set.")
-	fs.IntVar(&o.LogFileMaxAge, "log-file-max-age", 28, "Defines the maximum age to retain old operator log file in number of days.")
-	fs.IntVar(&o.LogFileMaxSize, "log-file-max-size", 250, "Defines the maximum size in megabytes of the operator log file before it gets rotated.")
-	fs.StringVar(&o.LogFilePermission, "log-file-permission", "0644",
-		"The file permission for the log file. Only used if log-file is set. Only the octal representation is supported.")
+	fs.IntVar(
+		&o.MaxCliTimeout,
+		"max-cli-timeout",
+		40,
+		"The maximum timeout to use for CLI commands in seconds. This timeout is used for CLI requests that are known to be potentially slow like get status or exclude.",
+	)
+	fs.IntVar(
+		&o.MaxConcurrentReconciles,
+		"max-concurrent-reconciles",
+		1,
+		"Defines the maximum number of concurrent reconciles for all controllers.",
+	)
+	fs.BoolVar(
+		&o.CleanUpOldLogFile,
+		"cleanup-old-cli-logs",
+		true,
+		"Defines if the operator should delete old fdbcli log files.",
+	)
+	fs.DurationVar(
+		&o.LogFileMinAge,
+		"log-file-min-age",
+		5*time.Minute,
+		"Defines the minimum age of fdbcli log files before removing when \"--cleanup-old-cli-logs\" is set.",
+	)
+	fs.IntVar(
+		&o.LogFileMaxAge,
+		"log-file-max-age",
+		28,
+		"Defines the maximum age to retain old operator log file in number of days.",
+	)
+	fs.IntVar(
+		&o.LogFileMaxSize,
+		"log-file-max-size",
+		250,
+		"Defines the maximum size in megabytes of the operator log file before it gets rotated.",
+	)
+	fs.StringVar(
+		&o.LogFilePermission,
+		"log-file-permission",
+		"0644",
+		"The file permission for the log file. Only used if log-file is set. Only the octal representation is supported.",
+	)
 	fs.StringVar(&o.ClusterLabelKeyForNodeTrigger, "cluster-label-key-for-node-trigger", "",
 		"The label key to use to trigger a reconciliation if a node resources changes.")
-	fs.IntVar(&o.MaxNumberOfOldLogFiles, "max-old-log-files", 3, "Defines the maximum number of old operator log files to retain.")
-	fs.BoolVar(&o.CompressOldFiles, "compress", false, "Defines whether the rotated log files should be compressed using gzip or not.")
+	fs.IntVar(
+		&o.MaxNumberOfOldLogFiles,
+		"max-old-log-files",
+		3,
+		"Defines the maximum number of old operator log files to retain.",
+	)
+	fs.BoolVar(
+		&o.CompressOldFiles,
+		"compress",
+		false,
+		"Defines whether the rotated log files should be compressed using gzip or not.",
+	)
 	fs.BoolVar(&o.PrintVersion, "version", false, "Prints the version of the operator and exits.")
-	fs.StringVar(&o.LabelSelector, "label-selector", "", "Defines a label-selector that will be used to select resources.")
-	fs.StringVar(&o.WatchNamespace, "watch-namespace", os.Getenv("WATCH_NAMESPACE"), "Defines which namespace the operator should watch.")
-	fs.StringVar(&o.PodUpdateMethod, "pod-update-method", string(podmanager.Update), "Defines how the Pod manager should update pods, possible values are \"update\" and \"patch\".")
-	fs.DurationVar(&o.GetTimeout, "get-timeout", 5*time.Second, "http timeout for get requests to the FDB sidecar.")
-	fs.DurationVar(&o.PostTimeout, "post-timeout", 10*time.Second, "http timeout for post requests to the FDB sidecar.")
-	fs.DurationVar(&o.LeaseDuration, "leader-election-lease-duration", 15*time.Second, "the duration that non-leader candidates will wait to force acquire leadership.")
-	fs.DurationVar(&o.RenewDeadline, "leader-election-renew-deadline", 10*time.Second, "the duration that the acting controlplane will retry refreshing leadership before giving up.")
-	fs.DurationVar(&o.RetryPeriod, "leader-election-retry-period", 2*time.Second, "the duration the LeaderElector clients should wait between tries of action.")
-	fs.DurationVar(&o.MaintenanceListStaleDuration, "maintenance-list-stale-duration", 4*time.Hour, "the duration after stale entries will be deleted form the maintenance list. Only has an affect if the operator is allowed to reset the maintenance zone.")
-	fs.DurationVar(&o.MaintenanceListWaitDuration, "maintenance-list-wait-duration", 5*time.Minute, "the duration where a process in the maintenance list in a different zone will be assumed to block the maintenance zone reset. Only has an affect if the operator is allowed to reset the maintenance zone.")
-	fs.DurationVar(&o.MinimumRequiredUptimeCCBounce, "minimum-required-uptime-for-cc-bounce", 1*time.Hour, "the minimum required uptime of the cluster before allowing the operator to restart the CC if there is a failed tester process.")
-	fs.DurationVar(&o.GlobalSynchronizationWaitDuration, "global-synchronization-wait-duration", 30*time.Second, "the wait time for the global synchronization mode in multi-region deployments")
-	fs.BoolVar(&o.EnableRestartIncompatibleProcesses, "enable-restart-incompatible-processes", true, "This flag enables/disables in the operator to restart incompatible fdbserver processes.")
-	fs.BoolVar(&o.ServerSideApply, "server-side-apply", false, "This flag enables server side apply.")
-	fs.BoolVar(&o.EnableRecoveryState, "enable-recovery-state", true, "This flag enables the use of the recovery state for the minimum uptime between bounced if the FDB version supports it.")
-	fs.BoolVar(&o.CacheDatabaseStatus, "cache-database-status", true, "Defines the default value for caching the database status.")
-	fs.BoolVar(&o.EnableNodeIndex, "enable-node-index", false, "Deprecated, not used anymore. Defines if the operator should add an index for accessing node objects. This requires a ClusterRoleBinding with node access. If the taint feature should be used, this setting should be set to true.")
-	fs.BoolVar(&o.ReplaceOnSecurityContextChange, "replace-on-security-context-change", false, "This flag enables the operator"+
-		" to automatically replace pods whose effective security context has one of the following fields change: "+
-		"FSGroup, FSGroupChangePolicy, RunAsGroup, RunAsUser")
-	fs.Float64Var(&o.MinimumRecoveryTimeForInclusion, "minimum-recovery-time-for-inclusion", 600.0, "Defines the minimum uptime of the cluster before inclusions are allowed. For clusters after 7.1 this will use the recovery state. This should reduce the risk of frequent recoveries because of inclusions.")
-	fs.Float64Var(&o.MinimumRecoveryTimeForExclusion, "minimum-recovery-time-for-exclusion", 120.0, "Defines the minimum uptime of the cluster before exclusions are allowed. For clusters after 7.1 this will use the recovery state. This should reduce the risk of frequent recoveries because of exclusions.")
+	fs.StringVar(
+		&o.LabelSelector,
+		"label-selector",
+		"",
+		"Defines a label-selector that will be used to select resources.",
+	)
+	fs.StringVar(
+		&o.WatchNamespace,
+		"watch-namespace",
+		os.Getenv("WATCH_NAMESPACE"),
+		"Defines which namespace the operator should watch.",
+	)
+	fs.StringVar(
+		&o.PodUpdateMethod,
+		"pod-update-method",
+		string(podmanager.Update),
+		"Defines how the Pod manager should update pods, possible values are \"update\" and \"patch\".",
+	)
+	fs.DurationVar(
+		&o.GetTimeout,
+		"get-timeout",
+		5*time.Second,
+		"http timeout for get requests to the FDB sidecar.",
+	)
+	fs.DurationVar(
+		&o.PostTimeout,
+		"post-timeout",
+		10*time.Second,
+		"http timeout for post requests to the FDB sidecar.",
+	)
+	fs.DurationVar(
+		&o.LeaseDuration,
+		"leader-election-lease-duration",
+		15*time.Second,
+		"the duration that non-leader candidates will wait to force acquire leadership.",
+	)
+	fs.DurationVar(
+		&o.RenewDeadline,
+		"leader-election-renew-deadline",
+		10*time.Second,
+		"the duration that the acting controlplane will retry refreshing leadership before giving up.",
+	)
+	fs.DurationVar(
+		&o.RetryPeriod,
+		"leader-election-retry-period",
+		2*time.Second,
+		"the duration the LeaderElector clients should wait between tries of action.",
+	)
+	fs.DurationVar(
+		&o.MaintenanceListStaleDuration,
+		"maintenance-list-stale-duration",
+		4*time.Hour,
+		"the duration after stale entries will be deleted form the maintenance list. Only has an affect if the operator is allowed to reset the maintenance zone.",
+	)
+	fs.DurationVar(
+		&o.MaintenanceListWaitDuration,
+		"maintenance-list-wait-duration",
+		5*time.Minute,
+		"the duration where a process in the maintenance list in a different zone will be assumed to block the maintenance zone reset. Only has an affect if the operator is allowed to reset the maintenance zone.",
+	)
+	fs.DurationVar(
+		&o.MinimumRequiredUptimeCCBounce,
+		"minimum-required-uptime-for-cc-bounce",
+		1*time.Hour,
+		"the minimum required uptime of the cluster before allowing the operator to restart the CC if there is a failed tester process.",
+	)
+	fs.DurationVar(
+		&o.GlobalSynchronizationWaitDuration,
+		"global-synchronization-wait-duration",
+		30*time.Second,
+		"the wait time for the global synchronization mode in multi-region deployments",
+	)
+	fs.BoolVar(
+		&o.EnableRestartIncompatibleProcesses,
+		"enable-restart-incompatible-processes",
+		true,
+		"This flag enables/disables in the operator to restart incompatible fdbserver processes.",
+	)
+	fs.BoolVar(
+		&o.ServerSideApply,
+		"server-side-apply",
+		false,
+		"This flag enables server side apply.",
+	)
+	fs.BoolVar(
+		&o.EnableRecoveryState,
+		"enable-recovery-state",
+		true,
+		"This flag enables the use of the recovery state for the minimum uptime between bounced if the FDB version supports it.",
+	)
+	fs.BoolVar(
+		&o.CacheDatabaseStatus,
+		"cache-database-status",
+		true,
+		"Defines the default value for caching the database status.",
+	)
+	fs.BoolVar(
+		&o.EnableNodeIndex,
+		"enable-node-index",
+		false,
+		"Deprecated, not used anymore. Defines if the operator should add an index for accessing node objects. This requires a ClusterRoleBinding with node access. If the taint feature should be used, this setting should be set to true.",
+	)
+	fs.BoolVar(
+		&o.ReplaceOnSecurityContextChange,
+		"replace-on-security-context-change",
+		false,
+		"This flag enables the operator"+
+			" to automatically replace pods whose effective security context has one of the following fields change: "+
+			"FSGroup, FSGroupChangePolicy, RunAsGroup, RunAsUser",
+	)
+	fs.Float64Var(
+		&o.MinimumRecoveryTimeForInclusion,
+		"minimum-recovery-time-for-inclusion",
+		600.0,
+		"Defines the minimum uptime of the cluster before inclusions are allowed. For clusters after 7.1 this will use the recovery state. This should reduce the risk of frequent recoveries because of inclusions.",
+	)
+	fs.Float64Var(
+		&o.MinimumRecoveryTimeForExclusion,
+		"minimum-recovery-time-for-exclusion",
+		120.0,
+		"Defines the minimum uptime of the cluster before exclusions are allowed. For clusters after 7.1 this will use the recovery state. This should reduce the risk of frequent recoveries because of exclusions.",
+	)
 }
 
 // StartManager will start the FoundationDB operator manager.
@@ -175,7 +335,12 @@ func StartManager(
 
 	logWriter, err := setupLogger(operatorOpts)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "unable to setup logger: %s, got error: %s\n", operatorOpts.LogFile, err.Error())
+		_, _ = fmt.Fprintf(
+			os.Stderr,
+			"unable to setup logger: %s, got error: %s\n",
+			operatorOpts.LogFile,
+			err.Error(),
+		)
 		os.Exit(1)
 	}
 
@@ -200,7 +365,12 @@ func StartManager(
 		// Parse the label selector, if the label selector is not parsable panic.
 		selector, parseErr := labels.Parse(operatorOpts.LabelSelector)
 		if parseErr != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "could not parse label selector: %s, got error: %s", operatorOpts.LabelSelector, parseErr)
+			_, _ = fmt.Fprintf(
+				os.Stderr,
+				"could not parse label selector: %s, got error: %s",
+				operatorOpts.LabelSelector,
+				parseErr,
+			)
 			os.Exit(1)
 		}
 
@@ -210,7 +380,11 @@ func StartManager(
 	}
 
 	if operatorOpts.WatchNamespace != "" {
-		setupLog.Info("Operator starting in single namespace mode", "namespace", operatorOpts.WatchNamespace)
+		setupLog.Info(
+			"Operator starting in single namespace mode",
+			"namespace",
+			operatorOpts.WatchNamespace,
+		)
 		cacheOptions.DefaultNamespaces = map[string]cache.Config{
 			operatorOpts.WatchNamespace: {},
 		}
@@ -246,7 +420,9 @@ func StartManager(
 		os.Exit(1)
 	}
 
-	labelSelector, err := metav1.ParseToLabelSelector(strings.Trim(operatorOpts.LabelSelector, "\""))
+	labelSelector, err := metav1.ParseToLabelSelector(
+		strings.Trim(operatorOpts.LabelSelector, "\""),
+	)
 	if err != nil {
 		setupLog.Error(err, "unable to parse provided label selector")
 		os.Exit(1)
@@ -270,7 +446,10 @@ func StartManager(
 		clusterReconciler.MaintenanceListWaitDuration = operatorOpts.MaintenanceListWaitDuration
 		clusterReconciler.MinimumRecoveryTimeForInclusion = operatorOpts.MinimumRecoveryTimeForInclusion
 		clusterReconciler.MinimumRecoveryTimeForExclusion = operatorOpts.MinimumRecoveryTimeForExclusion
-		clusterReconciler.ClusterLabelKeyForNodeTrigger = strings.Trim(operatorOpts.ClusterLabelKeyForNodeTrigger, "\"")
+		clusterReconciler.ClusterLabelKeyForNodeTrigger = strings.Trim(
+			operatorOpts.ClusterLabelKeyForNodeTrigger,
+			"\"",
+		)
 		clusterReconciler.Namespace = operatorOpts.WatchNamespace
 		clusterReconciler.GlobalSynchronizationWaitDuration = operatorOpts.GlobalSynchronizationWaitDuration
 
@@ -278,8 +457,14 @@ func StartManager(
 		// update method will be ignored.
 		castedPodManager, ok := clusterReconciler.PodLifecycleManager.(podmanager.PodLifecycleManagerWithPodUpdateMethod)
 		if ok {
-			setupLog.Info("Updating pod update method", "podUpdateMethod", operatorOpts.PodUpdateMethod)
-			castedPodManager.SetUpdateMethod(podmanager.PodUpdateMethod(operatorOpts.PodUpdateMethod))
+			setupLog.Info(
+				"Updating pod update method",
+				"podUpdateMethod",
+				operatorOpts.PodUpdateMethod,
+			)
+			castedPodManager.SetUpdateMethod(
+				podmanager.PodUpdateMethod(operatorOpts.PodUpdateMethod),
+			)
 		}
 		if err := clusterReconciler.SetupWithManager(mgr, operatorOpts.MaxConcurrentReconciles, *labelSelector, watchedObjects...); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "FoundationDBCluster")
@@ -318,7 +503,8 @@ func StartManager(
 	}
 
 	if operatorOpts.CleanUpOldLogFile {
-		setupLog.V(1).Info("setup log file cleaner", "LogFileMinAge", operatorOpts.LogFileMinAge.String())
+		setupLog.V(1).
+			Info("setup log file cleaner", "LogFileMinAge", operatorOpts.LogFileMinAge.String())
 		cleaner := internal.NewCliLogFileCleaner(logger, operatorOpts.LogFileMinAge)
 		ticker := time.NewTicker(operatorOpts.LogFileMinAge)
 		go func() {
@@ -346,7 +532,10 @@ func moveFDBBinaries(log logr.Logger) error {
 	libDir, err := os.Open(os.Getenv(fdbv1beta2.EnvNameFDBExternalClientDir))
 	if err != nil {
 		if os.IsNotExist(err) {
-			err = os.MkdirAll(os.Getenv(fdbv1beta2.EnvNameFDBExternalClientDir), os.ModeDir|os.ModePerm)
+			err = os.MkdirAll(
+				os.Getenv(fdbv1beta2.EnvNameFDBExternalClientDir),
+				os.ModeDir|os.ModePerm,
+			)
 			if err != nil {
 				return err
 			}
@@ -371,7 +560,9 @@ func moveFDBBinaries(log logr.Logger) error {
 			continue
 		}
 
-		versionBinFile, err := os.Open(path.Join(binFile.Name(), binEntry.Name(), "bin", binEntry.Name()))
+		versionBinFile, err := os.Open(
+			path.Join(binFile.Name(), binEntry.Name(), "bin", binEntry.Name()),
+		)
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
@@ -399,7 +590,9 @@ func moveFDBBinaries(log logr.Logger) error {
 		}
 		_ = versionBinFile.Close()
 
-		versionLibFile, err := os.Open(path.Join(binFile.Name(), binEntry.Name(), "lib", "libfdb_c.so"))
+		versionLibFile, err := os.Open(
+			path.Join(binFile.Name(), binEntry.Name(), "lib", "libfdb_c.so"),
+		)
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}


### PR DESCRIPTION
# Description

Enable additional linter and formatter to ensure a consistent style in our code base.

## Type of change

- Other

## Discussion

-

## Testing

Ran `make fmt lint test` locally.

## Documentation

-

## Follow-up

-
