### PR TITLE
Disable test for unified image, since the unified image doesn't have a check for this

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -192,12 +192,12 @@ endif
 	  --dump-operator-state=$(DUMP_OPERATOR_STATE) \
 	  --cluster-name=$(CLUSTER_NAME) \
 	  --storage-engine=$(STORAGE_ENGINE) \
-	  --fdb-version-tag-mapping=$(FDB_VERSION_TAG_MAPPING) \
+	  --fdb-version-tag-mapping="$(FDB_VERSION_TAG_MAPPING)" \
 	  --unified-fdb-image=$(UNIFIED_FDB_IMAGE) \
 	  --feature-unified-image=$(FEATURE_UNIFIED_IMAGE) \
 	  --feature-server-side-apply=$(FEATURE_SERVER_SIDE_APPLY) \
 	  --feature-synchronization-mode=$(FEATURE_SYNCHRONIZATION_MODE) \
 	  --node-selector="$(NODE_SELECTOR)" \
 	  --default-unavailable-threshold=$(DEFAULT_UNAVAILABLE_THRESHOLD) \
-	  --seaweedfs-image=$(SEAWEEDFS_IMAGE) $(FEATURE_LOCALITIES_FLAG) $(FEATURE_DNS) \
+	  --seaweedfs-image=$(SEAWEEDFS_IMAGE) $(FEATURE_LOCALITIES_FLAG) $(FEATURE_DNS_FLAG) \
 	  | grep -v 'constructing many client instances from the same exec auth config can cause performance problems during cert rotation' &> $(BASE_DIR)/../logs/$<.log

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -887,7 +887,7 @@ func (fdbCluster *FdbCluster) UpdateNode(node *corev1.Node) {
 
 // GetNode return Node with the given name
 func (fdbCluster *FdbCluster) GetNode(name string) *corev1.Node {
-	// Retry if for some reasons an error is returned
+	// Retry if for some reason an error is returned
 	node := &corev1.Node{}
 	gomega.Eventually(func() error {
 		return fdbCluster.getClient().

--- a/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
@@ -375,6 +375,14 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 				Skip("this test only affects version incompatible upgrades")
 			}
 
+			// Right now the operator doesn't check the binaries during a version incompatible upgrade. When the
+			// sidecar was updated and is running, the operator assumes that the process is ready to be restarted.
+			// In the future we can add some additional signals, so that the operator is able to check if the binary
+			// is present. This requires some changes in the fdb-kubernetes-monitor.
+			if factory.UseUnifiedImage() {
+				Skip("in the unified image setup the operator doesn't validate the binary")
+			}
+
 			clusterSetup(beforeVersion)
 
 			// Update the cluster version.
@@ -388,7 +396,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 
 			// We have to update the sidecar before the operator is doing it. If we don't do this here the operator
 			// will update the sidecar and then the sidecar will copy the binaries at start-up. So we prepare the faulty Pod to already
-			// be using the new sidecar image and then we delete he new fdbserver binary.
+			// be using the new sidecar image and then we delete the new fdbserver binary.
 			sidecarImage := fdbCluster.GetSidecarImageForVersion(targetVersion)
 			fdbCluster.UpdateContainerImage(
 				&faultyPod,


### PR DESCRIPTION
# Description

The unified image doesn't have a check if a file is present (it does in a sense that it checks the binary before starting the binary but not an external check from the operator side).

## Type of change

- Other

## Discussion

Disabling the test for now. If we don't disable this test we will see some spontaneous failures, e.g. because the upgrades moves forward and in cases where a transaction or stateless pod is picked the test could fail with:

```text
 [FAILED] Timed out after 120.000s.
  Unexpected error:
      <*errors.StatusError | 0x14000871400>:
      pods "jdev-stateless-59937" not found
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "pods \"jdev-stateless-59937\" not found",
              Reason: "NotFound",
              Details: {
                  Name: "jdev-stateless-59937",
                  Group: "",
                  Kind: "pods",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 404,
          },
      }
  occurred
  In [It] at: /Users/jscheuermann/go/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/fixtures/fdb_cluster.go:596 @
```

## Testing

Ran the test manually.

## Documentation

Added in the test case.

## Follow-up

-
