### PR TITLE
Print data loader result before waiting for signal and make use of json trace format

### DIFF
--- a/e2e/fixtures/fdb_data_loader.go
+++ b/e2e/fixtures/fdb_data_loader.go
@@ -90,8 +90,8 @@ spec:
             value: {{ .Name }}
           - name: FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY
             value: /var/dynamic/fdb/libs
-          - name: PYTHONUNBUFFERED
-            value: "on"
+          - name: FDB_NETWORK_OPTION_TRACE_FORMAT
+            value: "json"
         volumeMounts:
           - name: config-map
             mountPath: /var/dynamic-conf
@@ -214,8 +214,8 @@ spec:
             value: {{ .Name }}
           - name: FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY
             value: /var/dynamic/fdb
-          - name: PYTHONUNBUFFERED
-            value: "on"
+          - name: FDB_NETWORK_OPTION_TRACE_FORMAT
+            value: "json"
         volumeMounts:
           - name: config-map
             mountPath: /var/dynamic-conf

--- a/sample-apps/data-loader/main.go
+++ b/sample-apps/data-loader/main.go
@@ -37,8 +37,6 @@ type dataLoaderOptions struct {
 	loadDuration time.Duration
 	// clusterFile to connect to the FDB cluster to.
 	clusterFile string
-	// shutdown if set to false the data loader will not shutdown after load is done.
-	shutdown bool
 }
 
 // latencyStats represents a simplified latency metrics tracker.
@@ -83,7 +81,6 @@ func loadData(ctx context.Context, options *dataLoaderOptions) {
 			writeStats.count, writeStats.avg(), writeStats.min, writeStats.max)
 		log.Printf("reads  — count: %d, avg: %s, min: %s, max: %s",
 			readStats.count, readStats.avg(), readStats.min, readStats.max)
-
 	}()
 	batchCount := options.keys / options.batchSize
 
@@ -193,11 +190,6 @@ func loadData(ctx context.Context, options *dataLoaderOptions) {
 			readStats.record(time.Since(readStart))
 		}
 	}
-
-	if !options.shutdown {
-		// Block until signal is received
-		<-ctx.Done()
-	}
 }
 
 func getUuid(randomGen *rand.ChaCha8) (tuple.UUID, error) {
@@ -260,6 +252,10 @@ func main() {
 		readBatchSize: readBatchSize,
 		loadDuration:  loadDuration,
 		clusterFile:   clusterFile,
-		shutdown:      shutdown,
 	})
+
+	if !shutdown {
+		// Block until signal is received
+		<-ctx.Done()
+	}
 }


### PR DESCRIPTION
# Description

Print data loader result before waiting for signal and make use of json trace format

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Locally build the sample app, CI will run e2e tests.

## Documentation

Nothing to update.

## Follow-up

Nothing to update.
