### PR TITLE
Update the go version to 1.24.5

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24.4
+          go-version: 1.24.5
       - name: Get dependencies
         run: curl -L --fail "https://github.com/apple/foundationdb/releases/download/${FDB_VER}/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.24.4
+        go-version: 1.24.5
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Get dependencies
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.24.4
+        go-version: 1.24.5
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Get dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24.4
+          go-version: 1.24.5
       #  https://github.com/goreleaser/goreleaser/issues/1311
       - name: Get current semver tag
         run: echo "GORELEASER_CURRENT_TAG=$(git describe --tags --match "v*" --abbrev=0)" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG FDB_VERSION=7.1.67
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM docker.io/library/golang:1.24.4 AS builder
+FROM docker.io/library/golang:1.24.5 AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE


### PR DESCRIPTION
# Description

Update to the latest go 1.24.5 release (https://go.dev/doc/devel/release#go1.24.5)

## Type of change

- Other

## Discussion

-

## Testing

Ran `make fmt lint test` locally.

## Documentation

-

## Follow-up

-
