### PR TITLE
Prioritize degraded process groups for removal during cluster shrinks

### DIFF
--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -97,8 +97,9 @@ func (c chooseRemovals) reconcile(
 		excessCount := currentCounts[processClass] - desiredCount
 		processClassLocality := make([]locality.Info, 0, currentCounts[processClass])
 
-		// TODO (johscheuer): We could add a higher priority to the process groups that have a condition that requires
-		// an automatic replacement.
+		// Prioritize degraded process groups for removal. If a process group is degraded,
+		// we set its priority to a low value (-100) so that healthy process groups
+		// are prioritized to remain, and degraded ones are naturally chosen for removal.
 		for _, processGroup := range cluster.Status.ProcessGroupsByProcessClass(processClass) {
 			if processGroup.IsMarkedForRemoval() {
 				excessCount--
@@ -106,6 +107,14 @@ func (c chooseRemovals) reconcile(
 			}
 			localityInfo, present := localityMap[string(processGroup.ProcessGroupID)]
 			if present {
+				_, failureTime := processGroup.NeedsReplacementWithConditions(
+					cluster.GetFailureDetectionTimeSeconds(),
+					cluster.GetTaintReplacementTimeSeconds(),
+					cluster.GetConditionsThatNeedReplacement(),
+				)
+				if failureTime > 0 {
+					localityInfo.Priority = -100
+				}
 				processClassLocality = append(processClassLocality, localityInfo)
 			}
 		}

--- a/controllers/choose_removals_test.go
+++ b/controllers/choose_removals_test.go
@@ -121,6 +121,35 @@ var _ = Describe("choose_removals", func() {
 			})
 		})
 
+		Context("with a degraded process group", func() {
+			var degradedProcessGroupID fdbv1beta2.ProcessGroupID
+
+			BeforeEach(func() {
+				storageGroups := internal.PickProcessGroups(cluster, fdbv1beta2.ProcessClassStorage, 4)
+				Expect(storageGroups).To(HaveLen(4))
+
+				degradedGroup := storageGroups[0]
+				degradedProcessGroupID = degradedGroup.ProcessGroupID
+
+				degradedGroup.ProcessGroupConditions = append(degradedGroup.ProcessGroupConditions, &fdbv1beta2.ProcessGroupCondition{
+					ProcessGroupConditionType: fdbv1beta2.PodFailing,
+					Timestamp:                 1,
+				})
+
+				Expect(
+					clusterReconciler.updateOrApply(context.TODO(), cluster),
+				).NotTo(HaveOccurred())
+			})
+
+			It("should not requeue", func() {
+				Expect(requeue).To(BeNil())
+			})
+
+			It("should specifically mark the degraded process group for removal", func() {
+				Expect(removals).To(Equal([]fdbv1beta2.ProcessGroupID{degradedProcessGroupID}))
+			})
+		})
+
 		Context("with multiple processes on one rack", func() {
 			var processGroupIDs []fdbv1beta2.ProcessGroupID
 


### PR DESCRIPTION
# Description

When we shrink a cluster (scale down process counts), the operator previously didn't differentiate between healthy and degraded/failing nodes. This meant a healthy storage node could be marked for termination while a failing or degraded node was kept in the cluster.

This PR updates `chooseRemovals.reconcile` to check for active degraded conditions on each process group using `NeedsReplacementWithConditions(...)`. If a process group is degraded, we temporarily assign it a low locality priority (`-100`). Because `ChooseDistributedProcesses` uses `sortLocalities` (preferring higher-priority nodes to remain in the cluster), degraded nodes are naturally sorted to the end and selected first for removal.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Discussion

Mutating the priority on the copy of the `locality.Info` struct retrieved from `localityMap` is entirely side-effect free and integrates cleanly with the existing locality sorting and selection logic.

## Testing

I added a Ginkgo unit test context (`"with a degraded process group"`) inside `controllers/choose_removals_test.go`:
* It sets up 4 storage process groups, marks one as degraded with a `PodFailing` condition, and shrinks the desired storage count to 3.
* The test asserts that the operator specifically selects the degraded process group for removal instead of a healthy one.

Code is formatted with `go fmt`.

## Documentation

No documentation updates are needed. This is an internal optimization to the shrink reconciler and doesn't change any public-facing CRDs, defaults, or APIs.

## Follow-up

No immediate follow-ups. Since this doesn't add any new configurable defaults, we don't need to re-evaluate default behaviors in the future.
