### PR TITLE
Fetch error message if management API call fails

### DIFF
--- a/api/v1beta2/foundationdb_errors.go
+++ b/api/v1beta2/foundationdb_errors.go
@@ -23,6 +23,7 @@ package v1beta2
 import "fmt"
 
 // TimeoutError represents a timeout for either the fdb client library or fdbcli.
+// See: https://github.com/apple/foundationdb/blob/main/flow/include/flow/error_definitions.h
 // +k8s:deepcopy-gen=false
 type TimeoutError struct {
 	Err error
@@ -40,6 +41,14 @@ type BackupNotRunning struct {
 	Err error
 }
 
+// SpecialKeysAPIFailureError represents the error when an Api call through special keys failed.
+// For more information, call get on special key 0xff0xff/error_message to get a json string of the error message.
+// See: https://github.com/apple/foundationdb/blob/main/flow/include/flow/error_definitions.h
+// +k8s:deepcopy-gen=false
+type SpecialKeysAPIFailureError struct {
+	Err error
+}
+
 // Error returns the error message of the internal timeout error.
 func (err TimeoutError) Error() string {
 	return fmt.Sprintf("fdb timeout: %s", err.Err.Error())
@@ -53,4 +62,9 @@ func (err BackupDoesNotExist) Error() string {
 // Error returns the error message of the internal backup not running error.
 func (err BackupNotRunning) Error() string {
 	return fmt.Sprintf("fdb backup does not exist: %s", err.Err.Error())
+}
+
+// Error returns the error message from a failed Api call through special keys.
+func (err SpecialKeysAPIFailureError) Error() string {
+	return fmt.Sprintf("fdb special_keys_api_failure: %s", err.Err.Error())
 }

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -382,7 +382,7 @@ func (fdbClient *realFdbLibClient) executeTransactionForManagementAPI(
 				return nil, optErr
 			}
 
-			// Api call through special keys failed. For more information, read the 0xff0xff/error_message key.
+			// To get more information on why the Api call through special keys failed we need to read the 0xff0xff/error_message key.
 			return tr.Get(fdb.Key("\xff\xff/error_message")).Get()
 		})
 

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -298,9 +298,14 @@ func checkError(err error) error {
 		var fdbError *fdb.Error
 		if errors.As(err, &fdbError) {
 			// See: https://apple.github.io/foundationdb/api-error-codes.html
-			// 1031: Operation aborted because the transaction timed out
+			// 1031: Operation aborted because the transaction timed out.
 			if fdbError.Code == 1031 {
 				return fdbv1beta2.TimeoutError{Err: err}
+			}
+
+			// Api call through special keys failed. For more information, read the 0xff0xff/error_message key.
+			if fdbError.Code == 2117 {
+				return fdbv1beta2.SpecialKeysAPIFailureError{Err: err}
 			}
 		}
 
@@ -364,6 +369,46 @@ func (fdbClient *realFdbLibClient) executeTransactionForManagementAPI(
 
 		return nil, operation(tr)
 	})
+
+	// In case that the retuned error is SpecialKeysAPIFailureError we have to make another transaction to get the actual
+	// error message from FDB.
+	var specialKeysErr fdbv1beta2.SpecialKeysAPIFailureError
+	if errors.As(err, &specialKeysErr) {
+		message, trErr := fdbClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
+			// Allow the operator to read and write from/to a locked database e.g. in cases where a restore is ongoing.
+			// This allows the operator to read and write from/to the FDB cluster.
+			optErr := tr.Options().SetLockAware()
+			if optErr != nil {
+				return nil, optErr
+			}
+
+			// Api call through special keys failed. For more information, read the 0xff0xff/error_message key.
+			return tr.Get(fdb.Key("\xff\xff/error_message")).Get()
+		})
+
+		// If this transaction fails too, print out the additional information that 0xff0xff/error_message could not
+		// be read.
+		if trErr != nil {
+			return fdbv1beta2.SpecialKeysAPIFailureError{
+				Err: fmt.Errorf(
+					"could not read error from special key 0xff0xff/error_message got: %w, original error: %w",
+					trErr,
+					err,
+				),
+			}
+		}
+
+		fdbClient.logger.V(1).
+			Info("error message from special key 0xff0xff/error_message", "message", message, "err", err)
+		return fdbv1beta2.SpecialKeysAPIFailureError{
+			Err: fmt.Errorf(
+				"error from special key 0xff0xff/error_message is: %s, original error: %w",
+				message,
+				err,
+			),
+		}
+	}
+
 	return err
 }
 


### PR DESCRIPTION
# Description

Fetch error message if management API call fails. Otherwise a user will only see a generic failure message.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Discussion

-

## Testing

Ran the operator e2e tests manually.

## Documentation

Nothing to update, I added code comments where needed.

## Follow-up

-