### PR TITLE
Increase the threshold for the velocity test

### DIFF
--- a/e2e/test_operator_velocity/operator_velocity_test.go
+++ b/e2e/test_operator_velocity/operator_velocity_test.go
@@ -141,10 +141,10 @@ func CheckKnobRollout(
 		(finalGeneration-initialGeneration)/2,
 	)
 	// If the synchronization mode is global, we expect to see only a single recovery. Since those tests are running on
-	// a real cluster we add some additional buffer of one additional recovery. We check for an increase of 4 generation
+	// a real cluster we add some additional buffer of two additional recoveries. We check for an increase of 6 generations
 	// because FDB increase the current generation by 2 if a recovery is triggered.
 	if primary.GetCluster().GetSynchronizationMode() == fdbv1beta2.SynchronizationModeGlobal {
-		Expect(finalGeneration - initialGeneration).To(BeNumerically("<=", 4))
+		Expect(finalGeneration - initialGeneration).To(BeNumerically("<=", 6))
 	}
 }
 


### PR DESCRIPTION
# Description

Increase the threshold for the velocity test.

## Type of change

- Other

## Discussion

In our nightlies we saw a few failures because of 3 recoveries instead of 2.

## Testing

Ran `make fit lint test`.

## Documentation

Updated the comment.

## Follow-up

-