### PR TITLE
Support FDB knobs via CLI flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,16 +56,6 @@ func main() {
 	logOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	if len(operatorOpts.Knobs) > 0 {
-		fmt.Printf("Setting FDB client knobs: %v\n", operatorOpts.Knobs)
-		for _, knob := range operatorOpts.Knobs {
-			if err := fdb.Options().SetKnob(knob); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to set FDB knob %q: %s\n", knob, err.Error())
-				os.Exit(1)
-			}
-		}
-	}
-
 	mgr, file := setup.StartManager(
 		scheme,
 		operatorOpts,

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -54,6 +55,16 @@ func main() {
 	logOpts := zap.Options{}
 	logOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if len(operatorOpts.Knobs) > 0 {
+		fmt.Printf("Setting FDB client knobs: %v\n", operatorOpts.Knobs)
+		for _, knob := range operatorOpts.Knobs {
+			if err := fdb.Options().SetKnob(knob); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to set FDB knob %q: %s\n", knob, err.Error())
+				os.Exit(1)
+			}
+		}
+	}
 
 	mgr, file := setup.StartManager(
 		scheme,

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -375,7 +375,7 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 	fs.Var(
 		&o.Knobs,
 		"knob",
-		"FDB client knob in name=value format (repeatable). e.g. --knob enable_coordinator_dns_cache=true",
+		"FDB client knob in name=value format (repeatable). e.g. --knob coordinator_reconnection_delay=2.0",
 	)
 }
 

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -375,7 +375,7 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 	fs.Var(
 		&o.Knobs,
 		"knob",
-		"FDB client knob in name=value format (repeatable). e.g. --knob coordinator_reconnection_delay=2.0",
+		"FDB client knob in name=value format (repeatable). e.g. --knob coordinator_reconnection_delay=2.0. Used for operator go bindings only -- not other binaries like fdbcli",
 	)
 }
 
@@ -419,6 +419,16 @@ func StartManager(
 	setupLog := logger.WithName("setup")
 	fdbclient.DefaultTimeout = time.Duration(operatorOpts.CliTimeout) * time.Second
 	fdbclient.MaxTimeout = time.Duration(operatorOpts.MaxCliTimeout) * time.Second
+
+	if len(operatorOpts.Knobs) > 0 {
+		setupLog.Info("Setting FDB client knobs", "knobs", operatorOpts.Knobs)
+		for _, knob := range operatorOpts.Knobs {
+			if err := fdb.Options().SetKnob(knob); err != nil {
+				setupLog.Error(err, "Failed to set FDB knob", "knob", knob)
+				os.Exit(1)
+			}
+		}
+	}
 
 	// Define the cache options for the client cache used by the operator. If no label selector is defined, the
 	// default cache configuration will be used.

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -36,6 +36,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
+	"github.com/apple/foundationdb/bindings/go/src/fdb"
+
 	"github.com/go-logr/logr"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -112,6 +112,16 @@ type Options struct {
 	MinimumUptimeForCoordinatorChangeWithUndesiredProcess time.Duration
 	MinimumUptimeForConfigurationChanges                  time.Duration
 	MinimumAgeForTerminalPodDeletion                      time.Duration
+	Knobs                                                 knobList
+}
+
+// knobList implements flag.Value for a repeatable --knob flag.
+type knobList []string
+
+func (k *knobList) String() string { return fmt.Sprintf("%v", *k) }
+func (k *knobList) Set(value string) error {
+	*k = append(*k, value)
+	return nil
 }
 
 // BindFlags will parse the given flagset for the operator option flags
@@ -361,6 +371,11 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 		"minimum-age-for-terminal-pod-deletion",
 		30*time.Second,
 		"The minimum age of a terminal pod before it will be deleted.",
+	)
+	fs.Var(
+		&o.Knobs,
+		"knob",
+		"FDB client knob in name=value format (repeatable). e.g. --knob enable_coordinator_dns_cache=true",
 	)
 }
 

--- a/setup/setup_test.go
+++ b/setup/setup_test.go
@@ -117,13 +117,13 @@ var _ = Describe("setup", func() {
 			opts.BindFlags(fs)
 
 			err := fs.Parse([]string{
-				"--knob=enable_coordinator_dns_cache=true",
-				"--knob=coordinator_dns_cache_ttl=600",
+				"--knob=coordinator_reconnection_delay=2.0",
+				"--knob=status_idle_timeout=300",
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(opts.Knobs).To(Equal(knobList{
-				"enable_coordinator_dns_cache=true",
-				"coordinator_dns_cache_ttl=600",
+				"coordinator_reconnection_delay=2.0",
+				"status_idle_timeout=300",
 			}))
 		})
 

--- a/setup/setup_test.go
+++ b/setup/setup_test.go
@@ -21,6 +21,7 @@
 package setup
 
 import (
+	"flag"
 	"io/fs"
 	"os"
 	"path"
@@ -106,6 +107,34 @@ var _ = Describe("setup", func() {
 				Expect(resultFile.Mode()).To(Equal(fs.FileMode(0600)))
 				Expect(resultFile.Size()).To(BeNumerically(">", 0))
 			})
+		})
+	})
+
+	When("knob flags are provided", func() {
+		It("should parse repeatable --knob flags", func() {
+			opts := Options{}
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			opts.BindFlags(fs)
+
+			err := fs.Parse([]string{
+				"--knob=enable_coordinator_dns_cache=true",
+				"--knob=coordinator_dns_cache_ttl=600",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.Knobs).To(Equal(knobList{
+				"enable_coordinator_dns_cache=true",
+				"coordinator_dns_cache_ttl=600",
+			}))
+		})
+
+		It("should default to empty when no knobs are provided", func() {
+			opts := Options{}
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			opts.BindFlags(fs)
+
+			err := fs.Parse([]string{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.Knobs).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
# Description

Add support for passing fdb knobs to operator via flags.

## Type of change

*Please select one of the options below.*
- New feature (non-breaking change which adds functionality)

## Testing

Manual testing

## Documentation

Cli flags are self-documenting via --help

*Did you update relevant documentation within this repository?*

## Follow-up
n/a
