### PR TITLE
Fix stuck tls migration

### DIFF
--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -339,7 +339,19 @@ func getPodsToUpdate(
 
 		// The Pod is updated, so we can continue.
 		if pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] == specHash {
-			continue
+			// Check here if the Pod spec matches the desired Pod spec.
+			var updated bool
+			updated, err = reconciler.PodLifecycleManager.PodIsUpdated(ctx, reconciler, cluster, pod)
+			if err != nil {
+				logger.Info("Skipping Pod due to error generating spec hash",
+					"processGroupID", processGroup.ProcessGroupID,
+					"error", err.Error())
+				continue
+			}
+
+			if updated {
+				continue
+			}
 		}
 
 		needsReplacement, err := replacements.ProcessGroupNeedsReplacements(

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -341,7 +341,12 @@ func getPodsToUpdate(
 		if pod.ObjectMeta.Annotations[fdbv1beta2.LastSpecKey] == specHash {
 			// Check here if the Pod spec matches the desired Pod spec.
 			var updated bool
-			updated, err = reconciler.PodLifecycleManager.PodIsUpdated(ctx, reconciler, cluster, pod)
+			updated, err = reconciler.PodLifecycleManager.PodIsUpdated(
+				ctx,
+				reconciler,
+				cluster,
+				pod,
+			)
 			if err != nil {
 				logger.Info("Skipping Pod due to error generating spec hash",
 					"processGroupID", processGroup.ProcessGroupID,

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -790,18 +790,50 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), initialTLSSetting)
 		})
 
-		// Currently disabled until a new release of the operator is out
-		It("should update the TLS setting  and keep the cluster available", func() {
-			// Only change the TLS setting for the cluster and not for the sidecar otherwise we have to recreate
-			// all Pods which takes a long time since we recreate the Pods one by one.
-			Expect(
-				fdbCluster.SetTLS(
-					!initialTLSSetting,
-					fdbCluster.GetCluster().Spec.SidecarContainer.EnableTLS,
-				),
-			).NotTo(HaveOccurred())
-			Expect(fdbCluster.HasTLSEnabled()).To(Equal(!initialTLSSetting))
-			checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), !initialTLSSetting)
+		When("the pod spec stays the same", func() {
+			FIt("should update the TLS setting  and keep the cluster available", func() {
+				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				spec.MainContainer.EnableTLS = !initialTLSSetting
+
+				// Add a new env variable to ensure this will cause some additional replacements.
+				processSettings := spec.Processes[fdbv1beta2.ProcessClassGeneral]
+				for i, container := range processSettings.PodTemplate.Spec.Containers {
+					if container.Name != fdbv1beta2.MainContainerName {
+						continue
+					}
+
+					container.Env = append(container.Env, corev1.EnvVar{
+						Name:  "TESTING_TLS_CHANGE",
+						Value: "EMPTY",
+					})
+
+					processSettings.PodTemplate.Spec.Containers[i] = container
+					break
+				}
+
+				spec.Processes[fdbv1beta2.ProcessClassGeneral] = processSettings
+
+				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				//	return fdbCluster.WaitForReconciliation()
+
+				Expect(fdbCluster.HasTLSEnabled()).To(Equal(!initialTLSSetting))
+				checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), !initialTLSSetting)
+			})
+		})
+
+		When("the pod spec is changed", func() {
+			FIt("should update the TLS setting  and keep the cluster available", func() {
+				// Only change the TLS setting for the cluster and not for the sidecar otherwise we have to recreate
+				// all Pods which takes a long time since we recreate the Pods one by one.
+				Expect(
+					fdbCluster.SetTLS(
+						!initialTLSSetting,
+						fdbCluster.GetCluster().Spec.SidecarContainer.EnableTLS,
+					),
+				).NotTo(HaveOccurred())
+				Expect(fdbCluster.HasTLSEnabled()).To(Equal(!initialTLSSetting))
+				checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), !initialTLSSetting)
+			})
 		})
 	})
 

--- a/internal/restarts/restarts.go
+++ b/internal/restarts/restarts.go
@@ -36,7 +36,6 @@ func GetFilterConditions(
 		// not get any ConfigMap updates.
 		return map[fdbv1beta2.ProcessGroupConditionType]bool{
 			fdbv1beta2.IncorrectCommandLine: true,
-			fdbv1beta2.IncorrectPodSpec:     false,
 			fdbv1beta2.SidecarUnreachable:   false,
 			fdbv1beta2.IncorrectConfigMap:   false,
 		}

--- a/internal/restarts/restarts_test.go
+++ b/internal/restarts/restarts_test.go
@@ -43,7 +43,6 @@ var _ = Describe("restarts", func() {
 			},
 			map[fdbv1beta2.ProcessGroupConditionType]bool{
 				fdbv1beta2.IncorrectCommandLine: true,
-				fdbv1beta2.IncorrectPodSpec:     false,
 				fdbv1beta2.SidecarUnreachable:   false,
 				fdbv1beta2.IncorrectConfigMap:   false,
 			}),
@@ -55,7 +54,6 @@ var _ = Describe("restarts", func() {
 			},
 			map[fdbv1beta2.ProcessGroupConditionType]bool{
 				fdbv1beta2.IncorrectCommandLine: true,
-				fdbv1beta2.IncorrectPodSpec:     false,
 				fdbv1beta2.SidecarUnreachable:   false,
 				fdbv1beta2.IncorrectConfigMap:   false,
 			}),


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/871

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran the e2e test case manually (made it pending to reduce the running time, we probably should move this into a dedicated test suite).

```text
------------------------------
Operator when Changing the TLS setting when the pod spec stays the same should update the TLS setting  and keep the cluster available [e2e, pr]
...
  2025/07/16 09:20:04 reconciled name=jdev, namespace=jscheuermann, generation:3
• [313.651 seconds]
------------------------------
Operator when Changing the TLS setting when the pod spec is changed should update the TLS setting  and keep the cluster available [e2e, pr]
...
  2025/07/16 09:26:56 reconciled name=jdev, namespace=jscheuermann, generation:5
• [424.081 seconds]
------------------------------
[AfterSuite] 
/Users/jscheuermann/go/src/github.com/FoundationDB/fdb-kubernetes-operator/e2e/test_operator/operator_test.go:122
[AfterSuite] PASSED [0.000 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.002 seconds]
------------------------------

Ran 2 of 58 Specs in 999.422 seconds
SUCCESS! -- 2 Passed | 0 Failed | 8 Pending | 48 Skipped
PASS | FOCUSED
FAIL	github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/test_operator	999.995s
FAIL
```

The failure report is because of the focus.

## Documentation

Will update the docs to not update the pod spec when changing the TLS setting if possible.

## Follow-up

-
