### PR TITLE
Correct the HA test case for coordinator failure in the primary region

### DIFF
--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -785,7 +785,8 @@ func (fdbCluster *FdbCluster) SetPodAsUnschedulable(pod corev1.Pod) {
 
 		// Try deleting the Pod as a workaround until the operator handle all cases.
 		if fetchedPod.Spec.NodeName != "" && fetchedPod.DeletionTimestamp.IsZero() {
-			_ = fdbCluster.getClient().Delete(context.Background(), &pod)
+			g.Expect(fdbCluster.getClient().Delete(context.Background(), &pod)).
+				NotTo(gomega.HaveOccurred())
 		}
 
 		return fetchedPod.Spec.NodeName


### PR DESCRIPTION
# Description

The previous version was overwriting the unschedulable setting, so that only one coordinator was unschedulable.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

The test was working with the previous setup but it was testing something different from the test description.

## Testing

Ran the test manually a few times.

## Documentation

Updated the test description.

## Follow-up

-
