### PR TITLE
Update the golang version and disable the flaky mirror setup for RockyLinux

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24.6
+          go-version: 1.24.9
       - name: Get dependencies
         run: curl -L --fail "https://github.com/apple/foundationdb/releases/download/${FDB_VER}/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.24.6
+        go-version: 1.24.9
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Get dependencies
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.24.6
+        go-version: 1.24.9
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Get dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24.6
+          go-version: 1.24.9
       #  https://github.com/goreleaser/goreleaser/issues/1311
       - name: Get current semver tag
         run: echo "GORELEASER_CURRENT_TAG=$(git describe --tags --match "v*" --abbrev=0)" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG FDB_VERSION=7.1.67
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM docker.io/library/golang:1.24.6-bookworm AS builder
+FROM docker.io/library/golang:1.24.9-bookworm AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE
@@ -17,7 +17,7 @@ RUN set -eux && \
     elif [ "$TARGETARCH" = "arm64" ]; then \
          FDB_ARCH=aarch64; \
          if [ "${FDB_VERSION%.*}" = "7.1" ]; then \
-            FDB_VERSION="7.3.63"; \
+            FDB_VERSION="7.3.71"; \
          fi; \
     else \
          echo "ERROR: unsupported architecture $TARGETARCH" 1>&2; \
@@ -75,7 +75,7 @@ RUN set -eux && \
     elif [ "$TARGETARCH" = "arm64" ]; then \
          FDB_ARCH=aarch64; \
          if [ "${FDB_VERSION%.*}" = "7.1" ]; then \
-            FDB_VERSION="7.3.63"; \
+            FDB_VERSION="7.3.71"; \
          fi; \
     else \
          echo "ERROR: unsupported architecture $TARGETARCH" 1>&2; \
@@ -89,7 +89,9 @@ RUN set -eux && \
     fi; \
     curl --fail -L "${FDB_WEBSITE}/${FDB_VERSION}/foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm" -o foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm && \
     curl --fail -L "${FDB_WEBSITE}/${FDB_VERSION}/foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm.sha256" -o foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm.sha256 && \
-    microdnf install -y glibc pkg-config bind-utils && \
+    # Disable buggy mirrors for RockyLinux.
+    sed -i.bak 's/^#baseurl=/baseurl=/; s/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/rocky.repo && \
+    microdnf install --disablerepo=* --enablerepo=baseos --enablerepo=appstream -y glibc pkg-config bind-utils && \
     microdnf clean all && \
     sha256sum -c foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm.sha256 && \
     rpm -i foundationdb-clients-${FDB_VERSION}-1.${FDB_OS}.${FDB_ARCH}.rpm --excludepath=/usr/bin --excludepath=/usr/lib/foundationdb/backup_agent && \


### PR DESCRIPTION
# Description

The RockyLinux mirrors are fairly flaky: https://forums.rockylinux.org/t/yum-install-commands-failing-intermittently/19734 we should disable them until they get more stable.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Build the image locally.

## Documentation

-

## Follow-up

-
