### PR TITLE
Add script to remove additional tooling that is not needed

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,6 +45,8 @@ jobs:
         go-version: 1.24.9
     - name: Fetch all tags
       run: git fetch --force --tags
+    - name: Free disk space
+      run: bash ${GITHUB_WORKSPACE}/scripts/free_disk_space.sh
     - name: Get dependencies
       env:
         KIND_VER: "v0.29.0"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,8 @@ jobs:
           fetch-depth: 0
       - name: Fetch all tags
         run: git fetch --force --tags
+      - name: Free disk space
+        run: bash ${GITHUB_WORKSPACE}/scripts/free_disk_space.sh
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/scripts/free_disk_space.sh
+++ b/scripts/free_disk_space.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# There are multiple reports of low free disk space and the suggestion is always to remove pre-installed software
+# https://github.com/actions/runner-images/issues/2875
+
+# Source: https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+
+#
+# The Azure provided machines typically have the following disk allocation:
+# Total space: 85GB
+# Allocated: 67 GB
+# Free: 17 GB
+# This script frees up 28 GB of disk space by deleting unneeded packages and
+# large directories.
+# The Flink end to end tests download and generate more than 17 GB of files,
+# causing unpredictable behavior and build failures.
+#
+echo "=============================================================================="
+echo "Freeing up disk space on CI system"
+echo "=============================================================================="
+
+echo "Listing 100 largest packages"
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+df -h
+echo "Removing large packages"
+sudo apt-get remove -y '^dotnet-.*'
+sudo apt-get remove -y '^llvm-.*'
+sudo apt-get remove -y 'php.*'
+sudo apt-get remove -y '^mongodb-.*'
+sudo apt-get remove -y '^mysql-.*'
+sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+sudo apt-get autoremove -y
+sudo apt-get clean
+df -h
+echo "Removing large directories"
+
+sudo rm -rf /usr/share/dotnet/
+sudo rm -rf /usr/local/graalvm/
+sudo rm -rf /usr/local/.ghcup/
+sudo rm -rf /usr/local/share/powershell
+sudo rm -rf /usr/local/share/chromium
+sudo rm -rf /usr/local/lib/android
+sudo rm -rf /usr/local/lib/node_modules
+df -h


### PR DESCRIPTION
# Description

Fix the `no free disk space` issue: https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2396

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

The script is from the Apache Flink team (I referenced the origin of the script) and removes multiple tools that are not needed for our use case.

## Testing

CI :)

## Documentation

-

## Follow-up

-
