### PR TITLE
Move the update status into a single place

### DIFF
--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -35,7 +35,7 @@ type addProcessGroups struct{}
 
 // reconcile runs the reconciler's work.
 func (a addProcessGroups) reconcile(
-	ctx context.Context,
+	_ context.Context,
 	r *FoundationDBClusterReconciler,
 	cluster *fdbv1beta2.FoundationDBCluster,
 	status *fdbv1beta2.FoundationDBStatus,
@@ -64,7 +64,6 @@ func (a addProcessGroups) reconcile(
 		logger.Error(err, "Error getting exclusion list")
 	}
 
-	hasNewProcessGroups := false
 	for _, processClass := range fdbv1beta2.ProcessClasses {
 		desiredCount := desiredCounts[processClass]
 		if desiredCount < 0 {
@@ -80,7 +79,6 @@ func (a addProcessGroups) reconcile(
 			processGroupIDs[processClass] = map[int]bool{}
 		}
 
-		hasNewProcessGroups = true
 		logger.Info(
 			"Adding new Process Groups",
 			"processClass",
@@ -117,13 +115,6 @@ func (a addProcessGroups) reconcile(
 				cluster.Status.ProcessGroups,
 				fdbv1beta2.NewProcessGroupStatus(processGroupID, processClass, nil),
 			)
-		}
-	}
-
-	if hasNewProcessGroups {
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
 		}
 	}
 

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -71,8 +71,6 @@ var _ = Describe("add_process_groups", func() {
 			Expect(requeue.curError).NotTo(HaveOccurred())
 		}
 
-		_, err = reloadCluster(cluster)
-		Expect(err).NotTo(HaveOccurred())
 		newProcessCounts = fdbv1beta2.CreateProcessCountsFromProcessGroupStatus(
 			cluster.Status.ProcessGroups,
 			true,

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -111,7 +111,7 @@ func (r *FoundationDBBackupReconciler) Reconcile(
 			continue
 		}
 
-		return processRequeue(req, subReconciler, backup, r.Recorder, backupLog)
+		return processResult(processRequeue(req, subReconciler, backup, r.Recorder, backupLog))
 	}
 
 	if backup.Status.Generations.Reconciled < originalGeneration {

--- a/controllers/change_coordinators.go
+++ b/controllers/change_coordinators.go
@@ -39,7 +39,7 @@ type changeCoordinators struct{}
 
 // reconcile runs the reconciler's work.
 func (c changeCoordinators) reconcile(
-	ctx context.Context,
+	_ context.Context,
 	r *FoundationDBClusterReconciler,
 	cluster *fdbv1beta2.FoundationDBCluster,
 	status *fdbv1beta2.FoundationDBStatus,
@@ -129,11 +129,6 @@ func (c changeCoordinators) reconcile(
 
 	// Reset the SecondsSinceLastRecovered sine the operator just changed the coordinators, which will cause a recovery.
 	status.Cluster.RecoveryState.SecondsSinceLastRecovered = 0.0
-
-	err = r.updateOrApply(ctx, cluster)
-	if err != nil {
-		return &requeue{curError: err, delayedRequeue: true}
-	}
 
 	return nil
 }

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -38,7 +38,7 @@ type chooseRemovals struct{}
 
 // reconcile runs the reconciler's work.
 func (c chooseRemovals) reconcile(
-	ctx context.Context,
+	_ context.Context,
 	r *FoundationDBClusterReconciler,
 	cluster *fdbv1beta2.FoundationDBCluster,
 	status *fdbv1beta2.FoundationDBStatus,
@@ -150,10 +150,6 @@ func (c chooseRemovals) reconcile(
 			if !remainingProcessMap[string(processGroup.ProcessGroupID)] {
 				processGroup.MarkForRemoval()
 			}
-		}
-		err := r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err, delayedRequeue: true}
 		}
 	}
 

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -35,7 +35,6 @@ import (
 var _ = Describe("choose_removals", func() {
 	var cluster *fdbv1beta2.FoundationDBCluster
 	var adminClient *mock.AdminClient
-	var err error
 	var requeue *requeue
 	var removals []fdbv1beta2.ProcessGroupID
 
@@ -63,9 +62,6 @@ var _ = Describe("choose_removals", func() {
 			nil,
 			globalControllerLogger,
 		)
-		Expect(err).NotTo(HaveOccurred())
-		_, err = reloadCluster(cluster)
-		Expect(err).NotTo(HaveOccurred())
 
 		removals = nil
 		for _, processGroup := range cluster.Status.ProcessGroups {

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -47,7 +47,7 @@ type excludeEntry struct {
 
 // reconcile runs the reconciler's work.
 func (e excludeProcesses) reconcile(
-	ctx context.Context,
+	_ context.Context,
 	r *FoundationDBClusterReconciler,
 	cluster *fdbv1beta2.FoundationDBCluster,
 	status *fdbv1beta2.FoundationDBStatus,
@@ -335,11 +335,6 @@ func (e excludeProcesses) reconcile(
 		coordinatorErr := coordinator.ChangeCoordinators(logger, adminClient, cluster, status)
 		if coordinatorErr != nil {
 			return &requeue{curError: coordinatorErr, delayedRequeue: true}
-		}
-
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err, delayedRequeue: true}
 		}
 	}
 

--- a/controllers/exclude_processes_test.go
+++ b/controllers/exclude_processes_test.go
@@ -1730,8 +1730,6 @@ var _ = Describe("exclude_processes", func() {
 					Expect(req).To(BeNil())
 					Expect(adminClient.ExcludedAddresses).To(HaveLen(1))
 
-					_, err = reloadCluster(cluster)
-					Expect(err).NotTo(HaveOccurred())
 					Expect(initialConnectionString).NotTo(Equal(cluster.Status.ConnectionString))
 				})
 
@@ -1749,8 +1747,6 @@ var _ = Describe("exclude_processes", func() {
 						Expect(req).To(BeNil())
 						Expect(adminClient.ExcludedAddresses).To(HaveLen(1))
 
-						_, err = reloadCluster(cluster)
-						Expect(err).NotTo(HaveOccurred())
 						Expect(
 							initialConnectionString,
 						).NotTo(Equal(cluster.Status.ConnectionString))
@@ -1918,9 +1914,6 @@ var _ = Describe("exclude_processes", func() {
 
 					Expect(req).To(BeNil())
 					Expect(adminClient.ExcludedAddresses).To(HaveLen(1))
-
-					_, err = reloadCluster(cluster)
-					Expect(err).NotTo(HaveOccurred())
 					Expect(initialConnectionString).NotTo(Equal(cluster.Status.ConnectionString))
 				})
 
@@ -1937,9 +1930,6 @@ var _ = Describe("exclude_processes", func() {
 
 						Expect(req).To(BeNil())
 						Expect(adminClient.ExcludedAddresses).To(HaveLen(1))
-
-						_, err = reloadCluster(cluster)
-						Expect(err).NotTo(HaveOccurred())
 						Expect(
 							initialConnectionString,
 						).NotTo(Equal(cluster.Status.ConnectionString))

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -206,10 +206,6 @@ func (g generateInitialClusterFile) reconcile(
 	}
 
 	cluster.Status.ConnectionString = connectionString.String()
-	err = r.updateOrApply(ctx, cluster)
-	if err != nil {
-		return &requeue{curError: err}
-	}
 
 	return nil
 }

--- a/controllers/replace_failed_process_groups.go
+++ b/controllers/replace_failed_process_groups.go
@@ -37,7 +37,7 @@ type replaceFailedProcessGroups struct{}
 
 // return non-nil requeue if a process has been replaced
 func (c replaceFailedProcessGroups) reconcile(
-	ctx context.Context,
+	_ context.Context,
 	r *FoundationDBClusterReconciler,
 	cluster *fdbv1beta2.FoundationDBCluster,
 	status *fdbv1beta2.FoundationDBStatus,
@@ -93,11 +93,6 @@ func (c replaceFailedProcessGroups) reconcile(
 	)
 	// If the reconciler replaced at least one process group we want to update the status and requeue.
 	if hasReplacement {
-		err := r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
-		}
-
 		return &requeue{message: "Removals have been updated in the cluster status"}
 	}
 

--- a/controllers/replace_misconfigured_process_groups.go
+++ b/controllers/replace_misconfigured_process_groups.go
@@ -70,7 +70,7 @@ func (c replaceMisconfiguredProcessGroups) reconcile(
 		}
 	}
 
-	hasReplacements, err := replacements.ReplaceMisconfiguredProcessGroups(
+	_, err := replacements.ReplaceMisconfiguredProcessGroups(
 		ctx,
 		r.PodLifecycleManager,
 		r,
@@ -80,15 +80,6 @@ func (c replaceMisconfiguredProcessGroups) reconcile(
 	)
 	if err != nil {
 		return &requeue{curError: err}
-	}
-
-	if hasReplacements {
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
-		}
-
-		logger.Info("Replacements have been updated in the cluster status")
 	}
 
 	return nil

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -89,7 +89,8 @@ func (r *FoundationDBRestoreReconciler) Reconcile(
 		if req == nil {
 			continue
 		}
-		return processRequeue(req, subReconciler, restore, r.Recorder, restoreLog)
+
+		return processResult(processRequeue(req, subReconciler, restore, r.Recorder, restoreLog))
 	}
 
 	if restore.Status.State != fdbv1beta2.CompletedFoundationDBRestoreState {

--- a/controllers/update_pod_config.go
+++ b/controllers/update_pod_config.go
@@ -29,8 +29,6 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"k8s.io/apimachinery/pkg/api/equality"
-
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/pkg/podmanager"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
@@ -55,7 +53,6 @@ func (updatePodConfig) reconcile(
 		return &requeue{curError: err}
 	}
 
-	originalStatus := cluster.Status.DeepCopy()
 	allSynced := true
 	delayedRequeue := true
 	var errs []error
@@ -163,13 +160,6 @@ func (updatePodConfig) reconcile(
 		}
 
 		processGroup.UpdateCondition(fdbv1beta2.SidecarUnreachable, false)
-	}
-
-	if !equality.Semantic.DeepEqual(cluster.Status, *originalStatus) {
-		err = r.updateOrApply(ctx, cluster)
-		if err != nil {
-			return &requeue{curError: err}
-		}
 	}
 
 	// If any error has happened requeue.

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -1374,7 +1374,6 @@ var _ = Describe("update_status", func() {
 
 	Describe("Reconcile", func() {
 		var cluster *fdbv1beta2.FoundationDBCluster
-		var err error
 		var requeue *requeue
 
 		BeforeEach(func() {
@@ -1404,8 +1403,6 @@ var _ = Describe("update_status", func() {
 			if requeue != nil {
 				Expect(requeue.curError).NotTo(HaveOccurred())
 			}
-			_, err = reloadCluster(cluster)
-			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should mark the cluster as reconciled", func() {
@@ -1494,9 +1491,6 @@ var _ = Describe("update_status", func() {
 
 				Expect(adminClient.KillProcesses(addresses)).NotTo(HaveOccurred())
 				adminClient.VersionProcessGroups = versions
-
-				_, err = reloadCluster(cluster)
-				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should update the incorrect sidecar image condition", func() {

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -156,7 +156,7 @@ foundationdb-pr-tests: GINKGO_LABEL_FILTER=--ginkgo.label-filter="foundationdb-p
 # Run the actual foundationdb-pr tests.
 foundationdb-pr-tests: run
 
-# Only run tests that are labeled with the "foundationdb-nightly" or "foundationdb-pr"  label, this is used for the cluster tests in the
+# Only run tests that are labeled with the "foundationdb-nightly" or "foundationdb-pr" label, this is used for the cluster tests in the
 # foundationdb repo.
 foundationdb-nightly-tests: GINKGO_LABEL_FILTER=--ginkgo.label-filter="foundationdb-pr || foundationdb-nightly"
 


### PR DESCRIPTION
# Description

Move the update status into a single place and update the status only once if required per reconciliation.

## Type of change

- Other

## Discussion

This makes it easier to write the sub-reconcilers and should reduce possible conflicts.

## Testing

Ran the operator test suite with the new changes.

## Documentation

-

## Follow-up

-
