### PR TITLE
Fix ordering issue if an init container exists for a backup deployment

### DIFF
--- a/controllers/add_services.go
+++ b/controllers/add_services.go
@@ -116,7 +116,7 @@ func requiresRecreation(
 	existingService *corev1.Service,
 ) bool {
 	return cluster.IsPodIPFamily6() &&
-		(existingService.Spec.IPFamilies == nil || existingService.Spec.IPFamilies[0] != corev1.IPv6Protocol)
+		(len(existingService.Spec.IPFamilies) == 0 || existingService.Spec.IPFamilies[0] != corev1.IPv6Protocol)
 }
 
 // recreateService removes the existing service and create a new service.

--- a/controllers/update_pods.go
+++ b/controllers/update_pods.go
@@ -548,7 +548,7 @@ func deletePodsForUpdates(
 
 	newContext := logr.NewContext(ctx, logger)
 	if status != nil {
-		newContext = context.WithValue(ctx, fdbstatus.StatusContextKey{}, status)
+		newContext = context.WithValue(newContext, fdbstatus.StatusContextKey{}, status)
 	}
 
 	ready, err := r.PodLifecycleManager.CanDeletePods(newContext, adminClient, cluster)

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -78,38 +78,22 @@ func (client *realLockClient) takeLockInTransaction(transaction fdb.Transaction)
 		return nil
 	}
 
-	lockTuple, err := tuple.Unpack(lockValue)
+	currentLockOwnerID, currentLockStartTimestamp, currentLockEndTimestamp, err := unpackLockValue(
+		lockKey,
+		lockValue,
+	)
 	if err != nil {
 		return err
-	}
-
-	if len(lockTuple) < 3 {
-		return invalidLockValue{key: lockKey, value: lockValue}
-	}
-
-	currentLockOwnerID, valid := lockTuple[0].(string)
-	if !valid {
-		return invalidLockValue{key: lockKey, value: lockValue}
-	}
-
-	currentLockStartTime, valid := lockTuple[1].(int64)
-	if !valid {
-		return invalidLockValue{key: lockKey, value: lockValue}
-	}
-
-	currentLockEndTime, valid := lockTuple[2].(int64)
-	if !valid {
-		return invalidLockValue{key: lockKey, value: lockValue}
 	}
 
 	// ownerID represents the current cluster ID. If a lock is present the currentLockOwnerID represents the operator
 	// instance holding the lock.
 	ownerID := client.cluster.GetLockID()
 
-	endTime := time.Unix(currentLockEndTime, 0)
+	endTime := time.Unix(currentLockEndTimestamp, 0)
 	logger := client.log.WithValues(
 		"currentLockOwnerID", currentLockOwnerID,
-		"startTime", time.Unix(currentLockStartTime, 0),
+		"startTime", time.Unix(currentLockStartTimestamp, 0),
 		"endTime", endTime)
 
 	newOwnerDenied, err := transaction.Get(client.getDenyListKey(ownerID)).Get()
@@ -130,15 +114,15 @@ func (client *realLockClient) takeLockInTransaction(transaction fdb.Transaction)
 		return err
 	}
 
-	if currentLockEndTime < time.Now().Unix() || oldOwnerDenied != nil {
+	if currentLockEndTimestamp < time.Now().Unix() || oldOwnerDenied != nil {
 		logger.Info("Clearing expired lock")
-		client.updateLock(transaction, currentLockStartTime)
+		client.updateLock(transaction, currentLockStartTimestamp)
 		return nil
 	}
 
 	if currentLockOwnerID == ownerID {
 		logger.Info("Extending previous lock")
-		client.updateLock(transaction, currentLockStartTime)
+		client.updateLock(transaction, currentLockStartTimestamp)
 		return nil
 	}
 
@@ -310,24 +294,12 @@ func (client *realLockClient) ReleaseLock() error {
 			return nil, nil
 		}
 
-		lockTuple, err := tuple.Unpack(lockValue)
+		currentLockOwnerID, currentLockStartTimestamp, currentLockEndTimestamp, err := unpackLockValue(
+			lockKey,
+			lockValue,
+		)
 		if err != nil {
 			return nil, err
-		}
-
-		currentLockOwnerID, valid := lockTuple[0].(string)
-		if !valid {
-			return nil, invalidLockValue{key: lockKey, value: lockValue}
-		}
-
-		currentLockStartTimestamp, valid := lockTuple[1].(int64)
-		if !valid {
-			return nil, invalidLockValue{key: lockKey, value: lockValue}
-		}
-
-		currentLockEndTimestamp, valid := lockTuple[2].(int64)
-		if !valid {
-			return nil, invalidLockValue{key: lockKey, value: lockValue}
 		}
 
 		ownerID := client.cluster.GetLockID()
@@ -362,6 +334,35 @@ func (client *realLockClient) ReleaseLock() error {
 		return nil, nil
 	})
 	return err
