### PR TITLE
Allow encrypted backups for 7.3.72 or newer

### DIFF
--- a/api/v1beta2/foundationdb_version.go
+++ b/api/v1beta2/foundationdb_version.go
@@ -92,6 +92,10 @@ func (version Version) SupportsLocalityBasedExclusions() bool {
 
 // SupportsBackupEncryption returns true if the current version supports encryption of backups.
 func (version Version) SupportsBackupEncryption() bool {
+	if version.IsProtocolCompatible(Versions.SupportsBackupEncryption73) {
+		return version.IsAtLeast(Versions.SupportsBackupEncryption73)
+	}
+
 	return version.IsAtLeast(Versions.SupportsBackupEncryption)
 }
 
@@ -146,6 +150,7 @@ var Versions = struct {
 	SupportsShardedRocksDB,
 	SupportsRedwood1,
 	SupportsBackupEncryption,
+	SupportsBackupEncryption73,
 	IncompatibleVersion,
 	PreviousPatchVersion,
 	SupportsRecoveryState,
@@ -166,4 +171,5 @@ var Versions = struct {
 	SupportsLocalityBasedExclusions71: Version{api.Version{Major: 7, Minor: 1, Patch: 42}},
 	SupportsLocalityBasedExclusions:   Version{api.Version{Major: 7, Minor: 3, Patch: 26}},
 	SupportsBackupEncryption:          Version{api.Version{Major: 7, Minor: 4, Patch: 6}},
+	SupportsBackupEncryption73:        Version{api.Version{Major: 7, Minor: 3, Patch: 72}},
 }

--- a/e2e/test_operator_backups/operator_backup_test.go
+++ b/e2e/test_operator_backups/operator_backup_test.go
@@ -158,8 +158,7 @@ var _ = Describe("Operator Backup", Label("e2e", "pr"), func() {
 
 				When("encryption is enabled", func() {
 					BeforeEach(func() {
-						if !factory.GetFDBVersion().
-							IsAtLeast(fdbv1beta2.Versions.SupportsBackupEncryption) {
+						if !factory.GetFDBVersion().SupportsBackupEncryption() {
 							Skip(
 								"version doesn't support the encryption feature",
 							)
@@ -206,8 +205,7 @@ var _ = Describe("Operator Backup", Label("e2e", "pr"), func() {
 
 				When("encryption is enabled", func() {
 					BeforeEach(func() {
-						if !factory.GetFDBVersion().
-							IsAtLeast(fdbv1beta2.Versions.SupportsBackupEncryption) {
+						if !factory.GetFDBVersion().SupportsBackupEncryption() {
 							Skip(
 								"version doesn't support the encryption feature",
 							)


### PR DESCRIPTION
# Description

Since FDB 7.3.72 got the encrypted backup work back-ported, we should allow in the operator to use encrypted backups for the according version and newer.

## Type of change

- Other

## Discussion

*Are there any design details that you would like to discuss further?*

## Testing

Ran the backup tests manually and used the `fdbbackup describe` command to validate that the backup is encrypted:

```bash
$ fdbbackup describe -d 'blobstore://seaweedfs@seaweedfs:8333/operator-backup-test-3fbwlww4?bucket=fdb-backups&secure_connection=0&region=us-east-1'
URL: blobstore://seaweedfs@seaweedfs:8333/operator-backup-test-3fbwlww4?bucket=fdb-backups&secure_connection=0&region=us-east-1
Restorable: true
Partitioned logs: false
File-level encryption: true
Snapshot:  startVersion=29874126 (maxLogEnd -0.00 days)  endVersion=29915426 (maxLogEnd -0.00 days)  totalBytes=194  restorable=true  expiredPct=0.00
SnapshotBytes: 194
MinLogBeginVersion:      29595384 (maxLogEnd -0.00 days)
ContiguousLogEndVersion: 69595384 (maxLogEnd -0.00 days)
MaxLogEndVersion:        69595384 (maxLogEnd -0.00 days)
MinRestorableVersion:    29915426 (maxLogEnd -0.00 days)
MaxRestorableVersion:    69595383 (maxLogEnd -0.00 days)
```

## Documentation

Nothing to update,

## Follow-up

Finish: https://github.com/FoundationDB/fdb-kubernetes-operator/pull/2403
