### PR TITLE
Ensure process groups are removed from the pending restart list if they are stuck in terminating or the process is missing

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1758,7 +1758,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 						fdbCluster.GetCluster().Status.ProcessGroups,
 						processGroupID,
 					)
-				}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(BeNil())
+				}).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).Should(BeNil())
 
 				// Make sure the Pod is actually deleted after some time.
 				Eventually(func() bool {

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -401,7 +401,9 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			// update to the connection string.
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				Eventually(func(g Gomega) {
-					currentConnectionString := fdbCluster.GetPrimary().GetStatus().Cluster.ConnectionString
+					currentConnectionString := fdbCluster.GetPrimary().
+						GetStatus().
+						Cluster.ConnectionString
 					remoteSat := fdbCluster.GetRemoteSatellite()
 					remoteConnectionString := remoteSat.GetCluster().Status.ConnectionString
 
@@ -417,7 +419,8 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 						remoteSatStatus := remoteSat.GetCluster().Status.DeepCopy()
 						remoteSatStatus.ConnectionString = currentConnectionString
-						fdbCluster.GetRemoteSatellite().UpdateClusterStatusWithStatus(remoteSatStatus)
+						fdbCluster.GetRemoteSatellite().
+							UpdateClusterStatusWithStatus(remoteSatStatus)
 					}
 
 					g.Expect(remoteConnectionString).To(Equal(currentConnectionString))

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -397,7 +397,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 			// When using protocol compatible versions, the other operator instances are able to move forward. In some
 			// cases it can happen that new coordinators are selected and all the old coordinators are deleted. In this
-			// case the remote satellite operator with not be able to connect to the cluster anymore and needs an
+			// case the remote satellite operator will not be able to connect to the cluster anymore and needs an
 			// update to the connection string.
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				Eventually(func(g Gomega) {

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -555,7 +555,6 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				var processesToUpdate int
 
 				cluster := fdbCluster.GetCluster()
-
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					if processGroup.ProcessGroupID == processGroupMarkedForRemoval {
 						continue

--- a/internal/coordination/coordination.go
+++ b/internal/coordination/coordination.go
@@ -425,25 +425,64 @@ func UpdateGlobalCoordinationState(
 					updatesPendingForInclusion[processGroup.ProcessGroupID] = fdbv1beta2.UpdateActionAdd
 				}
 			} else {
+				reason := "process group is excluded and marked for removal"
 				// Check if the process group is present in pendingForExclusion or readyForExclusion.
 				// If so, add them to the set to remove those entries as the process is already excluded.
 				if _, ok := pendingForExclusion[processGroup.ProcessGroupID]; ok {
+					logger.V(1).
+						Info("Removing from pendingForExclusion", "processGroupID", processGroup.ProcessGroupID, "reason", reason)
 					updatesPendingForExclusion[processGroup.ProcessGroupID] = fdbv1beta2.UpdateActionDelete
 				}
 
 				if _, ok := readyForExclusion[processGroup.ProcessGroupID]; ok {
+					logger.V(1).
+						Info("Removing from readyForExclusion", "processGroupID", processGroup.ProcessGroupID, "reason", reason)
 					updatesReadyForExclusion[processGroup.ProcessGroupID] = fdbv1beta2.UpdateActionDelete
 				}
 
 				// Ensure the process is added to the pending for inclusion list.
 				if _, ok := pendingForInclusion[processGroup.ProcessGroupID]; !ok {
+					logger.V(1).
+						Info("Adding to pendingForInclusion", "processGroupID", processGroup.ProcessGroupID, "reason", reason)
 					updatesPendingForInclusion[processGroup.ProcessGroupID] = fdbv1beta2.UpdateActionAdd
 				}
 
 				if processGroup.ExclusionSkipped {
 					if _, ok := readyForInclusion[processGroup.ProcessGroupID]; !ok {
+						logger.V(1).
+							Info("Adding to readyForInclusion", "processGroupID", processGroup.ProcessGroupID, "reason", reason)
 						updatesReadyForInclusion[processGroup.ProcessGroupID] = fdbv1beta2.UpdateActionAdd
 					}
+				}
+
+				// if the process group is excluded, we don't need to restart it.
+				if _, ok := pendingForRestart[processGroup.ProcessGroupID]; ok {
+					logger.V(1).
+						Info("Removing from pendingForRestart", "processGroupID", processGroup.ProcessGroupID, "reason", reason)
+					updatesPendingForRestart[processGroup.ProcessGroupID] = fdbv1beta2.UpdateActionDelete
+				}
+
+				if _, ok := readyForRestart[processGroup.ProcessGroupID]; ok {
+					logger.V(1).
+						Info("Removing from readyForRestart", "processGroupID", processGroup.ProcessGroupID, "reason", reason)
+					updatesReadyForRestart[processGroup.ProcessGroupID] = fdbv1beta2.UpdateActionDelete
+				}
+			}
+
+			// If the process group is marked for removal and the resources are stuck in terminating or the processes are not running, we should
+			// remove them from the restart list, because there are no processes to restart.
+			if processGroup.GetConditionTime(fdbv1beta2.ResourcesTerminating) != nil ||
+				processGroup.GetConditionTime(fdbv1beta2.MissingProcesses) != nil {
+				if _, ok := pendingForRestart[processGroup.ProcessGroupID]; ok {
+					logger.V(1).
+						Info("Removing from pendingForRestart", "processGroupID", processGroup.ProcessGroupID, "reason", "process group is marked for removal")
+					updatesPendingForRestart[processGroup.ProcessGroupID] = fdbv1beta2.UpdateActionDelete
+				}
+
+				if _, ok := readyForRestart[processGroup.ProcessGroupID]; ok {
+					logger.V(1).
+						Info("Removing from readyForRestart", "processGroupID", processGroup.ProcessGroupID, "reason", "process group is marked for removal")
+					updatesReadyForRestart[processGroup.ProcessGroupID] = fdbv1beta2.UpdateActionDelete
 				}
 			}
 
@@ -457,7 +496,7 @@ func UpdateGlobalCoordinationState(
 			continue
 		}
 
-		// If the process groups is missing long enough to be ignored, ensure that it's removed from the pending
+		// If the process group is missing long enough to be ignored, ensure that it's removed from the pending
 		// and the ready list.
 		if processGroup.GetConditionTime(fdbv1beta2.IncorrectCommandLine) != nil &&
 			!restarts.ShouldBeIgnoredBecauseMissing(logger, cluster, processGroup) {

--- a/internal/restarts/restarts.go
+++ b/internal/restarts/restarts.go
@@ -84,5 +84,6 @@ func ShouldBeIgnoredBecauseMissing(
 		return true
 	}
 
-	return false
+	// If a process group is stuck in terminating we don't want to block further actions because of that.
+	return processGroup.GetConditionTime(fdbv1beta2.ResourcesTerminating) != nil
 }


### PR DESCRIPTION
# Description

In our e2e tests we have seen a few cases where the process groups were not removed if they are stuck in terminating. If the process is missing or stuck in terminating we should remove it from the pending restart set.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran the unit tests, CI will run the e2e tests.

## Documentation

-

## Follow-up

-
