### PR TITLE
Update the go version to 1.25.7

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.5
+          go-version: 1.25.7
       - name: Get dependencies
         run: curl -L --fail "https://github.com/apple/foundationdb/releases/download/${FDB_VER}/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.25.5
+        go-version: 1.25.7
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Free disk space
@@ -103,7 +103,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.25.5
+        go-version: 1.25.7
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Get dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.5
+          go-version: 1.25.7
       #  https://github.com/goreleaser/goreleaser/issues/1311
       - name: Get current semver tag
         run: echo "GORELEASER_CURRENT_TAG=$(git describe --tags --match "v*" --abbrev=0)" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG FDB_VERSION=7.1.67
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM golang:1.25.5-bookworm AS builder
+FROM golang:1.25.7-bookworm AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/FoundationDB/fdb-kubernetes-operator/v2
 
 go 1.24.0
 
-toolchain go1.24.4
-
 require (
 	// Binding version for 7.1.67
 	github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c

--- a/sample-apps/data-loader/Dockerfile
+++ b/sample-apps/data-loader/Dockerfile
@@ -2,7 +2,7 @@ ARG FDB_VERSION=7.1.67
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM golang:1.25.5-bookworm AS builder
+FROM golang:1.25.7-bookworm AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE

--- a/sample-apps/data-loader/go.mod
+++ b/sample-apps/data-loader/go.mod
@@ -2,7 +2,5 @@ module github.com/FoundationDB/fdb-data-loader
 
 go 1.24.0
 
-toolchain go1.24.4
-
 // Binding version for 7.1.67
 require github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c


### PR DESCRIPTION
# Description

Update the go version to 1.25.7

## Type of change

- Other

## Discussion

-

## Testing

Ran unit tests. CI will run e2e tests.

## Documentation

Nothing to update.

## Follow-up

-