### PR TITLE
Enable encryption in backup operator test

### DIFF
--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -22,6 +22,7 @@ package fixtures
 
 import (
 	"context"
+	cryptorand "crypto/rand"
 	"fmt"
 	"io"
 	"log"
@@ -39,6 +40,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -130,6 +132,33 @@ func (factory *Factory) GetSecretName() string {
 // GetBackupSecretName returns the name of the backup secret.
 func (factory *Factory) GetBackupSecretName() string {
 	return "backup-credentials"
+}
+
+// GetEncryptionKeySecretName returns the name for the encryption key secret
+func (factory *Factory) GetEncryptionKeySecretName() string {
+	return "backup-encryption-key"
+}
+
+// CreateEncryptionKeySecret creates a 32-byte encryption key secret.
+func (factory *Factory) CreateEncryptionKeySecret(namespace string) {
+	secretName := factory.GetEncryptionKeySecretName()
+
+	// Create 32-byte encryption key.
+	key := make([]byte, 32)
+	_, err := cryptorand.Read(key)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"key.bin": key,
+		},
+	}
+
+	gomega.Expect(factory.CreateIfAbsent(secret)).NotTo(gomega.HaveOccurred())
 }
 
 func (factory *Factory) getConfig() *rest.Config {

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -621,12 +621,12 @@ func (factory *Factory) getOperatorConfig(namespace string) *operatorConfig {
 		BackupSecretName:        factory.GetBackupSecretName(),
 		EncryptionKeySecretName: factory.GetEncryptionKeySecretName(),
 		Namespace:               namespace,
-		SidecarVersions:       factory.GetSidecarConfigs(),
-		ImagePullPolicy:       factory.getImagePullPolicy(),
-		CPURequests:           cpuRequests,
-		MemoryRequests:        MemoryRequests,
-		User:                  factory.options.username,
-		EnableServerSideApply: factory.options.featureOperatorServerSideApply,
+		SidecarVersions:         factory.GetSidecarConfigs(),
+		ImagePullPolicy:         factory.getImagePullPolicy(),
+		CPURequests:             cpuRequests,
+		MemoryRequests:          MemoryRequests,
+		User:                    factory.options.username,
+		EnableServerSideApply:   factory.options.featureOperatorServerSideApply,
 	}
 }
 

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -325,6 +325,9 @@ spec:
         - name: backup-credentials
           mountPath: /tmp/backup-credentials
           readOnly: true
+        - name: encryption-key
+          mountPath: /tmp/encryption-key
+          readOnly: true
       securityContext:
         fsGroup: 4059
         runAsGroup: 4059
@@ -339,6 +342,9 @@ spec:
       - name: backup-credentials
         secret:
           secretName: {{ .BackupSecretName }}
+      - name: encryption-key
+        secret:
+          secretName: {{ .EncryptionKeySecretName }}
       - name: fdb-certs
         secret:
           secretName: {{ .SecretName }}
@@ -459,6 +465,9 @@ spec:
         - name: backup-credentials
           mountPath: /tmp/backup-credentials
           readOnly: true
+        - name: encryption-key
+          mountPath: /tmp/encryption-key
+          readOnly: true
       securityContext:
         fsGroup: 4059
         runAsGroup: 4059
@@ -473,6 +482,9 @@ spec:
       - name: backup-credentials
         secret:
           secretName: {{ .BackupSecretName }}
+      - name: encryption-key
+        secret:
+          secretName: {{ .EncryptionKeySecretName }}
       - name: fdb-certs
         secret:
           secretName: {{ .SecretName }}
@@ -505,6 +517,8 @@ type operatorConfig struct {
 	SecretName string
 	// BackupSecretName represents the secret that should be used to communicate with the backup blobstore.
 	BackupSecretName string
+	// EncryptionKeySecretName represents the secret that contains the encryption key for backup operations.
+	EncryptionKeySecretName string
 	// SidecarVersions represents the sidecar configurations for different FoundationDB versions.
 	SidecarVersions []SidecarConfig
 	// Namespace represents the namespace for the Deployment and all associated resources
@@ -602,10 +616,11 @@ func (factory *Factory) getOperatorConfig(namespace string) *operatorConfig {
 	}
 
 	return &operatorConfig{
-		OperatorImage:         factory.GetOperatorImage(),
-		SecretName:            factory.GetSecretName(),
-		BackupSecretName:      factory.GetBackupSecretName(),
-		Namespace:             namespace,
+		OperatorImage:           factory.GetOperatorImage(),
+		SecretName:              factory.GetSecretName(),
+		BackupSecretName:        factory.GetBackupSecretName(),
+		EncryptionKeySecretName: factory.GetEncryptionKeySecretName(),
+		Namespace:               namespace,
 		SidecarVersions:       factory.GetSidecarConfigs(),
 		ImagePullPolicy:       factory.getImagePullPolicy(),
 		CPURequests:           cpuRequests,

--- a/e2e/fixtures/fdb_restore.go
+++ b/e2e/fixtures/fdb_restore.go
@@ -60,6 +60,7 @@ func (factory *Factory) CreateRestoreForCluster(
 				BlobStoreConfiguration: backup.backup.Spec.BlobStoreConfiguration,
 				CustomParameters:       backup.backup.Spec.CustomParameters,
 				BackupVersion:          backupVersion,
+				EncryptionKeyPath:      backup.backup.Spec.EncryptionKeyPath,
 			},
 		},
 		fdbCluster: backup.fdbCluster,

--- a/e2e/fixtures/kubernetes_fixtures.go
+++ b/e2e/fixtures/kubernetes_fixtures.go
@@ -156,6 +156,9 @@ func (factory *Factory) createNamespace(suffix string) string {
 	}
 	gomega.Expect(factory.CreateIfAbsent(backupCredentials)).NotTo(gomega.HaveOccurred())
 
+	// Create the encryption key secret for backup encryption operations.
+	factory.CreateEncryptionKeySecret(namespace)
+
 	factory.ensureRBACSetupExists(namespace)
 	gomega.Expect(factory.ensureFDBOperatorExists(namespace)).ToNot(gomega.HaveOccurred())
 	log.Printf("using namespace %s for testing", namespace)


### PR DESCRIPTION
# Description

Enable encryption in backup operator test.

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

## Testing

`CLEANUP=false NAMESPACE=ak make -C e2e test_operator_backups.run
`

## Documentation

## Follow-up
