### PR TITLE
Enable backup tests for FoundationDB PRs

### DIFF
--- a/e2e/test_operator_backups/operator_backup_test.go
+++ b/e2e/test_operator_backups/operator_backup_test.go
@@ -73,7 +73,7 @@ var _ = AfterSuite(func() {
 	factory.Shutdown()
 })
 
-var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-nightly"), func() {
+var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func() {
 	When("a cluster has backups enabled and then restored", func() {
 		var keyValues []fixtures.KeyValue
 		var prefix byte = 'a'


### PR DESCRIPTION
# Description

Enable backup tests for FoundationDB PRs. The nightlies were running fine since we enabled those tests.

## Type of change

- Other

## Discussion

-

## Testing

CI will run those tests.

## Documentation

Nothing to update.

## Follow-up

Nothing.
