### PR TITLE
Fix the IP family conversion with the unified image if the IP family was unset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,301 @@
+# FoundationDB Kubernetes Operator - Claude Development Guide
+
+## Project Overview
+
+The FoundationDB Kubernetes Operator is a sophisticated Kubernetes controller that manages FoundationDB clusters in Kubernetes environments. It automates deployment, scaling, backup, restore, and maintenance operations for FoundationDB distributed database clusters.
+
+### Architecture Components
+
+- **API Types** (`api/v1beta2/`): Custom Resource Definitions (CRDs) for FoundationDBCluster, FoundationDBBackup, FoundationDBRestore
+- **Controllers** (`controllers/`): Reconciliation logic for cluster lifecycle management
+- **Internal Packages** (`internal/`): Core business logic for coordination, replacements, maintenance, etc.
+- **PKG Packages** (`pkg/`): Reusable components like admin clients, pod managers, status checks
+- **E2E Tests** (`e2e/`): Comprehensive end-to-end testing with chaos engineering
+
+### Key Patterns
+
+- **Controller-Runtime**: Built on `sigs.k8s.io/controller-runtime` framework
+- **Reconciliation Loops**: Event-driven state reconciliation
+- **Mock-Based Testing**: Extensive mocking for unit tests
+- **Chaos Engineering**: Production-like failure testing with chaos-mesh
+
+## Development Environment Setup
+
+### Prerequisites
+
+```bash
+# Go 1.24+ required
+go version
+
+# Install dependencies
+make deps
+
+# Install FoundationDB client package
+# For macOS: Download from https://github.com/apple/foundationdb/releases
+# For arm64 Mac: Make sure to install the arm64 package
+```
+
+### Local Development
+
+```bash
+# Clone repository
+git clone https://github.com/FoundationDB/fdb-kubernetes-operator
+cd fdb-kubernetes-operator
+
+# Set up test certificates
+config/test-certs/generate_secrets.bash
+
+# Build and deploy operator (requires local K8s cluster)
+make rebuild-operator
+
+# Create test cluster
+kubectl apply -k ./config/tests/base
+```
+
+## Build System & Tooling
+
+### Primary Make Commands
+
+| Command | Purpose |
+|---------|---------|
+| `make all` | Complete build pipeline: deps, generate, fmt, vet, test, build |
+| `make test` | Run unit tests (Ginkgo with race detection if TEST_RACE_CONDITIONS=1) |
+| `make lint` | Run golangci-lint with project rules |
+| `make fmt` | Format code using golines + goimports + golangci-lint --fix |
+| `make vet` | Run go vet static analysis |
+| `make generate` | Generate deepcopy methods and CRDs |
+| `make manifests` | Generate CRD YAML files |
+| `make container-build` | Build Docker image |
+| `make deploy` | Deploy operator to Kubernetes cluster |
+| `make rebuild-operator` | Build, push (if remote), deploy, and bounce operator |
+
+### Environment Variables
+
+- `IMG`: Operator image name (default: `fdb-kubernetes-operator:latest`)
+- `SIDECAR_IMG`: Sidecar image name
+- `REMOTE_BUILD`: Set to 1 for remote builds (enables image push)
+- `BUILD_PLATFORM`: Override build platform (e.g., `linux/amd64`)
+- `TEST_RACE_CONDITIONS`: Set to 1 to enable race detection in tests
+- `SKIP_TEST`: Set to 1 to skip tests in build
+
+## Testing Framework
+
+### Unit Testing (Ginkgo v2 + Gomega)
+
+```go
+// Example test structure from controllers/suite_test.go
+var _ = Describe("ControllerName", func() {
+    BeforeEach(func() {
+        // Setup test environment
+        k8sClient = mockclient.NewMockClient()
+    })
+
+    It("should reconcile successfully", func() {
+        // Test implementation
+        Expect(result).To(BeNil())
+    })
+})
+```
+
+### E2E Testing
+
+- **Location**: `e2e/` directory with test packages
+- **Framework**: Ginkgo + Gomega + chaos-mesh for failure injection
+- **Types**: Upgrades, HA failures, stress testing, maintenance mode
+- **Run**: `make test` with e2e labels
+
+### Mock Objects
+
+- **Kubernetes Client**: `mockclient.MockClient`
+- **FDB Admin Client**: `mock.DatabaseClientProvider`
+- **Pod Client**: `mockpodclient.NewMockFdbPodClient`
+
+## Code Standards & Conventions
+
+### Linting & Formatting
+
+**golangci-lint Configuration** (`.golangci.yml`):
+- **Enabled Linters**: errcheck, govet, staticcheck, revive, misspell, ineffassign, unused
+- **Formatters**: gofmt with golines (120 char limit)
+- **Dependency Guard**: Restricted import paths for clean architecture
+
+**Formatting Tools**:
+- `golines`: Line length formatting with gofmt base
+- `goimports`: Import organization
+- `golangci-lint run --fix`: Auto-fix issues
+
+### Package Organization
+
+```
+├── api/v1beta2/           # CRD types and API definitions
+├── controllers/           # Controller reconciliation logic
+├── internal/              # Internal business logic packages
+├── pkg/                   # Reusable library packages
+├── e2e/                   # End-to-end tests
+├── kubectl-fdb/           # kubectl plugin
+├── fdbclient/             # FDB client utilities
+└── setup/                 # Operator setup and configuration
+```
+
+### Naming Conventions
+
+- **Types**: PascalCase (e.g., `FoundationDBCluster`)
+- **Functions**: PascalCase for exported, camelCase for internal
+- **Constants**: PascalCase or UPPER_SNAKE_CASE for public constants
+- **Files**: snake_case.go
+- **Test Files**: `*_test.go` with corresponding suite_test.go
+
+### Error Handling
+
+```go
+// Preferred error handling pattern
+err := someOperation()
+if err != nil {
+    return reconcile.Result{}, fmt.Errorf("failed to perform operation: %w", err)
+}
+
+// Use structured errors from internal/error_helper.go
+return internal.ReconcileResult{
+    Message: "Operation failed",
+    Err:     err,
+}
+```
+
+## Development Workflow
+
+### 1. Understanding Existing Patterns
+
+Before implementing new features:
+
+```bash
+# Find similar implementations
+grep -r "similar_pattern" controllers/
+grep -r "ProcessGroup" api/v1beta2/
+
+# Study existing controller structure
+ls controllers/*_controller.go
+```
+
+### 2. Controller Development
+
+**Controller Structure**:
+```go
+type FoundationDBClusterReconciler struct {
+    client.Client
+    Log                     logr.Logger
+    Recorder                record.EventRecorder
+    DatabaseClientProvider  DatabaseClientProvider
+    PodLifecycleManager     podmanager.PodLifecycleManager
+}
+
+func (r *FoundationDBClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+    // Implementation
+}
+```
+
+### 3. API Changes
+
+```bash
+# After modifying API types in api/v1beta2/
+make clean all  # Generate new CRD structs.
+```
+
+### 4. Testing Strategy
+
+1. **Write unit tests first** using Ginkgo/Gomega
+2. **Use mock clients** for Kubernetes operations
+3. **Add e2e tests** for complex scenarios
+4. **Run race detection**: `TEST_RACE_CONDITIONS=1 make test`
+
+### 5. Common Development Tasks
+
+**Adding a new CRD field**:
+1. Modify struct in `api/v1beta2/*_types.go`
+2. Add validation tags and documentation
+3. Run `make generate manifests`
+4. Add tests in `api/v1beta2/*_test.go`
+
+**Adding a new controller reconciler**:
+1. Create new file in `controllers/`
+2. Implement reconciliation logic
+3. Add to `main.go` and controller setup
+4. Write comprehensive tests
+
+## Key Libraries & Dependencies
+
+### Core Dependencies
+
+- **controller-runtime** (`sigs.k8s.io/controller-runtime`): Kubernetes operator framework
+- **client-go** (`k8s.io/client-go`): Kubernetes API client
+- **FoundationDB Bindings** (`github.com/apple/foundationdb/bindings/go`): FDB Go client
+- **logr** (`github.com/go-logr/logr`): Structured logging interface
+
+### Testing Dependencies
+
+- **Ginkgo v2** (`github.com/onsi/ginkgo/v2`): BDD testing framework
+- **Gomega** (`github.com/onsi/gomega`): Assertion library
+- **chaos-mesh**: Chaos engineering for e2e tests
+
+### Development Tools
+
+- **controller-gen**: CRD and deepcopy generation
+- **kustomize**: Kubernetes configuration management
+- **golangci-lint**: Go linting
+- **golines + goimports**: Code formatting
+- **goreleaser**: Binary releases
+
+## Debugging & Troubleshooting
+
+### Local Debugging
+
+```bash
+# View operator logs
+kubectl logs -f -l app=fdb-kubernetes-operator-controller-manager --container=manager
+
+# Check cluster status
+kubectl get foundationdbcluster test-cluster -o yaml
+
+# Access FDB CLI
+kubectl fdb exec -it test-cluster -- fdbcli
+```
+
+### Common Issues
+
+1. **Build Failures**: Ensure FoundationDB client is installed for your platform
+2. **Test Failures**: Check mock setup and race conditions
+3. **CRD Issues**: Regenerate with `make manifests` after API changes
+4. **Image Issues**: Verify BUILD_PLATFORM matches your cluster architecture
+
+## Contributing Guidelines
+
+### Before Opening PRs
+
+1. **Run full test suite**: `make all`
+2. **Check formatting**: `make fmt`
+3. **Update documentation** if adding new features
+4. **Add/update tests** for new functionality
+5. **Follow existing patterns** in similar controllers
+
+### Commit Messages
+
+Follow conventional commit format:
+```
+feat(controller): add new reconciliation step for process replacement
+fix(api): correct validation for database configuration
+test(e2e): add chaos testing for network partitions
+```
+
+### Pull Request Process
+
+1. Create feature branch from `main`
+2. Implement changes following this guide
+3. Ensure all tests pass
+4. Update documentation if needed
+5. Reference any related GitHub issues
+
+## Additional Resources
+
+- [FoundationDB Documentation](https://apple.github.io/foundationdb/)
+- [controller-runtime Book](https://book.kubebuilder.io/)
+- [Operator Pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
+- [Community Forums](https://forums.foundationdb.org)

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -66,7 +66,7 @@ func (e excludeProcesses) reconcile(
 	if status == nil {
 		status, err = adminClient.GetStatus()
 		if err != nil {
-			return &requeue{curError: err}
+			return &requeue{curError: err, delayedRequeue: true}
 		}
 	}
 

--- a/controllers/update_database_configuration.go
+++ b/controllers/update_database_configuration.go
@@ -62,7 +62,7 @@ func (u updateDatabaseConfiguration) reconcile(
 	if status == nil {
 		status, err = adminClient.GetStatus()
 		if err != nil {
-			return &requeue{curError: err}
+			return &requeue{curError: err, delayedRequeue: true}
 		}
 	}
 

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -456,6 +456,7 @@ func checkAndSetProcessStatus(
 				processNumber,
 				processCount,
 				imageType,
+				pod,
 			)
 			if err != nil {
 				return err

--- a/internal/configmap_helper.go
+++ b/internal/configmap_helper.go
@@ -161,7 +161,7 @@ func getDataForMonitorConf(
 	pClass fdbv1beta2.ProcessClass,
 	serversPerPod int,
 ) (string, []byte, error) {
-	config := GetMonitorProcessConfiguration(cluster, pClass, serversPerPod, imageType)
+	config := GetMonitorProcessConfiguration(cluster, pClass, serversPerPod, imageType, nil)
 	jsonData, err := json.Marshal(config)
 	if err != nil {
 		return "", nil, err
@@ -181,7 +181,7 @@ func setMonitorConfForFilename(
 	if connectionString == "" {
 		data[filename] = ""
 	} else {
-		conf, err := GetMonitorConf(cluster, processClass, nil, serversPerPod)
+		conf, err := GetMonitorConf(cluster, processClass, nil, serversPerPod, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/configmap_helper_test.go
+++ b/internal/configmap_helper_test.go
@@ -72,7 +72,13 @@ var _ = Describe("configmap_helper", func() {
 			})
 
 			It("should have the basic files", func() {
-				expectedConf, err := GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 1)
+				expectedConf, err := GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					1,
+					nil,
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(
@@ -102,6 +108,7 @@ var _ = Describe("configmap_helper", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config).To(Equal(expectedConfig))
 			})
@@ -118,7 +125,13 @@ var _ = Describe("configmap_helper", func() {
 			})
 
 			It("includes the data for the split monitor conf", func() {
-				expectedConf, err := GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 1)
+				expectedConf, err := GetMonitorConf(
+					cluster,
+					fdbv1beta2.ProcessClassStorage,
+					nil,
+					1,
+					nil,
+				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(configMap.Data["fdbmonitor-conf-storage"]).To(Equal(expectedConf))
 			})
@@ -157,6 +170,7 @@ var _ = Describe("configmap_helper", func() {
 						fdbv1beta2.ProcessClassStorage,
 						nil,
 						1,
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(configMap.Data["fdbmonitor-conf-storage"]).To(Equal(expectedConf))
@@ -166,6 +180,7 @@ var _ = Describe("configmap_helper", func() {
 						fdbv1beta2.ProcessClassStorage,
 						nil,
 						2,
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(
@@ -192,6 +207,7 @@ var _ = Describe("configmap_helper", func() {
 						fdbv1beta2.ProcessClassStorage,
 						1,
 						fdbv1beta2.ImageTypeUnified,
+						nil,
 					)
 					Expect(config).To(Equal(expectedConfig))
 
@@ -205,6 +221,7 @@ var _ = Describe("configmap_helper", func() {
 						fdbv1beta2.ProcessClassStorage,
 						2,
 						fdbv1beta2.ImageTypeUnified,
+						nil,
 					)
 					Expect(config).To(Equal(expectedConfig))
 				})
@@ -221,11 +238,23 @@ var _ = Describe("configmap_helper", func() {
 					cluster.Status.ImageTypes = []fdbv1beta2.ImageType{"split"}
 				})
 				It("includes the data for both configurations", func() {
-					expectedConf, err := GetMonitorConf(cluster, fdbv1beta2.ProcessClassLog, nil, 1)
+					expectedConf, err := GetMonitorConf(
+						cluster,
+						fdbv1beta2.ProcessClassLog,
+						nil,
+						1,
+						nil,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(configMap.Data["fdbmonitor-conf-log"]).To(Equal(expectedConf))
 
-					expectedConf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassLog, nil, 2)
+					expectedConf, err = GetMonitorConf(
+						cluster,
+						fdbv1beta2.ProcessClassLog,
+						nil,
+						2,
+						nil,
+					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(configMap.Data["fdbmonitor-conf-log-density-2"]).To(Equal(expectedConf))
 				})
@@ -249,6 +278,7 @@ var _ = Describe("configmap_helper", func() {
 						fdbv1beta2.ProcessClassLog,
 						1,
 						fdbv1beta2.ImageTypeUnified,
+						nil,
 					)
 					Expect(config).To(Equal(expectedConfig))
 
@@ -262,6 +292,7 @@ var _ = Describe("configmap_helper", func() {
 						fdbv1beta2.ProcessClassLog,
 						2,
 						fdbv1beta2.ImageTypeUnified,
+						nil,
 					)
 					Expect(config).To(Equal(expectedConfig))
 				})

--- a/internal/monitor_conf_test.go
+++ b/internal/monitor_conf_test.go
@@ -62,6 +62,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.RunServers).NotTo(BeNil())
 				Expect(*config.RunServers).To(BeFalse())
@@ -76,6 +77,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Version).To(Equal(&fdbv1beta2.Versions.Default.Version))
 				Expect(config.BinaryPath).To(BeEmpty())
@@ -150,6 +152,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassLog,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Version).To(Equal(&fdbv1beta2.Versions.Default.Version))
 				Expect(config.BinaryPath).To(BeEmpty())
@@ -167,6 +170,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeSplit,
+					nil,
 				)
 				Expect(config.Version).To(Equal(&fdbv1beta2.Versions.Default.Version))
 				Expect(config.BinaryPath).To(BeEmpty())
@@ -241,6 +245,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					2,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(
@@ -271,6 +276,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					2,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments[6]).To(Equal(monitorapi.Argument{
 					ArgumentType: monitorapi.ConcatenateArgumentType,
@@ -294,6 +300,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(
@@ -327,6 +334,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(
@@ -372,6 +380,7 @@ var _ = Describe("monitor_conf", func() {
 						fdbv1beta2.ProcessClassStorage,
 						1,
 						fdbv1beta2.ImageTypeUnified,
+						nil,
 					)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 					Expect(
@@ -406,6 +415,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(
@@ -440,6 +450,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(
@@ -485,6 +496,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(
@@ -535,6 +547,7 @@ var _ = Describe("monitor_conf", func() {
 						fdbv1beta2.ProcessClassStorage,
 						1,
 						fdbv1beta2.ImageTypeUnified,
+						nil,
 					)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 					Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
@@ -579,6 +592,7 @@ var _ = Describe("monitor_conf", func() {
 						fdbv1beta2.ProcessClassStorage,
 						1,
 						fdbv1beta2.ImageTypeUnified,
+						nil,
 					)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 					Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
@@ -613,6 +627,7 @@ var _ = Describe("monitor_conf", func() {
 						fdbv1beta2.ProcessClassStorage,
 						1,
 						fdbv1beta2.ImageTypeUnified,
+						nil,
 					)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 					Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
@@ -640,6 +655,7 @@ var _ = Describe("monitor_conf", func() {
 							fdbv1beta2.ProcessClassStorage,
 							1,
 							fdbv1beta2.ImageTypeUnified,
+							nil,
 						)
 						Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 						Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
@@ -682,6 +698,7 @@ var _ = Describe("monitor_conf", func() {
 							fdbv1beta2.ProcessClassStorage,
 							1,
 							fdbv1beta2.ImageTypeUnified,
+							nil,
 						)
 						Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 						Expect(config.Arguments[10]).To(Equal(monitorapi.Argument{
@@ -723,6 +740,7 @@ var _ = Describe("monitor_conf", func() {
 						fdbv1beta2.ProcessClassStorage,
 						1,
 						fdbv1beta2.ImageTypeUnified,
+						nil,
 					)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 					Expect(
@@ -755,6 +773,7 @@ var _ = Describe("monitor_conf", func() {
 						fdbv1beta2.ProcessClassStorage,
 						1,
 						fdbv1beta2.ImageTypeUnified,
+						nil,
 					)
 					Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 					Expect(
@@ -791,6 +810,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 
@@ -814,6 +834,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(
@@ -833,6 +854,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength))
 				Expect(
@@ -852,6 +874,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(
@@ -871,6 +894,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					1,
 					fdbv1beta2.ImageTypeUnified,
+					nil,
 				)
 				Expect(config.Arguments).To(HaveLen(baseArgumentLength + 1))
 				Expect(
@@ -917,6 +941,7 @@ var _ = Describe("monitor_conf", func() {
 						1,
 						1,
 						cluster.DesiredImageType(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -961,6 +986,7 @@ var _ = Describe("monitor_conf", func() {
 						1,
 						1,
 						cluster.DesiredImageType(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1000,6 +1026,7 @@ var _ = Describe("monitor_conf", func() {
 						1,
 						2,
 						cluster.DesiredImageType(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1030,6 +1057,7 @@ var _ = Describe("monitor_conf", func() {
 						2,
 						2,
 						cluster.DesiredImageType(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
@@ -1073,6 +1101,7 @@ var _ = Describe("monitor_conf", func() {
 						1,
 						1,
 						cluster.DesiredImageType(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1122,6 +1151,7 @@ var _ = Describe("monitor_conf", func() {
 						1,
 						1,
 						cluster.DesiredImageType(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1166,6 +1196,7 @@ var _ = Describe("monitor_conf", func() {
 						1,
 						1,
 						cluster.DesiredImageType(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1213,6 +1244,7 @@ var _ = Describe("monitor_conf", func() {
 					1,
 					1,
 					cluster.DesiredImageType(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1248,6 +1280,7 @@ var _ = Describe("monitor_conf", func() {
 						2,
 						3,
 						cluster.DesiredImageType(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1296,6 +1329,7 @@ var _ = Describe("monitor_conf", func() {
 						1,
 						1,
 						cluster.DesiredImageType(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
@@ -1345,6 +1379,7 @@ var _ = Describe("monitor_conf", func() {
 						1,
 						1,
 						cluster.DesiredImageType(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
@@ -1393,6 +1428,7 @@ var _ = Describe("monitor_conf", func() {
 						1,
 						1,
 						cluster.DesiredImageType(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(command).To(Equal(strings.Join([]string{
@@ -1434,6 +1470,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					nil,
 					cluster.GetStorageServersPerPod(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1467,6 +1504,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassTest,
 					nil,
 					cluster.GetStorageServersPerPod(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1501,6 +1539,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					nil,
 					cluster.GetStorageServersPerPod(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1534,6 +1573,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					nil,
 					cluster.GetStorageServersPerPod(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1579,7 +1619,7 @@ var _ = Describe("monitor_conf", func() {
 			BeforeEach(func() {
 				source := fdbv1beta2.PublicIPSourcePod
 				cluster.Spec.Routing.PublicIPSource = &source
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 1)
+				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1610,7 +1650,7 @@ var _ = Describe("monitor_conf", func() {
 				source := fdbv1beta2.PublicIPSourceService
 				cluster.Spec.Routing.PublicIPSource = &source
 				cluster.Status.HasListenIPsForAllPods = true
-				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 1)
+				conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1639,7 +1679,7 @@ var _ = Describe("monitor_conf", func() {
 			Context("with pods without the listen IP environment variable", func() {
 				BeforeEach(func() {
 					cluster.Status.HasListenIPsForAllPods = false
-					conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 1)
+					conf, err = GetMonitorConf(cluster, fdbv1beta2.ProcessClassStorage, nil, 1, nil)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -1676,6 +1716,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					nil,
 					cluster.GetStorageServersPerPod(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1713,6 +1754,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					nil,
 					cluster.GetStorageServersPerPod(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1754,6 +1796,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					nil,
 					cluster.GetStorageServersPerPod(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1799,6 +1842,7 @@ var _ = Describe("monitor_conf", func() {
 						fdbv1beta2.ProcessClassStorage,
 						nil,
 						cluster.GetStorageServersPerPod(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1850,6 +1894,7 @@ var _ = Describe("monitor_conf", func() {
 						fdbv1beta2.ProcessClassStorage,
 						nil,
 						cluster.GetStorageServersPerPod(),
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1889,6 +1934,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					nil,
 					cluster.GetStorageServersPerPod(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1923,6 +1969,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					nil,
 					cluster.GetStorageServersPerPod(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1958,6 +2005,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					nil,
 					cluster.GetStorageServersPerPod(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1992,6 +2040,7 @@ var _ = Describe("monitor_conf", func() {
 					fdbv1beta2.ProcessClassStorage,
 					nil,
 					cluster.GetStorageServersPerPod(),
+					nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/internal/pod_client.go
+++ b/internal/pod_client.go
@@ -485,10 +485,13 @@ func GetSubstitutionsFromClusterAndPod(
 			return nil, fmt.Errorf("failed to parse IP from pod: %s", ipString)
 		}
 
-		if ip.To4() == nil {
+		// The unified image handles this case in the right way. In the split image this logic would be handled by
+		// the sidecar when generating the monitor conf file.
+		if GetImageType(pod) == fdbv1beta2.ImageTypeSplit && ip.To4() == nil {
 			substitutions[fdbv1beta2.EnvNamePublicIP] = fmt.Sprintf("[%s]", ipString)
 		}
 	}
+
 	substitutions[fdbv1beta2.EnvNamePodIP] = substitutions[fdbv1beta2.EnvNamePublicIP]
 
 	if cluster.Spec.FaultDomain.Key == fdbv1beta2.NoneFaultDomainKey {

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -250,6 +250,7 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 					processIndex,
 					processCount,
 					internal.GetImageType(&pod),
+					&pod,
 				)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
# Description

When converting to IP family 6 from unset (and assuming that the used IP address is IPv4), the unified image is currently not able to migrate to the new IP family and the operator will be stuck and requires manual interaction because some of the methods already try to access the IPv6 address which will be absent for the older pods. The idea was to make use of the "old" IP family if present (pods will be replaced anyways when the IP family changes).

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

I sneaked in the `Claude.md` (the file was generated by Claude and might need some fine tuning).

## Testing

Running e2e tests and doing some manual tests since our e2e test setup doesn't have dual stack.

## Documentation

-

## Follow-up

-
