### PR TITLE
Make use of hex string instead of FDB printable to remove test failures because of special characters

### DIFF
--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -533,7 +533,7 @@ func (fdbCluster *FdbCluster) GetCommandlineForProcessesPerClassWithStatus(
 }
 
 // FdbPrintable copied from foundationdb bindings/go/src/fdb/fdb.go func Printable(d []byte) string
-// Printable returns a human readable version of a byte array. The bytes that correspond with
+// Printable returns a human-readable version of a byte array. The bytes that correspond with
 // ASCII printable characters [32-127) are passed through. Other bytes are
 // replaced with \x followed by a two character zero-padded hex code for byte.
 func FdbPrintable(d []byte) string {
@@ -543,6 +543,21 @@ func FdbPrintable(d []byte) string {
 			buf.WriteByte(b)
 			continue
 		}
+		if b == '\\' {
+			buf.WriteString("\\\\")
+			continue
+		}
+
+		_, _ = fmt.Fprintf(buf, "\\x%02x", b)
+	}
+
+	return buf.String()
+}
+
+// FdbHexString returns a string where bytes are replaced with \x followed by a two character zero-padded hex code for byte.
+func FdbHexString(d []byte) string {
+	buf := new(bytes.Buffer)
+	for _, b := range d {
 		if b == '\\' {
 			buf.WriteString("\\\\")
 			continue

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1944,7 +1944,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				cmd := fmt.Sprintf(
 					"writemode on; option on ACCESS_SYSTEM_KEYS; set %s %s",
 					fixtures.FdbPrintable([]byte(key)),
-					fixtures.FdbPrintable(timestampByteBuffer.Bytes()),
+					fixtures.FdbHexString(timestampByteBuffer.Bytes()),
 				)
 				_, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(cmd, true, 20)
 


### PR DESCRIPTION
# Description

We've seen a few cases in our nightly testing where the tests have failed because of a special character in the value, e.g. a semicolon (`;`) where the `fdbcli` command thought the current command is split. Using only the hex format is a better approach to prevent those failures.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran the test manually.

## Documentation

-

## Follow-up

-
