### PR TITLE
Allow to replace process groups with a high run loop busy value

### DIFF
--- a/api/v1beta2/foundationdb_status.go
+++ b/api/v1beta2/foundationdb_status.go
@@ -198,6 +198,9 @@ type FoundationDBStatusProcessInfo struct {
 	// The time that the process has been up for.
 	UptimeSeconds float64 `json:"uptime_seconds,omitempty"`
 
+	// RunLoopBusy represents the busyness of the run loop of the fdbserver.
+	RunLoopBusy float64 `json:"run_loop_busy,omitempty"`
+
 	// Roles contains a slice of all roles of the process
 	Roles []FoundationDBStatusProcessRoleInfo `json:"roles,omitempty"`
 

--- a/api/v1beta2/foundationdb_status_test.go
+++ b/api/v1beta2/foundationdb_status_test.go
@@ -119,7 +119,8 @@ var _ = Describe("FoundationDBStatus", func() {
 							},
 						},
 					},
-					Messages: []FoundationDBStatusProcessMessage{},
+					Messages:    []FoundationDBStatusProcessMessage{},
+					RunLoopBusy: 0.024864200000000003,
 				},
 				"eab0db1aa7aae81a50ca97e9814a1b7d": {
 					Address: ProcessAddress{
@@ -161,7 +162,8 @@ var _ = Describe("FoundationDBStatus", func() {
 							ID:   "dfd679875a386d06",
 						},
 					},
-					Messages: []FoundationDBStatusProcessMessage{},
+					Messages:    []FoundationDBStatusProcessMessage{},
+					RunLoopBusy: 0.0080509299999999978,
 				},
 				"f483247d4d5f279ef02c549680cbde64": {
 					Address: ProcessAddress{
@@ -208,7 +210,8 @@ var _ = Describe("FoundationDBStatus", func() {
 							},
 						},
 					},
-					Messages: []FoundationDBStatusProcessMessage{},
+					Messages:    []FoundationDBStatusProcessMessage{},
+					RunLoopBusy: 0.0101502,
 				},
 				"f6e0f7fd80da429d20329ad95d793ca3": {
 					Address: ProcessAddress{
@@ -240,7 +243,8 @@ var _ = Describe("FoundationDBStatus", func() {
 							ID:   "cbeb915c6cceb4a9",
 						},
 					},
-					Messages: []FoundationDBStatusProcessMessage{},
+					Messages:    []FoundationDBStatusProcessMessage{},
+					RunLoopBusy: 0.027578200000000001,
 				},
 				"f75644abdf1b06c803b5c3c124fdd0a0": {
 					Address: ProcessAddress{
@@ -264,7 +268,8 @@ var _ = Describe("FoundationDBStatus", func() {
 							ID:   "1f953018ad2e746f",
 						},
 					},
-					Messages: []FoundationDBStatusProcessMessage{},
+					Messages:    []FoundationDBStatusProcessMessage{},
+					RunLoopBusy: 0.0075524900000000002,
 				},
 				"105bf6c041f8ec315d03e889c2746ecf": {
 					Address: ProcessAddress{
@@ -292,7 +297,8 @@ var _ = Describe("FoundationDBStatus", func() {
 							KVStoreAvailableBytes: ptr.To[int64](84178214912),
 						},
 					},
-					Messages: []FoundationDBStatusProcessMessage{},
+					Messages:    []FoundationDBStatusProcessMessage{},
+					RunLoopBusy: 0.0081051000000000005,
 				},
 				"78c1c84af4481f0df628d40358f0930a": {
 					Address: ProcessAddress{
@@ -320,7 +326,8 @@ var _ = Describe("FoundationDBStatus", func() {
 							KVStoreAvailableBytes: ptr.To[int64](84178214912),
 						},
 					},
-					Messages: []FoundationDBStatusProcessMessage{},
+					Messages:    []FoundationDBStatusProcessMessage{},
+					RunLoopBusy: 0.0088742700000000001,
 				},
 				"83084479b50c9c3a09b0286297be3796": {
 					Address: ProcessAddress{
@@ -348,7 +355,8 @@ var _ = Describe("FoundationDBStatus", func() {
 							KVStoreAvailableBytes: ptr.To[int64](84178202624),
 						},
 					},
-					Messages: []FoundationDBStatusProcessMessage{},
+					Messages:    []FoundationDBStatusProcessMessage{},
+					RunLoopBusy: 0.0089497099999999979,
 				},
 			},
 			Data: FoundationDBStatusDataStatistics{

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -141,6 +141,8 @@ type FoundationDBClusterReconciler struct {
 	ClusterLabelKeyForNodeTrigger string
 	decodingSerializer            runtime.Serializer
 	SimulationOptions             SimulationOptions
+	// Defines the threshold for the high run loop busy condition, the default is 1.0.
+	HighRunLoopBusyThreshold float64
 }
 
 // NewFoundationDBClusterReconciler creates a new FoundationDBClusterReconciler with defaults.

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -795,6 +795,56 @@ var _ = Describe("replace_failed_process_groups", func() {
 					})
 				},
 			)
+
+			When("a process has the ProcessHasHighRunLoopBusy condition",
+				func() {
+					BeforeEach(func() {
+						processGroup.ProcessGroupConditions = append(
+							processGroup.ProcessGroupConditions,
+							&fdbv1beta2.ProcessGroupCondition{
+								ProcessGroupConditionType: fdbv1beta2.ProcessHasHighRunLoopBusy,
+								Timestamp:                 time.Now().Add(-1 * time.Hour).Unix(),
+							},
+						)
+					})
+
+					It("should requeue", func() {
+						Expect(result).NotTo(BeNil())
+					})
+
+					It("should mark the process group to be removed", func() {
+						removedIDs := getRemovedProcessGroupIDs(cluster)
+						Expect(removedIDs).To(HaveLen(1))
+						Expect(
+							removedIDs,
+						).To(ConsistOf([]fdbv1beta2.ProcessGroupID{processGroup.ProcessGroupID}))
+					})
+				})
+
+			When("a process has the SidecarUnreachable condition",
+				func() {
+					BeforeEach(func() {
+						processGroup.ProcessGroupConditions = append(
+							processGroup.ProcessGroupConditions,
+							&fdbv1beta2.ProcessGroupCondition{
+								ProcessGroupConditionType: fdbv1beta2.SidecarUnreachable,
+								Timestamp:                 time.Now().Add(-1 * time.Hour).Unix(),
+							},
+						)
+					})
+
+					It("should requeue", func() {
+						Expect(result).NotTo(BeNil())
+					})
+
+					It("should mark the process group to be removed", func() {
+						removedIDs := getRemovedProcessGroupIDs(cluster)
+						Expect(removedIDs).To(HaveLen(1))
+						Expect(
+							removedIDs,
+						).To(ConsistOf([]fdbv1beta2.ProcessGroupID{processGroup.ProcessGroupID}))
+					})
+				})
 		})
 
 		When("fault domain replacements are enabled", func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -214,5 +214,6 @@ func createTestClusterReconciler() *FoundationDBClusterReconciler {
 		DatabaseClientProvider:       mock.DatabaseClientProvider{},
 		MaintenanceListStaleDuration: 4 * time.Hour,
 		MaintenanceListWaitDuration:  5 * time.Minute,
+		HighRunLoopBusyThreshold:     1.0,
 	}
 }

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -80,6 +80,8 @@ type AdminClient struct {
 	mockError                                error
 	LagInfo                                  map[string]fdbv1beta2.FoundationDBStatusLagInfo
 	processesUnderMaintenance                map[fdbv1beta2.ProcessGroupID]int64
+	RunLoopBusy                              map[fdbv1beta2.ProcessGroupID]float64
+	ProcessMessages                          map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessMessage
 }
 
 var _ fdbadminclient.AdminClient = (*AdminClient)(nil)
@@ -136,6 +138,10 @@ func NewMockAdminClientUncast(
 				map[string]fdbv1beta2.FoundationDBStatusLagInfo,
 			),
 			processesUnderMaintenance: make(map[fdbv1beta2.ProcessGroupID]int64),
+			RunLoopBusy:               make(map[fdbv1beta2.ProcessGroupID]float64),
+			ProcessMessages: make(
+				map[fdbv1beta2.ProcessGroupID][]fdbv1beta2.FoundationDBStatusProcessMessage,
+			),
 		}
 		adminClientCache[cluster.Name] = cachedClient
 		cachedClient.Backups = make(map[string]fdbv1beta2.FoundationDBBackupStatusBackupDetails)
@@ -348,6 +354,8 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 				Version:          version,
 				UptimeSeconds:    uptimeSeconds,
 				Roles:            fdbRoles,
+				RunLoopBusy:      client.RunLoopBusy[processGroupID],
+				Messages:         client.ProcessMessages[processGroupID],
 			}
 		}
 	}


### PR DESCRIPTION
# Description

Allow to replace process groups with a high run loop busy value

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

In some scenarios problems in the infrastructure might not result in unavailability and may not be caught by grey failure system, so this would be an additional check. A process with a high run loop busy value could indicate issues with the process of the node where it's currently running on.

## Testing

Added unit tests and ran the e2e tests. I'll test how I can increase the run loop busy value for a dedicated test, but this test might not be reliable, depending on the feature in chaos-mesh that we can use.

## Documentation

-

## Follow-up

-
