### PR TITLE
fix(docs,controllers): remove /v2/ from GitHub repository URLs

### DIFF
--- a/api/v1beta2/applyconfiguration/api/v1beta2/maintenancemodeoptions.go
+++ b/api/v1beta2/applyconfiguration/api/v1beta2/maintenancemodeoptions.go
@@ -15,7 +15,7 @@ type MaintenanceModeOptionsApplyConfiguration struct {
 	UseMaintenanceModeChecker *bool `json:"UseMaintenanceModeChecker,omitempty"`
 	// ResetMaintenanceMode defines whether the operator should reset the maintenance mode if all storage processes
 	// under the maintenance zone have been restarted. The default is false. For more details see:
-	// https://github.com/FoundationDB/fdb-kubernetes-operator/v2/blob/improve-maintenance-mode-integration/docs/manual/operations.md#maintenance
+	// https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/docs/manual/operations.md#maintenance
 	// Default is false.
 	ResetMaintenanceMode *bool `json:"resetMaintenanceMode,omitempty"`
 	// MaintenanceModeTimeSeconds provides the duration for the zone to be in maintenance. It will automatically be switched off after the time elapses.

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -1410,7 +1410,7 @@ type MaintenanceModeOptions struct {
 
 	// ResetMaintenanceMode defines whether the operator should reset the maintenance mode if all storage processes
 	// under the maintenance zone have been restarted. The default is false. For more details see:
-	// https://github.com/FoundationDB/fdb-kubernetes-operator/v2/blob/improve-maintenance-mode-integration/docs/manual/operations.md#maintenance
+	// https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/docs/manual/operations.md#maintenance
 	// Default is false.
 	ResetMaintenanceMode *bool `json:"resetMaintenanceMode,omitempty"`
 
@@ -3474,7 +3474,7 @@ func (cluster *FoundationDBCluster) GetCurrentProcessGroupsAndProcessCounts() (m
 // GetNextRandomProcessGroupID will return a randomly picked ProcessGroupID, the ID number will be between 1 and maxProcessGroupIDNum.
 // This method makes sure that the returned ProcessGroupID is not in use and not marked to be removed.
 // Using a randomized ProcessGroupID will reduce the risk of reusing the same ProcessGroupID for different process groups, see:
-// https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/2071
+// https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2071
 func (cluster *FoundationDBCluster) GetNextRandomProcessGroupID(
 	processClass ProcessClass,
 	processGroupIDs map[int]bool,
@@ -3485,7 +3485,7 @@ func (cluster *FoundationDBCluster) GetNextRandomProcessGroupID(
 // GetNextRandomProcessGroupIDWithExclusions will return a randomly picked ProcessGroupID, the ID number will be between 1 and MaxProcessGroupIDNum.
 // This method makes sure that the returned ProcessGroupID is not in use and not marked to be removed and is not excluded.
 // Using a randomized ProcessGroupID will reduce the risk of reusing the same ProcessGroupID for different process groups, see:
-// https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/2071
+// https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2071
 func (cluster *FoundationDBCluster) GetNextRandomProcessGroupIDWithExclusions(
 	processClass ProcessClass,
 	processGroupIDs map[int]bool,
@@ -3525,7 +3525,7 @@ func (cluster *FoundationDBCluster) newProcessGroupIDAllowed(
 	}
 
 	// If the randomly picked process group is part of the locality based exclusions, we shouldn't pick it.
-	// See: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/1862
+	// See: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1862
 	if _, ok := exclusions[processGroupID]; ok {
 		return false
 	}

--- a/controllers/exclude_processes.go
+++ b/controllers/exclude_processes.go
@@ -331,7 +331,7 @@ func (e excludeProcesses) reconcile(
 	// Only if a coordinator was excluded we have to check for an error and update the cluster.
 	if coordinatorExcluded {
 		// If a coordinator should be excluded, we will change the coordinators directly after the exclusion.
-		// This should reduce the observed recoveries, see: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/2018.
+		// This should reduce the observed recoveries, see: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2018.
 		coordinatorErr := coordinator.ChangeCoordinators(logger, adminClient, cluster, status)
 		if coordinatorErr != nil {
 			return &requeue{curError: coordinatorErr, delayedRequeue: true}

--- a/controllers/remove_incompatible_processes.go
+++ b/controllers/remove_incompatible_processes.go
@@ -32,7 +32,7 @@ import (
 )
 
 // removeIncompatibleProcesses is a reconciler that will restart incompatible fdbserver processes, this can happen
-// during an upgrade when the kill command doesn't reach all processes, see: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/1281
+// during an upgrade when the kill command doesn't reach all processes, see: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1281
 type removeIncompatibleProcesses struct{}
 
 // reconcile runs the reconciler's work.

--- a/controllers/remove_process_groups.go
+++ b/controllers/remove_process_groups.go
@@ -227,7 +227,7 @@ func removeProcessGroup(
 		}
 	}
 
-	// TODO(johscheuer): https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/1638
+	// TODO(johscheuer): https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1638
 	pvcs := &corev1.PersistentVolumeClaimList{}
 	err = r.List(
 		ctx,

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -378,7 +378,7 @@ func checkAndSetProcessStatus(
 	// later by validating additional messages in the machine-readable status.
 	if len(processMap) == 0 {
 		// TODO (johscheuer): Should we reset the exclusion state if the processes are missing? In this case we cannot
-		// know if the process was fully excluded or not and we could run into issues like: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/1912
+		// know if the process was fully excluded or not and we could run into issues like: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1912
 		// This change needs some additional testing to ensure we understand the possible side effects.
 		return nil
 	}
@@ -475,7 +475,7 @@ func checkAndSetProcessStatus(
 
 			// If the new command line is longer than 10.000 characters we will throw an error to make sure the operator
 			// is not restarting the cluster the whole time.
-			// See https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/2105
+			// See: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2105
 			if len(commandLine) > 10000 {
 				r.Recorder.Event(
 					cluster,

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -382,7 +382,7 @@ MaintenanceModeOptions controls options for placing zones in maintenance mode.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | UseMaintenanceModeChecker | UseMaintenanceModeChecker defines whether the operator is allowed to use maintenance mode before updating pods. If this setting is set to true the operator will set and reset the maintenance mode when updating pods. If this setting is set to true, then ResetMaintenanceMode will also be enabled to make sure the operator is able to reset the maintenance mode again. Default is false. | *bool | false |
-| resetMaintenanceMode | ResetMaintenanceMode defines whether the operator should reset the maintenance mode if all storage processes under the maintenance zone have been restarted. The default is false. For more details see: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/blob/improve-maintenance-mode-integration/docs/manual/operations.md#maintenance Default is false. | *bool | false |
+| resetMaintenanceMode | ResetMaintenanceMode defines whether the operator should reset the maintenance mode if all storage processes under the maintenance zone have been restarted. The default is false. For more details see: https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/docs/manual/operations.md#maintenance Default is false. | *bool | false |
 | maintenanceModeTimeSeconds | MaintenanceModeTimeSeconds provides the duration for the zone to be in maintenance. It will automatically be switched off after the time elapses. Default is 600. | *int | false |
 
 [Back to TOC](#table-of-contents)

--- a/e2e/fixtures/fdb_backup.go
+++ b/e2e/fixtures/fdb_backup.go
@@ -76,7 +76,7 @@ func (factory *Factory) GenerateBackupSpecForCluster(
 	config *FdbBackupConfiguration,
 ) *fdbv1beta2.FoundationDBBackup {
 	// For more information how the backup system with the operator is working please look at
-	// the operator documentation: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/blob/master/docs/manual/backup.md
+	// the operator documentation: https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/docs/manual/backup.md
 	fdbVersion := factory.GetFDBVersion()
 
 	// If the config is nil, create a default config.

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -128,12 +128,12 @@ func (factory *Factory) createPodTemplate(
 	config *ClusterConfig,
 ) *corev1.PodTemplateSpec {
 	// The operator is causing this to not work as desired reference:
-	// https://github.com/FoundationDB/fdb-kubernetes-operator/v2/blob/main/internal/deprecations.go#L75-L77
+	// https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/internal/deprecations.go#L75-L77
 	mainContainerResources := corev1.ResourceRequirements{
 		Requests: config.generatePodResources(processClass),
 	}
 
-	// See: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/blob/main/docs/manual/warnings.md#resource-requirements otherwise
+	// See: https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/docs/manual/warnings.md#resource-requirements otherwise
 	// the operator will set the default limits.
 	if !config.Performance {
 		mainContainerResources.Limits = corev1.ResourceList{

--- a/e2e/fixtures/fdb_restore.go
+++ b/e2e/fixtures/fdb_restore.go
@@ -43,7 +43,7 @@ type FdbRestore struct {
 
 // CreateRestoreForCluster will create a FoundationDBRestore resource based on the provided backup resource.
 // For more information how the backup system with the operator is working please look at
-// the operator documentation: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/blob/master/docs/manual/backup.md
+// the operator documentation: https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/docs/manual/backup.md
 func (factory *Factory) CreateRestoreForCluster(
 	backup *FdbBackup,
 	backupVersion *uint64,

--- a/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
+++ b/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e"), func() {
 		factory.Shutdown()
 	})
 
-	// https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/172, debug why this test is flaky and how
+	// https://github.com/FoundationDB/fdb-kubernetes-operator/issues/172, debug why this test is flaky and how
 	// to make it stable.
 	DescribeTable(
 		"when no remote processes are restarted",

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -555,7 +555,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 	// TODO (johscheuer): Ensure this test passes reliably. Right now the cluster sometimes gets stuck and needs
 	// manual intervention.
-	// See: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/2196
+	// See: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2196
 	PDescribeTable(
 		"when no remote storage processes are restarted",
 		func(beforeVersion string, targetVersion string) {

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -79,7 +79,7 @@ func selectCandidates(
 			continue
 		}
 
-		// Ignore processes with missing locality, see: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/1254
+		// Ignore processes with missing locality, see: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1254
 		if len(process.Locality) == 0 {
 			continue
 		}
@@ -115,7 +115,7 @@ func selectCandidates(
 		// that means this process is pending a Pod recreation and will therefore be down for some time.
 		// We reduce the priority in this case to reduce the risk of successive coordinator changes. Reducing the
 		// priority should help in reducing the overall coordinator changes.
-		// See: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/2015
+		// See: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2015
 		if process.Version != cluster.Spec.Version ||
 			strings.HasPrefix(process.CommandLine, "/var/") {
 			// math.MinInt64 is the lowest possible priority. By adding the actual priority we make sure that we

--- a/internal/replacements/replace_failed_process_groups.go
+++ b/internal/replacements/replace_failed_process_groups.go
@@ -216,7 +216,7 @@ func ReplaceFailedProcessGroups(
 		// Only if localities are not used for exclusions we should be skipping the exclusion.
 		// Skipping the exclusion could lead to a race condition, which can be prevented if
 		// we are able to exclude by locality.
-		// see: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/1890
+		// see: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1890
 		if len(processGroup.Addresses) == 0 && !localitiesUsedForExclusion {
 			if !hasDesiredFaultTolerance {
 				logger.Info(

--- a/internal/replacements/replacements.go
+++ b/internal/replacements/replacements.go
@@ -408,7 +408,7 @@ type containerFileSecurityContext struct {
 // fileSecurityContextChanged checks for changes in the effective security context by checking that there are no changes
 // to the following SecurityContext (or PodSecurityContext) fields:
 // RunAsGroup, RunAsUser, FSGroup, or FSGroupChangePolicy
-// See https://github.com/FoundationDB/fdb-kubernetes-operator/v2/issues/208 for motivation
+// See https://github.com/FoundationDB/fdb-kubernetes-operator/issues/208 for motivation
 // only makes sense if both pods have containers with matching names
 func fileSecurityContextChanged(desired, current *corev1.PodSpec, log logr.Logger) bool {
 	// first check for FSGroup or FSGroupChangePolicy changes as that cannot be overridden at container level

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -173,7 +173,7 @@ func usingLatestPluginVersion(cmd *cobra.Command, pluginVersionChecker VersionCh
 	if pluginVersion != latestPluginVersion {
 		versionMessage := "kubectl-fdb plugin is not up-to-date, please install the latest version and try again!\n" +
 			"Your version:[" + pluginVersion + "], latest release version:[" + latestPluginVersion + "].\n" +
-			"Installation instructions can be found here: https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/kubectl-fdb/Readme.md"
+			"Installation instructions can be found here: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/blob/main/kubectl-fdb/Readme.md"
 		cmd.Println(versionMessage)
 		return fmt.Errorf("outdated plugin version")
 	}

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -173,7 +173,7 @@ func usingLatestPluginVersion(cmd *cobra.Command, pluginVersionChecker VersionCh
 	if pluginVersion != latestPluginVersion {
 		versionMessage := "kubectl-fdb plugin is not up-to-date, please install the latest version and try again!\n" +
 			"Your version:[" + pluginVersion + "], latest release version:[" + latestPluginVersion + "].\n" +
-			"Installation instructions can be found here: https://github.com/FoundationDB/fdb-kubernetes-operator/v2/blob/main/kubectl-fdb/Readme.md"
+			"Installation instructions can be found here: https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/kubectl-fdb/Readme.md"
 		cmd.Println(versionMessage)
 		return fmt.Errorf("outdated plugin version")
 	}


### PR DESCRIPTION
# Description

This PR extends #2462 and fixes the links and documentation which broke during v2 release. The previous URL incorrectly included a /v2/ path segment, leading to a broken link (404).

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)

## Discussion

*None

## Testing

Manual testing?*
Verified the updated URL manually to ensure it resolves to the correct documentation page

## Documentation

*No documentation updates were required as this change fixes a reference to existing documentation.

## Follow-up

*None