### PR TITLE
In the multi-region recover command handle cases where the cluster entries cannot be resolved.

### DIFF
--- a/e2e/test_operator_plugin/operator_plugin_test.go
+++ b/e2e/test_operator_plugin/operator_plugin_test.go
@@ -199,11 +199,6 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 					false,
 				)
 				log.Println("stdout:", stdout, "stderr:", stderr)
-				if strings.Contains(stderr, "Error determining public address") {
-					Skip(
-						"plugin was not able to determine public address, this means that all coordinators are probably gone",
-					)
-				}
 				Expect(err).NotTo(HaveOccurred())
 
 				// Ensure the cluster is available again.
@@ -255,6 +250,11 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 					false,
 				)
 				log.Println("stdout:", stdout, "stderr:", stderr)
+				if strings.Contains(stderr, "Error determining public address") {
+					Skip(
+						"plugin was not able to determine public address, this means that all coordinators are probably gone",
+					)
+				}
 				Expect(err).NotTo(HaveOccurred())
 
 				// Ensure the cluster is available again.

--- a/kubectl-fdb/cmd/recover_multi_region_cluster.go
+++ b/kubectl-fdb/cmd/recover_multi_region_cluster.go
@@ -746,7 +746,7 @@ func checkIfClusterIsUnavailableAndMajorityOfCoordinatorsAreUnreachable(
 	//  Error: error getting status: Error determining public address.
 	//  ERROR: Unable to bind to network (1512)
 	if err != nil && strings.Contains(err.Error(), "Error determining public address") {
-		return nil
+		return err
 	}
 
 	return err


### PR DESCRIPTION
# Description

If the cluster has no entries in the cluster file that can be resolved, assume in the multi-region recover command that the cluster should be recovered (e.g. because all the coordinators are down or have changed their IP address).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

I updated the e2e test case to not fail in this case but rather skip the test case. In such a scenario some manual intervention is required.

## Testing

Ran test manually.

## Documentation

-

## Follow-up

-
