### PR TITLE
Make use of the local sync mode per default to reduce the different variables during e2e testing

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -48,14 +48,16 @@ FEATURE_UNIFIED_IMAGE?=true
 STORAGE_ENGINE?="ssd-rocksdb-v1"
 # If the FEATURE_SYNCHRONIZATION_MODE environment variable is not defined the test suite will be randomly enable (1) or disable (0)
 # the the global synchronization mode.
-ifndef FEATURE_SYNCHRONIZATION_MODE
-  ifeq ($(shell shuf -i 0-1 -n 1), 0)
-    # Default case
-    FEATURE_SYNCHRONIZATION_MODE="local"
-  else
-    FEATURE_SYNCHRONIZATION_MODE="global"
-  endif
-endif
+FEATURE_SYNCHRONIZATION_MODE?="local"
+# TODO(j-scheuermann): Enable this in the future again.
+#ifndef FEATURE_SYNCHRONIZATION_MODE
+#  ifeq ($(shell shuf -i 0-1 -n 1), 0)
+#    # Default case
+#    FEATURE_SYNCHRONIZATION_MODE="local"
+#  else
+#    FEATURE_SYNCHRONIZATION_MODE="global"
+#  endif
+#endif
 
 FEATURE_LOCALITIES?=true
 FEATURE_DNS?=true


### PR DESCRIPTION
# Description

Make use of the local sync mode per default to reduce the different variables during e2e testing.

## Type of change

- Other

## Discussion

We will enable the `global` mode later again and probably run it in a dedicated pipeline.

## Testing

CI will run the e2e test cases (I verified that `FEATURE_SYNCHRONIZATION_MODE=local` was set).
 
## Documentation

Nothing other than update.

## Follow-up

-
