### PR TITLE
Fix passing incompatible parameters to fdbbackup and fdbrestore via CustomParameters

### DIFF
--- a/api/v1beta2/foundationdb_custom_parameter.go
+++ b/api/v1beta2/foundationdb_custom_parameter.go
@@ -45,6 +45,22 @@ func (customParameters FoundationDBCustomParameters) GetKnobsForCLI() []string {
 	return args
 }
 
+// GetKnobsForBackupRestoreCLI returns the list of knobs that should be provided to the fdbbackup and fdbrestore
+// when running them over the admin client. It filters out the incompatible ones.
+func (customParameters FoundationDBCustomParameters) GetKnobsForBackupRestoreCLI() []string {
+	args := make([]string, 0, len(customParameters))
+
+	for _, arg := range customParameters {
+		parameterName := strings.Split(string(arg), "=")[0]
+		parameterName = strings.TrimSpace(parameterName)
+		if _, ok := backupAgentExclusiveParameters[parameterName]; ok {
+			continue
+		}
+		args = append(args, fmt.Sprintf("--%s", arg))
+	}
+	return args
+}
+
 var (
 	protectedParameters = map[string]None{
 		"datadir": {},
@@ -61,6 +77,11 @@ var (
 		"restart-delay-reset-interval": {},
 		"user":                         {},
 		"group":                        {},
+	}
+	// these parameters are supported by backup_agents but not by fdbbackup and fdbrestore.
+	backupAgentExclusiveParameters = map[string]None{
+		"locality-data_hall":   {},
+		"locality_data_center": {},
 	}
 )
 

--- a/api/v1beta2/foundationdb_custom_parameter_test.go
+++ b/api/v1beta2/foundationdb_custom_parameter_test.go
@@ -47,6 +47,26 @@ var _ = Describe("FoundationDBCustomParameters", func() {
 		})
 	})
 
+	When("getting the custom parameters for the fdbbackup and fdbrestore CLI", func() {
+		var customParameters FoundationDBCustomParameters
+		BeforeEach(func() {
+			customParameters = []FoundationDBCustomParameter{
+				"knob_http_verbose_level=3",
+				"locality-data_hall=az1",
+			}
+		})
+
+		It("", func() {
+			expected := []string{
+				"--knob_http_verbose_level=3",
+			}
+
+			result := customParameters.GetKnobsForBackupRestoreCLI()
+			Expect(result).To(ContainElements(expected))
+			Expect(len(result)).To(Equal(len(expected)))
+		})
+	})
+
 	When("Validating the custom parameters", func() {
 		DescribeTable("should print the correct string",
 			func(customParameters FoundationDBCustomParameters, expected error) {

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -140,7 +140,7 @@ func (r *FoundationDBBackupReconciler) adminClientForBackup(
 		return nil, err
 	}
 
-	adminClient.SetKnobs(backup.Spec.CustomParameters.GetKnobsForCLI())
+	adminClient.SetKnobs(backup.Spec.CustomParameters.GetKnobsForBackupRestoreCLI())
 
 	return adminClient, nil
 }

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -141,7 +141,7 @@ func (r *FoundationDBRestoreReconciler) adminClientForRestore(
 		return nil, err
 	}
 
-	adminClient.SetKnobs(restore.Spec.CustomParameters.GetKnobsForCLI())
+	adminClient.SetKnobs(restore.Spec.CustomParameters.GetKnobsForBackupRestoreCLI())
 
 	return adminClient, nil
 }


### PR DESCRIPTION



# Description

CustomParameters in `FoundationDBBackup` and `FoundationDBRestore` CRDs are meant to be passed to `backup_agent`. 
However, they are also passed to `fdbbackup` and `fdbrestore` commands when `admincli` object is built. An incompatible `backup_agent` parameter will be rejected by `fdbbackup/restore`, causing the operator to never reconcile the backup. We filter out the parameters that are exclusive to `backup_agents`.

## Type of change

*Please select one of the options below.*

X Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation
- Other

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?

We added a unit test. 

Manual testing?*

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

No

## Documentation

*Did you update relevant documentation within this repository?*

N/A

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
