### PR TITLE
Correct the reconciliation status after the initial run after the cluster wide bounce

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1805,6 +1805,7 @@ func (cluster *FoundationDBCluster) CheckReconciliation(log logr.Logger) (bool, 
 			"reconciledProcessGroups",
 			cluster.Status.ReconciledProcessGroups,
 		)
+		reconciled = false
 	}
 
 	if !cluster.Status.Health.Available {
@@ -1901,6 +1902,19 @@ func (cluster *FoundationDBCluster) CheckReconciliation(log logr.Logger) (bool, 
 			reconciled = false
 			break
 		}
+	}
+
+	// If the cluster is currently in the process to be upgraded, don't set the reconciled version.
+	if cluster.IsBeingUpgraded() {
+		logger.Info(
+			"Pending cluster upgrade",
+			"runningVersion",
+			cluster.GetRunningVersion(),
+			"desiredVersion",
+			cluster.Spec.Version,
+		)
+
+		reconciled = false
 	}
 
 	if reconciled && cluster.Status.Generations.Reconciled != cluster.Generation {

--- a/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
+++ b/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
@@ -192,7 +192,7 @@ func performUpgrade(config testConfig, preUpgradeFunction func(cluster *fixtures
 	// replacements during an upgrade.
 	expectedProcessCounts := (processCounts.Total()-processCounts.Storage)*2 + 5
 	Expect(len(transactionSystemProcessGroups)).To(BeNumerically("<=", expectedProcessCounts))
-	// Ensure we have not data loss.
+	// Ensure we have no data loss.
 	fdbCluster.EnsureTeamTrackersAreHealthy()
 	fdbCluster.EnsureTeamTrackersHaveMinReplicas()
 }


### PR DESCRIPTION
# Description

Before this change the runningVersion would be updated before the updateStatus reconciler ends its work. This would lead to cases where the operator things that the cluster is reconciled after an upgrade, even thought the cluster shouldn't be marked as reconciled. In the next iteration the operator notice that the reconciliation is not done and would update it accordingly. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

The issue above could only be a problem if another system was waiting for the operator to mark the cluster as reconciled.

## Testing

Ran e2e test and made sure we don't see the behaviour mentioned above. I will add an additional test or extend a test case.

## Documentation

-

## Follow-up

-
