### PR TITLE
Make sure we use the bookworm version of the go container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG FDB_VERSION=7.1.67
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM docker.io/library/golang:1.24.6 AS builder
+FROM docker.io/library/golang:1.24.6-bookworm AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE


### PR DESCRIPTION
# Description

The default golang image changed the base image from `bookworm` to `trixie` and seems like this breaks the build, so switching back to `bookworm`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Build the image locally (the `trixie` one also worked).

## Documentation

-

## Follow-up

-
