### PR TITLE
Ignore the locality parameters in the fdbbackup and fdbrestore commands

### DIFF
--- a/api/v1beta2/foundationdb_custom_parameter_test.go
+++ b/api/v1beta2/foundationdb_custom_parameter_test.go
@@ -28,31 +28,12 @@ import (
 )
 
 var _ = Describe("FoundationDBCustomParameters", func() {
-	When("getting the custom parameters for the CLI", func() {
-		var customParameters FoundationDBCustomParameters
-		BeforeEach(func() {
-			customParameters = []FoundationDBCustomParameter{
-				"knob_http_verbose_level=3",
-			}
-		})
-
-		It("", func() {
-			expected := []string{
-				"--knob_http_verbose_level=3",
-			}
-
-			result := customParameters.GetKnobsForCLI()
-			Expect(result).To(ContainElements(expected))
-			Expect(len(result)).To(Equal(len(expected)))
-		})
-	})
-
 	When("getting the custom parameters for the fdbbackup and fdbrestore CLI", func() {
 		var customParameters FoundationDBCustomParameters
 		BeforeEach(func() {
 			customParameters = []FoundationDBCustomParameter{
 				"knob_http_verbose_level=3",
-				"locality-data_hall=az1",
+				"locality_data_hall=az1",
 			}
 		})
 


### PR DESCRIPTION
# Description

Ignore the locality parameters in the fdbbackup and fdbrestore commands

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Ran unit tests, CI will run e2e tests.

## Documentation

Nothing to update.

## Follow-up

-
