### PR TITLE
Enable management API e2e test cases

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -96,6 +96,15 @@ ifndef FEATURE_DNS
     FEATURE_DNS=true
   endif
 endif
+
+ifndef FEATURE_MANAGEMENT_API
+  ifeq ($(shell shuf -i 0-1 -n 1), 0)
+    FEATURE_MANAGEMENT_API=false
+  else
+    FEATURE_MANAGEMENT_API=true
+  endif
+endif
+
 # Make bash pickier about errors.
 SHELL=/bin/bash -euo pipefail
 
@@ -210,6 +219,7 @@ foundationdb-nightly-tests: run
 	  --feature-synchronization-mode=$(FEATURE_SYNCHRONIZATION_MODE) \
 	  --feature-dns=$(FEATURE_DNS) \
 	  --feature-localities=$(FEATURE_LOCALITIES) \
+	  --feature-management-api=$(FEATURE_MANAGEMENT_API) \
 	  --node-selector="$(NODE_SELECTOR)" \
 	  --default-unavailable-threshold=$(DEFAULT_UNAVAILABLE_THRESHOLD) \
 	  --seaweedfs-image=$(SEAWEEDFS_IMAGE)  \

--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -83,6 +83,8 @@ type ClusterConfig struct {
 	UseDNS *bool
 	// If enabled the cluster will be setup with the unified image.
 	UseUnifiedImage *bool
+	// ManagementAPI if set to true, the operator will make use of the management API.
+	ManagementAPI *bool
 	// SimulateCustomFaultDomainEnv will simulate the use case that a user has set a custom environment variable to
 	// be used as zone ID.
 	SimulateCustomFaultDomainEnv bool
@@ -224,6 +226,10 @@ func (config *ClusterConfig) SetDefaults(factory *Factory) {
 
 	if config.Version == nil {
 		config.Version = ptr.To(factory.GetFDBVersion().String())
+	}
+
+	if config.ManagementAPI == nil {
+		config.ManagementAPI = ptr.To(factory.options.featureManagementAPI)
 	}
 }
 
@@ -632,5 +638,6 @@ func (config *ClusterConfig) Copy() *ClusterConfig {
 		SynchronizationMode:        config.SynchronizationMode,
 		EnableTLS:                  config.EnableTLS,
 		Version:                    config.Version,
+		ManagementAPI:              config.ManagementAPI,
 	}
 }

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -106,6 +106,7 @@ func (factory *Factory) createFDBClusterSpec(
 				},
 				UseLocalitiesForExclusion: config.UseLocalityBasedExclusions,
 				SynchronizationMode:       ptr.To(string(config.SynchronizationMode)),
+				UseManagementAPI:          config.ManagementAPI,
 			},
 			Routing: fdbv1beta2.RoutingConfig{
 				UseDNSInClusterFile: config.UseDNS,

--- a/e2e/fixtures/options.go
+++ b/e2e/fixtures/options.go
@@ -59,6 +59,7 @@ type FactoryOptions struct {
 	featureOperatorLocalities      bool
 	featureOperatorUnifiedImage    bool
 	featureOperatorServerSideApply bool
+	featureManagementAPI           bool
 	dumpOperatorState              bool
 	defaultUnavailableThreshold    time.Duration
 }
@@ -203,6 +204,12 @@ func (options *FactoryOptions) BindFlags(fs *flag.FlagSet) {
 		"feature-server-side-apply",
 		false,
 		"defines if the operator should make use of server side apply.",
+	)
+	fs.BoolVar(
+		&options.featureManagementAPI,
+		"feature-management-api",
+		false,
+		"defines if the operator should make use of the management API",
 	)
 	fs.StringVar(
 		&options.clusterName,


### PR DESCRIPTION
# Description

Fixes: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2285

## Type of change

- Other

## Discussion

-

## Testing

Ran test suite manually.

## Documentation

-

## Follow-up

-
