### PR TITLE
Update go version to 1.26.3 and pin GitHub action to sha not tags

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #6.4.0
         with:
-          go-version: 1.25.8
+          go-version: 1.26.3
       - name: Get dependencies
         run: curl -L --fail "https://github.com/apple/foundationdb/releases/download/${FDB_VER}/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
       - name: Install dependencies
@@ -36,13 +36,13 @@ jobs:
         kubever: [ "v1.30.0", "v1.31.0", "v1.32.0", "v1.33.0"  ]
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #6.4.0
       with:
-        go-version: 1.25.8
+        go-version: 1.26.3
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Free disk space
@@ -97,13 +97,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #6.4.0
       with:
-        go-version: 1.25.8
+        go-version: 1.26.3
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Get dependencies
@@ -138,19 +138,19 @@ jobs:
             file: ./sample-apps/data-loader/Dockerfile
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.02
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Login to DockerHub
         if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           build-args: |
             TAG=${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       tag: ${{ steps.get_tag.outputs.TAG  }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get the tag without ref
         id: get_tag
         run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
@@ -19,7 +19,7 @@ jobs:
         run: touch ./docs/changelog/${{ steps.get_tag.outputs.TAG }}.md
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         # Otherwise we can't rerun this to build new binaries
         continue-on-error: true
         env:
@@ -35,7 +35,7 @@ jobs:
     needs: create-release
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Fetch all tags
@@ -43,9 +43,9 @@ jobs:
       - name: Free disk space
         run: bash ${GITHUB_WORKSPACE}/scripts/free_disk_space.sh
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #6.4.0
         with:
-          go-version: 1.25.8
+          go-version: 1.26.3
       #  https://github.com/goreleaser/goreleaser/issues/1311
       - name: Get current semver tag
         run: echo "GORELEASER_CURRENT_TAG=$(git describe --tags --match "v*" --abbrev=0)" >> $GITHUB_ENV
@@ -73,21 +73,21 @@ jobs:
             file: ./sample-apps/data-loader/Dockerfile
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get the version
         id: get_tag
         run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push to registry
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           build-args: |
             TAG=${{ steps.get_sha.outputs.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG FDB_VERSION=7.1.67
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM golang:1.25.8-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE

--- a/sample-apps/data-loader/Dockerfile
+++ b/sample-apps/data-loader/Dockerfile
@@ -2,7 +2,7 @@ ARG FDB_VERSION=7.1.67
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE

--- a/sample-apps/data-loader/go.mod
+++ b/sample-apps/data-loader/go.mod
@@ -1,6 +1,6 @@
 module github.com/FoundationDB/fdb-data-loader
 
-go 1.24.0
+go 1.25.0
 
 // Binding version for 7.1.67
 require github.com/apple/foundationdb/bindings/go v0.0.0-20250115161953-f1ab8147ed1c


### PR DESCRIPTION
# Description

Update the go version to 1.26.3 and pin the GitHub Actions to commit SHAs and not the tags.

## Type of change

- Other

## Discussion

-

## Testing

Build the operator image locally.

## Documentation

Nothing to update.

## Follow-up

Nothing.
