### PR TITLE
Adding test for abort command on encrypted backup

### DIFF
--- a/api/v1beta2/foundationdbbackup_types.go
+++ b/api/v1beta2/foundationdbbackup_types.go
@@ -399,6 +399,9 @@ type FoundationDBLiveBackupStatus struct {
 type FoundationDBLiveBackupStatusState struct {
 	// Running determines whether the backup is currently running.
 	Running bool `json:"Running,omitempty"`
+
+	// Completed determines whether the backup has completed.
+	Completed bool `json:"Completed,omitempty"`
 }
 
 // LatestRestorablePoint contains information about the latest restorable point if any exists.

--- a/api/v1beta2/foundationdbbackup_types.go
+++ b/api/v1beta2/foundationdbbackup_types.go
@@ -397,6 +397,9 @@ type FoundationDBLiveBackupStatus struct {
 // FoundationDBLiveBackupStatusState provides the state of a backup in the
 // backup status.
 type FoundationDBLiveBackupStatusState struct {
+	// Name is the name of the backup state.
+	Name string `json:"Name,omitempty"`
+
 	// Running determines whether the backup is currently running.
 	Running bool `json:"Running,omitempty"`
 

--- a/api/v1beta2/foundationdbcluster_types_test.go
+++ b/api/v1beta2/foundationdbcluster_types_test.go
@@ -836,6 +836,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				SnapshotIntervalSeconds: 864000,
 				Status: FoundationDBLiveBackupStatusState{
 					Running: true,
+					Name:    "Running",
 				},
 				Restorable: ptr.To(false),
 				UID:        ptr.To("3874300eea1e154e4079530b381f71c3"),

--- a/docs/backup_spec.md
+++ b/docs/backup_spec.md
@@ -183,7 +183,9 @@ FoundationDBLiveBackupStatusState provides the state of a backup in the backup s
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
+| Name | Name is the name of the backup state. | string | false |
 | Running | Running determines whether the backup is currently running. | bool | false |
+| Completed | Completed determines whether the backup has completed. | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/e2e/fixtures/fdb_backup.go
+++ b/e2e/fixtures/fdb_backup.go
@@ -318,6 +318,11 @@ func (fdbBackup *FdbBackup) RunStatusCommand() *fdbv1beta2.FoundationDBLiveBacku
 	return status
 }
 
+// RunAbortCommand runs the abort command on a randomly chosen backup pod.
+func (fdbBackup *FdbBackup) RunAbortCommand() {
+	fdbBackup.RunCommandOnBackupPod("fdbbackup abort")
+}
+
 // RunListCommand runs the list command on a randomly chosen backup pod.
 func (fdbBackup *FdbBackup) RunListCommand() []string {
 	backupURL, err := fdbBackup.backup.BaseURL()

--- a/e2e/test_operator_backups/operator_backup_test.go
+++ b/e2e/test_operator_backups/operator_backup_test.go
@@ -218,6 +218,18 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 						backupConfiguration.EncryptionEnabled = true
 					})
 
+					AfterEach(func() {
+						if backup != nil {
+							statusCommandOutput := backup.RunStatusCommand()
+							if statusCommandOutput.Status.Running {
+								backup.RunAbortCommand()
+								statusCommandOutput = backup.RunStatusCommand()
+								Expect(statusCommandOutput.Status.Running).To(BeFalse())
+								Expect(statusCommandOutput.Status.Completed).To(BeTrue())
+							}
+						}
+					})
+
 					When("running fdbbackup commands", func() {
 						BeforeEach(func() {
 							skipRestore = true

--- a/e2e/test_operator_backups/operator_backup_test.go
+++ b/e2e/test_operator_backups/operator_backup_test.go
@@ -26,6 +26,7 @@ This test suite contains tests related to backup and restore with the operator.
 
 import (
 	"log"
+	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/fixtures"
@@ -219,15 +220,32 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 					})
 
 					AfterEach(func() {
-						if backup != nil {
-							statusCommandOutput := backup.RunStatusCommand()
-							if statusCommandOutput.Status.Running {
-								backup.RunAbortCommand()
-								statusCommandOutput = backup.RunStatusCommand()
-								Expect(statusCommandOutput.Status.Running).To(BeFalse())
-								Expect(statusCommandOutput.Status.Completed).To(BeTrue())
-							}
+						if backup == nil {
+							return
 						}
+
+						backup.Start()
+
+						var statusBeforeAbort *fdbv1beta2.FoundationDBLiveBackupStatus
+						Eventually(func(g Gomega) {
+							statusBeforeAbort = backup.RunStatusCommand()
+							g.Expect(statusBeforeAbort.Status.Running).To(BeTrue())
+							g.Expect(statusBeforeAbort.Status.Name).To(Equal("RunningDifferentially"))
+							g.Expect(statusBeforeAbort.UID).NotTo(BeNil())
+							g.Expect(ptr.Deref(statusBeforeAbort.Restorable, false)).To(BeTrue())
+							g.Expect(statusBeforeAbort.LatestRestorablePoint).NotTo(BeNil())
+						}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+						uidBeforeAbort := *statusBeforeAbort.UID
+
+						backup.RunAbortCommand()
+
+						Eventually(func(g Gomega) {
+							statusAfterAbort := backup.RunStatusCommand()
+							g.Expect(statusAfterAbort.Status.Running).To(BeFalse())
+							g.Expect(statusAfterAbort.Status.Name).To(Equal("Aborted"))
+							g.Expect(statusAfterAbort.UID).NotTo(BeNil())
+							g.Expect(*statusAfterAbort.UID).To(Equal(uidBeforeAbort))
+						}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
 					})
 
 					When("running fdbbackup commands", func() {

--- a/e2e/test_operator_backups/operator_backup_test.go
+++ b/e2e/test_operator_backups/operator_backup_test.go
@@ -230,7 +230,8 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 						Eventually(func(g Gomega) {
 							statusBeforeAbort = backup.RunStatusCommand()
 							g.Expect(statusBeforeAbort.Status.Running).To(BeTrue())
-							g.Expect(statusBeforeAbort.Status.Name).To(Equal("RunningDifferentially"))
+							g.Expect(statusBeforeAbort.Status.Name).
+								To(Equal("RunningDifferentially"))
 							g.Expect(statusBeforeAbort.UID).NotTo(BeNil())
 							g.Expect(ptr.Deref(statusBeforeAbort.Restorable, false)).To(BeTrue())
 							g.Expect(statusBeforeAbort.LatestRestorablePoint).NotTo(BeNil())


### PR DESCRIPTION
# Description

Adding operator e2e test that runs abort command on an encrypted backup

## Type of change

*Please select one of the options below.*

- New feature (non-breaking change which adds functionality)


## Discussion

*Are there any design details that you would like to discuss further?*
No
## Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

Ran the test locally 
```
Ran 1 of 8 Specs in 306.279 seconds
SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 5 Skipped
```

## Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

N/A

## Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*

N/A