### PR TITLE
Restructure e2e test suite for better run times

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2610,7 +2610,7 @@ func (cluster *FoundationDBCluster) IsEligibleAsCandidate(pClass ProcessClass) b
 
 // GetEligibleCandidateClasses returns process classes that are eligible to become coordinators.
 func (cluster *FoundationDBCluster) GetEligibleCandidateClasses() []ProcessClass {
-	candidateClasses := []ProcessClass{}
+	var candidateClasses []ProcessClass
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if cluster.IsEligibleAsCandidate(processGroup.ProcessClass) {

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -121,8 +121,9 @@ func (g generateInitialClusterFile) reconcile(
 	if time.Since(newestPendingPod) < cluster.GetIgnorePendingPodsDuration() {
 		return &requeue{
 			message: fmt.Sprintf(
-				"at least one Pod is in pending phase since %s. Will wait for IgnorePendingPodsDuration before proceeding",
+				"at least one Pod is in pending phase since %s. Will wait for IgnorePendingPodsDuration (%s) before proceeding",
 				time.Since(newestPendingPod).String(),
+				cluster.GetIgnorePendingPodsDuration(),
 			),
 			delay: podSchedulingDelayDuration,
 		}

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -94,7 +94,8 @@ func (g generateInitialClusterFile) reconcile(
 				"processGroupID", processGroup.ProcessGroupID,
 				"phase", pod.Status.Phase)
 
-			if pod.Status.Phase == corev1.PodPending && pod.CreationTimestamp.After(newestPendingPod) {
+			if pod.Status.Phase == corev1.PodPending &&
+				pod.CreationTimestamp.After(newestPendingPod) {
 				newestPendingPod = pod.CreationTimestamp.Time
 			}
 			continue

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -23,6 +23,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal/coordinator"
 
@@ -67,6 +68,7 @@ func (g generateInitialClusterFile) reconcile(
 	}
 
 	var pods = make([]*corev1.Pod, 0, processCounts.Total())
+	var newestPendingPod time.Time
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.IsMarkedForRemoval() {
 			logger.V(1).Info("Ignore process group marked for removal",
@@ -91,6 +93,10 @@ func (g generateInitialClusterFile) reconcile(
 			logger.V(1).Info("Ignore process group with Pod not in running state",
 				"processGroupID", processGroup.ProcessGroupID,
 				"phase", pod.Status.Phase)
+
+			if pod.Status.Phase == corev1.PodPending && pod.CreationTimestamp.After(newestPendingPod) {
+				newestPendingPod = pod.CreationTimestamp.Time
+			}
 			continue
 		}
 
@@ -104,6 +110,18 @@ func (g generateInitialClusterFile) reconcile(
 				"cannot find enough running Pods to recruit coordinators. Require %d, got %d Pods",
 				count,
 				len(pods),
+			),
+			delay: podSchedulingDelayDuration,
+		}
+	}
+
+	// Wait for the pending pods that are in the pending phase until all pods are running or the operator waited
+	// for IgnorePendingPodsDuration.
+	if time.Since(newestPendingPod) < cluster.GetIgnorePendingPodsDuration() {
+		return &requeue{
+			message: fmt.Sprintf(
+				"at least one Pod is in pending phase since %s. Will wait for IgnorePendingPodsDuration before proceeding",
+				time.Since(newestPendingPod).String(),
 			),
 			delay: podSchedulingDelayDuration,
 		}

--- a/controllers/replace_misconfigured_process_groups.go
+++ b/controllers/replace_misconfigured_process_groups.go
@@ -57,6 +57,19 @@ func (c replaceMisconfiguredProcessGroups) reconcile(
 		}
 	}
 
+	// If the cluster is currently in the process to enable or disable TLS, we wait with pod updates to prevent
+	// additional configuration changes in one step.
+	if cluster.Status.RequiredAddresses.TLS && cluster.Status.RequiredAddresses.NonTLS {
+		logger.Info(
+			"Replacements because of misconfiguration are skipped because of an ongoing TLS conversion",
+		)
+		return &requeue{
+			message:        "Replacements because of misconfiguration are skipped because of an ongoing TLS conversion",
+			delayedRequeue: true,
+			delay:          5 * time.Second,
+		}
+	}
+
 	hasReplacements, err := replacements.ReplaceMisconfiguredProcessGroups(
 		ctx,
 		r.PodLifecycleManager,

--- a/docs/manual/tls.md
+++ b/docs/manual/tls.md
@@ -103,6 +103,26 @@ Connections to FDB will use the peer verification logic provided by the FDB clie
 
 Connections to the sidecar will use the peer verification logic provided by go's tls library. This means that the sidecar's certificate must be valid for the pod's IP. You can disable verification for the connections to the sidecar by setting the environment variable `DISABLE_SIDECAR_TLS_CHECK=1` on the operator, but this will also disable the validation of the certificate chain, so it is not recommended to use this in real environments.
 
+## TLS Migration
+
+The operator supports to migrate a non-TLS cluster to TLS and visa versa.
+It is not recommended to perform additional changes outside of the TLS migration, as those could lead to some side effects.
+If the processes are missing the TLS environment variables, it's recommended to first update the `FDB_TLS_CERTIFICATE_FILE`, `FDB_TLS_KEY_FILE` and `FDB_TLS_CA_FILE`.
+Once the cluster is reconciled the TLS conversion can be started by enabling TLS in the main container:
+
+```yaml
+apiVersion: apps.foundationdb.org/v1beta2
+kind: FoundationDBCluster
+metadata:
+  name: sample-cluster
+spec:
+  # Other settings
+  mainContainer:
+    enableTls: true
+    peerVerificationRules: "S.CN=sample-cluster.foundationdb.example|S.CN=sample-cluster-client.foundationdb.example|S.CN=fdb-kubernetes-operator.foundationdb.example"
+  # Other settings
+```
+
 ## Next
 
 You can continue on to the [next section](backup.md) or go back to the [table of contents](index.md).

--- a/e2e/fixtures/chaos_common.go
+++ b/e2e/fixtures/chaos_common.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"golang.org/x/sync/errgroup"
 
 	"github.com/onsi/gomega"
@@ -35,7 +37,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -213,13 +214,8 @@ func (factory *Factory) waitUntilExperimentRunning(
 }
 
 // PodSelector returns the PodSelectorSpec for the provided Pod.
-// TODO(j-scheuermann): This should be merged with the method below (PodsSelector).
 func PodSelector(pod *corev1.Pod) chaosmesh.PodSelectorSpec {
-	pods := make(map[string][]string)
-	pods[pod.Namespace] = []string{pod.Name}
-	return chaosmesh.PodSelectorSpec{
-		Pods: pods,
-	}
+	return PodsSelector([]corev1.Pod{*pod})
 }
 
 // PodsSelector returns the PodSelectorSpec for the provided Pods.

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -381,7 +381,7 @@ func (factory *Factory) startFDBFromClusterSpec(
 		fdbCluster.cluster.Namespace,
 	)
 
-	gomega.Expect(fdbCluster.WaitUntilAvailable()).ToNot(gomega.HaveOccurred())
+	fdbCluster.WaitUntilAvailable()
 	return fdbCluster
 }
 

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -1224,9 +1224,14 @@ func (fdbCluster *FdbCluster) SetIgnoreMissingProcessesSeconds(duration time.Dur
 }
 
 // SetKillProcesses sets the automation option to allow the operator to restart processes or not.
-func (fdbCluster *FdbCluster) SetKillProcesses(allowKill bool) {
+func (fdbCluster *FdbCluster) SetKillProcesses(allowKill bool, wait bool) {
 	fdbCluster.cluster.Spec.AutomationOptions.KillProcesses = ptr.To(allowKill)
 	fdbCluster.UpdateClusterSpec()
+
+	if !wait {
+		return
+	}
+
 	gomega.Expect(fdbCluster.WaitForReconciliation()).NotTo(gomega.HaveOccurred())
 }
 

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -34,7 +34,6 @@ import (
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // getStatusFromOperatorPod returns fdb status queried through the operator Pod.
@@ -222,16 +221,10 @@ func (fdbCluster *FdbCluster) IsAvailable() bool {
 }
 
 // WaitUntilAvailable waits until the cluster is available.
-func (fdbCluster *FdbCluster) WaitUntilAvailable() error {
-	return wait.PollUntilContextTimeout(
-		context.Background(),
-		100*time.Millisecond,
-		60*time.Second,
-		true,
-		func(_ context.Context) (bool, error) {
-			return fdbCluster.IsAvailable(), nil
-		},
-	)
+func (fdbCluster *FdbCluster) WaitUntilAvailable() {
+	gomega.Eventually(func() bool {
+		return fdbCluster.IsAvailable()
+	}).To(gomega.BeTrue())
 }
 
 // StatusInvariantChecker provides a way to check an invariant for the cluster status.

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1991,7 +1991,6 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var pickedProcessGroup *fdbv1beta2.ProcessGroupStatus
 
 		BeforeEach(func() {
-			// Make sure we reset the previous behaviour.
 			cluster := fdbCluster.GetCluster()
 			spec := cluster.Spec.DeepCopy()
 			// TODO (johscheuer): Once the new CRD is available change this to ResetMaintenanceMode.
@@ -2038,7 +2037,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			// Make sure the maintenance mode is not reset until the Pod is recreated
 			Consistently(func() fdbv1beta2.FaultDomain {
 				return fdbCluster.GetStatus().Cluster.MaintenanceZone
-			}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Equal(faultDomain))
+			}).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(Equal(faultDomain))
 
 			podName := pickedProcessGroup.GetPodName(fdbCluster.GetCluster())
 			log.Println("Delete Pod", podName)

--- a/e2e/test_operator_migrations/operator_migration_test.go
+++ b/e2e/test_operator_migrations/operator_migration_test.go
@@ -30,8 +30,6 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/utils/ptr"
-
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/fixtures"
 	. "github.com/onsi/ginkgo/v2"
@@ -39,6 +37,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -46,6 +46,17 @@ var (
 	fdbCluster  *fixtures.FdbCluster
 	testOptions *fixtures.FactoryOptions
 )
+
+func validateStorageClass(processClass fdbv1beta2.ProcessClass, targetStorageClass string) {
+	Eventually(func() map[string]fdbv1beta2.None {
+		storageClassNames := make(map[string]fdbv1beta2.None)
+		volumeClaims := fdbCluster.GetVolumeClaimsForProcesses(processClass)
+		for _, volumeClaim := range volumeClaims.Items {
+			storageClassNames[*volumeClaim.Spec.StorageClassName] = fdbv1beta2.None{}
+		}
+		return storageClassNames
+	}, 5*time.Minute).Should(Equal(map[string]fdbv1beta2.None{targetStorageClass: {}}))
+}
 
 func init() {
 	testOptions = fixtures.InitFlags()
@@ -125,6 +136,321 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 				return true
 			}).WithTimeout(40 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
 			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+		})
+	})
+
+	When("changing the public IP source", func() {
+		BeforeEach(func() {
+			if fdbCluster.GetCluster().UseDNSInClusterFile() {
+				Skip("using DNS and public IP from service is not tested")
+			}
+
+			log.Printf("set public IP source to %s", fdbv1beta2.PublicIPSourceService)
+			Expect(
+				fdbCluster.SetPublicIPSource(fdbv1beta2.PublicIPSourceService),
+			).ShouldNot(HaveOccurred())
+		})
+
+		It("should change the public IP source and create/delete services", func() {
+			Eventually(func() bool {
+				pods := fdbCluster.GetPods()
+				svcList := fdbCluster.GetServices()
+
+				svcMap := make(map[string]struct{}, len(svcList.Items))
+				for _, svc := range svcList.Items {
+					svcMap[svc.Name] = struct{}{}
+				}
+
+				for _, pod := range pods.Items {
+					if fdbv1beta2.PublicIPSource(
+						pod.Annotations[fdbv1beta2.PublicIPAnnotation],
+					) == fdbv1beta2.PublicIPSourcePod {
+						continue
+					}
+
+					if _, ok := svcMap[pod.Name]; !ok {
+						return false
+					}
+
+					delete(svcMap, pod.Name)
+				}
+
+				// We only expect one service here at the end since we run the cluster with a headless service.
+				if fdbCluster.HasHeadlessService() {
+					return len(svcMap) == 1
+				}
+				return len(svcMap) == 0
+			}).Should(BeTrue())
+		})
+
+		AfterEach(func() {
+			log.Printf("set public IP source to %s", fdbv1beta2.PublicIPSourcePod)
+			Expect(
+				fdbCluster.SetPublicIPSource(fdbv1beta2.PublicIPSourcePod),
+			).ShouldNot(HaveOccurred())
+			svcList := fdbCluster.GetServices()
+
+			var expectedSvcCnt int
+			if fdbCluster.HasHeadlessService() {
+				expectedSvcCnt = 1
+			}
+			Expect(len(svcList.Items)).To(BeNumerically("==", expectedSvcCnt))
+		})
+	})
+
+	When("changing the volume size", func() {
+		var initialPods *corev1.PodList
+		var newSize, initialStorageSize resource.Quantity
+
+		BeforeEach(func() {
+			var err error
+
+			initialPods = fdbCluster.GetLogPods()
+			// We use ProcessClassGeneral here because we are not setting any specific settings for the Log processes.
+			initialStorageSize, err = fdbCluster.GetVolumeSize(fdbv1beta2.ProcessClassGeneral)
+			Expect(err).NotTo(HaveOccurred())
+			// Add 10G to the current size
+			newSize = initialStorageSize.DeepCopy()
+			newSize.Add(resource.MustParse("10G"))
+			Expect(
+				fdbCluster.SetVolumeSize(fdbv1beta2.ProcessClassGeneral, newSize),
+			).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			Expect(
+				fdbCluster.SetVolumeSize(fdbv1beta2.ProcessClassGeneral, initialStorageSize),
+			).NotTo(HaveOccurred())
+		})
+
+		It("should replace all the log Pods and use the new volume size", func() {
+			pods := fdbCluster.GetLogPods()
+			Expect(pods.Items).NotTo(ContainElements(initialPods.Items))
+			volumeClaims := fdbCluster.GetVolumeClaimsForProcesses(
+				fdbv1beta2.ProcessClassLog,
+			)
+			Expect(len(volumeClaims.Items)).To(Equal(len(initialPods.Items)))
+			for _, volumeClaim := range volumeClaims.Items {
+				req := volumeClaim.Spec.Resources.Requests[corev1.ResourceStorage]
+				Expect((&req).Value()).To(Equal(newSize.Value()))
+			}
+		})
+	})
+
+	When("the pod IP family is changed", func() {
+		var initialPods []string
+		var podIPFamily = fdbv1beta2.PodIPFamilyIPv4
+
+		BeforeEach(func() {
+			pods := fdbCluster.GetPods()
+			for _, pod := range pods.Items {
+				initialPods = append(initialPods, pod.Name)
+			}
+
+			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec.Routing.PodIPFamily = ptr.To(podIPFamily)
+			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			Expect(fdbCluster.WaitForReconciliation()).To(Succeed())
+		})
+
+		AfterEach(func() {
+			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec.Routing.PodIPFamily = nil
+			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			Expect(
+				fdbCluster.WaitForReconciliation(fixtures.SoftReconcileOption(true)),
+			).To(Succeed())
+		})
+
+		It("should replace all pods and configure them properly", func() {
+			pods := fdbCluster.GetPods()
+			podIPFamilyString := strconv.Itoa(podIPFamily)
+			var expectedContainerWithEnv string
+			// In the case of the split image the sidecar will have that env variable.
+			if fdbCluster.GetCluster().UseUnifiedImage() {
+				expectedContainerWithEnv = fdbv1beta2.MainContainerName
+			} else {
+				expectedContainerWithEnv = fdbv1beta2.SidecarContainerName
+			}
+
+			newPods := make([]string, 0, len(pods.Items))
+			for _, pod := range pods.Items {
+				if !pod.DeletionTimestamp.IsZero() {
+					continue
+				}
+
+				if pod.Status.Phase != corev1.PodRunning {
+					log.Println(
+						"ignoring pod:",
+						pod.Name,
+						"with pod phase",
+						pod.Status.Phase,
+						"message:",
+						pod.Status.Message,
+					)
+					continue
+				}
+
+				var checked bool
+
+				for _, container := range pod.Spec.Containers {
+					if container.Name != expectedContainerWithEnv {
+						continue
+					}
+
+					// Make sure the FDB_PUBLIC_IP env variable is set.
+					for _, env := range container.Env {
+						if env.Name == fdbv1beta2.EnvNamePublicIP {
+							checked = true
+							break
+						}
+					}
+
+					Expect(checked).To(BeTrue())
+					break
+				}
+
+				newPods = append(newPods, pod.Name)
+				Expect(
+					pod.Annotations,
+				).To(HaveKeyWithValue(fdbv1beta2.IPFamilyAnnotation, podIPFamilyString))
+			}
+
+			Expect(newPods).NotTo(ContainElements(initialPods))
+
+		})
+	})
+
+	When("maxConcurrentReplacements is lower than the number of storage pods", func() {
+		var initialConcurrentReplacements *int
+		var initialPodUpdateStrategy fdbv1beta2.PodUpdateStrategy
+		var initialReplaceInstancesWhenResourcesChange *bool
+
+		BeforeEach(func() {
+			// Remember the current settings before updating the spec
+			initialConcurrentReplacements = fdbCluster.GetCluster().Spec.AutomationOptions.MaxConcurrentReplacements
+			initialPodUpdateStrategy = fdbCluster.GetClusterSpec().AutomationOptions.PodUpdateStrategy
+			initialReplaceInstancesWhenResourcesChange = fdbCluster.GetCluster().Spec.ReplaceInstancesWhenResourcesChange
+			// Allow to replacement of 3 pods concurrently, as there are 5 storage servers, there need to be at least 2 rounds of replacements to replace all.
+			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec.AutomationOptions.MaxConcurrentReplacements = ptr.To(3)
+			spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyDelete
+			spec.ReplaceInstancesWhenResourcesChange = ptr.To(true)
+			fdbCluster.UpdateClusterSpecWithSpec(spec)
+		})
+
+		AfterEach(func() {
+			// Reset to the initial settings
+			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec.AutomationOptions.MaxConcurrentReplacements = initialConcurrentReplacements
+			spec.AutomationOptions.PodUpdateStrategy = initialPodUpdateStrategy
+			spec.ReplaceInstancesWhenResourcesChange = initialReplaceInstancesWhenResourcesChange
+			fdbCluster.UpdateClusterSpecWithSpec(spec)
+		})
+
+		When("a change that requires a replacement of all storage pods", func() {
+			var initialVolumeClaims []types.UID
+			var newCPURequest, initialCPURequest resource.Quantity
+
+			BeforeEach(func() {
+				initialVolumeClaims = fdbCluster.GetListOfUIDsFromVolumeClaims(
+					fdbv1beta2.ProcessClassStorage,
+				)
+				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				initialCPURequest = spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+				newCPURequest = initialCPURequest.DeepCopy()
+
+				// An increase in request requires a replacement when ReplaceInstancesWhenResourcesChange is set to true
+				newCPURequest.Add(resource.MustParse("1m"))
+				spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = newCPURequest
+				fdbCluster.UpdateClusterSpecWithSpec(spec)
+
+				// Wait for the reconciliation to finish
+				Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				// Undo the change to cpu requests
+				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = initialCPURequest
+				fdbCluster.UpdateClusterSpecWithSpec(spec)
+
+				// Wait for the reconciliation to finish
+				Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			})
+
+			It("should replace all storage pods", func() {
+				// A replacement of a storage pod will create a new PVC. After reconciliation the set of PVCs should be completely changed.
+				Expect(
+					initialVolumeClaims,
+				).NotTo(ContainElements(fdbCluster.GetListOfUIDsFromVolumeClaims(fdbv1beta2.ProcessClassStorage)), "PVC should not be present in the new set of PVCs")
+			})
+		})
+	})
+
+	When("migrating a cluster to make use of DNS in the cluster file", func() {
+		BeforeEach(func() {
+			if fdbCluster.GetCluster().UseDNSInClusterFile() {
+				Skip("cluster already uses DNS")
+			}
+
+			Expect(fdbCluster.SetUseDNSInClusterFile(true)).ToNot(HaveOccurred())
+		})
+
+		It("should migrate the cluster", func() {
+			cluster := fdbCluster.GetCluster()
+			Eventually(func() string {
+				return fdbCluster.GetStatus().Cluster.ConnectionString
+			}).Should(ContainSubstring(cluster.GetDNSDomain()))
+		})
+
+		AfterEach(func() {
+			Expect(fdbCluster.SetUseDNSInClusterFile(false)).ToNot(HaveOccurred())
+		})
+	})
+
+	When("Migrating a cluster to a different storage class", func() {
+		var defaultStorageClass, targetStorageClass string
+
+		BeforeEach(func() {
+			// This will only return StorageClasses that have a label foundationdb.org/operator-testing=true defined.
+			storageClasses := factory.GetStorageClasses(map[string]string{
+				"foundationdb.org/operator-testing": "true",
+			})
+			if len(storageClasses.Items) < 2 {
+				Skip("This test requires at least two available StorageClasses")
+			}
+
+			defaultStorageClass = factory.GetDefaultStorageClass()
+			// Select all StorageClasses that are not the default one as candidate.
+			candidates := make([]string, 0, len(storageClasses.Items))
+			for _, storageClass := range storageClasses.Items {
+				if storageClass.Name == defaultStorageClass {
+					continue
+				}
+
+				candidates = append(candidates, storageClass.Name)
+			}
+
+			targetStorageClass = candidates[factory.Intn(len(candidates))]
+
+			Expect(fdbCluster.UpdateStorageClass(
+				targetStorageClass,
+				fdbv1beta2.ProcessClassLog,
+			)).NotTo(HaveOccurred())
+		})
+
+		It("should migrate the cluster", func() {
+			validateStorageClass(fdbv1beta2.ProcessClassLog, targetStorageClass)
+		})
+
+		AfterEach(func() {
+			if defaultStorageClass != "" {
+				Expect(fdbCluster.UpdateStorageClass(
+					defaultStorageClass,
+					fdbv1beta2.ProcessClassLog,
+				)).NotTo(HaveOccurred())
+			}
 		})
 	})
 

--- a/e2e/test_operator_migrations/operator_migration_test.go
+++ b/e2e/test_operator_migrations/operator_migration_test.go
@@ -58,6 +58,21 @@ func validateStorageClass(processClass fdbv1beta2.ProcessClass, targetStorageCla
 	}, 5*time.Minute).Should(Equal(map[string]fdbv1beta2.None{targetStorageClass: {}}))
 }
 
+func checkCoordinatorsTLSFlag(cluster *fdbv1beta2.FoundationDBCluster, listenOnTLS bool) {
+	connectionString := cluster.Status.ConnectionString
+	log.Println("connection string after conversion: ", connectionString)
+	parsedConnectionString, err := fdbv1beta2.ParseConnectionString(connectionString)
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, coordinator := range parsedConnectionString.Coordinators {
+		if listenOnTLS {
+			Expect(coordinator).To(HaveSuffix(":tls"))
+		} else {
+			Expect(coordinator).NotTo(HaveSuffix(":tls"))
+		}
+	}
+}
+
 func init() {
 	testOptions = fixtures.InitFlags()
 }
@@ -451,6 +466,70 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 					fdbv1beta2.ProcessClassLog,
 				)).NotTo(HaveOccurred())
 			}
