### PR TITLE
Remove the upgrade check during reconiliation

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1904,19 +1904,6 @@ func (cluster *FoundationDBCluster) CheckReconciliation(log logr.Logger) (bool, 
 		}
 	}
 
-	// If the cluster is currently in the process to be upgraded, don't set the reconciled version.
-	if cluster.IsBeingUpgraded() {
-		logger.Info(
-			"Pending cluster upgrade",
-			"runningVersion",
-			cluster.GetRunningVersion(),
-			"desiredVersion",
-			cluster.Spec.Version,
-		)
-
-		reconciled = false
-	}
-
 	if reconciled && cluster.Status.Generations.Reconciled != cluster.Generation {
 		logger.Info(
 			"Update reconciled generation",

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -331,7 +331,7 @@ func confirmRemoval(
 		return false, err
 	}
 
-	// The Pod resource still exists, so we have to validate the deletion timestamp.
+	// The service resource still exists, so we have to validate the deletion timestamp.
 	if err == nil {
 		if service.DeletionTimestamp.IsZero() {
 			logger.Info(

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -460,13 +460,12 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 					for _, pod := range coordinators {
 						coordinatorMap[pod.UID] = pod
 					}
-					dbCluster := cluster.GetCluster()
 
-					if dbCluster.Status.RunningVersion == targetVersion {
+					if cluster.GetCluster().GetRunningVersion() == targetVersion {
 						log.Println(
 							"Cluster",
 							cluster.Name(),
-							"is running at version ",
+							"is running at version",
 							targetVersion,
 						)
 						continue


### PR DESCRIPTION
# Description

In https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2341/ we added an additional check to set `reconciled` to false if the cluster is still in upgrade mode. For version incompatible upgrades this is fine, but for version compatible upgrades this could cause issues where one operator is done with everything in its local cluster but since the majority of pods (processes) must be updated to detect the new version, the operator would think reconciliation is not done yet and wouldn't release the lock.

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran e2e test manually.

## Documentation

-

## Follow-up

-
