### PR TITLE
Fix the Helm chart CRB for globalMode.enabled=false (the default case)

### DIFF
--- a/charts/fdb-operator/templates/rbac/rbac_role_binding.yaml
+++ b/charts/fdb-operator/templates/rbac/rbac_role_binding.yaml
@@ -38,7 +38,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "fdb-operator.serviceAccountName" . }}
-  {{- if .Values.globalMode.enabled }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
 {{- end }}


### PR DESCRIPTION
# Description

Installing the Helm chart with the default values fails, as `globalMode.enabled=false`, and this misconfigures the Cluster Role Binding in `templates/rbac/rbac_role_binding.yaml`. This is particularly disruptive since the default values presents a sort of "getting started"/"quickstart" scenario, yet this fails in a way that requires Helm configs hacking.

```
Error: INSTALLATION FAILED: 1 error occurred:
        * ClusterRoleBinding.rbac.authorization.k8s.io "fdb-operator-clusterrolebinding" is invalid: subjects[0].namespace: Required value
```

This makes sense - Service Accounts are namespaced and so the Cluster Role Bindings subject needs to specify a namespace.

With the submitted fix, the default-values Helm installation, as well as the broader RBAC setup of the Helm chart, should be working.

## Type of change

Bug fix

## Testing

Manually tested with `globalMode.enabled=true` and `globalMode.enabled=false`

## Documentation

I don't believe there are documentation updating requirements here.