+}
+
+// unpackLockValue will unpack the lock value and cast the tuple values into the expected types.
+func unpackLockValue(lockKey fdb.Key, lockValue []byte) (string, int64, int64, error) {
+	lockTuple, err := tuple.Unpack(lockValue)
+	if err != nil {
+		return "", 0, 0, err
+	}
+
+	if len(lockTuple) < 3 {
+		return "", 0, 0, invalidLockValue{key: lockKey, value: lockValue}
+	}
+
+	currentLockOwnerID, valid := lockTuple[0].(string)
+	if !valid {
+		return "", 0, 0, invalidLockValue{key: lockKey, value: lockValue}
+	}
+
+	currentLockStartTimestamp, valid := lockTuple[1].(int64)
+	if !valid {
+		return "", 0, 0, invalidLockValue{key: lockKey, value: lockValue}
+	}
+
+	currentLockEndTimestamp, valid := lockTuple[2].(int64)
+	if !valid {
+		return "", 0, 0, invalidLockValue{key: lockKey, value: lockValue}
+	}
+
+	return currentLockOwnerID, currentLockStartTimestamp, currentLockEndTimestamp, nil
 }
 
 // invalidLockValue is an error we can return when we cannot parse the existing

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -1291,7 +1291,8 @@ func GetBackupDeployment(backup *fdbv1beta2.FoundationDBBackup) (*appsv1.Deploym
 			podTemplate.Spec.InitContainers,
 			corev1.Container{Name: fdbv1beta2.InitContainerName},
 		)
-		initContainer = &podTemplate.Spec.InitContainers[0]
+		// Take the last init container as we just added the new init container.
+		initContainer = &podTemplate.Spec.InitContainers[len(podTemplate.Spec.InitContainers)-1]
 	}
 
 	err = configureSidecarContainerForBackup(backup, initContainer)

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -4201,6 +4201,49 @@ var _ = Describe("pod_models", func() {
 				},
 			)
 		})
+
+		Context("with a custom init container in the pod template", func() {
+			BeforeEach(func() {
+				backup.Spec.PodTemplateSpec = &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							{
+								Name:  "custom-init",
+								Image: "custom-init:latest",
+							},
+						},
+					},
+				}
+				deployment, err = GetBackupDeployment(backup)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(deployment).NotTo(BeNil())
+			})
+
+			It("should have two init containers", func() {
+				Expect(deployment.Spec.Template.Spec.InitContainers).To(HaveLen(2))
+			})
+
+			It("should preserve the custom init container as the first init container", func() {
+				Expect(
+					deployment.Spec.Template.Spec.InitContainers[0].Name,
+				).To(Equal("custom-init"))
+				Expect(
+					deployment.Spec.Template.Spec.InitContainers[0].Image,
+				).To(Equal("custom-init:latest"))
+				Expect(deployment.Spec.Template.Spec.InitContainers[0].Args).To(BeEmpty())
+			})
+
+			It("should configure the FDB init container as the last init container", func() {
+				initContainer := deployment.Spec.Template.Spec.InitContainers[1]
+				Expect(initContainer.Name).To(Equal(fdbv1beta2.InitContainerName))
+				Expect(initContainer.Args).To(ContainElements(
+					"--copy-file",
+					"fdb.cluster",
+					"--require-not-empty",
+					"fdb.cluster",
+				))
+			})
+		})
 	})
 
 	Context("Get image for container", func() {


### PR DESCRIPTION
# Description

If a user would specify an additional init container in the backup deployment, the current code would pick the first init container and add all the specific settings for the FDB init container. Instead of picking the first element in the init container slice, it must pick the last one (which was just added).

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Discussion

I touched some other code too. I can split those changes up into multiple smaller PRs.

## Testing

Ran unit tests.

## Documentation

Nothing to add.

## Follow-up

-