+		})
+	})
+
+	When("Changing the TLS setting", func() {
+		var initialTLSSetting bool
+
+		BeforeEach(func() {
+			initialTLSSetting = fdbCluster.GetCluster().Spec.MainContainer.EnableTLS
+		})
+
+		AfterEach(func() {
+			Expect(
+				fdbCluster.SetTLS(
+					initialTLSSetting,
+					fdbCluster.GetCluster().Spec.SidecarContainer.EnableTLS,
+				),
+			).NotTo(HaveOccurred())
+			Expect(fdbCluster.HasTLSEnabled()).To(Equal(initialTLSSetting))
+			checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), initialTLSSetting)
+		})
+
+		When("the pod spec stays the same", func() {
+			It("should update the TLS setting  and keep the cluster available", func() {
+				// Only change the TLS setting for the cluster and not for the sidecar otherwise we have to recreate
+				// all Pods which takes a long time since we recreate the Pods one by one.
+				Expect(
+					fdbCluster.SetTLS(
+						!initialTLSSetting,
+						fdbCluster.GetCluster().Spec.SidecarContainer.EnableTLS,
+					),
+				).NotTo(HaveOccurred())
+				Expect(fdbCluster.HasTLSEnabled()).To(Equal(!initialTLSSetting))
+				checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), !initialTLSSetting)
+			})
+		})
+
+		When("the pod spec is changed", func() {
+			It("should update the TLS setting  and keep the cluster available", func() {
+				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				spec.MainContainer.EnableTLS = !initialTLSSetting
+
+				// Add a new env variable to ensure this will cause some additional replacements.
+				processSettings := spec.Processes[fdbv1beta2.ProcessClassGeneral]
+				for i, container := range processSettings.PodTemplate.Spec.Containers {
+					if container.Name != fdbv1beta2.MainContainerName {
+						continue
+					}
+
+					container.Env = append(container.Env, corev1.EnvVar{
+						Name:  "TESTING_TLS_CHANGE",
+						Value: "EMPTY",
+					})
+
+					processSettings.PodTemplate.Spec.Containers[i] = container
+					break
+				}
+
+				spec.Processes[fdbv1beta2.ProcessClassGeneral] = processSettings
+
+				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				Expect(fdbCluster.WaitForReconciliation()).To(Succeed())
+				Expect(fdbCluster.HasTLSEnabled()).To(Equal(!initialTLSSetting))
+				checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), !initialTLSSetting)
+			})
 		})
 	})
 

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -206,7 +206,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 			// Disable the feature that the operator restarts processes. This allows us to restart the coordinator
 			// once all new binaries are present.
