### PR TITLE
Improve migration test case to reduce runtime

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1745,7 +1745,7 @@ func (cluster *FoundationDBCluster) CheckReconciliation(log logr.Logger) (bool, 
 				)
 				cluster.Status.Generations.HasPendingRemoval = cluster.Generation
 			} else {
-				logger.Info("Has process group with pending shrink", "processGroupID", processGroup.ProcessGroupID, "state", "NeedsShrink")
+				logger.Info("Has process group with pending shrink", "processGroupID", processGroup.ProcessGroupID, "state", "NeedsShrink", "conditions", processGroup.ProcessGroupConditions)
 				cluster.Status.Generations.NeedsShrink = cluster.Generation
 				reconciled = false
 			}

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -1153,12 +1153,22 @@ func (fdbCluster *FdbCluster) SetPodTemplateSpec(
 func (fdbCluster *FdbCluster) GetPodTemplateSpec(
 	processClass fdbv1beta2.ProcessClass,
 ) *corev1.PodSpec {
-	if classSpec, ok := fdbCluster.cluster.Spec.Processes[processClass]; ok {
-		return &classSpec.PodTemplate.Spec
+	return &fdbCluster.GetProcessSettings(processClass).PodTemplate.Spec
+}
+
+// GetProcessSettings returns the process settings for the process class. If no settings are defined for the specific
+// process class the process settings for the general class will be returned.
+func (fdbCluster *FdbCluster) GetProcessSettings(
+	processClass fdbv1beta2.ProcessClass,
+) *fdbv1beta2.ProcessSettings {
+	if settings, ok := fdbCluster.cluster.Spec.Processes[processClass]; ok {
+		return &settings
 	}
-	if generalSpec, ok := fdbCluster.cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]; ok {
-		return &generalSpec.PodTemplate.Spec
+
+	if settings, ok := fdbCluster.cluster.Spec.Processes[fdbv1beta2.ProcessClassGeneral]; ok {
+		return &settings
 	}
+
 	return nil
 }
 

--- a/e2e/test_operator_migrations/operator_migration_test.go
+++ b/e2e/test_operator_migrations/operator_migration_test.go
@@ -102,13 +102,12 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 	})
 
 	When("a migration is triggered and the namespace quota is limited", func() {
-		prefix := "banana"
 		var quota *corev1.ResourceQuota
 
 		BeforeEach(func() {
 			processCounts, err := fdbCluster.GetCluster().GetProcessCountsWithDefaults()
 			Expect(err).NotTo(HaveOccurred())
-			// Create Quota to limit the additional Pods that can be created to 5, the actual value here is 7 ,because we run
+			// Create Quota to limit the additional Pods that can be created to 5, the actual value here is 7, because we run
 			// 2 Operator Pods.
 			quota = &corev1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
@@ -122,35 +121,57 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 				},
 			}
 			Expect(factory.CreateIfAbsent(quota)).NotTo(HaveOccurred())
-			Expect(fdbCluster.SetProcessGroupPrefix(prefix)).NotTo(HaveOccurred())
+
+			logSettings := fdbCluster.GetProcessSettings(fdbv1beta2.ProcessClassLog).DeepCopy()
+			for idx, container := range logSettings.PodTemplate.Spec.Containers {
+				if container.Name != fdbv1beta2.MainContainerName {
+					continue
+				}
+
+				container.Env = append(container.Env, corev1.EnvVar{
+					Name:  "TESTING_MIGRATION",
+					Value: "true",
+				})
+
+				logSettings.PodTemplate.Spec.Containers[idx] = container
+			}
+
+			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec.Processes[fdbv1beta2.ProcessClassLog] = *logSettings
+			fdbCluster.UpdateClusterSpecWithSpec(spec)
+
+			Expect(fdbCluster.WaitForReconciliation()).To(Succeed())
 		})
 
 		AfterEach(func() {
 			factory.Delete(quota)
 		})
 
-		It("should add the prefix to all instances", func() {
+		FIt("should add the new env variable to all log pods", func() {
 			lastForcedReconciliationTime := time.Now()
 			forceReconcileDuration := 4 * time.Minute
 
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				// Force a reconcile if needed to make sure we speed up the reconciliation if needed.
 				if time.Since(lastForcedReconciliationTime) >= forceReconcileDuration {
 					fdbCluster.ForceReconcile()
 					lastForcedReconciliationTime = time.Now()
 				}
 
-				// Check if all process groups are migrated
-				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
-					if processGroup.IsMarkedForRemoval() && processGroup.IsExcluded() {
-						continue
-					}
-					g.Expect(string(processGroup.ProcessGroupID)).To(HavePrefix(prefix))
-				}
+				// Check if all log pods are migrated
+				for _, pod := range fdbCluster.GetLogPods().Items {
+					for _, container := range pod.Spec.Containers {
+						if container.Name != fdbv1beta2.MainContainerName {
+							continue
+						}
 
-				return true
-			}).WithTimeout(40 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+						g.Expect(container.Env).To(ContainElement(corev1.EnvVar{
+							Name:  "TESTING_MIGRATION",
+							Value: "true",
+						}))
+					}
+				}
+			}).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 		})
 	})
 

--- a/e2e/test_operator_migrations/operator_migration_test.go
+++ b/e2e/test_operator_migrations/operator_migration_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 			factory.Delete(quota)
 		})
 
-		FIt("should add the new env variable to all log pods", func() {
+		It("should add the new env variable to all log pods", func() {
 			lastForcedReconciliationTime := time.Now()
 			forceReconcileDuration := 4 * time.Minute
 


### PR DESCRIPTION
# Description

Improve migration test case to reduce runtime, otherwise the migration will take a long  eventually timeout with the global sync mode.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

I changed the migration test to only update log processes and not all processes, that should be good enough for what we are testing.

## Testing

Ran the test case manually.

## Documentation

-

## Follow-up

-
