### PR TITLE
Update Lock client to make use of FDB lib client

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -160,7 +160,7 @@ func (command cliCommand) getTimeout() time.Duration {
 		return command.timeout
 	}
 
-	return DefaultCLITimeout
+	return DefaultTimeout
 }
 
 // getVersion returns the versions defined in the command or if not present returns the running version of the
@@ -504,7 +504,7 @@ func (client *cliAdminClient) ExcludeProcessesWithNoWait(
 		}
 
 		// Ensure we are stopping the check after the timeout time.
-		timeout := time.Now().Add(client.timeout)
+		timeout := time.Now().Add(client.getTimeout())
 		for {
 			err = client.executeTransactionForManagementAPI(func(tr fdb.Transaction) error {
 				inProgressKeyRange, err := fdb.PrefixRange(
@@ -1071,10 +1071,10 @@ func (client *cliAdminClient) SetTimeout(timeout time.Duration) {
 	client.timeout = timeout
 }
 
-// getTimeout will return the timeout that is specified for the admin client or otherwise the MaxCliTimeout.
+// getTimeout will return the timeout that is specified for the admin client or otherwise the MaxTimeout.
 func (client *cliAdminClient) getTimeout() time.Duration {
 	if client.timeout == 0 {
-		return MaxCliTimeout
+		return MaxTimeout
 	}
 
 	return client.timeout
@@ -1221,7 +1221,7 @@ func (client *cliAdminClient) UpdatePendingForRemoval(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		pendingForRemoval,
 		updates,
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1232,7 +1232,7 @@ func (client *cliAdminClient) UpdatePendingForExclusion(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		pendingForExclusion,
 		updates,
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1243,7 +1243,7 @@ func (client *cliAdminClient) UpdatePendingForInclusion(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		pendingForInclusion,
 		updates,
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1254,7 +1254,7 @@ func (client *cliAdminClient) UpdatePendingForRestart(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		pendingForRestart,
 		updates,
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1265,7 +1265,7 @@ func (client *cliAdminClient) UpdateReadyForExclusion(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		readyForExclusion,
 		updates,
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1276,7 +1276,7 @@ func (client *cliAdminClient) UpdateReadyForInclusion(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		readyForInclusion,
 		updates,
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1287,7 +1287,7 @@ func (client *cliAdminClient) UpdateReadyForRestart(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		readyForRestart,
 		updates,
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1297,7 +1297,7 @@ func (client *cliAdminClient) GetPendingForRemoval(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(pendingForRemoval, prefix),
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1307,7 +1307,7 @@ func (client *cliAdminClient) GetPendingForExclusion(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(pendingForExclusion, prefix),
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1317,7 +1317,7 @@ func (client *cliAdminClient) GetPendingForInclusion(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(pendingForInclusion, prefix),
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1327,7 +1327,7 @@ func (client *cliAdminClient) GetPendingForRestart(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(pendingForRestart, prefix),
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1337,7 +1337,7 @@ func (client *cliAdminClient) GetReadyForExclusion(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(readyForExclusion, prefix),
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1347,7 +1347,7 @@ func (client *cliAdminClient) GetReadyForInclusion(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(readyForInclusion, prefix),
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
@@ -1357,37 +1357,37 @@ func (client *cliAdminClient) GetReadyForRestart(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(readyForRestart, prefix),
-		client.timeout,
+		client.getTimeout(),
 	)
 }
 
 // ClearReadyForRestart removes all the process group IDs for all the process groups that are ready to be restarted.
 func (client *cliAdminClient) ClearReadyForRestart() error {
-	return client.fdbLibClient.clearGlobalCoordinationKeys(readyForRestart, client.timeout)
+	return client.fdbLibClient.clearGlobalCoordinationKeys(readyForRestart, client.getTimeout())
 }
 
 func (client *cliAdminClient) UpdateProcessAddresses(
 	updates map[fdbv1beta2.ProcessGroupID][]string,
 ) error {
-	return client.fdbLibClient.updateProcessAddresses(updates, client.timeout)
+	return client.fdbLibClient.updateProcessAddresses(updates, client.getTimeout())
 }
 
 func (client *cliAdminClient) GetProcessAddresses(
 	prefix string,
 ) (map[fdbv1beta2.ProcessGroupID][]string, error) {
-	return client.fdbLibClient.getProcessAddresses(prefix, client.timeout)
+	return client.fdbLibClient.getProcessAddresses(prefix, client.getTimeout())
 }
 
 // executeTransactionForManagementAPI will run an operation for the management API. This method handles all the common options.
 func (client *cliAdminClient) executeTransactionForManagementAPI(
 	operation func(transaction fdb.Transaction) error,
 ) error {
-	return client.fdbLibClient.executeTransactionForManagementAPI(operation, client.timeout)
+	return client.fdbLibClient.executeTransactionForManagementAPI(operation, client.getTimeout())
 }
 
 // executeTransaction will run a transaction for the target cluster. This method will handle all the common options.
 func (client *cliAdminClient) executeTransaction(
 	operation func(transaction fdb.Transaction) error,
 ) error {
-	return client.fdbLibClient.executeTransaction(operation, client.timeout)
+	return client.fdbLibClient.executeTransaction(operation, client.getTimeout())
 }

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -307,10 +307,10 @@ func (client *cliAdminClient) runCommand(command cliCommand) (string, error) {
 func (client *cliAdminClient) getStatusFromCli(
 	checkForProcesses bool,
 ) (*fdbv1beta2.FoundationDBStatus, error) {
-	// Always use the max timeout here. Otherwise we will retry multiple times with an increasing timeout. As the
+	// Always use the max timeout here. Otherwise, we will retry multiple times with an increasing timeout. As the
 	// timeout is only the upper bound using directly the max timeout reduces the calls to a single call.
 	output, err := client.runCommand(
-		cliCommand{command: "status json", timeout: client.getTimeout()},
+		cliCommand{command: "status json", timeout: getMaxTimeout(client.timeout)},
 	)
 	if err != nil {
 		return nil, err
@@ -350,7 +350,7 @@ func (client *cliAdminClient) getStatus() (*fdbv1beta2.FoundationDBStatus, error
 func (client *cliAdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 	startTime := time.Now()
 	// This will call directly the database and fetch the status information from the system key space.
-	status, err := getStatusFromDB(client.fdbLibClient, client.log, client.getTimeout())
+	status, err := getStatusFromDB(client.fdbLibClient, client.log, getMaxTimeout(client.timeout))
 	// There is a limitation in the multi version client if the cluster is only partially upgraded e.g. because not
 	// all fdbserver processes are restarted, then the multi version client sometimes picks the wrong version
 	// to connect to the cluster. This will result in an empty status only reporting the unreachable coordinators.
@@ -504,7 +504,7 @@ func (client *cliAdminClient) ExcludeProcessesWithNoWait(
 		}
 
 		// Ensure we are stopping the check after the timeout time.
-		timeout := time.Now().Add(client.getTimeout())
+		timeout := time.Now().Add(getMaxTimeout(client.timeout))
 		for {
 			err = client.executeTransactionForManagementAPI(func(tr fdb.Transaction) error {
 				inProgressKeyRange, err := fdb.PrefixRange(
@@ -570,7 +570,7 @@ func (client *cliAdminClient) ExcludeProcessesWithNoWait(
 	excludeCommand.WriteString(getAddressStringsWithoutPorts(addresses))
 
 	_, err := client.runCommand(
-		cliCommand{command: excludeCommand.String(), timeout: client.getTimeout()},
+		cliCommand{command: excludeCommand.String(), timeout: getMaxTimeout(client.timeout)},
 	)
 
 	return err
@@ -724,7 +724,10 @@ func (client *cliAdminClient) KillProcesses(addresses []fdbv1beta2.ProcessAddres
 
 	// Run the kill command once with the max timeout to reduce the risk of multiple recoveries happening.
 	_, err := client.runCommand(
-		cliCommand{command: getKillCommand(addresses, false), timeout: client.getTimeout()},
+		cliCommand{
+			command: getKillCommand(addresses, false),
+			timeout: getMaxTimeout(client.timeout),
+		},
 	)
 
 	return err
@@ -743,7 +746,10 @@ func (client *cliAdminClient) KillProcessesForUpgrade(addresses []fdbv1beta2.Pro
 
 	// Run the kill command once with the max timeout to reduce the risk of multiple recoveries happening.
 	_, err := client.runCommand(
-		cliCommand{command: getKillCommand(addresses, true), timeout: client.getTimeout()},
+		cliCommand{
+			command: getKillCommand(addresses, true),
+			timeout: getMaxTimeout(client.timeout),
+		},
 	)
 
 	return err
@@ -784,7 +790,7 @@ func (client *cliAdminClient) ChangeCoordinators(
 	// Increment the coordinator changes counter for this cluster
 	metrics.CoordinatorChangesCounter.WithLabelValues(client.Cluster.Namespace, client.Cluster.Name).
 		Inc()
-	return getConnectionStringFromDB(client.fdbLibClient, client.getTimeout())
+	return getConnectionStringFromDB(client.fdbLibClient, getDefaultTimeout(client.timeout))
 }
 
 // VersionSupported reports whether we can support a cluster with a given
@@ -1071,15 +1077,6 @@ func (client *cliAdminClient) SetTimeout(timeout time.Duration) {
 	client.timeout = timeout
 }
 
-// getTimeout will return the timeout that is specified for the admin client or otherwise the MaxTimeout.
-func (client *cliAdminClient) getTimeout() time.Duration {
-	if client.timeout == 0 {
-		return MaxTimeout
-	}
-
-	return client.timeout
-}
-
 // GetProcessesUnderMaintenance will return all process groups that are currently stored to be under maintenance.
 // The result is a map with the process group ID as key and the start of the maintenance as value.
 func (client *cliAdminClient) GetProcessesUnderMaintenance() (map[fdbv1beta2.ProcessGroupID]int64, error) {
@@ -1221,7 +1218,6 @@ func (client *cliAdminClient) UpdatePendingForRemoval(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		pendingForRemoval,
 		updates,
-		client.getTimeout(),
 	)
 }
 
@@ -1232,7 +1228,6 @@ func (client *cliAdminClient) UpdatePendingForExclusion(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		pendingForExclusion,
 		updates,
-		client.getTimeout(),
 	)
 }
 
@@ -1243,7 +1238,6 @@ func (client *cliAdminClient) UpdatePendingForInclusion(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		pendingForInclusion,
 		updates,
-		client.getTimeout(),
 	)
 }
 
@@ -1254,7 +1248,6 @@ func (client *cliAdminClient) UpdatePendingForRestart(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		pendingForRestart,
 		updates,
-		client.getTimeout(),
 	)
 }
 
@@ -1265,7 +1258,6 @@ func (client *cliAdminClient) UpdateReadyForExclusion(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		readyForExclusion,
 		updates,
-		client.getTimeout(),
 	)
 }
 
@@ -1276,7 +1268,6 @@ func (client *cliAdminClient) UpdateReadyForInclusion(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		readyForInclusion,
 		updates,
-		client.getTimeout(),
 	)
 }
 
@@ -1287,7 +1278,6 @@ func (client *cliAdminClient) UpdateReadyForRestart(
 	return client.fdbLibClient.updateGlobalCoordinationKeys(
 		readyForRestart,
 		updates,
-		client.getTimeout(),
 	)
 }
 
@@ -1297,7 +1287,6 @@ func (client *cliAdminClient) GetPendingForRemoval(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(pendingForRemoval, prefix),
-		client.getTimeout(),
 	)
 }
 
@@ -1307,7 +1296,6 @@ func (client *cliAdminClient) GetPendingForExclusion(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(pendingForExclusion, prefix),
-		client.getTimeout(),
 	)
 }
 
@@ -1317,7 +1305,6 @@ func (client *cliAdminClient) GetPendingForInclusion(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(pendingForInclusion, prefix),
-		client.getTimeout(),
 	)
 }
 
@@ -1327,7 +1314,6 @@ func (client *cliAdminClient) GetPendingForRestart(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(pendingForRestart, prefix),
-		client.getTimeout(),
 	)
 }
 
@@ -1337,7 +1323,6 @@ func (client *cliAdminClient) GetReadyForExclusion(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(readyForExclusion, prefix),
-		client.getTimeout(),
 	)
 }
 
@@ -1347,7 +1332,6 @@ func (client *cliAdminClient) GetReadyForInclusion(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(readyForInclusion, prefix),
-		client.getTimeout(),
 	)
 }
 
@@ -1357,37 +1341,36 @@ func (client *cliAdminClient) GetReadyForRestart(
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	return client.fdbLibClient.getGlobalCoordinationKeys(
 		path.Join(readyForRestart, prefix),
-		client.getTimeout(),
 	)
 }
 
 // ClearReadyForRestart removes all the process group IDs for all the process groups that are ready to be restarted.
 func (client *cliAdminClient) ClearReadyForRestart() error {
-	return client.fdbLibClient.clearGlobalCoordinationKeys(readyForRestart, client.getTimeout())
+	return client.fdbLibClient.clearGlobalCoordinationKeys(readyForRestart)
 }
 
 func (client *cliAdminClient) UpdateProcessAddresses(
 	updates map[fdbv1beta2.ProcessGroupID][]string,
 ) error {
-	return client.fdbLibClient.updateProcessAddresses(updates, client.getTimeout())
+	return client.fdbLibClient.updateProcessAddresses(updates)
 }
 
 func (client *cliAdminClient) GetProcessAddresses(
 	prefix string,
 ) (map[fdbv1beta2.ProcessGroupID][]string, error) {
-	return client.fdbLibClient.getProcessAddresses(prefix, client.getTimeout())
+	return client.fdbLibClient.getProcessAddresses(prefix)
 }
 
 // executeTransactionForManagementAPI will run an operation for the management API. This method handles all the common options.
 func (client *cliAdminClient) executeTransactionForManagementAPI(
 	operation func(transaction fdb.Transaction) error,
 ) error {
-	return client.fdbLibClient.executeTransactionForManagementAPI(operation, client.getTimeout())
+	return client.fdbLibClient.executeTransactionForManagementAPI(operation)
 }
 
 // executeTransaction will run a transaction for the target cluster. This method will handle all the common options.
 func (client *cliAdminClient) executeTransaction(
 	operation func(transaction fdb.Transaction) error,
 ) error {
-	return client.fdbLibClient.executeTransaction(operation, client.getTimeout())
+	return client.fdbLibClient.executeTransaction(operation)
 }

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -790,7 +790,7 @@ func (client *cliAdminClient) ChangeCoordinators(
 	// Increment the coordinator changes counter for this cluster
 	metrics.CoordinatorChangesCounter.WithLabelValues(client.Cluster.Namespace, client.Cluster.Name).
 		Inc()
-	return getConnectionStringFromDB(client.fdbLibClient, getDefaultTimeout(client.timeout))
+	return getConnectionStringFromDB(client.fdbLibClient)
 }
 
 // VersionSupported reports whether we can support a cluster with a given
@@ -1083,10 +1083,10 @@ func (client *cliAdminClient) GetProcessesUnderMaintenance() (map[fdbv1beta2.Pro
 	maintenancePrefix := client.Cluster.GetMaintenancePrefix() + "/"
 
 	var upgrades map[fdbv1beta2.ProcessGroupID]int64
-	err := client.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := client.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		keyRange, err := fdb.PrefixRange([]byte(client.Cluster.GetMaintenancePrefix()))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		results := tr.GetRange(keyRange, fdb.RangeOptions{}).GetSliceOrPanic()
@@ -1113,7 +1113,7 @@ func (client *cliAdminClient) GetProcessesUnderMaintenance() (map[fdbv1beta2.Pro
 
 			upgrades[fdbv1beta2.ProcessGroupID(processGroupID)] = timestamp
 		}
-		return nil
+		return nil, nil
 	})
 
 	if err != nil {
@@ -1128,7 +1128,7 @@ func (client *cliAdminClient) GetProcessesUnderMaintenance() (map[fdbv1beta2.Pro
 func (client *cliAdminClient) RemoveProcessesUnderMaintenance(
 	processGroupIDs []fdbv1beta2.ProcessGroupID,
 ) error {
-	return client.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := client.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		for _, processGroupID := range processGroupIDs {
 			strKey := path.Join(client.Cluster.GetMaintenancePrefix(), string(processGroupID))
 			client.log.V(1).
@@ -1136,8 +1136,9 @@ func (client *cliAdminClient) RemoveProcessesUnderMaintenance(
 			tr.Clear(fdb.Key(strKey))
 		}
 
-		return nil
+		return nil, nil
 	})
+	return err
 }
 
 // SetProcessesUnderMaintenance will add the provided process groups to the list of processes that will be taken
@@ -1152,15 +1153,17 @@ func (client *cliAdminClient) SetProcessesUnderMaintenance(
 		return err
 	}
 
-	return client.executeTransaction(func(tr fdb.Transaction) error {
+	_, err = client.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		for _, processGroupID := range processGroupIDs {
 			strKey := fmt.Sprintf("%s/%s", client.Cluster.GetMaintenancePrefix(), processGroupID)
 			client.log.V(1).
 				Info("adding process to maintenance list", "processGroupID", processGroupID, "timestamp", timestamp, "key", strKey)
 			tr.Set(fdb.Key(strKey), timestampByteBuffer.Bytes())
 		}
-		return nil
+		return nil, nil
 	})
+
+	return err
 }
 
 // GetVersionFromReachableCoordinators will return the running version based on the reachable coordinators. This method
@@ -1370,7 +1373,7 @@ func (client *cliAdminClient) executeTransactionForManagementAPI(
 
 // executeTransaction will run a transaction for the target cluster. This method will handle all the common options.
 func (client *cliAdminClient) executeTransaction(
-	operation func(transaction fdb.Transaction) error,
-) error {
+	operation func(transaction fdb.Transaction) (any, error),
+) (any, error) {
 	return client.fdbLibClient.executeTransaction(operation)
 }

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -187,15 +187,28 @@ func createClusterFileForCommandLine(cluster *fdbv1beta2.FoundationDBCluster) (*
 }
 
 // getConnectionStringFromDB gets the database's connection string directly from the system key
-func getConnectionStringFromDB(libClient fdbLibClient, timeout time.Duration) (string, error) {
-	outputBytes, err := libClient.getValueFromDBUsingKey("\xff/coordinators", timeout)
+func getConnectionStringFromDB(libClient fdbLibClient) (string, error) {
+	result, err := libClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
+		contents, trErr := tr.Get(fdb.Key("\xff/coordinators")).Get()
+		// If the value is empty return an empty byte slice. Otherwise, an error will be thrown.
+		if len(contents) == 0 {
+			contents = []byte{}
+		}
+
+		return contents, trErr
+	})
+
 	if err != nil {
 		return "", err
 	}
 
+	contents, ok := result.([]byte)
+	if !ok {
+		return "", fmt.Errorf("could not convert result to []byte")
+	}
 	var connectionString fdbv1beta2.ConnectionString
 	connectionString, err = fdbv1beta2.ParseConnectionString(
-		cleanConnectionStringOutput(string(outputBytes)),
+		cleanConnectionStringOutput(string(contents)),
 	)
 	if err != nil {
 		return "", err
@@ -210,9 +223,28 @@ func getStatusFromDB(
 	logger logr.Logger,
 	timeout time.Duration,
 ) (*fdbv1beta2.FoundationDBStatus, error) {
-	contents, err := libClient.getValueFromDBUsingKey("\xff\xff/status/json", timeout)
+	result, err := libClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
+		trErr := tr.Options().SetTimeout(timeout.Milliseconds())
+		if trErr != nil {
+			return nil, trErr
+		}
+
+		contents, trErr := tr.Get(fdb.Key("\xff\xff/status/json")).Get()
+		// If the value is empty return an empty byte slice. Otherwise, an error will be thrown.
+		if len(contents) == 0 {
+			contents = []byte{}
+		}
+
+		return contents, trErr
+	})
+
 	if err != nil {
 		return nil, err
+	}
+
+	contents, ok := result.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("could not convert result to []byte")
 	}
 
 	return parseMachineReadableStatus(logger, contents, true)

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -38,11 +38,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// DefaultCLITimeout is the default timeout for CLI commands.
-var DefaultCLITimeout = 10 * time.Second
+// DefaultTimeout is the default timeout for any FDB interactions.
+var DefaultTimeout = 10 * time.Second
 
-// MaxCliTimeout is the maximum CLI timeout that will be used for requests that might be slower to respond.
-var MaxCliTimeout = 40 * time.Second
+// MaxTimeout is the maximum timeout that will be used for requests that might be slower to respond.
+var MaxTimeout = 40 * time.Second
 
 const (
 	defaultTransactionTimeout = 5 * time.Second

--- a/fdbclient/common.go
+++ b/fdbclient/common.go
@@ -44,10 +44,6 @@ var DefaultTimeout = 10 * time.Second
 // MaxTimeout is the maximum timeout that will be used for requests that might be slower to respond.
 var MaxTimeout = 40 * time.Second
 
-const (
-	defaultTransactionTimeout = 5 * time.Second
-)
-
 func parseMachineReadableStatus(
 	logger logr.Logger,
 	contents []byte,
@@ -116,7 +112,14 @@ func getFDBDatabase(cluster *fdbv1beta2.FoundationDBCluster) (fdb.Database, erro
 		return fdb.Database{}, err
 	}
 
-	err = database.Options().SetTransactionTimeout(defaultTransactionTimeout.Milliseconds())
+	// Sets the default timeout for transaction to the default timeout provided byt the user.
+	err = database.Options().SetTransactionTimeout(getDefaultTimeout(0).Milliseconds())
+	if err != nil {
+		return fdb.Database{}, err
+	}
+
+	// We set a low retry limit as the operator will retry the reconciliation process anyway.
+	err = database.Options().SetTransactionRetryLimit(1)
 	if err != nil {
 		return fdb.Database{}, err
 	}
@@ -225,6 +228,27 @@ func cleanConnectionStringOutput(input string) string {
 	}
 
 	return input[startIdx+1 : endIdx]
+}
+
+// getDefaultTimeout will return the timeout that is specified for the client or otherwise the maximum of the DefaultTimeout and MaxTimeout.
+// If the provided timeout is higher than MaxTimeout, MaxTimeout will be returned.
+func getDefaultTimeout(timeout time.Duration) time.Duration {
+	result := timeout
+	if result == 0 {
+		result = DefaultTimeout
+	}
+
+	return min(result, MaxTimeout)
+}
+
+// getMaxTimeout will return the timeout that is specified for the client or otherwise the MaxTimeout.
+// If the provided timeout is higher than MaxTimeout, MaxTimeout will be returned.
+func getMaxTimeout(timeout time.Duration) time.Duration {
+	if timeout == 0 {
+		return MaxTimeout
+	}
+
+	return min(timeout, MaxTimeout)
 }
 
 type realDatabaseClientProvider struct {

--- a/fdbclient/common_test.go
+++ b/fdbclient/common_test.go
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,26 @@ import (
 )
 
 var _ = Describe("common_test", func() {
+	DescribeTable("getDefaultTimeout returns the correct timeout",
+		func(input time.Duration, expected time.Duration) {
+			Expect(getDefaultTimeout(input)).To(Equal(expected))
+		},
+		Entry("zero returns DefaultTimeout", time.Duration(0), DefaultTimeout),
+		Entry("value below MaxTimeout is returned as-is", 5*time.Second, 5*time.Second),
+		Entry("value equal to MaxTimeout is returned as-is", MaxTimeout, MaxTimeout),
+		Entry("value above MaxTimeout is capped to MaxTimeout", MaxTimeout+time.Second, MaxTimeout),
+	)
+
+	DescribeTable("getMaxTimeout returns the correct timeout",
+		func(input time.Duration, expected time.Duration) {
+			Expect(getMaxTimeout(input)).To(Equal(expected))
+		},
+		Entry("zero returns MaxTimeout", time.Duration(0), MaxTimeout),
+		Entry("value below MaxTimeout is returned as-is", 20*time.Second, 20*time.Second),
+		Entry("value equal to MaxTimeout is returned as-is", MaxTimeout, MaxTimeout),
+		Entry("value above MaxTimeout is capped to MaxTimeout", MaxTimeout+time.Second, MaxTimeout),
+	)
+
 	When("creating the cluster file", func() {
 		var clusterFile string
 		var tmpDir string

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -42,34 +42,35 @@ type fdbLibClient interface {
 	updateGlobalCoordinationKeys(
 		prefix string,
 		updates map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction,
-		timeout time.Duration,
 	) error
 	// getGlobalCoordinationKeys will return the entries under the provided prefix.
 	getGlobalCoordinationKeys(
 		prefix string,
-		timeout time.Duration,
 	) (map[fdbv1beta2.ProcessGroupID]time.Time, error)
 	// clearGlobalCoordinationKeys will remove all the ready information for the provided prefix.
-	clearGlobalCoordinationKeys(prefix string, timeout time.Duration) error
+	clearGlobalCoordinationKeys(prefix string) error
 	// updateProcessAddresses will update the provided addresses associated with the provided process group. If the address slice
 	// is empty or nil, the entry will be removed.
 	updateProcessAddresses(
 		updates map[fdbv1beta2.ProcessGroupID][]string,
-		timeout time.Duration,
 	) error
 	// getProcessAddresses gets the process group IDs and their associated process addresses.
 	getProcessAddresses(
 		prefix string,
-		timeout time.Duration,
 	) (map[fdbv1beta2.ProcessGroupID][]string, error)
 	// executeTransactionForManagementAPI will run an operation for the management API. This method handles all the common
 	// options.
 	executeTransactionForManagementAPI(
 		operation func(tr fdb.Transaction) error,
-		timeout time.Duration,
 	) error
 	// executeTransaction will run a transaction for the target cluster. This method will handle all the common options.
-	executeTransaction(operation func(tr fdb.Transaction) error, timeout time.Duration) error
+	executeTransaction(operation func(tr fdb.Transaction) error) error
+	// executeTransactionWithCustomTimeout will run a transaction for the target cluster. This method will add all the common options
+	// and allows to use a custom timeout
+	executeTransactionWithCustomTimeout(
+		operation func(tr fdb.Transaction) error,
+		timeout time.Duration,
+	) error
 }
 
 var _ fdbLibClient = &realFdbLibClient{}
@@ -90,7 +91,7 @@ func (fdbClient *realFdbLibClient) getValueFromDBUsingKey(
 	}()
 
 	var result []byte
-	err := fdbClient.executeTransaction(func(tr fdb.Transaction) error {
+	err := fdbClient.executeTransactionWithCustomTimeout(func(tr fdb.Transaction) error {
 		rawResult := tr.Get(fdb.Key(fdbKey)).MustGet()
 		// If the value is empty return an empty byte slice. Otherwise, an error will be thrown.
 		if len(rawResult) == 0 {
@@ -109,7 +110,6 @@ func (fdbClient *realFdbLibClient) getValueFromDBUsingKey(
 func (fdbClient *realFdbLibClient) updateGlobalCoordinationKeys(
 	prefix string,
 	updates map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction,
-	timeout time.Duration,
 ) error {
 	if len(updates) == 0 {
 		return nil
@@ -150,7 +150,7 @@ func (fdbClient *realFdbLibClient) updateGlobalCoordinationKeys(
 			}
 		}
 		return nil
-	}, timeout)
+	})
 
 	return checkError(err)
 }
@@ -158,7 +158,6 @@ func (fdbClient *realFdbLibClient) updateGlobalCoordinationKeys(
 // getGlobalCoordinationKeys will return the entries under the provided prefix.
 func (fdbClient *realFdbLibClient) getGlobalCoordinationKeys(
 	prefix string,
-	timeout time.Duration,
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	var mapResult map[fdbv1beta2.ProcessGroupID]time.Time
 	fdbClient.logger.V(1).Info("Fetching global coordination keys in FDB", "prefix", prefix)
@@ -204,7 +203,7 @@ func (fdbClient *realFdbLibClient) getGlobalCoordinationKeys(
 
 		resultProcessGroups = processGroups
 		return nil
-	}, timeout)
+	})
 
 	return resultProcessGroups, checkError(trErr)
 }
@@ -212,7 +211,6 @@ func (fdbClient *realFdbLibClient) getGlobalCoordinationKeys(
 // getGlobalCoordinationKeys will return the entries under the provided prefix.
 func (fdbClient *realFdbLibClient) clearGlobalCoordinationKeys(
 	prefix string,
-	timeout time.Duration,
 ) error {
 	fdbClient.logger.V(1).Info("Clearing global coordination keys in FDB", "prefix", prefix)
 	defer func() {
@@ -229,14 +227,13 @@ func (fdbClient *realFdbLibClient) clearGlobalCoordinationKeys(
 
 		tr.ClearRange(keyRange)
 		return nil
-	}, timeout)
+	})
 
 	return checkError(err)
 }
 
 func (fdbClient *realFdbLibClient) updateProcessAddresses(
 	updates map[fdbv1beta2.ProcessGroupID][]string,
-	timeout time.Duration,
 ) error {
 	if len(updates) == 0 {
 		return nil
@@ -282,7 +279,7 @@ func (fdbClient *realFdbLibClient) updateProcessAddresses(
 		}
 
 		return nil
-	}, timeout)
+	})
 
 	return checkError(err)
 }
@@ -290,7 +287,6 @@ func (fdbClient *realFdbLibClient) updateProcessAddresses(
 // getProcessAddresses gets the process group IDs and their associated process addresses.
 func (fdbClient *realFdbLibClient) getProcessAddresses(
 	prefix string,
-	timeout time.Duration,
 ) (map[fdbv1beta2.ProcessGroupID][]string, error) {
 	var result map[fdbv1beta2.ProcessGroupID][]string
 	fdbClient.logger.V(1).
@@ -325,7 +321,7 @@ func (fdbClient *realFdbLibClient) getProcessAddresses(
 
 		result = processGroups
 		return nil
-	}, timeout)
+	})
 
 	return result, checkError(err)
 }
@@ -356,19 +352,22 @@ func setCommonOptions(
 	if err != nil {
 		return err
 	}
-	err = tr.Options().SetTimeout(timeout.Milliseconds())
-	if err != nil {
-		return err
+	if timeout > 0 {
+		return tr.Options().SetTimeout(timeout.Milliseconds())
 	}
 
 	// TODO (https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2445): We should add an option to allow read
 	// and writes to a locked database. Right now only the management API calls will be allowed in a locked database.
-
-	// We set a low retry limit as the operator will retry the reconciliation process anyway.
-	return tr.Options().SetRetryLimit(1)
+	return nil
 }
 
 func (fdbClient *realFdbLibClient) executeTransaction(
+	operation func(tr fdb.Transaction) error,
+) error {
+	return fdbClient.executeTransactionWithCustomTimeout(operation, 0)
+}
+
+func (fdbClient *realFdbLibClient) executeTransactionWithCustomTimeout(
 	operation func(tr fdb.Transaction) error,
 	timeout time.Duration,
 ) error {
@@ -398,7 +397,6 @@ func (fdbClient *realFdbLibClient) executeTransaction(
 // options.
 func (fdbClient *realFdbLibClient) executeTransactionForManagementAPI(
 	operation func(tr fdb.Transaction) error,
-	timeout time.Duration,
 ) error {
 	db, err := getFDBDatabase(fdbClient.cluster)
 	if err != nil {
@@ -406,7 +404,7 @@ func (fdbClient *realFdbLibClient) executeTransactionForManagementAPI(
 	}
 
 	_, err = db.Transact(func(tr fdb.Transaction) (interface{}, error) {
-		err = setCommonOptions(&tr, timeout)
+		err = setCommonOptions(&tr, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -461,7 +459,6 @@ func (fdbClient *mockFdbLibClient) getValueFromDBUsingKey(
 func (fdbClient *mockFdbLibClient) updateGlobalCoordinationKeys(
 	keyPrefix string,
 	updates map[fdbv1beta2.ProcessGroupID]fdbv1beta2.UpdateAction,
-	_ time.Duration,
 ) error {
 	for processGroupID, action := range updates {
 		key := path.Join(keyPrefix, string(processGroupID))
@@ -485,7 +482,6 @@ func (fdbClient *mockFdbLibClient) updateGlobalCoordinationKeys(
 // getGlobalCoordinationKeys will return the entries under the provided prefix.
 func (fdbClient *mockFdbLibClient) getGlobalCoordinationKeys(
 	keyPrefix string,
-	_ time.Duration,
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
 	result := map[fdbv1beta2.ProcessGroupID]time.Time{}
 	for key, timeStamp := range fdbClient.coordinationState {
@@ -501,7 +497,6 @@ func (fdbClient *mockFdbLibClient) getGlobalCoordinationKeys(
 
 func (fdbClient *mockFdbLibClient) clearGlobalCoordinationKeys(
 	keyPrefix string,
-	_ time.Duration,
 ) error {
 	for key := range fdbClient.coordinationState {
 		if !strings.HasPrefix(key, keyPrefix) {
@@ -516,7 +511,6 @@ func (fdbClient *mockFdbLibClient) clearGlobalCoordinationKeys(
 
 func (fdbClient *mockFdbLibClient) updateProcessAddresses(
 	_ map[fdbv1beta2.ProcessGroupID][]string,
-	_ time.Duration,
 ) error {
 	// TODO (johscheuer)
 	return nil
@@ -524,13 +518,19 @@ func (fdbClient *mockFdbLibClient) updateProcessAddresses(
 
 func (fdbClient *mockFdbLibClient) getProcessAddresses(
 	_ string,
-	_ time.Duration,
 ) (map[fdbv1beta2.ProcessGroupID][]string, error) {
 	// TODO (johscheuer)
 	return nil, nil
 }
 
 func (fdbClient *mockFdbLibClient) executeTransactionForManagementAPI(
+	operation func(tr fdb.Transaction) error,
+) error {
+	// TODO implement and add unit tests.
+	return fdbClient.executeTransactionWithCustomTimeout(operation, 0)
+}
+
+func (fdbClient *mockFdbLibClient) executeTransactionWithCustomTimeout(
 	_ func(tr fdb.Transaction) error,
 	_ time.Duration,
 ) error {
@@ -540,7 +540,6 @@ func (fdbClient *mockFdbLibClient) executeTransactionForManagementAPI(
 
 func (fdbClient *mockFdbLibClient) executeTransaction(
 	_ func(tr fdb.Transaction) error,
-	_ time.Duration,
 ) error {
 	// TODO implement and add unit tests.
 	return nil

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -36,8 +36,6 @@ import (
 
 // fdbLibClient is an interface to interact with FDB over the client libraries
 type fdbLibClient interface {
-	// getValueFromDBUsingKey returns the value of the provided key.
-	getValueFromDBUsingKey(fdbKey string, timeout time.Duration) ([]byte, error)
 	// updateGlobalCoordinationKeys will update the provided updates in FDB.
 	updateGlobalCoordinationKeys(
 		prefix string,
@@ -64,13 +62,8 @@ type fdbLibClient interface {
 		operation func(tr fdb.Transaction) error,
 	) error
 	// executeTransaction will run a transaction for the target cluster. This method will handle all the common options.
-	executeTransaction(operation func(tr fdb.Transaction) error) error
-	// executeTransactionWithCustomTimeout will run a transaction for the target cluster. This method will add all the common options
-	// and allows to use a custom timeout
-	executeTransactionWithCustomTimeout(
-		operation func(tr fdb.Transaction) error,
-		timeout time.Duration,
-	) error
+	// The operation may return a result, which will be passed through to the caller.
+	executeTransaction(operation func(tr fdb.Transaction) (any, error)) (any, error)
 }
 
 var _ fdbLibClient = &realFdbLibClient{}
@@ -79,31 +72,6 @@ var _ fdbLibClient = &realFdbLibClient{}
 type realFdbLibClient struct {
 	cluster *fdbv1beta2.FoundationDBCluster
 	logger  logr.Logger
-}
-
-func (fdbClient *realFdbLibClient) getValueFromDBUsingKey(
-	fdbKey string,
-	timeout time.Duration,
-) ([]byte, error) {
-	fdbClient.logger.Info("Fetch values from FDB", "key", fdbKey)
-	defer func() {
-		fdbClient.logger.Info("Done fetching values from FDB", "key", fdbKey)
-	}()
-
-	var result []byte
-	err := fdbClient.executeTransactionWithCustomTimeout(func(tr fdb.Transaction) error {
-		rawResult := tr.Get(fdb.Key(fdbKey)).MustGet()
-		// If the value is empty return an empty byte slice. Otherwise, an error will be thrown.
-		if len(rawResult) == 0 {
-			result = []byte{}
-			return nil
-		}
-
-		result = rawResult
-		return nil
-	}, timeout)
-
-	return result, checkError(err)
 }
 
 // updateGlobalCoordinationKeys will update the provided updates in FDB.
@@ -128,7 +96,7 @@ func (fdbClient *realFdbLibClient) updateGlobalCoordinationKeys(
 		fdbClient.cluster.Spec.ProcessGroupIDPrefix,
 	)
 
-	err := fdbClient.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := fdbClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		timestampTuple := tuple.Tuple{time.Now().Unix()}
 		timestampBytes := timestampTuple.Pack()
 
@@ -149,29 +117,28 @@ func (fdbClient *realFdbLibClient) updateGlobalCoordinationKeys(
 				continue
 			}
 		}
-		return nil
+		return nil, nil
 	})
 
-	return checkError(err)
+	return err
 }
 
 // getGlobalCoordinationKeys will return the entries under the provided prefix.
 func (fdbClient *realFdbLibClient) getGlobalCoordinationKeys(
 	prefix string,
 ) (map[fdbv1beta2.ProcessGroupID]time.Time, error) {
-	var mapResult map[fdbv1beta2.ProcessGroupID]time.Time
+	var resultProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time
 	fdbClient.logger.V(1).Info("Fetching global coordination keys in FDB", "prefix", prefix)
 	defer func() {
 		fdbClient.logger.V(1).
-			Info("Done fetching global coordination keys in FDB", "prefix", prefix, "results", len(mapResult))
+			Info("Done fetching global coordination keys in FDB", "prefix", prefix, "results", len(resultProcessGroups))
 	}()
 
-	var resultProcessGroups map[fdbv1beta2.ProcessGroupID]time.Time
-	trErr := fdbClient.executeTransaction(func(tr fdb.Transaction) error {
+	_, trErr := fdbClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		keyPrefix := path.Join(fdbClient.cluster.GetLockPrefix(), prefix)
 		keyRange, err := fdb.PrefixRange([]byte(keyPrefix))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		results := tr.GetRange(keyRange, fdb.RangeOptions{}).GetSliceOrPanic()
@@ -183,11 +150,11 @@ func (fdbClient *realFdbLibClient) getGlobalCoordinationKeys(
 
 			timestampBytes, err := tuple.Unpack(result.Value)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			if len(timestampBytes) < 1 {
-				return fmt.Errorf(
+				return nil, fmt.Errorf(
 					"expected that the tuple contains one element, got %d elements",
 					len(timestampBytes),
 				)
@@ -195,17 +162,17 @@ func (fdbClient *realFdbLibClient) getGlobalCoordinationKeys(
 
 			timestamp, valid := timestampBytes[0].(int64)
 			if !valid {
-				return fmt.Errorf("could not cast timestamp bytes into timestamp")
+				return nil, fmt.Errorf("could not cast timestamp bytes into timestamp")
 			}
 
 			processGroups[fdbv1beta2.ProcessGroupID(processGroupID)] = time.Unix(timestamp, 0)
 		}
 
 		resultProcessGroups = processGroups
-		return nil
+		return nil, nil
 	})
 
-	return resultProcessGroups, checkError(trErr)
+	return resultProcessGroups, trErr
 }
 
 // getGlobalCoordinationKeys will return the entries under the provided prefix.
@@ -218,18 +185,18 @@ func (fdbClient *realFdbLibClient) clearGlobalCoordinationKeys(
 			Info("Done clearing global coordination keys in FDB", "prefix", prefix)
 	}()
 
-	err := fdbClient.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := fdbClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		keyPrefix := path.Join(fdbClient.cluster.GetLockPrefix(), prefix)
 		keyRange, err := fdb.PrefixRange([]byte(keyPrefix))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		tr.ClearRange(keyRange)
-		return nil
+		return nil, nil
 	})
 
-	return checkError(err)
+	return err
 }
 
 func (fdbClient *realFdbLibClient) updateProcessAddresses(
@@ -252,7 +219,7 @@ func (fdbClient *realFdbLibClient) updateProcessAddresses(
 		fdbClient.cluster.Spec.ProcessGroupIDPrefix,
 	)
 
-	err := fdbClient.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := fdbClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		for processGroupID, addresses := range updates {
 			if processGroupID.GetProcessClass() == fdbv1beta2.ProcessClassTest {
 				continue
@@ -265,7 +232,7 @@ func (fdbClient *realFdbLibClient) updateProcessAddresses(
 				addressesBytes, parseError := json.Marshal(addresses)
 				// Should we continue here?
 				if parseError != nil {
-					return parseError
+					return nil, parseError
 				}
 
 				tr.Set(key, addressesBytes)
@@ -278,10 +245,10 @@ func (fdbClient *realFdbLibClient) updateProcessAddresses(
 			}
 		}
 
-		return nil
+		return nil, nil
 	})
 
-	return checkError(err)
+	return err
 }
 
 // getProcessAddresses gets the process group IDs and their associated process addresses.
@@ -296,11 +263,11 @@ func (fdbClient *realFdbLibClient) getProcessAddresses(
 			Info("Done fetching process addresses for global coordination in FDB", "prefix", prefix, "results", len(result))
 	}()
 
-	err := fdbClient.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := fdbClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		keyPrefix := path.Join(fdbClient.cluster.GetLockPrefix(), processAddresses, prefix)
 		keyRange, err := fdb.PrefixRange([]byte(keyPrefix))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		slice := tr.GetRange(keyRange, fdb.RangeOptions{}).GetSliceOrPanic()
@@ -313,17 +280,17 @@ func (fdbClient *realFdbLibClient) getProcessAddresses(
 			var addresses []string
 			parseErr := json.Unmarshal(sliceResult.Value, &addresses)
 			if parseErr != nil {
-				return parseErr
+				return nil, parseErr
 			}
 
 			processGroups[fdbv1beta2.ProcessGroupID(processGroupID)] = addresses
 		}
 
 		result = processGroups
-		return nil
+		return nil, nil
 	})
 
-	return result, checkError(err)
+	return result, err
 }
 
 func checkError(err error) error {
@@ -346,14 +313,10 @@ func checkError(err error) error {
 // setCommonOptions sets the common FDB transaction options.
 func setCommonOptions(
 	tr *fdb.Transaction,
-	timeout time.Duration,
 ) error {
 	err := tr.Options().SetAccessSystemKeys()
 	if err != nil {
 		return err
-	}
-	if timeout > 0 {
-		return tr.Options().SetTimeout(timeout.Milliseconds())
 	}
 
 	// TODO (https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2445): We should add an option to allow read
@@ -362,35 +325,23 @@ func setCommonOptions(
 }
 
 func (fdbClient *realFdbLibClient) executeTransaction(
-	operation func(tr fdb.Transaction) error,
-) error {
-	return fdbClient.executeTransactionWithCustomTimeout(operation, 0)
-}
-
-func (fdbClient *realFdbLibClient) executeTransactionWithCustomTimeout(
-	operation func(tr fdb.Transaction) error,
-	timeout time.Duration,
-) error {
+	operation func(tr fdb.Transaction) (any, error),
+) (any, error) {
 	db, err := getFDBDatabase(fdbClient.cluster)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = db.Transact(func(tr fdb.Transaction) (interface{}, error) {
-		err = setCommonOptions(&tr, timeout)
+	result, err := db.Transact(func(tr fdb.Transaction) (interface{}, error) {
+		err = setCommonOptions(&tr)
 		if err != nil {
 			return nil, err
 		}
 
-		err = operation(tr)
-		if err != nil {
-			return nil, err
-		}
-
-		return nil, nil
+		return operation(tr)
 	})
 
-	return err
+	return result, checkError(err)
 }
 
 // executeTransactionForManagementAPI will run an operation for the management API. This method handles all the common
@@ -398,18 +349,8 @@ func (fdbClient *realFdbLibClient) executeTransactionWithCustomTimeout(
 func (fdbClient *realFdbLibClient) executeTransactionForManagementAPI(
 	operation func(tr fdb.Transaction) error,
 ) error {
-	db, err := getFDBDatabase(fdbClient.cluster)
-	if err != nil {
-		return err
-	}
-
-	_, err = db.Transact(func(tr fdb.Transaction) (interface{}, error) {
-		err = setCommonOptions(&tr, 0)
-		if err != nil {
-			return nil, err
-		}
-
-		err = tr.Options().SetSpecialKeySpaceEnableWrites()
+	_, err := fdbClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
+		err := tr.Options().SetSpecialKeySpaceEnableWrites()
 		if err != nil {
 			return nil, err
 		}
@@ -421,14 +362,8 @@ func (fdbClient *realFdbLibClient) executeTransactionForManagementAPI(
 			return nil, err
 		}
 
-		err = operation(tr)
-		if err != nil {
-			return nil, err
-		}
-
-		return nil, nil
+		return nil, operation(tr)
 	})
-
 	return err
 }
 
@@ -436,24 +371,15 @@ func (fdbClient *realFdbLibClient) executeTransactionForManagementAPI(
 type mockFdbLibClient struct {
 	// mockedOutput is the output returned by getValueFromDBUsingKey.
 	mockedOutput []byte
-	// mockedError is the error returned by getValueFromDBUsingKey.
+	// mockedError is the error returned by executeTransaction.
 	mockedError error
-	// requestedKey will be the key that was used to call getValueFromDBUsingKey.
-	requestedKey string
 	// coordinationState represents the current coordination state.
 	coordinationState map[string]time.Time
+	// executeTransactionCallCount tracks how many times executeTransaction was called.
+	executeTransactionCallCount int
 }
 
 var _ fdbLibClient = (*mockFdbLibClient)(nil)
-
-func (fdbClient *mockFdbLibClient) getValueFromDBUsingKey(
-	fdbKey string,
-	_ time.Duration,
-) ([]byte, error) {
-	fdbClient.requestedKey = fdbKey
-
-	return fdbClient.mockedOutput, fdbClient.mockedError
-}
 
 // updateGlobalCoordinationKeys will update the provided updates in FDB.
 func (fdbClient *mockFdbLibClient) updateGlobalCoordinationKeys(
@@ -476,7 +402,7 @@ func (fdbClient *mockFdbLibClient) updateGlobalCoordinationKeys(
 		}
 	}
 
-	return nil
+	return fdbClient.mockedError
 }
 
 // getGlobalCoordinationKeys will return the entries under the provided prefix.
@@ -492,7 +418,7 @@ func (fdbClient *mockFdbLibClient) getGlobalCoordinationKeys(
 		result[fdbv1beta2.ProcessGroupID(path.Base(key))] = timeStamp
 	}
 
-	return nil, nil
+	return nil, fdbClient.mockedError
 }
 
 func (fdbClient *mockFdbLibClient) clearGlobalCoordinationKeys(
@@ -506,41 +432,33 @@ func (fdbClient *mockFdbLibClient) clearGlobalCoordinationKeys(
 		delete(fdbClient.coordinationState, path.Base(key))
 	}
 
-	return nil
+	return fdbClient.mockedError
 }
 
 func (fdbClient *mockFdbLibClient) updateProcessAddresses(
 	_ map[fdbv1beta2.ProcessGroupID][]string,
 ) error {
 	// TODO (johscheuer)
-	return nil
+	return fdbClient.mockedError
 }
 
 func (fdbClient *mockFdbLibClient) getProcessAddresses(
 	_ string,
 ) (map[fdbv1beta2.ProcessGroupID][]string, error) {
 	// TODO (johscheuer)
-	return nil, nil
+	return nil, fdbClient.mockedError
 }
 
 func (fdbClient *mockFdbLibClient) executeTransactionForManagementAPI(
-	operation func(tr fdb.Transaction) error,
-) error {
-	// TODO implement and add unit tests.
-	return fdbClient.executeTransactionWithCustomTimeout(operation, 0)
-}
-
-func (fdbClient *mockFdbLibClient) executeTransactionWithCustomTimeout(
 	_ func(tr fdb.Transaction) error,
-	_ time.Duration,
 ) error {
 	// TODO implement and add unit tests.
-	return nil
+	return fdbClient.mockedError
 }
 
 func (fdbClient *mockFdbLibClient) executeTransaction(
-	_ func(tr fdb.Transaction) error,
-) error {
-	// TODO implement and add unit tests.
-	return nil
+	_ func(tr fdb.Transaction) (any, error),
+) (any, error) {
+	fdbClient.executeTransactionCallCount++
+	return fdbClient.mockedOutput, fdbClient.mockedError
 }

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -61,9 +61,10 @@ func (client *realLockClient) TakeLock() error {
 		return nil
 	}
 
-	return client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
-		return client.takeLockInTransaction(tr)
+	_, err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
+		return nil, client.takeLockInTransaction(tr)
 	})
+	return err
 }
 
 // takeLockInTransaction attempts to acquire a lock using an open transaction.
@@ -170,7 +171,7 @@ func (client *realLockClient) AddPendingUpgrades(
 	version fdbv1beta2.Version,
 	processGroupIDs []fdbv1beta2.ProcessGroupID,
 ) error {
-	return client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		for _, processGroupID := range processGroupIDs {
 			key := fdb.Key(
 				fmt.Sprintf(
@@ -182,8 +183,9 @@ func (client *realLockClient) AddPendingUpgrades(
 			)
 			tr.Set(key, []byte(processGroupID))
 		}
-		return nil
+		return nil, nil
 	})
+	return err
 }
 
 // GetPendingUpgrades returns the stored information about which process
@@ -192,13 +194,13 @@ func (client *realLockClient) GetPendingUpgrades(
 	version fdbv1beta2.Version,
 ) (map[fdbv1beta2.ProcessGroupID]bool, error) {
 	var upgrades map[fdbv1beta2.ProcessGroupID]bool
-	err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		keyPrefix := []byte(
 			fmt.Sprintf("%s/upgrades/%s/", client.cluster.GetLockPrefix(), version.String()),
 		)
 		keyRange, err := fdb.PrefixRange(keyPrefix)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		results := tr.GetRange(keyRange, fdb.RangeOptions{}).GetSliceOrPanic()
 		upgrades = make(map[fdbv1beta2.ProcessGroupID]bool, len(results))
@@ -206,7 +208,7 @@ func (client *realLockClient) GetPendingUpgrades(
 			upgrades[fdbv1beta2.ProcessGroupID(result.Value)] = true
 		}
 
-		return nil
+		return nil, nil
 	})
 
 	return upgrades, err
@@ -215,25 +217,26 @@ func (client *realLockClient) GetPendingUpgrades(
 // ClearPendingUpgrades clears any stored information about pending
 // upgrades.
 func (client *realLockClient) ClearPendingUpgrades() error {
-	return client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		keyPrefix := []byte(fmt.Sprintf("%s/upgrades/", client.cluster.GetLockPrefix()))
 		keyRange, err := fdb.PrefixRange(keyPrefix)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		tr.ClearRange(keyRange)
-		return nil
+		return nil, nil
 	})
+	return err
 }
 
 // GetDenyList retrieves the current deny list from the database.
 func (client *realLockClient) GetDenyList() ([]string, error) {
 	var list []string
-	err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		keyRange, err := client.getDenyListKeyRange()
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		values := tr.GetRange(keyRange, fdb.RangeOptions{}).GetSliceOrPanic()
@@ -242,7 +245,7 @@ func (client *realLockClient) GetDenyList() ([]string, error) {
 			list[index] = string(value.Value)
 		}
 
-		return nil
+		return nil, nil
 	})
 
 	return list, err
@@ -250,10 +253,10 @@ func (client *realLockClient) GetDenyList() ([]string, error) {
 
 // UpdateDenyList updates the deny list to match a list of entries.
 func (client *realLockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntry) error {
-	return client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		keyRange, err := client.getDenyListKeyRange()
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		values := tr.GetRange(keyRange, fdb.RangeOptions{}).GetSliceOrPanic()
@@ -269,8 +272,9 @@ func (client *realLockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntr
 				tr.Set(client.getDenyListKey(entry.ID), []byte(entry.ID))
 			}
 		}
-		return nil
+		return nil, nil
 	})
+	return err
 }
 
 // getDenyListKeyRange defines a key range containing the full deny list.
@@ -292,31 +296,31 @@ func (client *realLockClient) ReleaseLock() error {
 	}
 
 	lockKey := fdb.Key(fmt.Sprintf("%s/global", client.cluster.GetLockPrefix()))
-	return client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
+	_, err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
 		lockValue := tr.Get(lockKey).MustGet()
 		// The lock value is not set, so no action is required.
 		if len(lockValue) == 0 {
-			return nil
+			return nil, nil
 		}
 
 		lockTuple, err := tuple.Unpack(lockValue)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		currentLockOwnerID, valid := lockTuple[0].(string)
 		if !valid {
-			return invalidLockValue{key: lockKey, value: lockValue}
+			return nil, invalidLockValue{key: lockKey, value: lockValue}
 		}
 
 		currentLockStartTimestamp, valid := lockTuple[1].(int64)
 		if !valid {
-			return invalidLockValue{key: lockKey, value: lockValue}
+			return nil, invalidLockValue{key: lockKey, value: lockValue}
 		}
 
 		currentLockEndTimestamp, valid := lockTuple[2].(int64)
 		if !valid {
-			return invalidLockValue{key: lockKey, value: lockValue}
+			return nil, invalidLockValue{key: lockKey, value: lockValue}
 		}
 
 		ownerID := client.cluster.GetLockID()
@@ -329,7 +333,7 @@ func (client *realLockClient) ReleaseLock() error {
 
 		if currentLockOwnerID != ownerID {
 			logger.Info("cannot release lock from other owner")
-			return nil
+			return nil, nil
 		}
 
 		// Check the timestamp of the logs and make sure to only release locks when the timestamps are valid.
@@ -337,19 +341,20 @@ func (client *realLockClient) ReleaseLock() error {
 		now := time.Now()
 		if currentLockStartTimestamp > now.Unix() {
 			logger.Info("cannot release lock that is taken in the future")
-			return nil
+			return nil, nil
 		}
 
 		if currentLockEndTimestamp < now.Unix() {
 			logger.Info("cannot release a lock that is expired")
-			return nil
+			return nil, nil
 		}
 
 		logger.Info("releasing lock")
 		tr.Clear(lockKey)
 
-		return nil
+		return nil, nil
 	})
+	return err
 }
 
 // invalidLockValue is an error we can return when we cannot parse the existing

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -42,11 +42,24 @@ type realLockClient struct {
 	// Whether we should disable locking completely.
 	disableLocks bool
 
-	// The connection to the database.
-	database fdb.Database
+	// fdbLibClient is an interface to interact with a FDB cluster over the FDB client libraries. In the real fdb lib client
+	// we will issue the actual requests against FDB. In the mock runner we will return predefined output.
+	fdbLibClient fdbLibClient
+
+	// timeout defines the timeout that should be used for interacting with FDB.
+	timeout time.Duration
 
 	// log implementation for logging output
 	log logr.Logger
+}
+
+// getTimeout returns the timeout for the transactions with FDB.
+func (client *realLockClient) getTimeout() time.Duration {
+	if client.timeout == 0 {
+		return DefaultTimeout
+	}
+
+	return client.timeout
 }
 
 // Disabled determines if the client should automatically grant locks.
@@ -60,21 +73,13 @@ func (client *realLockClient) TakeLock() error {
 		return nil
 	}
 
-	_, err := client.database.Transact(func(transaction fdb.Transaction) (interface{}, error) {
-		lockErr := client.takeLockInTransaction(transaction)
-		return nil, lockErr
-	})
-
-	return err
+	return client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
+		return client.takeLockInTransaction(tr)
+	}, client.getTimeout())
 }
 
 // takeLockInTransaction attempts to acquire a lock using an open transaction.
 func (client *realLockClient) takeLockInTransaction(transaction fdb.Transaction) error {
-	err := transaction.Options().SetAccessSystemKeys()
-	if err != nil {
-		return err
-	}
-
 	lockKey := fdb.Key(fmt.Sprintf("%s/global", client.cluster.GetLockPrefix()))
 	lockValue := transaction.Get(lockKey).MustGet()
 
@@ -177,11 +182,7 @@ func (client *realLockClient) AddPendingUpgrades(
 	version fdbv1beta2.Version,
 	processGroupIDs []fdbv1beta2.ProcessGroupID,
 ) error {
-	_, err := client.database.Transact(func(tr fdb.Transaction) (interface{}, error) {
-		err := tr.Options().SetAccessSystemKeys()
-		if err != nil {
-			return nil, err
-		}
+	return client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
 		for _, processGroupID := range processGroupIDs {
 			key := fdb.Key(
 				fmt.Sprintf(
@@ -193,9 +194,8 @@ func (client *realLockClient) AddPendingUpgrades(
 			)
 			tr.Set(key, []byte(processGroupID))
 		}
-		return nil, nil
-	})
-	return err
+		return nil
+	}, client.getTimeout())
 }
 
 // GetPendingUpgrades returns the stored information about which process
@@ -203,104 +203,69 @@ func (client *realLockClient) AddPendingUpgrades(
 func (client *realLockClient) GetPendingUpgrades(
 	version fdbv1beta2.Version,
 ) (map[fdbv1beta2.ProcessGroupID]bool, error) {
-	upgrades, err := client.database.Transact(func(tr fdb.Transaction) (interface{}, error) {
-		err := tr.Options().SetReadSystemKeys()
-		if err != nil {
-			return nil, err
-		}
-
+	var upgrades map[fdbv1beta2.ProcessGroupID]bool
+	err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
 		keyPrefix := []byte(
 			fmt.Sprintf("%s/upgrades/%s/", client.cluster.GetLockPrefix(), version.String()),
 		)
 		keyRange, err := fdb.PrefixRange(keyPrefix)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		results := tr.GetRange(keyRange, fdb.RangeOptions{}).GetSliceOrPanic()
-		upgrades := make(map[fdbv1beta2.ProcessGroupID]bool, len(results))
+		upgrades = make(map[fdbv1beta2.ProcessGroupID]bool, len(results))
 		for _, result := range results {
 			upgrades[fdbv1beta2.ProcessGroupID(result.Value)] = true
 		}
 
-		return upgrades, nil
-	})
+		return nil
+	}, client.getTimeout())
 
-	if err != nil {
-		return nil, err
-	}
-
-	upgradeMap, isMap := upgrades.(map[fdbv1beta2.ProcessGroupID]bool)
-	if !isMap {
-		return nil, fmt.Errorf(
-			"invalid return value from transaction in GetPendingUpgrades: %v",
-			upgrades,
-		)
-	}
-
-	return upgradeMap, nil
+	return upgrades, err
 }
 
 // ClearPendingUpgrades clears any stored information about pending
 // upgrades.
 func (client *realLockClient) ClearPendingUpgrades() error {
-	_, err := client.database.Transact(func(tr fdb.Transaction) (interface{}, error) {
-		err := tr.Options().SetAccessSystemKeys()
-		if err != nil {
-			return nil, err
-		}
-
+	return client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
 		keyPrefix := []byte(fmt.Sprintf("%s/upgrades/", client.cluster.GetLockPrefix()))
 		keyRange, err := fdb.PrefixRange(keyPrefix)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		tr.ClearRange(keyRange)
-		return nil, nil
-	})
-
-	return err
+		return nil
+	}, client.getTimeout())
 }
 
 // GetDenyList retrieves the current deny list from the database.
 func (client *realLockClient) GetDenyList() ([]string, error) {
-	list, err := client.database.Transact(func(tr fdb.Transaction) (interface{}, error) {
-		err := tr.Options().SetReadSystemKeys()
-		if err != nil {
-			return nil, err
-		}
-
+	var list []string
+	err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
 		keyRange, err := client.getDenyListKeyRange()
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		values := tr.GetRange(keyRange, fdb.RangeOptions{}).GetSliceOrPanic()
-		list := make([]string, len(values))
+		list = make([]string, len(values))
 		for index, value := range values {
 			list[index] = string(value.Value)
 		}
-		return list, nil
-	})
 
-	if err != nil {
-		return nil, err
-	}
+		return nil
+	}, client.getTimeout())
 
-	return list.([]string), nil
+	return list, err
 }
 
 // UpdateDenyList updates the deny list to match a list of entries.
 func (client *realLockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntry) error {
-	_, err := client.database.Transact(func(tr fdb.Transaction) (interface{}, error) {
-		err := tr.Options().SetAccessSystemKeys()
-		if err != nil {
-			return nil, err
-		}
-
+	return client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
 		keyRange, err := client.getDenyListKeyRange()
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		values := tr.GetRange(keyRange, fdb.RangeOptions{}).GetSliceOrPanic()
@@ -316,10 +281,8 @@ func (client *realLockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntr
 				tr.Set(client.getDenyListKey(entry.ID), []byte(entry.ID))
 			}
 		}
-		return nil, nil
-	})
-
-	return err
+		return nil
+	}, client.getTimeout())
 }
 
 // getDenyListKeyRange defines a key range containing the full deny list.
@@ -341,36 +304,31 @@ func (client *realLockClient) ReleaseLock() error {
 	}
 
 	lockKey := fdb.Key(fmt.Sprintf("%s/global", client.cluster.GetLockPrefix()))
-	_, err := client.database.Transact(func(transaction fdb.Transaction) (interface{}, error) {
-		err := transaction.Options().SetAccessSystemKeys()
-		if err != nil {
-			return false, err
-		}
-
-		lockValue := transaction.Get(lockKey).MustGet()
+	return client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
+		lockValue := tr.Get(lockKey).MustGet()
 		// The lock value is not set, so no action is required.
 		if len(lockValue) == 0 {
-			return false, nil
+			return nil
 		}
 
 		lockTuple, err := tuple.Unpack(lockValue)
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		currentLockOwnerID, valid := lockTuple[0].(string)
 		if !valid {
-			return false, invalidLockValue{key: lockKey, value: lockValue}
+			return invalidLockValue{key: lockKey, value: lockValue}
 		}
 
 		currentLockStartTimestamp, valid := lockTuple[1].(int64)
 		if !valid {
-			return false, invalidLockValue{key: lockKey, value: lockValue}
+			return invalidLockValue{key: lockKey, value: lockValue}
 		}
 
 		currentLockEndTimestamp, valid := lockTuple[2].(int64)
 		if !valid {
-			return false, invalidLockValue{key: lockKey, value: lockValue}
+			return invalidLockValue{key: lockKey, value: lockValue}
 		}
 
 		ownerID := client.cluster.GetLockID()
@@ -383,7 +341,7 @@ func (client *realLockClient) ReleaseLock() error {
 
 		if currentLockOwnerID != ownerID {
 			logger.Info("cannot release lock from other owner")
-			return false, nil
+			return nil
 		}
 
 		// Check the timestamp of the logs and make sure to only release locks when the timestamps are valid.
@@ -391,21 +349,19 @@ func (client *realLockClient) ReleaseLock() error {
 		now := time.Now()
 		if currentLockStartTimestamp > now.Unix() {
 			logger.Info("cannot release lock that is taken in the future")
-			return false, nil
+			return nil
 		}
 
 		if currentLockEndTimestamp < now.Unix() {
 			logger.Info("cannot release a lock that is expired")
-			return false, nil
+			return nil
 		}
 
 		logger.Info("releasing lock")
-		transaction.Clear(lockKey)
+		tr.Clear(lockKey)
 
-		return nil, nil
-	})
-
-	return err
+		return nil
+	}, client.getTimeout())
 }
 
 // invalidLockValue is an error we can return when we cannot parse the existing
@@ -429,18 +385,19 @@ func NewRealLockClient(
 		return &realLockClient{disableLocks: true}, nil
 	}
 
-	database, err := getFDBDatabase(cluster)
-	if err != nil {
-		return nil, err
-	}
+	logger := log.WithValues(
+		"namespace", cluster.Namespace,
+		"cluster", cluster.Name,
+		"ownerID", cluster.GetLockID(),
+	)
 
 	return &realLockClient{
-		cluster:  cluster,
-		database: database,
-		log: log.WithValues(
-			"namespace", cluster.Namespace,
-			"cluster", cluster.Name,
-			"ownerID", cluster.GetLockID(),
-		),
+		cluster: cluster,
+		fdbLibClient: &realFdbLibClient{
+			cluster: cluster,
+			logger:  logger,
+		},
+		timeout: 10 * time.Second,
+		log:     logger,
 	}, nil
 }

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -46,20 +46,8 @@ type realLockClient struct {
 	// we will issue the actual requests against FDB. In the mock runner we will return predefined output.
 	fdbLibClient fdbLibClient
 
-	// timeout defines the timeout that should be used for interacting with FDB.
-	timeout time.Duration
-
 	// log implementation for logging output
 	log logr.Logger
-}
-
-// getTimeout returns the timeout for the transactions with FDB.
-func (client *realLockClient) getTimeout() time.Duration {
-	if client.timeout == 0 {
-		return DefaultTimeout
-	}
-
-	return client.timeout
 }
 
 // Disabled determines if the client should automatically grant locks.
@@ -75,7 +63,7 @@ func (client *realLockClient) TakeLock() error {
 
 	return client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) error {
 		return client.takeLockInTransaction(tr)
-	}, client.getTimeout())
+	})
 }
 
 // takeLockInTransaction attempts to acquire a lock using an open transaction.
@@ -195,7 +183,7 @@ func (client *realLockClient) AddPendingUpgrades(
 			tr.Set(key, []byte(processGroupID))
 		}
 		return nil
-	}, client.getTimeout())
+	})
 }
 
 // GetPendingUpgrades returns the stored information about which process
@@ -219,7 +207,7 @@ func (client *realLockClient) GetPendingUpgrades(
 		}
 
 		return nil
-	}, client.getTimeout())
+	})
 
 	return upgrades, err
 }
@@ -236,7 +224,7 @@ func (client *realLockClient) ClearPendingUpgrades() error {
 
 		tr.ClearRange(keyRange)
 		return nil
-	}, client.getTimeout())
+	})
 }
 
 // GetDenyList retrieves the current deny list from the database.
@@ -255,7 +243,7 @@ func (client *realLockClient) GetDenyList() ([]string, error) {
 		}
 
 		return nil
-	}, client.getTimeout())
+	})
 
 	return list, err
 }