-			fdbCluster.SetKillProcesses(false)
+			fdbCluster.SetKillProcesses(false, true)
 
 			// Start the upgrade.
 			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
@@ -245,7 +245,10 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			}).WithTimeout(180 * time.Second).WithPolling(4 * time.Second).Should(And(HaveLen(1), HaveKey(selectedCoordinator.Status.PodIP)))
 
 			// Allow the operator to restart processes and the upgrade should continue and finish.
-			fdbCluster.SetKillProcesses(true)
+			fdbCluster.SetKillProcesses(true, false)
+
+			// Ensure that the cluster was upgraded.
+			fdbCluster.VerifyVersion(targetVersion)
 
 			// Make sure the cluster has no data loss.
 			fdbCluster.EnsureTeamTrackersHaveMinReplicas()

--- a/internal/restarts/restarts.go
+++ b/internal/restarts/restarts.go
@@ -41,7 +41,7 @@ func GetFilterConditions(
 		}
 	}
 
-	// In case of TL/Non-TLS conversion we can ignore the fdbv1beta2.IncorrectPodSpec, otherwise if a user tries
+	// In case of TLS/Non-TLS conversion we can ignore the fdbv1beta2.IncorrectPodSpec, otherwise if a user tries
 	// to change the Pod spec and the TLS settings, the operator gets stuck. Because the bounce processes sub-reconciler
 	// would wait for the Pod update and the Pod update sub-reconciler would wait for the process restart.
 	if cluster.Status.RequiredAddresses.NonTLS && cluster.Status.RequiredAddresses.TLS {

--- a/internal/restarts/restarts_test.go
+++ b/internal/restarts/restarts_test.go
@@ -44,6 +44,7 @@ var _ = Describe("restarts", func() {
 			map[fdbv1beta2.ProcessGroupConditionType]bool{
 				fdbv1beta2.IncorrectCommandLine: true,
 				fdbv1beta2.SidecarUnreachable:   false,
+				fdbv1beta2.IncorrectPodSpec:     false,
 				fdbv1beta2.IncorrectConfigMap:   false,
 			}),
 		Entry("when the running version is missing",
@@ -55,6 +56,7 @@ var _ = Describe("restarts", func() {
 			map[fdbv1beta2.ProcessGroupConditionType]bool{
 				fdbv1beta2.IncorrectCommandLine: true,
 				fdbv1beta2.SidecarUnreachable:   false,
+				fdbv1beta2.IncorrectPodSpec:     false,
 				fdbv1beta2.IncorrectConfigMap:   false,
 			}),
 		Entry("when a version incompatible upgrade is performed",
@@ -70,6 +72,24 @@ var _ = Describe("restarts", func() {
 				fdbv1beta2.IncorrectCommandLine:  true,
 				fdbv1beta2.IncorrectSidecarImage: false,
 				fdbv1beta2.IncorrectConfigMap:    false,
+			}),
+		Entry("when a TLS migration is ongoing",
+			&fdbv1beta2.FoundationDBCluster{
+				Spec: fdbv1beta2.FoundationDBClusterSpec{
+					Version: "7.1.25",
+				},
+				Status: fdbv1beta2.FoundationDBClusterStatus{
+					RunningVersion: "7.1.25",
+					RequiredAddresses: fdbv1beta2.RequiredAddressSet{
+						TLS:    true,
+						NonTLS: true,
+					},
+				},
+			},
+			map[fdbv1beta2.ProcessGroupConditionType]bool{
+				fdbv1beta2.IncorrectCommandLine: true,
+				fdbv1beta2.SidecarUnreachable:   false,
+				fdbv1beta2.IncorrectConfigMap:   false,
 			}),
 	)
 })


### PR DESCRIPTION
# Description

Restructure of our e2e tests, to balance the tests between the different test suites to achieve higher concurrency.

## Type of change

- Other

## Discussion

I deleted a test case that was pending for multiple years now with a feature that we probably will never use.

## Testing

Ran some test manually and CI is running all of them.

## Documentation

Not needed.

## Follow-up

-