### PR TITLE
Fix bug with leaked fdb connections

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -494,7 +494,6 @@ func (client *cliAdminClient) ExcludeProcessesWithNoWait(
 
 			return nil
 		})
-
 		if err != nil {
 			return err
 		}
@@ -708,6 +707,7 @@ func (client *cliAdminClient) killWithManagementAPI(addresses []fdbv1beta2.Proce
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 
 	return db.RebootWorker(fdbv1beta2.ProcessAddressesStringWithoutFlags(addresses, ","), false, 0)
 }
@@ -767,7 +767,6 @@ func (client *cliAdminClient) ChangeCoordinators(
 			)
 			return nil
 		})
-
 		if err != nil {
 			return "", err
 		}
@@ -964,7 +963,6 @@ func (client *cliAdminClient) GetBackupStatus() (*fdbv1beta2.FoundationDBLiveBac
 			"--json",
 		},
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -1118,7 +1116,6 @@ func (client *cliAdminClient) GetProcessesUnderMaintenance() (map[fdbv1beta2.Pro
 		}
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -101,7 +101,8 @@ func parseMachineReadableStatus(
 	return status, nil
 }
 
-// getFDBDatabase opens an FDB database.
+// getFDBDatabase opens an FDB database. Caller should make sure to close the
+// database with [fdb.Database.Close] when done with it.
 func getFDBDatabase(cluster *fdbv1beta2.FoundationDBCluster) (fdb.Database, error) {
 	clusterFile, err := ensureClusterFileIsPresent(
 		path.Join(os.TempDir(), string(cluster.UID)),

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -376,6 +376,7 @@ func (fdbClient *realFdbLibClient) executeTransaction(
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 
 	_, err = db.Transact(func(tr fdb.Transaction) (interface{}, error) {
 		err = setCommonOptions(&tr, timeout)
@@ -404,6 +405,7 @@ func (fdbClient *realFdbLibClient) executeTransactionForManagementAPI(
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 
 	_, err = db.Transact(func(tr fdb.Transaction) (interface{}, error) {
 		err = setCommonOptions(&tr, timeout)

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -42,9 +42,6 @@ type realLockClient struct {
 	// Whether we should disable locking completely.
 	disableLocks bool
 
-	// The connection to the database.
-	database fdb.Database
-
 	// log implementation for logging output
 	log logr.Logger
 }
@@ -60,7 +57,13 @@ func (client *realLockClient) TakeLock() error {
 		return nil
 	}
 
-	_, err := client.database.Transact(func(transaction fdb.Transaction) (interface{}, error) {
+	db, err := getFDBDatabase(client.cluster)
+	if err != nil {
+		return fmt.Errorf("get db: %w", err)
+	}
+	defer db.Close()
+
+	_, err = db.Transact(func(transaction fdb.Transaction) (any, error) {
 		lockErr := client.takeLockInTransaction(transaction)
 		return nil, lockErr
 	})
@@ -177,7 +180,13 @@ func (client *realLockClient) AddPendingUpgrades(
 	version fdbv1beta2.Version,
 	processGroupIDs []fdbv1beta2.ProcessGroupID,
 ) error {
-	_, err := client.database.Transact(func(tr fdb.Transaction) (interface{}, error) {
+	db, err := getFDBDatabase(client.cluster)
+	if err != nil {
+		return fmt.Errorf("get db: %w", err)
+	}
+	defer db.Close()
+
+	_, err = db.Transact(func(tr fdb.Transaction) (interface{}, error) {
 		err := tr.Options().SetAccessSystemKeys()
 		if err != nil {
 			return nil, err
@@ -203,7 +212,13 @@ func (client *realLockClient) AddPendingUpgrades(
 func (client *realLockClient) GetPendingUpgrades(
 	version fdbv1beta2.Version,
 ) (map[fdbv1beta2.ProcessGroupID]bool, error) {
-	upgrades, err := client.database.Transact(func(tr fdb.Transaction) (interface{}, error) {
+	db, err := getFDBDatabase(client.cluster)
+	if err != nil {
+		return nil, fmt.Errorf("get db: %w", err)
+	}
+	defer db.Close()
+
+	upgrades, err := db.Transact(func(tr fdb.Transaction) (interface{}, error) {
 		err := tr.Options().SetReadSystemKeys()
 		if err != nil {
 			return nil, err
@@ -224,7 +239,6 @@ func (client *realLockClient) GetPendingUpgrades(
 
 		return upgrades, nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +257,13 @@ func (client *realLockClient) GetPendingUpgrades(
 // ClearPendingUpgrades clears any stored information about pending
 // upgrades.
 func (client *realLockClient) ClearPendingUpgrades() error {
-	_, err := client.database.Transact(func(tr fdb.Transaction) (interface{}, error) {
+	db, err := getFDBDatabase(client.cluster)
+	if err != nil {
+		return fmt.Errorf("get db: %w", err)
+	}
+	defer db.Close()
+
+	_, err = db.Transact(func(tr fdb.Transaction) (interface{}, error) {
 		err := tr.Options().SetAccessSystemKeys()
 		if err != nil {
 			return nil, err
@@ -264,7 +284,13 @@ func (client *realLockClient) ClearPendingUpgrades() error {
 
 // GetDenyList retrieves the current deny list from the database.
 func (client *realLockClient) GetDenyList() ([]string, error) {
-	list, err := client.database.Transact(func(tr fdb.Transaction) (interface{}, error) {
+	db, err := getFDBDatabase(client.cluster)
+	if err != nil {
+		return nil, fmt.Errorf("get db: %w", err)
+	}
+	defer db.Close()
+
+	list, err := db.Transact(func(tr fdb.Transaction) (interface{}, error) {
 		err := tr.Options().SetReadSystemKeys()
 		if err != nil {
 			return nil, err
@@ -282,7 +308,6 @@ func (client *realLockClient) GetDenyList() ([]string, error) {
 		}
 		return list, nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +317,13 @@ func (client *realLockClient) GetDenyList() ([]string, error) {
 
 // UpdateDenyList updates the deny list to match a list of entries.
 func (client *realLockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntry) error {
-	_, err := client.database.Transact(func(tr fdb.Transaction) (interface{}, error) {
+	db, err := getFDBDatabase(client.cluster)
+	if err != nil {
+		return fmt.Errorf("get db: %w", err)
+	}
+	defer db.Close()
+
+	_, err = db.Transact(func(tr fdb.Transaction) (interface{}, error) {
 		err := tr.Options().SetAccessSystemKeys()
 		if err != nil {
 			return nil, err
@@ -340,8 +371,14 @@ func (client *realLockClient) ReleaseLock() error {
 		return nil
 	}
 
+	db, err := getFDBDatabase(client.cluster)
+	if err != nil {
+		return fmt.Errorf("get db: %w", err)
+	}
+	defer db.Close()
+
 	lockKey := fdb.Key(fmt.Sprintf("%s/global", client.cluster.GetLockPrefix()))
-	_, err := client.database.Transact(func(transaction fdb.Transaction) (interface{}, error) {
+	_, err = db.Transact(func(transaction fdb.Transaction) (interface{}, error) {
 		err := transaction.Options().SetAccessSystemKeys()
 		if err != nil {
 			return false, err
@@ -425,18 +462,9 @@ func NewRealLockClient(
 	cluster *fdbv1beta2.FoundationDBCluster,
 	log logr.Logger,
 ) (fdbadminclient.LockClient, error) {
-	if !cluster.ShouldUseLocks() {
-		return &realLockClient{disableLocks: true}, nil
-	}
-
-	database, err := getFDBDatabase(cluster)
-	if err != nil {
-		return nil, err
-	}
-
 	return &realLockClient{
-		cluster:  cluster,
-		database: database,
+		disableLocks: !cluster.ShouldUseLocks(),
+		cluster:      cluster,
 		log: log.WithValues(
 			"namespace", cluster.Namespace,
 			"cluster", cluster.Name,

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/FoundationDB/fdb-kubernetes-operator/v2
 go 1.25.0
 
 require (
-	// Binding version for 7.1.67
-	github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c
+	// Binding version for 7.3.63
+	github.com/apple/foundationdb/bindings/go v0.0.0-20250702211439-37fcf1c8ce08
 	// fdbkubernetesmonitor version for 7.1.67
 	github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20250115161953-f1ab8147ed1c
 	github.com/fatih/color v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c h1:Nnun3T50beIpO6YKDZInHuZMgnNtYJafSlQAvkXwOWc=
 github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=
+github.com/apple/foundationdb/bindings/go v0.0.0-20250702211439-37fcf1c8ce08 h1:FBu5q43+8pMQO5IgC+anjjz+3djUWg2jfCp7rz+IyWM=
+github.com/apple/foundationdb/bindings/go v0.0.0-20250702211439-37fcf1c8ce08/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=
+github.com/apple/foundationdb/bindings/go v0.0.0-20260324175018-6ff7cbb811fe h1:z2S2j7k+A5SxDe8XB7dsG3qPHy/CIlxUXW/of3U4dWg=
+github.com/apple/foundationdb/bindings/go v0.0.0-20260324175018-6ff7cbb811fe/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=
 github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20250115161953-f1ab8147ed1c h1:soTXYmkZfzTDDooU4vTFHYK5pcA/gEDM/3qKc1/bFWM=
 github.com/apple/foundationdb/fdbkubernetesmonitor v0.0.0-20250115161953-f1ab8147ed1c/go.mod h1:o+Nph7J4aa1boTEl2qhs/p0qy1mtY01P/3dpFh4Xt4w=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/sample-apps/data-loader/go.mod
+++ b/sample-apps/data-loader/go.mod
@@ -1,6 +1,6 @@
 module github.com/FoundationDB/fdb-data-loader
 
-go 1.24.0
+go 1.25.0
 
-// Binding version for 7.1.67
-require github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c
+// Binding version for 7.3.63
+require github.com/apple/foundationdb/bindings/go v0.0.0-20250221231555-5140696da2df

--- a/sample-apps/data-loader/go.sum
+++ b/sample-apps/data-loader/go.sum
@@ -1,2 +1,4 @@
 github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c h1:Nnun3T50beIpO6YKDZInHuZMgnNtYJafSlQAvkXwOWc=
 github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=
+github.com/apple/foundationdb/bindings/go v0.0.0-20250221231555-5140696da2df h1:XlE/l8moueBRTJr7xt0/9f0HJ1FaLupzguIKoj0a74g=
+github.com/apple/foundationdb/bindings/go v0.0.0-20250221231555-5140696da2df/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=

--- a/sample-apps/data-loader/main.go
+++ b/sample-apps/data-loader/main.go
@@ -44,6 +44,7 @@ func loadData(ctx context.Context, keys int, batchSize int, valueSize int, clust
 	if err != nil {
 		log.Fatalf("could not open database: %s", err)
 	}
+	defer db.Close()
 
 	err = db.Options().SetTransactionTimeout(10 * time.Second.Milliseconds())
 	if err != nil {
@@ -79,7 +80,6 @@ func loadData(ctx context.Context, keys int, batchSize int, valueSize int, clust
 
 				return nil, nil
 			})
-
 			if err != nil {
 				log.Printf("could not write data: %s\n", err)
 			}


### PR DESCRIPTION
# Description

This change fixes a resource leak issue caused by using short-lived FoundationDB connections without properly closing them when done. The previously used version of the Go bindings (from the 7.1.67 release) did not expose any way to close and destory the underlaying FoundationDB resources created from the C library. Newer versions of the bindings introduces a `Close()` that can be used to properly release resources.

The PR upgrades the Go bindings to the version from release 7.3.63, and makes sure that all connections created from `fdb.OpenDatabase(...)` are properly closed when no longer needed.

This required a small refactor of the lock client, such that it uses short-lived database connections that are created for each method call, instead of keeping a long-lived connection over the lifetime of the lock client. This approach creates a consistent behavior with how the fdb and admin clients are implemented (which also utilize short-lived connections), and makes sure that the connection can be closed safely without pushing this responsibility out to the user of the lock client.

We discovered this bug (i.e. the resource and connection leakage) in our production cluster. We only noticed it beacuase we use quite short lived mTLS certificates (shorter than the default `TLS_CERT_REFRESH_DELAY_SECONDS` in FoundationDB of 12 hours). We started seeing TLS issues in the trace logs, originating from the operator, which ultimately lead us to find the `fdb.OpenDatabase` without `Close()` in the operator. This was not a problem for operations e.g. directly calling `fdbcli`, since we had configured the `--knob-tls-cert-refresh-delay-seconds` knob in `customParameters`. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

- N/a

## Testing

Did run unit tests, but unit tests are mostly useless for this type of fix. Hopefully e2e tests in CI is better. We also use the 7.3.63 bindings with this pattern (i.e. `Close()` of the db connection) heavily, and have substantial tests on our side. Feel confident about this change.

## Documentation

- N/a

## Follow-up

As described above, we ultimately discovered this bug because of TLS issues. If implementation is ever changed in the future to have long-lived connections opened by `fdb.OpenDatabase`, it would be good if the TLS refersh knob (or any other custom parameters) could be configured. Seems like low prio right now though, given that all opened connections are now short-lived.