### PR TITLE
Add input validation for the configure command

### DIFF
--- a/api/v1beta2/foundationdb_database_configuration.go
+++ b/api/v1beta2/foundationdb_database_configuration.go
@@ -76,6 +76,7 @@ type DatabaseConfiguration struct {
 
 	// PerpetualStorageWiggleLocality if defined the specified locality will be migrated.
 	// Format is: <<LOCALITY_KEY>:<LOCALITY_VALUE>|0>
+	// +kubebuilder:validation:Pattern=`^([\w.-]+:[\w.-]+|0)$`
 	PerpetualStorageWiggleLocality *string `json:"perpetual_storage_wiggle_locality,omitempty"`
 
 	// PerpetualStorageWiggleEngine defines the perpetual storage engine type.

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -324,6 +324,7 @@ spec:
                     maxLength: 100
                     type: string
                   perpetual_storage_wiggle_locality:
+                    pattern: ^([\w.-]+:[\w.-]+|0)$
                     type: string
                   proxies:
                     type: integer
@@ -4714,6 +4715,7 @@ spec:
                     maxLength: 100
                     type: string
                   perpetual_storage_wiggle_locality:
+                    pattern: ^([\w.-]+:[\w.-]+|0)$
                     type: string
                   proxies:
                     type: integer

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -384,6 +384,12 @@ func (client *cliAdminClient) ConfigureDatabase(
 		configurationString = "new " + configurationString
 	}
 
+	// Ensure the provided configuration string doesn't contain any invalid characters, e.g. to run another fdbcli
+	// command.
+	if strings.ContainsAny(configurationString, ";\n\r") {
+		return fmt.Errorf("configuration string contains invalid characters")
+	}
+
 	_, err = client.runCommand(
 		cliCommand{command: fmt.Sprintf("configure %s", configurationString)},
 	)

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -1325,6 +1325,106 @@ protocol fdb00b071010000`,
 			).To(BeNumerically(">", 0), "coordinator changes counter should be incremented after a coordinator change")
 		})
 	})
+
+	When("changing the configuration", func() {
+		var cliClient *cliAdminClient
+		var mockRunner *mockCommandRunner
+		var newDatabase bool
+		var configuration *fdbv1beta2.DatabaseConfiguration
+		var configurationErr error
+
+		BeforeEach(func() {
+			mockRunner = &mockCommandRunner{
+				mockedError:  nil,
+				mockedOutput: []string{""},
+			}
+
+			cliClient = &cliAdminClient{
+				Cluster: &fdbv1beta2.FoundationDBCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Spec: fdbv1beta2.FoundationDBClusterSpec{
+						Version: "7.3.1",
+					},
+					Status: fdbv1beta2.FoundationDBClusterStatus{
+						RunningVersion:   "7.3.1",
+						ConnectionString: "abc:dfg@test:4500",
+					},
+				},
+				log:       logr.Discard(),
+				cmdRunner: mockRunner,
+				fdbLibClient: &mockFdbLibClient{
+					mockedOutput: []byte(""),
+				},
+			}
+
+		})
+
+		JustBeforeEach(func() {
+			configurationErr = cliClient.ConfigureDatabase(*configuration, newDatabase)
+		})
+
+		When("the database is not yet configured with the default configuration", func() {
+			BeforeEach(func() {
+				newDatabase = true
+				configuration = &fdbv1beta2.DatabaseConfiguration{}
+			})
+
+			It("should configure the database", func() {
+				Expect(configurationErr).NotTo(HaveOccurred())
+				Expect(mockRunner.receivedArgs).To(HaveLen(1))
+				Expect(
+					mockRunner.receivedArgs[0][:2],
+				).To(Equal([]string{"--exec", "configure new   usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[]"}))
+			})
+
+			When("invalid input is provided", func() {
+				BeforeEach(func() {
+					newDatabase = true
+					configuration = &fdbv1beta2.DatabaseConfiguration{
+						PerpetualStorageWiggleLocality: ptr.To("; status details\n"),
+					}
+				})
+
+				It("should not configure the database and return an error", func() {
+					Expect(configurationErr).To(HaveOccurred())
+					Expect(mockRunner.receivedArgs).To(BeEmpty())
+				})
+			})
+		})
+
+		When("the database is already configured", func() {
+			BeforeEach(func() {
+				newDatabase = false
+				configuration = &fdbv1beta2.DatabaseConfiguration{}
+			})
+
+			It("should configure the database", func() {
+				Expect(configurationErr).NotTo(HaveOccurred())
+				Expect(mockRunner.receivedArgs).To(HaveLen(1))
+				Expect(
+					mockRunner.receivedArgs[0][:2],
+				).To(Equal([]string{"--exec", "configure   usable_regions=0 logs=0 resolvers=0 log_routers=0 remote_logs=0 proxies=3 regions=[]"}))
+			})
+
+			When("invalid input is provided", func() {
+				BeforeEach(func() {
+					newDatabase = true
+					configuration = &fdbv1beta2.DatabaseConfiguration{
+						PerpetualStorageWiggleLocality: ptr.To("; status details\n"),
+					}
+				})
+
+				It("should not configure the database and return an error", func() {
+					Expect(configurationErr).To(HaveOccurred())
+					Expect(mockRunner.receivedArgs).To(BeEmpty())
+				})
+			})
+		})
+
+	})
 })
 
 // getCounterValue extracts the current value of a prometheus counter for specific labels


### PR DESCRIPTION
# Description

Add input validation for the configure command to prevent running additional fdbcli commands and reducing the risk of malformed input.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Added a unit test and CI will run e2e tests.

## Documentation

Nothing to update.

## Follow-up

-
