### PR TITLE
Mark process as missing if important process information like commandline and version are missing

### DIFF
--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -460,6 +460,29 @@ func checkAndSetProcessStatus(
 				continue
 			}
 
+			// If the process.CommandLine or process.Version fields are empty something is wrong with the process, so
+			// we assume the process is "missing". If the process is long enough in this state the operator will
+			// replace the faulty process.
+			if process.CommandLine == "" {
+				hasMissingProcesses = true
+				logger.Info(
+					"found process with missing commandline information",
+					"processGroupID",
+					processGroupStatus.ProcessGroupID,
+				)
+				continue
+			}
+
+			if process.Version == "" {
+				hasMissingProcesses = true
+				logger.Info(
+					"found process with missing version information",
+					"processGroupID",
+					processGroupStatus.ProcessGroupID,
+				)
+				continue
+			}
+
 			commandLine, err := internal.GetStartCommandWithSubstitutions(
 				cluster,
 				processGroupStatus.ProcessClass,

--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -737,6 +737,90 @@ var _ = Describe("update_status", func() {
 			})
 		})
 
+		When("a process has an empty command line", func() {
+			JustBeforeEach(func() {
+				processes := processMap[pickedProcessGroup.ProcessGroupID]
+				for i := range processes {
+					processes[i].CommandLine = ""
+				}
+				processMap[pickedProcessGroup.ProcessGroupID] = processes
+			})
+
+			It(
+				"should get the MissingProcesses condition and not the IncorrectCommandLine condition",
+				func() {
+					err := validateProcessGroups(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						&cluster.Status,
+						processMap,
+						configMap,
+						logger,
+						"",
+					)
+					Expect(err).NotTo(HaveOccurred())
+
+					missingProcesses := fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.MissingProcesses,
+						false,
+					)
+					Expect(missingProcesses).To(ConsistOf(pickedProcessGroup.ProcessGroupID))
+
+					incorrectCommandLine := fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.IncorrectCommandLine,
+						false,
+					)
+					Expect(incorrectCommandLine).To(BeEmpty())
+					Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
+				},
+			)
+		})
+
+		When("a process has an empty version", func() {
+			JustBeforeEach(func() {
+				processes := processMap[pickedProcessGroup.ProcessGroupID]
+				for i := range processes {
+					processes[i].Version = ""
+				}
+				processMap[pickedProcessGroup.ProcessGroupID] = processes
+			})
+
+			It(
+				"should get the MissingProcesses condition and not the IncorrectCommandLine condition",
+				func() {
+					err := validateProcessGroups(
+						context.TODO(),
+						clusterReconciler,
+						cluster,
+						&cluster.Status,
+						processMap,
+						configMap,
+						logger,
+						"",
+					)
+					Expect(err).NotTo(HaveOccurred())
+
+					missingProcesses := fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.MissingProcesses,
+						false,
+					)
+					Expect(missingProcesses).To(ConsistOf(pickedProcessGroup.ProcessGroupID))
+
+					incorrectCommandLine := fdbv1beta2.FilterByCondition(
+						cluster.Status.ProcessGroups,
+						fdbv1beta2.IncorrectCommandLine,
+						false,
+					)
+					Expect(incorrectCommandLine).To(BeEmpty())
+					Expect(cluster.Status.ProcessGroups).To(HaveLen(17))
+				},
+			)
+		})
+
 		When("a process group is not reporting to the cluster", func() {
 			BeforeEach(func() {
 				adminClient.MockMissingProcessGroup(pickedProcessGroup.ProcessGroupID, true)


### PR DESCRIPTION
# Description

In some cases there could be a case where a process is part of the machine-readable status (status json) but misses some important fields like `version` or `commandline`:

```text
  So a process appears in the status processes list (the CC knows about it) but has no version or command_line when:

  1. The worker is temporarily unreachable — network hiccup, packet loss, or the worker is just coming up and its network endpoint isn't ready yet.
  2. The worker's network thread is blocked — a disk I/O stall or CPU spike on the worker can prevent it from processing the eventLogRequest within 2 seconds even though it appears alive to the CC (which uses a slower failure detector). This is the most common production cause.
  3. The process just restarted — there's a brief window between when the CC registers the new process (after the old one died) and when the new process has fully initialised its network stack and can respond to requests. ProgramStart is logged very early but the endpoint may not be ready.
```

In this case we should assume the process is unreachable and mark it as missing. If the `MissingProcesses` is present for long enough the process group will be replaced. I think this is better than trying to restart the process (because in the current logic we compare an empty string for command line and version. against the expected version/command line which will always cause adding the `IncorrectCommandLine` condition and then the process will eventually be restarted.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Discussion

-

## Testing

Added unit tests.

## Documentation

Nothing to update.

## Follow-up

-
