### PR TITLE
Ensure that IP based environment variables are passed down as the correct argument type

### DIFF
--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -600,7 +600,7 @@ var _ = Describe("monitor_conf", func() {
 					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
 						fdbv1beta2.ProcessClassGeneral: {
 							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
-								"localtiy_my_fancy_ip = $FDB_PUBLIC_IP",
+								"locality_my_fancy_ip = $FDB_PUBLIC_IP",
 							},
 						},
 					}
@@ -619,7 +619,7 @@ var _ = Describe("monitor_conf", func() {
 						Values: []monitorapi.Argument{
 							{
 								ArgumentType: monitorapi.LiteralArgumentType,
-								Value:        "--localtiy_my_fancy_ip=",
+								Value:        "--locality_my_fancy_ip=",
 							},
 							{
 								ArgumentType: monitorapi.EnvironmentArgumentType,
@@ -646,7 +646,7 @@ var _ = Describe("monitor_conf", func() {
 							Values: []monitorapi.Argument{
 								{
 									ArgumentType: monitorapi.LiteralArgumentType,
-									Value:        "--localtiy_my_fancy_ip=",
+									Value:        "--locality_my_fancy_ip=",
 								},
 								{
 									ArgumentType: monitorapi.IPListArgumentType,
@@ -666,7 +666,7 @@ var _ = Describe("monitor_conf", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(
 							commandLineArgs[10],
-						).To(Equal("--localtiy_my_fancy_ip=2001:db8:dead:beef::1"))
+						).To(Equal("--locality_my_fancy_ip=2001:db8:dead:beef::1"))
 					})
 				})
 
@@ -688,7 +688,7 @@ var _ = Describe("monitor_conf", func() {
 							Values: []monitorapi.Argument{
 								{
 									ArgumentType: monitorapi.LiteralArgumentType,
-									Value:        "--localtiy_my_fancy_ip=",
+									Value:        "--locality_my_fancy_ip=",
 								},
 								{
 									ArgumentType: monitorapi.IPListArgumentType,
@@ -706,7 +706,7 @@ var _ = Describe("monitor_conf", func() {
 								"FDB_DNS_NAME":    "test",
 							})
 						Expect(err).NotTo(HaveOccurred())
-						Expect(commandLineArgs[10]).To(Equal("--localtiy_my_fancy_ip=192.168.0.2"))
+						Expect(commandLineArgs[10]).To(Equal("--locality_my_fancy_ip=192.168.0.2"))
 					})
 				})
 			})

--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -53,7 +53,7 @@ var _ = Describe("monitor_conf", func() {
 		})
 
 		When("there is no connection string", func() {
-			It("generates conf with an no processes", func() {
+			It("generates conf with no processes", func() {
 				Expect(cluster).NotTo(BeNil())
 				cluster.Status.ConnectionString = ""
 				config := GetMonitorProcessConfiguration(
@@ -595,9 +595,125 @@ var _ = Describe("monitor_conf", func() {
 				})
 			})
 
+			When("there are parameters in the general section that use the public IP", func() {
+				BeforeEach(func() {
+					cluster.Spec.Processes = map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
+						fdbv1beta2.ProcessClassGeneral: {
+							CustomParameters: fdbv1beta2.FoundationDBCustomParameters{
+								"localtiy_my_fancy_ip = $FDB_PUBLIC_IP",
+							},
+						},
+					}
+				})
+
+				It("includes the custom parameters", func() {
+					config := GetMonitorProcessConfiguration(
+						cluster,
+						fdbv1beta2.ProcessClassStorage,
+						1,
+						fdbv1beta2.ImageTypeUnified,
+					)
+					Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
+					Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
+						ArgumentType: monitorapi.ConcatenateArgumentType,
+						Values: []monitorapi.Argument{
+							{
+								ArgumentType: monitorapi.LiteralArgumentType,
+								Value:        "--localtiy_my_fancy_ip=",
+							},
+							{
+								ArgumentType: monitorapi.EnvironmentArgumentType,
+								Source:       "FDB_PUBLIC_IP",
+							},
+						}}))
+				})
+
+				When("using IPv6 as PodIPFamily", func() {
+					BeforeEach(func() {
+						cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv6)
+					})
+
+					It("specifies the IP family for the public address", func() {
+						config := GetMonitorProcessConfiguration(
+							cluster,
+							fdbv1beta2.ProcessClassStorage,
+							1,
+							fdbv1beta2.ImageTypeUnified,
+						)
+						Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
+						Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
+							ArgumentType: monitorapi.ConcatenateArgumentType,
+							Values: []monitorapi.Argument{
+								{
+									ArgumentType: monitorapi.LiteralArgumentType,
+									Value:        "--localtiy_my_fancy_ip=",
+								},
+								{
+									ArgumentType: monitorapi.IPListArgumentType,
+									Source:       "FDB_PUBLIC_IP",
+									IPFamily:     fdbv1beta2.PodIPFamilyIPv6,
+								},
+							}}))
+
+						commandLineArgs, err := config.GenerateArguments(1,
+							map[string]string{
+								"FDB_PUBLIC_IP":   "2001:db8:dead:beef::1,192.168.0.2",
+								"FDB_INSTANCE_ID": "test",
+								"FDB_MACHINE_ID":  "test",
+								"FDB_ZONE_ID":     "test",
+								"FDB_DNS_NAME":    "test",
+							})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(
+							commandLineArgs[10],
+						).To(Equal("--localtiy_my_fancy_ip=2001:db8:dead:beef::1"))
+					})
+				})
+
+				When("using IPv4 as PodIPFamily", func() {
+					BeforeEach(func() {
+						cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
+					})
+
+					It("specifies the IP family for the public address", func() {
+						config := GetMonitorProcessConfiguration(
+							cluster,
+							fdbv1beta2.ProcessClassStorage,
+							1,
+							fdbv1beta2.ImageTypeUnified,
+						)
+						Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
+						Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
+							ArgumentType: monitorapi.ConcatenateArgumentType,
+							Values: []monitorapi.Argument{
+								{
+									ArgumentType: monitorapi.LiteralArgumentType,
+									Value:        "--localtiy_my_fancy_ip=",
+								},
+								{
+									ArgumentType: monitorapi.IPListArgumentType,
+									Source:       "FDB_PUBLIC_IP",
+									IPFamily:     fdbv1beta2.PodIPFamilyIPv4,
+								},
+							}}))
+
+						commandLineArgs, err := config.GenerateArguments(1,
+							map[string]string{
+								"FDB_PUBLIC_IP":   "2001:db8:dead:beef::1,192.168.0.2",
+								"FDB_INSTANCE_ID": "test",
+								"FDB_MACHINE_ID":  "test",
+								"FDB_ZONE_ID":     "test",
+								"FDB_DNS_NAME":    "test",
+							})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(commandLineArgs[10]).To(Equal("--localtiy_my_fancy_ip=192.168.0.2"))
+					})
+				})
+			})
+
 			When("using IPv6 as PodIPFamily", func() {
 				BeforeEach(func() {
-					cluster.Spec.Routing.PodIPFamily = pointer.Int(6)
+					cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv6)
 				})
 
 				It("specifies the IP family for the public address", func() {
@@ -629,7 +745,7 @@ var _ = Describe("monitor_conf", func() {
 
 			When("using IPv4 as PodIPFamily", func() {
 				BeforeEach(func() {
-					cluster.Spec.Routing.PodIPFamily = pointer.Int(4)
+					cluster.Spec.Routing.PodIPFamily = pointer.Int(fdbv1beta2.PodIPFamilyIPv4)
 				})
 
 				It("specifies the IP family for the public address", func() {

--- a/internal/pod_client_test.go
+++ b/internal/pod_client_test.go
@@ -36,8 +36,7 @@ var _ = Describe("pod_client", func() {
 
 	BeforeEach(func() {
 		cluster = CreateDefaultCluster()
-		err := NormalizeClusterSpec(cluster, DeprecationOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(NormalizeClusterSpec(cluster, DeprecationOptions{})).To(Succeed())
 	})
 
 	Context("with TLS disabled", func() {


### PR DESCRIPTION
# Description

In cases where the Pod IP Family was set and the `FDB_PUBLIC_IP` was used as an environment variables, the operator created the wrong configuration, which could result in the cluster being stuck.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Added unit tests and will do some additional manual testing.

## Documentation

-

## Follow-up

-