@@ -282,7 +270,7 @@ func (client *realLockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntr
 			}
 		}
 		return nil
-	}, client.getTimeout())
+	})
 }
 
 // getDenyListKeyRange defines a key range containing the full deny list.
@@ -361,7 +349,7 @@ func (client *realLockClient) ReleaseLock() error {
 		tr.Clear(lockKey)
 
 		return nil
-	}, client.getTimeout())
+	})
 }
 
 // invalidLockValue is an error we can return when we cannot parse the existing
@@ -397,7 +385,6 @@ func NewRealLockClient(
 			cluster: cluster,
 			logger:  logger,
 		},
-		timeout: 10 * time.Second,
-		log:     logger,
+		log: logger,
 	}, nil
 }

--- a/fdbclient/lock_client_test.go
+++ b/fdbclient/lock_client_test.go
@@ -1,0 +1,247 @@
+/*
+ * lock_client_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fdbclient
+
+import (
+	"fmt"
+
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+// newTestCluster returns a minimal FoundationDBCluster with locking explicitly enabled via LockOptions.
+func newTestCluster() *fdbv1beta2.FoundationDBCluster {
+	return &fdbv1beta2.FoundationDBCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-ns",
+		},
+		Spec: fdbv1beta2.FoundationDBClusterSpec{
+			ProcessGroupIDPrefix: "test-operator",
+			LockOptions: fdbv1beta2.LockOptions{
+				DisableLocks: ptr.To(false),
+			},
+		},
+	}
+}
+
+var _ = Describe("LockClient", func() {
+	var (
+		cluster *fdbv1beta2.FoundationDBCluster
+		mockLib *mockFdbLibClient
+		lc      *realLockClient
+	)
+
+	BeforeEach(func() {
+		cluster = newTestCluster()
+		mockLib = &mockFdbLibClient{}
+		lc = &realLockClient{
+			cluster:      cluster,
+			fdbLibClient: mockLib,
+			log:          logr.Discard(),
+		}
+	})
+
+	Describe("Disabled", func() {
+		When("disableLocks is false", func() {
+			It("returns false", func() {
+				Expect(lc.Disabled()).To(BeFalse())
+			})
+		})
+
+		When("disableLocks is true", func() {
+			BeforeEach(func() {
+				lc.disableLocks = true
+			})
+
+			It("returns true", func() {
+				Expect(lc.Disabled()).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("TakeLock", func() {
+		When("locking is disabled", func() {
+			BeforeEach(func() {
+				lc.disableLocks = true
+			})
+
+			It("returns nil without calling executeTransaction", func() {
+				Expect(lc.TakeLock()).To(Succeed())
+				Expect(mockLib.executeTransactionCallCount).To(Equal(0))
+			})
+		})
+
+		When("locking is enabled", func() {
+			It("delegates to executeTransaction", func() {
+				Expect(lc.TakeLock()).To(Succeed())
+				Expect(mockLib.executeTransactionCallCount).To(Equal(1))
+			})
+
+			When("executeTransaction returns an error", func() {
+				BeforeEach(func() {
+					mockLib.mockedError = fmt.Errorf("fdb unavailable")
+				})
+
+				It("propagates the error", func() {
+					Expect(lc.TakeLock()).To(MatchError("fdb unavailable"))
+				})
+			})
+		})
+	})
+
+	Describe("ReleaseLock", func() {
+		When("locking is disabled", func() {
+			BeforeEach(func() {
+				lc.disableLocks = true
+			})
+
+			It("returns nil without calling executeTransaction", func() {
+				Expect(lc.ReleaseLock()).To(Succeed())
+				Expect(mockLib.executeTransactionCallCount).To(Equal(0))
+			})
+		})
+
+		When("locking is enabled", func() {
+			It("delegates to executeTransaction", func() {
+				Expect(lc.ReleaseLock()).To(Succeed())
+				Expect(mockLib.executeTransactionCallCount).To(Equal(1))
+			})
+
+			When("executeTransaction returns an error", func() {
+				BeforeEach(func() {
+					mockLib.mockedError = fmt.Errorf("fdb unavailable")
+				})
+
+				It("propagates the error", func() {
+					Expect(lc.ReleaseLock()).To(MatchError("fdb unavailable"))
+				})
+			})
+		})
+	})
+
+	Describe("AddPendingUpgrades", func() {
+		It("delegates to executeTransaction", func() {
+			version, err := fdbv1beta2.ParseFdbVersion("7.1.0")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(
+				lc.AddPendingUpgrades(version, []fdbv1beta2.ProcessGroupID{"pod-1", "pod-2"}),
+			).To(Succeed())
+			Expect(mockLib.executeTransactionCallCount).To(Equal(1))
+		})
+
+		When("executeTransaction returns an error", func() {
+			BeforeEach(func() {
+				mockLib.mockedError = fmt.Errorf("fdb unavailable")
+			})
+
+			It("propagates the error", func() {
+				version, err := fdbv1beta2.ParseFdbVersion("7.1.0")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(
+					lc.AddPendingUpgrades(version, []fdbv1beta2.ProcessGroupID{"pod-1"}),
+				).To(MatchError("fdb unavailable"))
+			})
+		})
+	})
+
+	Describe("GetPendingUpgrades", func() {
+		It("delegates to executeTransaction", func() {
+			version, err := fdbv1beta2.ParseFdbVersion("7.1.0")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = lc.GetPendingUpgrades(version)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockLib.executeTransactionCallCount).To(Equal(1))
+		})
+
+		When("executeTransaction returns an error", func() {
+			BeforeEach(func() {
+				mockLib.mockedError = fmt.Errorf("fdb unavailable")
+			})
+
+			It("propagates the error", func() {
+				version, err := fdbv1beta2.ParseFdbVersion("7.1.0")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = lc.GetPendingUpgrades(version)
+				Expect(err).To(MatchError("fdb unavailable"))
+			})
+		})
+	})
+
+	Describe("ClearPendingUpgrades", func() {
+		It("delegates to executeTransaction", func() {
+			Expect(lc.ClearPendingUpgrades()).To(Succeed())
+			Expect(mockLib.executeTransactionCallCount).To(Equal(1))
+		})
+
+		When("executeTransaction returns an error", func() {
+			BeforeEach(func() {
+				mockLib.mockedError = fmt.Errorf("fdb unavailable")
+			})
+
+			It("propagates the error", func() {
+				Expect(lc.ClearPendingUpgrades()).To(MatchError("fdb unavailable"))
+			})
+		})
+	})
+
+	Describe("GetDenyList", func() {
+		It("delegates to executeTransaction", func() {
+			_, err := lc.GetDenyList()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockLib.executeTransactionCallCount).To(Equal(1))
+		})
+
+		When("executeTransaction returns an error", func() {
+			BeforeEach(func() {
+				mockLib.mockedError = fmt.Errorf("fdb unavailable")
+			})
+
+			It("propagates the error", func() {
+				_, err := lc.GetDenyList()
+				Expect(err).To(MatchError("fdb unavailable"))
+			})
+		})
+	})
+
+	Describe("UpdateDenyList", func() {
+		It("delegates to executeTransaction", func() {
+			Expect(lc.UpdateDenyList([]fdbv1beta2.LockDenyListEntry{
+				{ID: "test-operator", Allow: false},
+			})).To(Succeed())
+			Expect(mockLib.executeTransactionCallCount).To(Equal(1))
+		})
+
+		When("executeTransaction returns an error", func() {
+			BeforeEach(func() {
+				mockLib.mockedError = fmt.Errorf("fdb unavailable")
+			})
+
+			It("propagates the error", func() {
+				Expect(lc.UpdateDenyList(nil)).To(MatchError("fdb unavailable"))
+			})
+		})
+	})
+})

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -140,12 +140,17 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 		"Apply defaults from the next major version of the operator. This is only intended for use in development.",
 	)
 	fs.StringVar(&o.LogFile, "log-file", "", "The path to a file to write logs to.")
-	fs.IntVar(&o.CliTimeout, "cli-timeout", 10, "The timeout to use for CLI commands in seconds.")
+	fs.IntVar(
+		&o.CliTimeout,
+		"cli-timeout",
+		10,
+		"The timeout to use for interactions with FDB in seconds.",
+	)
 	fs.IntVar(
 		&o.MaxCliTimeout,
 		"max-cli-timeout",
 		40,
-		"The maximum timeout to use for CLI commands in seconds. This timeout is used for CLI requests that are known to be potentially slow like get status or exclude.",
+		"The maximum timeout to use for interactions with FDB in seconds. This timeout is used for requests that are known to be potentially slow like get status or exclude.",
 	)
 	fs.IntVar(
 		&o.MaxConcurrentReconciles,
@@ -390,8 +395,8 @@ func StartManager(
 	klog.SetLogger(logger)
 
 	setupLog := logger.WithName("setup")
-	fdbclient.DefaultCLITimeout = time.Duration(operatorOpts.CliTimeout) * time.Second
-	fdbclient.MaxCliTimeout = time.Duration(operatorOpts.MaxCliTimeout) * time.Second
+	fdbclient.DefaultTimeout = time.Duration(operatorOpts.CliTimeout) * time.Second
+	fdbclient.MaxTimeout = time.Duration(operatorOpts.MaxCliTimeout) * time.Second
 
 	// Define the cache options for the client cache used by the operator. If no label selector is defined, the
 	// default cache configuration will be used.


### PR DESCRIPTION
# Description

Align the FDB usage over the lock client and the fdb client and make sure they use the same fdb lib client. This adds the same default knobs to the lock client (setting the timeout and setting the max retries).

## Type of change

- Other

## Discussion

In a follow up we could add additional testing and we should revisit the timeout handling, e.g. how we use the `DefaultTimeout` and the `MaxTimeout`. Right now the usage is quite different from what we documented.

I refactored the timeout usage, as it made sense for me to do that in this PR.

## Testing

Ran unit tests, CI will run e2e tests.

## Documentation

Nothing to update.

## Follow-up

-
