### PR TITLE
Update go version to 1.26.4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #6.4.0
         with:
-          go-version: 1.26.3
+          go-version: 1.26.4
       - name: Get dependencies
         run: curl -L --fail "https://github.com/apple/foundationdb/releases/download/${FDB_VER}/foundationdb-clients_${FDB_VER}-1_amd64.deb" -o fdb.deb
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #6.4.0
       with:
-        go-version: 1.26.3
+        go-version: 1.26.4
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Free disk space
@@ -103,7 +103,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #6.4.0
       with:
-        go-version: 1.26.3
+        go-version: 1.26.4
     - name: Fetch all tags
       run: git fetch --force --tags
     - name: Get dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #6.4.0
         with:
-          go-version: 1.26.3
+          go-version: 1.26.4
       #  https://github.com/goreleaser/goreleaser/issues/1311
       - name: Get current semver tag
         run: echo "GORELEASER_CURRENT_TAG=$(git describe --tags --match "v*" --abbrev=0)" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG FDB_VERSION=7.1.67
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE

--- a/sample-apps/data-loader/Dockerfile
+++ b/sample-apps/data-loader/Dockerfile
@@ -2,7 +2,7 @@ ARG FDB_VERSION=7.1.67
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE


### PR DESCRIPTION
Patches three Go stdlib vulnerabilities flagged by govulnchbeck: https://github.com/FoundationDB/fdb-kubernetes-operator/actions/runs/27043094732/job/79823307008

## Summary
  - Bump Go from 1.26.3 to 1.26.4 in workflows and Dockerfiles
  - Patches stdlib vulnerabilities flagged by govulncheck:
    - GO-2026-5037 (crypto/x509)
    - GO-2026-5038 (mime)
    - GO-2026-5039 (net/textproto)
