### PR TITLE
Use FaultDomain.ValueFrom when bucketing pods by zone in getPodsToUpdate

### DIFF
--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2830,14 +2830,11 @@ func (cluster *FoundationDBCluster) GetDNSDomain() string {
 // carries the FDB zone ID for this cluster. When FaultDomain.ValueFrom is set
 // to a value prefixed with "$" (the convention used to source the zone from a
 // node label resolved by the fdb-kubernetes-monitor at runtime), the name of
-// that variable is returned with the "$" stripped. Otherwise the canonical
+// that variable is returned with the "$" stripped. Otherwise, the canonical
 // EnvNameZoneID ("FDB_ZONE_ID") is returned.
-//
-// Both monitor_conf generation and pod-update zone bucketing must agree on
-// this name; centralising the lookup keeps them consistent.
 func (cluster *FoundationDBCluster) GetZoneVariableName() string {
-	if src := cluster.Spec.FaultDomain.ValueFrom; strings.HasPrefix(src, "$") {
-		return src[1:]
+	if strings.HasPrefix(cluster.Spec.FaultDomain.ValueFrom, "$") {
+		return cluster.Spec.FaultDomain.ValueFrom[1:]
 	}
 	return EnvNameZoneID
 }

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -2826,6 +2826,22 @@ func (cluster *FoundationDBCluster) GetDNSDomain() string {
 	return ptr.Deref(cluster.Spec.Routing.DNSDomain, "cluster.local")
 }
 
+// GetZoneVariableName returns the name of the environment variable that
+// carries the FDB zone ID for this cluster. When FaultDomain.ValueFrom is set
+// to a value prefixed with "$" (the convention used to source the zone from a
+// node label resolved by the fdb-kubernetes-monitor at runtime), the name of
+// that variable is returned with the "$" stripped. Otherwise the canonical
+// EnvNameZoneID ("FDB_ZONE_ID") is returned.
+//
+// Both monitor_conf generation and pod-update zone bucketing must agree on
+// this name; centralising the lookup keeps them consistent.
+func (cluster *FoundationDBCluster) GetZoneVariableName() string {
+	if src := cluster.Spec.FaultDomain.ValueFrom; strings.HasPrefix(src, "$") {
+		return src[1:]
+	}
+	return EnvNameZoneID
+}
+
 // GetRemovalMode returns the removal mode of the cluster or default to PodUpdateModeZone if unset.
 func (cluster *FoundationDBCluster) GetRemovalMode() PodUpdateMode {
 	if cluster.Spec.AutomationOptions.RemovalMode == "" {

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -4731,22 +4731,20 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				}
 				Expect(cluster.GetZoneVariableName()).To(Equal(expected))
 			},
-			Entry("when FaultDomain is unset, defaults to FDB_ZONE_ID",
+			Entry("when FaultDomain is unset, defaults to EnvNameZoneID",
 				FoundationDBClusterFaultDomain{}, EnvNameZoneID),
-			Entry("when ValueFrom is a downward-API path, defaults to FDB_ZONE_ID",
+			Entry("when FaultDomain is set but ValueFrom not $-prefixed, defaults to EnvNameZoneID",
 				FoundationDBClusterFaultDomain{
 					Key:       "kubernetes.io/hostname",
 					ValueFrom: "spec.nodeName",
 				},
 				EnvNameZoneID),
-			Entry("when ValueFrom is a $-prefixed node-label name, strips the $",
+			Entry("when FaultDomain is set and ValueFrom is $-prefixed, strips the $",
 				FoundationDBClusterFaultDomain{
-					Key:       "infra.x.com/rack",
-					ValueFrom: "$NODE_LABEL_INFRA_X_COM_RACK",
+					Key:       "foo.com/rack",
+					ValueFrom: "$NODE_LABEL_FOO_COM_RACK",
 				},
-				"NODE_LABEL_INFRA_X_COM_RACK"),
-			Entry("when ValueFrom is just '$', returns an empty string",
-				FoundationDBClusterFaultDomain{ValueFrom: "$"}, ""),
+				"NODE_LABEL_FOO_COM_RACK"),
 		)
 	})
 

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -4723,6 +4723,33 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 		})
 	})
 
