### PR TITLE
Add the backup test suite to the FoundationDB nightly tests

### DIFF
--- a/e2e/test_operator_backups/operator_backup_test.go
+++ b/e2e/test_operator_backups/operator_backup_test.go
@@ -73,7 +73,7 @@ var _ = AfterSuite(func() {
 	factory.Shutdown()
 })
 
-var _ = Describe("Operator Backup", Label("e2e", "pr"), func() {
+var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-nightly"), func() {
 	When("a cluster has backups enabled and then restored", func() {
 		var keyValues []fixtures.KeyValue
 		var prefix byte = 'a'


### PR DESCRIPTION
# Description

Add the backup test suite to the FoundationDB nightly tests. 

## Type of change

- Other

## Discussion

In the operator nightlies those tests are passing reliable. I would start with the FoundationDB nightlies and win we observe that those tests are passing reliable we could enable them for PR` too.

## Testing

Ran the make command.

## Documentation

Nothing to update.

## Follow-up

-