### PR TITLE
Allow the pod metadata updater to update the metdadata for Pods marked as removal

### DIFF
--- a/controllers/update_metadata.go
+++ b/controllers/update_metadata.go
@@ -44,8 +44,8 @@ func (updateMetadata) reconcile(
 ) *requeue {
 	var shouldRequeue bool
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		if processGroup.IsMarkedForRemoval() {
-			logger.V(1).Info("Ignore process group marked for removal",
+		if processGroup.GetConditionTime(fdbv1beta2.ResourcesTerminating) != nil {
+			logger.V(1).Info("Ignore process group marked that is stuck terminating",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue
 		}

--- a/controllers/update_metadata.go
+++ b/controllers/update_metadata.go
@@ -45,7 +45,7 @@ func (updateMetadata) reconcile(
 	var shouldRequeue bool
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.GetConditionTime(fdbv1beta2.ResourcesTerminating) != nil {
-			logger.V(1).Info("Ignore process group marked that is stuck terminating",
+			logger.V(1).Info("Ignore process group that is stuck in terminating state",
 				"processGroupID", processGroup.ProcessGroupID)
 			continue
 		}

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -63,7 +63,7 @@ func (updatePodConfig) reconcile(
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		curLogger := logger.WithValues("processGroupID", processGroup.ProcessGroupID)
 		if processGroup.GetConditionTime(fdbv1beta2.ResourcesTerminating) != nil {
-			curLogger.V(1).Info("Ignore process group marked that is stuck terminating")
+			curLogger.V(1).Info("Ignore process group that is stuck terminating")
 			continue
 		}
 

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -493,6 +493,9 @@ func checkAndSetProcessStatus(
 
 	processGroupStatus.UpdateCondition(fdbv1beta2.MissingProcesses, hasMissingProcesses)
 	processGroupStatus.UpdateCondition(fdbv1beta2.SidecarUnreachable, sidecarUnreachable)
+	// If the processes are not up and running, we will reset the incorrect command line, e.g. in case that the processes
+	// were just restarted by the operator.
+	processGroupStatus.UpdateCondition(fdbv1beta2.IncorrectCommandLine, hasIncorrectCommandLine)
 	// If the processes are absent, we are not able to determine the state of the processes, therefore we won't change it.
 	if hasMissingProcesses {
 		return nil
@@ -520,7 +523,6 @@ func checkAndSetProcessStatus(
 	if sidecarUnreachable {
 		return nil
 	}
-	processGroupStatus.UpdateCondition(fdbv1beta2.IncorrectCommandLine, hasIncorrectCommandLine)
 
 	return nil
 }


### PR DESCRIPTION
# Description

Allow the pod metadata updater to update the metdadata for Pods marked as removal. This allows to update the knobs for process groups that are marked for removal. Otherwise a long running exclusion could lead to multiple restarts of the excluded process.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

Added a new e2e test and ran different configurations.

## Documentation

-

## Follow-up

-
