### PR TITLE
Run `go fix` to apply Go 1.26+ modernizers to api/, cmd/ and controllers/ packages

### DIFF
--- a/api/v1beta2/foundationdb_database_configuration.go
+++ b/api/v1beta2/foundationdb_database_configuration.go
@@ -949,7 +949,7 @@ var versionFlagIndices = make(map[string]int)
 var roleNames = fieldNames(RoleCounts{})
 
 // fieldNames provides the names of fields on a structure.
-func fieldNames(value interface{}) []ProcessClass {
+func fieldNames(value any) []ProcessClass {
 	countType := reflect.TypeOf(value)
 	names := make([]ProcessClass, 0, countType.NumField())
 	for index := 0; index < countType.NumField(); index++ {
@@ -968,14 +968,14 @@ var processClassIndices = make(map[ProcessClass]int)
 var ProcessClasses = fieldNames(ProcessCounts{})
 
 func init() {
-	fieldIndices(ProcessCounts{}, processClassIndices, reflect.TypeOf(ProcessClassStorage))
-	fieldIndices(RoleCounts{}, roleIndices, reflect.TypeOf(ProcessClassStorage))
-	fieldIndices(VersionFlags{}, versionFlagIndices, reflect.TypeOf(""))
+	fieldIndices(ProcessCounts{}, processClassIndices, reflect.TypeFor[ProcessClass]())
+	fieldIndices(RoleCounts{}, roleIndices, reflect.TypeFor[ProcessClass]())
+	fieldIndices(VersionFlags{}, versionFlagIndices, reflect.TypeFor[string]())
 }
 
 // fieldIndices provides a map from the names of fields in a structure to the
 // index of each field in the list of fields.
-func fieldIndices(value interface{}, result interface{}, keyType reflect.Type) {
+func fieldIndices(value any, result any, keyType reflect.Type) {
 	countType := reflect.TypeOf(value)
 	resultValue := reflect.ValueOf(result)
 	for index := 0; index < countType.NumField(); index++ {

--- a/api/v1beta2/foundationdb_process_address.go
+++ b/api/v1beta2/foundationdb_process_address.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -101,9 +101,7 @@ func (address ProcessAddress) SortedFlags() []string {
 		}
 	}
 
-	sort.Slice(flags, func(i int, j int) bool {
-		return flags[i] < flags[j]
-	})
+	slices.Sort(flags)
 
 	return flags
 }
@@ -154,7 +152,7 @@ func (address *ProcessAddress) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON defines the parsing method for the ProcessAddress field from struct to JSON
 func (address ProcessAddress) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"%s\"", address.String())), nil
+	return fmt.Appendf(nil, "\"%s\"", address.String()), nil
 }
 
 // ParseProcessAddress parses a structured address from its string
@@ -165,8 +163,8 @@ func ParseProcessAddress(address string) (ProcessAddress, error) {
 		return result, fmt.Errorf("cannot parse empty address")
 	}
 
-	if strings.HasSuffix(address, "(fromHostname)") {
-		address = strings.TrimSuffix(address, "(fromHostname)")
+	if before, ok := strings.CutSuffix(address, "(fromHostname)"); ok {
+		address = before
 		result.FromHostname = true
 	}
 

--- a/api/v1beta2/foundationdbcluster_types.go
+++ b/api/v1beta2/foundationdbcluster_types.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"math/rand/v2"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -2120,7 +2121,7 @@ func (str *ConnectionString) String() string {
 // GenerateNewGenerationID builds a new generation ID
 func (str *ConnectionString) GenerateNewGenerationID() error {
 	id := strings.Builder{}
-	for i := 0; i < 32; i++ {
+	for range 32 {
 		err := id.WriteByte(alphanum[rand.IntN(len(alphanum))])
 		if err != nil {
 			return err
@@ -2353,19 +2354,11 @@ func (cluster *FoundationDBCluster) ProcessGroupIsBeingRemoved(processGroupID Pr
 		}
 	}
 
-	for _, id := range cluster.Spec.ProcessGroupsToRemove {
-		if id == processGroupID {
-			return true
-		}
+	if slices.Contains(cluster.Spec.ProcessGroupsToRemove, processGroupID) {
+		return true
 	}
 
-	for _, id := range cluster.Spec.ProcessGroupsToRemoveWithoutExclusion {
-		if id == processGroupID {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(cluster.Spec.ProcessGroupsToRemoveWithoutExclusion, processGroupID)
 }
 
 // ShouldUseLocks determine whether we should use locks to coordinator global
@@ -2588,10 +2581,8 @@ func (clusterStatus *FoundationDBClusterStatus) AddServersPerDisk(
 	pClass ProcessClass,
 ) {
 	if pClass == ProcessClassStorage {
-		for _, curServersPerDisk := range clusterStatus.StorageServersPerDisk {
-			if curServersPerDisk == serversPerDisk {
-				return
-			}
+		if slices.Contains(clusterStatus.StorageServersPerDisk, serversPerDisk) {
+			return
 		}
 		clusterStatus.StorageServersPerDisk = append(
 			clusterStatus.StorageServersPerDisk,
@@ -2601,10 +2592,8 @@ func (clusterStatus *FoundationDBClusterStatus) AddServersPerDisk(
 	}
 
 	if pClass.SupportsMultipleLogServers() {
-		for _, curServersPerDisk := range clusterStatus.LogServersPerDisk {
-			if curServersPerDisk == serversPerDisk {
-				return
-			}
+		if slices.Contains(clusterStatus.LogServersPerDisk, serversPerDisk) {
+			return
 		}
 		clusterStatus.LogServersPerDisk = append(clusterStatus.LogServersPerDisk, serversPerDisk)
 	}

--- a/cmd/po-docgen/api.go
+++ b/cmd/po-docgen/api.go
@@ -178,7 +178,7 @@ func fmtRawDoc(rawDoc string) string {
 	// Ignore all lines after ---
 	rawDoc = strings.Split(rawDoc, "---")[0]
 
-	for _, line := range strings.Split(rawDoc, "\n") {
+	for line := range strings.SplitSeq(rawDoc, "\n") {
 		line = strings.TrimRight(line, " ")
 		leading := strings.TrimLeft(line, " ")
 		switch {

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -66,10 +66,7 @@ func (a addProcessGroups) reconcile(
 
 	hasNewProcessGroups := false
 	for _, processClass := range fdbv1beta2.ProcessClasses {
-		desiredCount := desiredCounts[processClass]
-		if desiredCount < 0 {
-			desiredCount = 0
-		}
+		desiredCount := max(desiredCounts[processClass], 0)
 		newCount := desiredCount - processCounts[processClass]
 		if newCount <= 0 {
 			continue
@@ -98,7 +95,7 @@ func (a addProcessGroups) reconcile(
 			"AddingProcesses",
 			fmt.Sprintf("Adding %d %s processes", newCount, processClass),
 		)
-		for i := 0; i < newCount; i++ {
+		for range newCount {
 			processGroupID := cluster.GetNextRandomProcessGroupIDWithExclusions(
 				processClass,
 				processGroupIDs[processClass],

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -258,7 +258,7 @@ var _ = Describe("add_process_groups", func() {
 				excludedCnt := 100
 				exclusions := make([]fdbv1beta2.ProcessAddress, 0, excludedCnt)
 				excludedProcessGroupIDs = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None{}
-				for i := 0; i < excludedCnt; i++ {
+				for i := range excludedCnt {
 					processGroupID := fdbv1beta2.ProcessGroupID(fmt.Sprintf("storage-%d", i))
 					if _, ok := currentProcessGroupIDs[processGroupID]; ok {
 						continue

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -151,10 +151,7 @@ func (c bounceProcesses) reconcile(
 	if err != nil {
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsBounce", err.Error())
 		// Retry after we waited the minimum uptime or at least 15 seconds.
-		delayTime := cluster.GetMinimumUptimeSecondsForBounce() - int(currentMinimumUptime)
-		if delayTime < 15 {
-			delayTime = 15
-		}
+		delayTime := max(cluster.GetMinimumUptimeSecondsForBounce()-int(currentMinimumUptime), 15)
 
 		return &requeue{
 			message: err.Error(),

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -836,7 +836,7 @@ var _ = Describe("cluster_controller", func() {
 
 					sortPodsByName(pods)
 
-					for i := 0; i < 17; i++ {
+					for i := range 17 {
 						Expect(pods.Items[i].Name).To(Equal(originalPods.Items[i].Name))
 					}
 				})

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -69,7 +69,7 @@ type requeue struct {
 // processRequeue interprets a requeue result from a subreconciler.
 func processRequeue(
 	requeue *requeue,
-	subReconciler interface{},
+	subReconciler any,
 	object runtime.Object,
 	recorder record.EventRecorder,
 	logger logr.Logger,

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -190,7 +190,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 
 			BeforeEach(func() {
 				targetProcessGroups = make([]fdbv1beta2.ProcessGroupID, 2)
-				for i := 0; i < 2; i++ {
+				for i := range 2 {
 					targetProcessGroup := cluster.Status.ProcessGroups[i]
 					timestamp := time.Now().Add(-10 * time.Minute).Unix()
 					targetProcessGroup.UpdateCondition(fdbv1beta2.NodeTaintDetected, true)

--- a/controllers/update_backup_status.go
+++ b/controllers/update_backup_status.go
@@ -69,10 +69,7 @@ func (s updateBackupStatus) reconcile(
 	}
 
 	if currentBackupDeployment != nil && desiredBackupDeployment != nil {
-		status.AgentCount = int(currentBackupDeployment.Status.ReadyReplicas)
-		if status.AgentCount > int(currentBackupDeployment.Status.UpdatedReplicas) {
-			status.AgentCount = int(currentBackupDeployment.Status.UpdatedReplicas)
-		}
+		status.AgentCount = min(int(currentBackupDeployment.Status.ReadyReplicas), int(currentBackupDeployment.Status.UpdatedReplicas))
 		generationsMatch := currentBackupDeployment.Status.ObservedGeneration == currentBackupDeployment.ObjectMeta.Generation
 
 		annotationChange := internal.MergeAnnotations(

--- a/controllers/update_backup_status.go
+++ b/controllers/update_backup_status.go
@@ -69,7 +69,10 @@ func (s updateBackupStatus) reconcile(
 	}
 
 	if currentBackupDeployment != nil && desiredBackupDeployment != nil {
-		status.AgentCount = min(int(currentBackupDeployment.Status.ReadyReplicas), int(currentBackupDeployment.Status.UpdatedReplicas))
+		status.AgentCount = min(
+			int(currentBackupDeployment.Status.ReadyReplicas),
+			int(currentBackupDeployment.Status.UpdatedReplicas),
+		)
 		generationsMatch := currentBackupDeployment.Status.ObservedGeneration == currentBackupDeployment.ObjectMeta.Generation
 
 		annotationChange := internal.MergeAnnotations(

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"time"
 
@@ -697,13 +698,7 @@ func validateProcessGroups(
 		status.AddServersPerDisk(processCount, processGroup.ProcessClass)
 
 		imageType := internal.GetImageType(pod)
-		imageTypeFound := false
-		for _, currentImageType := range status.ImageTypes {
-			if imageType == currentImageType {
-				imageTypeFound = true
-				break
-			}
-		}
+		imageTypeFound := slices.Contains(status.ImageTypes, imageType)
 		if !imageTypeFound {
 			status.ImageTypes = append(status.ImageTypes, imageType)
 		}


### PR DESCRIPTION
# Description

This is the first PR that applies Go 1.26+ fix modernizers to the codebase using `go fix`. Following PRs will apply this tool to the other packages to keep the LoC changed small/PR and easy to review.

**What changed:**
- Ran `go fix` across the `api/`, `cmd/` and `controllers/` packages to apply Go 1.26+ modernizers

**Why:**
Go 1.26 introduced [fix modernizers](https://go.dev/doc/modules/fix) that automatically update code to use newer, more idiomatic Go patterns. These fixes improve code quality and maintainability.

Main changes here are:
- Replace the `interface{}` type with `any`
- Use `slices.Contains` over manual lookup loops
- Use `slices.Sort` over `sort.Slice`
- Use the `min`/`max` builtins over manual clamping
- Use `for range n` / `for i := range n` over index-based loops
- Use `fmt.Appendf` over `[]byte(fmt.Sprintf(...))`
- Use `strings.CutSuffix` over a `strings.HasSuffix` + `strings.TrimSuffix` pair
- Use `strings.SplitSeq` over `strings.Split` when we only iterate the result
- Use `reflect.TypeFor[T]()` over `reflect.TypeOf(...)`

## Type of change

- Other

Slight refactoring

## Discussion

Perhaps this should be enforced before merging future PRs to keep the code paradigm consistent. Any thoughts on this?

## Testing

Eyeballed changes and it generally makes sense, this is a small change. All existing tests pass.
