### PR TITLE
Run `go fix` to apply Go 1.26+ modernizers to cmd/ and controllers/ packages

### DIFF
--- a/cmd/po-docgen/api.go
+++ b/cmd/po-docgen/api.go
@@ -178,7 +178,7 @@ func fmtRawDoc(rawDoc string) string {
 	// Ignore all lines after ---
 	rawDoc = strings.Split(rawDoc, "---")[0]
 
-	for _, line := range strings.Split(rawDoc, "\n") {
+	for line := range strings.SplitSeq(rawDoc, "\n") {
 		line = strings.TrimRight(line, " ")
 		leading := strings.TrimLeft(line, " ")
 		switch {

--- a/controllers/add_process_groups.go
+++ b/controllers/add_process_groups.go
@@ -66,10 +66,7 @@ func (a addProcessGroups) reconcile(
 
 	hasNewProcessGroups := false
 	for _, processClass := range fdbv1beta2.ProcessClasses {
-		desiredCount := desiredCounts[processClass]
-		if desiredCount < 0 {
-			desiredCount = 0
-		}
+		desiredCount := max(desiredCounts[processClass], 0)
 		newCount := desiredCount - processCounts[processClass]
 		if newCount <= 0 {
 			continue
@@ -98,7 +95,7 @@ func (a addProcessGroups) reconcile(
 			"AddingProcesses",
 			fmt.Sprintf("Adding %d %s processes", newCount, processClass),
 		)
-		for i := 0; i < newCount; i++ {
+		for range newCount {
 			processGroupID := cluster.GetNextRandomProcessGroupIDWithExclusions(
 				processClass,
 				processGroupIDs[processClass],

--- a/controllers/add_process_groups_test.go
+++ b/controllers/add_process_groups_test.go
@@ -258,7 +258,7 @@ var _ = Describe("add_process_groups", func() {
 				excludedCnt := 100
 				exclusions := make([]fdbv1beta2.ProcessAddress, 0, excludedCnt)
 				excludedProcessGroupIDs = map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None{}
-				for i := 0; i < excludedCnt; i++ {
+				for i := range excludedCnt {
 					processGroupID := fdbv1beta2.ProcessGroupID(fmt.Sprintf("storage-%d", i))
 					if _, ok := currentProcessGroupIDs[processGroupID]; ok {
 						continue

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -151,10 +151,7 @@ func (c bounceProcesses) reconcile(
 	if err != nil {
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "NeedsBounce", err.Error())
 		// Retry after we waited the minimum uptime or at least 15 seconds.
-		delayTime := cluster.GetMinimumUptimeSecondsForBounce() - int(currentMinimumUptime)
-		if delayTime < 15 {
-			delayTime = 15
-		}
+		delayTime := max(cluster.GetMinimumUptimeSecondsForBounce()-int(currentMinimumUptime), 15)
 
 		return &requeue{
 			message: err.Error(),

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -836,7 +836,7 @@ var _ = Describe("cluster_controller", func() {
 
 					sortPodsByName(pods)
 
-					for i := 0; i < 17; i++ {
+					for i := range 17 {
 						Expect(pods.Items[i].Name).To(Equal(originalPods.Items[i].Name))
 					}
 				})

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -69,7 +69,7 @@ type requeue struct {
 // processRequeue interprets a requeue result from a subreconciler.
 func processRequeue(
 	requeue *requeue,
-	subReconciler interface{},
+	subReconciler any,
 	object runtime.Object,
 	recorder record.EventRecorder,
 	logger logr.Logger,

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -190,7 +190,7 @@ var _ = Describe("replace_failed_process_groups", func() {
 
 			BeforeEach(func() {
 				targetProcessGroups = make([]fdbv1beta2.ProcessGroupID, 2)
-				for i := 0; i < 2; i++ {
+				for i := range 2 {
 					targetProcessGroup := cluster.Status.ProcessGroups[i]
 					timestamp := time.Now().Add(-10 * time.Minute).Unix()
 					targetProcessGroup.UpdateCondition(fdbv1beta2.NodeTaintDetected, true)

--- a/controllers/update_backup_status.go
+++ b/controllers/update_backup_status.go
@@ -69,10 +69,7 @@ func (s updateBackupStatus) reconcile(
 	}
 
 	if currentBackupDeployment != nil && desiredBackupDeployment != nil {
-		status.AgentCount = int(currentBackupDeployment.Status.ReadyReplicas)
-		if status.AgentCount > int(currentBackupDeployment.Status.UpdatedReplicas) {
-			status.AgentCount = int(currentBackupDeployment.Status.UpdatedReplicas)
-		}
+		status.AgentCount = min(int(currentBackupDeployment.Status.ReadyReplicas), int(currentBackupDeployment.Status.UpdatedReplicas))
 		generationsMatch := currentBackupDeployment.Status.ObservedGeneration == currentBackupDeployment.ObjectMeta.Generation
 
 		annotationChange := internal.MergeAnnotations(

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"time"
 
@@ -697,13 +698,7 @@ func validateProcessGroups(
 		status.AddServersPerDisk(processCount, processGroup.ProcessClass)
 
 		imageType := internal.GetImageType(pod)
-		imageTypeFound := false
-		for _, currentImageType := range status.ImageTypes {
-			if imageType == currentImageType {
-				imageTypeFound = true
-				break
-			}
-		}
+		imageTypeFound := slices.Contains(status.ImageTypes, imageType)
 		if !imageTypeFound {
 			status.ImageTypes = append(status.ImageTypes, imageType)
 		}


### PR DESCRIPTION
# Description

This is a follow up (but independent) PR to #2491 that applies Go 1.26+ fix modernizers to the codebase using `go fix`.

**What changed:**
- Ran `go fix` across to `cmd/` and `controllers/` packages to apply Go 1.26+ modernizers

**Why:**
Go 1.26 introduced [fix modernizers](https://go.dev/doc/modules/fix) that automatically update code to use newer, more idiomatic Go patterns. These fixes improve code quality and maintainability.

## Type of change

- Other

Slight refactoring

## Testing

Eyeballed changes and it generally makes sense, this is a small change. All existing tests pass.