### PR TITLE
Fix the usage of the management API in the e2e test framework

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2769,6 +2769,7 @@ func (cluster *FoundationDBCluster) GetMaxConcurrentReplacements() int {
 }
 
 // UseManagementAPI returns the value of UseManagementAPI or false if unset.
+// Deprecated: Use DatabaseInteractionMode instead.
 func (cluster *FoundationDBCluster) UseManagementAPI() bool {
 	return ptr.Deref(cluster.Spec.AutomationOptions.UseManagementAPI, false)
 }

--- a/controllers/maintenance_mode_checker.go
+++ b/controllers/maintenance_mode_checker.go
@@ -150,5 +150,9 @@ func (c maintenanceModeChecker) reconcile(
 		return &requeue{curError: err, delayedRequeue: true}
 	}
 
+	// Reset the maintenance zone in the cached status for this run. In this code path the maintenance off command
+	// returned without an error, so we can assume that the maintenance zone was reset.
+	status.Cluster.MaintenanceZone = ""
+
 	return nil
 }

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -63,6 +63,11 @@ func (factory *Factory) createFDBClusterSpec(
 		faultDomain.ValueFrom = ""
 	}
 
+	var databaseInteractionMode *fdbv1beta2.DatabaseInteractionMode
+	if ptr.Deref(config.ManagementAPI, false) {
+		databaseInteractionMode = ptr.To(fdbv1beta2.DatabaseInteractionModeMgmtAPI)
+	}
+
 	return &fdbv1beta2.FoundationDBCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Name,
@@ -106,7 +111,7 @@ func (factory *Factory) createFDBClusterSpec(
 				},
 				UseLocalitiesForExclusion: config.UseLocalityBasedExclusions,
 				SynchronizationMode:       ptr.To(string(config.SynchronizationMode)),
-				UseManagementAPI:          config.ManagementAPI,
+				DatabaseInteractionMode:   databaseInteractionMode,
 			},
 			Routing: fdbv1beta2.RoutingConfig{
 				UseDNSInClusterFile: config.UseDNS,


### PR DESCRIPTION
# Description

Fix the usage of the management API in the e2e test framework.

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## Discussion

Before this change the test framework used the old setting, which will be ignored in the operator. When the maintenance zone is removed by the operator the cached status will be updated too.

## Testing

Ran unit tests and CI will run the e2e tests.

## Documentation

-

## Follow-up

-
