### PR TITLE
Make use of storage pods instead of log pods in I/O latency e2e test

### DIFF
--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -1026,7 +1026,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				Skip("Chaos tests are skipped for the operator")
 			}
 			availabilityCheck = false
-			initialPods := fdbCluster.GetLogPods()
+			initialPods := fdbCluster.GetStoragePods()
 			podWithIOError = factory.RandomPickOnePod(initialPods.Items)
 			log.Printf("injecting iochaos to %s", podWithIOError.Name)
 			exp = factory.InjectIOLatency(fixtures.PodSelector(&podWithIOError), "2s")


### PR DESCRIPTION
# Description

Testing the replacement with high I/O latency for SS will better test the interactions between SS and DD.

## Type of change

- Other

## Discussion

-

## Testing

Ran unit tests.

## Documentation

-

## Follow-up

-