+	When("getting the zone variable name", func() {
+		DescribeTable("it returns the env var name that carries the zone ID",
+			func(faultDomain FoundationDBClusterFaultDomain, expected string) {
+				cluster := &FoundationDBCluster{
+					Spec: FoundationDBClusterSpec{FaultDomain: faultDomain},
+				}
+				Expect(cluster.GetZoneVariableName()).To(Equal(expected))
+			},
+			Entry("when FaultDomain is unset, defaults to FDB_ZONE_ID",
+				FoundationDBClusterFaultDomain{}, EnvNameZoneID),
+			Entry("when ValueFrom is a downward-API path, defaults to FDB_ZONE_ID",
+				FoundationDBClusterFaultDomain{
+					Key:       "kubernetes.io/hostname",
+					ValueFrom: "spec.nodeName",
+				},
+				EnvNameZoneID),
+			Entry("when ValueFrom is a $-prefixed node-label name, strips the $",
+				FoundationDBClusterFaultDomain{
+					Key:       "infra.x.com/rack",
+					ValueFrom: "$NODE_LABEL_INFRA_X_COM_RACK",
+				},
+				"NODE_LABEL_INFRA_X_COM_RACK"),
+			Entry("when ValueFrom is just '$', returns an empty string",
+				FoundationDBClusterFaultDomain{ValueFrom: "$"}, ""),
+		)
+	})
+
 	When("checking if the process group must be replaced", func() {
 		DescribeTable("it should return to correct update strategy",
 			func(cluster *FoundationDBCluster, processGroup *ProcessGroupStatus, expected bool) {

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -426,7 +426,7 @@ func getPodsToUpdate(
 			continue
 		}
 
-		zone := substitutions[fdbv1beta2.EnvNameZoneID]
+		zone := substitutions[cluster.GetZoneVariableName()]
 		if reconciler.SimulationOptions.SimulateZones {
 			zone = "simulation"
 		}

--- a/internal/monitor_conf.go
+++ b/internal/monitor_conf.go
@@ -258,12 +258,7 @@ func GetMonitorProcessConfiguration(
 
 	logGroup := cluster.GetLogGroup()
 
-	var zoneVariable string
-	if strings.HasPrefix(cluster.Spec.FaultDomain.ValueFrom, "$") {
-		zoneVariable = cluster.Spec.FaultDomain.ValueFrom[1:]
-	} else {
-		zoneVariable = fdbv1beta2.EnvNameZoneID
-	}
+	zoneVariable := cluster.GetZoneVariableName()
 
 	// currentPodIPFamily will reflect the current IP family of the Pod. If the Pod doesn't exist, we fall back
 	// to the default IP family defined on the cluster level.


### PR DESCRIPTION
# Description

Per the operator docs:

```
The operator supports different deletion modes (`All`, `Zone`, `ProcessGroup`).
The default deletion mode is `Zone`.

* `All` will delete all pods at once.
* `Zone` deletes all Pods in fault domain at once.
* `ProcessGroup` delete one Pod at a time.
```

However, this does *not* reflect the current behaviour when the fault domain is configured from a node label, for example:
```
 faultDomain:
    valueFrom: $NODE_LABEL_FOO_COM_RACK
```

When the operator builds the environment for the FDB pods, it explicitly does *not* set `EnvNameZoneID` -> `<fault domain>` if the fault domain source is $-prefixed (comes from a node label):

```
if !strings.HasPrefix(faultDomainSource, "$") {
	env = append(
		env,
		corev1.EnvVar{Name: fdbv1beta2.EnvNameZoneID, ValueFrom: &corev1.EnvVarSource{
			FieldRef: &corev1.ObjectFieldSelector{FieldPath: faultDomainSource},
		}},
	)
}
```

(This makes sense -- the downward api can't read node labels).

The result of this is that `EnvNameZoneID` is not set on the pod. Instead, the monitor for the pod synthesises any node label vars, and these are written as an annotation on the pod like:

```
foundationdb.org/launcher-environment: '{..."NODE_LABEL_FOO_COM_RACK":"abc"...}'
```

Then, when the operator is updating the pods and grouping by zone, it uses `EnvNameZoneID` (`FDB_ZONE_ID`) as the key to look up in this environment map. The key does not exist, so we get an empty zone, and all pods for the current reconciliation are put into a single bucket for the update -- which can cause all storage pods to be operated on at once, causing potentially significant unavailability

To address this, we share the logic that the monitor_conf uses when constructing the ` --locality_zoneid` param; use the fault domain node label if present, otherwise fall back to `EnvNameZoneID`.

## Type of change
 Bug fix

## Discussion

This is technically a behaviour change for clusters with valueFrom: $NODE_LABEL_*, but it restores the documented Zone deletion mode behaviour. Configurations that don't use node-label fault domains see no change.

## Testing

Unit tests + Manual testing. 

Example prior output from operator:
```
{"level":"info","ts":"2026-04-23T09:40:23Z","logger":"controller","msg":"Deleting pods","namespace":"fdb-jillianc-test","cluster":"fdb-jillianc-test","traceID":"c7affc23-0800-4354-ad8c-62a9a1f4ca55","reconciler":"controllers.updatePods","zone":"","count":300,"deletionMode":""}
```

With the fix:
```
{"level":"info","ts":"2026-04-23T12:34:59Z","logger":"controller","msg":"Deleting pods","namespace":"fdb-jillianc-test","cluster":"fdb-jillianc-test","traceID":"c857fad4-0739-4845-8ef2-db9e7111a38e","reconciler":"controllers.updatePods","zone":"dnx","count":9,"deletionMode":""}
```

