### PR TITLE
Fix format after linter change

### DIFF
--- a/e2e/fixtures/pods.go
+++ b/e2e/fixtures/pods.go
@@ -114,7 +114,8 @@ func (factory *Factory) RandomPickCluster(input []*FdbCluster, count int) []*Fdb
 
 // RandomPickOneCluster will pick one FdbCluster randomly from the FdbCluster slice.
 func (factory *Factory) RandomPickOneCluster(input []*FdbCluster) *FdbCluster {
-	gomega.Expect(input).NotTo(gomega.BeEmpty(), "cannot pick a random FDB cluster from an empty slice")
+	gomega.Expect(input).
+		NotTo(gomega.BeEmpty(), "cannot pick a random FDB cluster from an empty slice")
 	randomClusters := factory.RandomPickCluster(input, 1)
 	if len(randomClusters) > 0 {
 		return randomClusters[0]


### PR DESCRIPTION
# Description

We recently merged https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2318 but we had another PR merged in between, so one file had a wrong style.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran `make fmt lint` locally.

## Documentation

-

## Follow-up

-