### PR TITLE
Remove uuid dependency and use a simple approach to generate the uuid

### DIFF
--- a/sample-apps/data-loader/Dockerfile
+++ b/sample-apps/data-loader/Dockerfile
@@ -7,7 +7,6 @@ FROM golang:1.25.5-bookworm AS builder
 ARG FDB_VERSION
 ARG FDB_WEBSITE
 ARG TARGETARCH
-ARG TAG="latest"
 
 RUN set -eux && \
     if [ "$TARGETARCH" = "amd64" ]; then \
@@ -80,11 +79,16 @@ RUN set -eux && \
 RUN groupadd --gid 4059 fdb && \
 	useradd --gid 4059 --uid 4059 --shell /usr/sbin/nologin fdb && \
 	mkdir -p /var/log/fdb && \
-	touch /var/log/fdb/.keep
+	touch /var/log/fdb/.keep && \
+	chown -R fdb:fdb /var/log/fdb
 
 COPY --chown=fdb:fdb --from=builder /workspace/bin/data-loader /usr/local/bin/data-loader
 
 # Set to the numeric UID of fdb user to satisfy PodSecurityPolices which enforce runAsNonRoot
 USER 4059
+
+# Enable tracing per default.
+ENV FDB_NETWORK_OPTION_TRACE_ENABLE=/var/log/fdb
+ENV FDB_NETWORK_OPTION_TRACE_LOG_GROUP=fdb-data-loader
 
 ENTRYPOINT ["/usr/local/bin/data-loader"]

--- a/sample-apps/data-loader/go.mod
+++ b/sample-apps/data-loader/go.mod
@@ -4,8 +4,5 @@ go 1.24.0
 
 toolchain go1.24.4
 
-require (
-	// Binding version for 7.1.67
-	github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c
-	github.com/google/uuid v1.6.0
-)
+// Binding version for 7.1.67
+require github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c

--- a/sample-apps/data-loader/go.sum
+++ b/sample-apps/data-loader/go.sum
@@ -1,4 +1,2 @@
 github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c h1:Nnun3T50beIpO6YKDZInHuZMgnNtYJafSlQAvkXwOWc=
 github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/sample-apps/data-loader/job.yaml
+++ b/sample-apps/data-loader/job.yaml
@@ -24,17 +24,18 @@ spec:
             mountPath: /var/dynamic-conf
       initContainers:
         - name: foundationdb-kubernetes-init
-          image: foundationdb/foundationdb-kubernetes-sidecar:6.3.3-1
+          image: foundationdb/fdb-kubernetes-monitor:7.3.63
           args:
             - "--copy-file"
             - "fdb.cluster"
             - "--copy-library"
-            - "6.3"
-            - "--copy-library"
-            - "6.2"
-            - "--init-mode"
+            - "7.3"
             - "--require-not-empty"
             - "fdb.cluster"
+            - "--output-dir"
+            - "/var/output-files"
+            - "--mode"
+            - "init"
           volumeMounts:
             - name: config-map
               mountPath: /var/input-files


### PR DESCRIPTION
# Description

We use the UUID only as a prefix, so importing a new library for this is a bit heavy weight and we can utilize (most of) the FDB tuple UUID implementation.

## Type of change

- Other

## Discussion

I updated the init container to the `fdb-kubernetes-monitor` and fixed a permission issue with the log directory for the FDB trace events.

## Testing

Build the `fdb-data-loader` locally and ran some tests.

## Documentation

-

## Follow-up

-