### PR TITLE
Run `go fix` to apply Go 1.26+ modernizers to fdbclient/ and internal/ packages

### DIFF
--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -410,7 +410,7 @@ func (client *cliAdminClient) SetMaintenanceZone(zone string, timeoutSeconds int
 			// The value is a literal text of a non-negative double which represents the remaining time for the zone to be in maintenance.
 			tr.Set(
 				fdb.Key(path.Join("\xff\xff/management/maintenance/", zone)),
-				[]byte(fmt.Sprintf("%d.0", timeoutSeconds)),
+				fmt.Appendf(nil, "%d.0", timeoutSeconds),
 			)
 			return nil
 		})
@@ -1071,7 +1071,7 @@ func (client *cliAdminClient) SetKnobs(knobs []string) {
 
 // WithValues will update the logger used by the current AdminClient to contain the provided key value pairs. The provided
 // arguments must be even.
-func (client *cliAdminClient) WithValues(keysAndValues ...interface{}) {
+func (client *cliAdminClient) WithValues(keysAndValues ...any) {
 	newLogger := client.log.WithValues(keysAndValues...)
 	client.log = newLogger
 

--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -337,7 +337,7 @@ func (fdbClient *realFdbLibClient) executeTransaction(
 		return nil, err
 	}
 
-	result, err := db.Transact(func(tr fdb.Transaction) (interface{}, error) {
+	result, err := db.Transact(func(tr fdb.Transaction) (any, error) {
 		err = setCommonOptions(&tr)
 		if err != nil {
 			return nil, err

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -186,9 +186,8 @@ func (client *realLockClient) GetPendingUpgrades(
 ) (map[fdbv1beta2.ProcessGroupID]bool, error) {
 	var upgrades map[fdbv1beta2.ProcessGroupID]bool
 	_, err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
-		keyPrefix := []byte(
-			fmt.Sprintf("%s/upgrades/%s/", client.cluster.GetLockPrefix(), version.String()),
-		)
+		keyPrefix :=
+			fmt.Appendf(nil, "%s/upgrades/%s/", client.cluster.GetLockPrefix(), version.String())
 		keyRange, err := fdb.PrefixRange(keyPrefix)
 		if err != nil {
 			return nil, err
@@ -209,7 +208,7 @@ func (client *realLockClient) GetPendingUpgrades(
 // upgrades.
 func (client *realLockClient) ClearPendingUpgrades() error {
 	_, err := client.fdbLibClient.executeTransaction(func(tr fdb.Transaction) (any, error) {
-		keyPrefix := []byte(fmt.Sprintf("%s/upgrades/", client.cluster.GetLockPrefix()))
+		keyPrefix := fmt.Appendf(nil, "%s/upgrades/", client.cluster.GetLockPrefix())
 		keyRange, err := fdb.PrefixRange(keyPrefix)
 		if err != nil {
 			return nil, err
@@ -270,7 +269,7 @@ func (client *realLockClient) UpdateDenyList(locks []fdbv1beta2.LockDenyListEntr
 
 // getDenyListKeyRange defines a key range containing the full deny list.
 func (client *realLockClient) getDenyListKeyRange() (fdb.KeyRange, error) {
-	return fdb.PrefixRange([]byte(fmt.Sprintf("%s/denyList/", client.cluster.GetLockPrefix())))
+	return fdb.PrefixRange(fmt.Appendf(nil, "%s/denyList/", client.cluster.GetLockPrefix()))
 }
 
 // getDenyListKeyRange defines a key range containing a potential deny list

--- a/internal/configmap_helper.go
+++ b/internal/configmap_helper.go
@@ -23,6 +23,7 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
@@ -124,9 +125,7 @@ func GetConfigMap(cluster *fdbv1beta2.FoundationDBCluster) (*corev1.ConfigMap, e
 	}
 
 	if cluster.Spec.ConfigMap != nil {
-		for k, v := range cluster.Spec.ConfigMap.Data {
-			data[k] = v
-		}
+		maps.Copy(data, cluster.Spec.ConfigMap.Data)
 	}
 
 	metadata := getConfigMapMetadata(cluster)

--- a/internal/coordinator/coordinator_test.go
+++ b/internal/coordinator/coordinator_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Change coordinators", func() {
 				It("should return always the same processes", func() {
 					initialCandidates := candidates
 
-					for i := 0; i < 100; i++ {
+					for range 100 {
 						newCandidates, err := selectCoordinatorsLocalities(
 							logr.Discard(),
 							cluster,
@@ -459,7 +459,7 @@ var _ = Describe("Change coordinators", func() {
 					It("should return always the same processes", func() {
 						initialCandidates := candidates
 
-						for i := 0; i < 100; i++ {
+						for range 100 {
 							newCandidates, err := selectCoordinatorsLocalities(
 								logr.Discard(),
 								cluster,
@@ -703,7 +703,7 @@ var _ = Describe("Change coordinators", func() {
 					It("should return always the same processes", func() {
 						initialCandidates := candidates
 
-						for i := 0; i < 100; i++ {
+						for range 100 {
 							newCandidates, err := selectCoordinatorsLocalities(
 								logr.Discard(),
 								cluster,
@@ -1124,7 +1124,7 @@ func generateProcessInfoForThreeDataHall(
 	res := map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{}
 	logCnt := 4
 
-	for i := 0; i < dataHallCount; i++ {
+	for range dataHallCount {
 		dataHallID := internal.GenerateRandomString(10)
 		generateProcessInfoDetails(
 			res,
@@ -1158,7 +1158,7 @@ func generateProcessInfoDetails(
 	pClass fdbv1beta2.ProcessClass,
 	version string,
 ) {
-	for idx := 0; idx < cnt; idx++ {
+	for idx := range cnt {
 		excluded := false
 		var zoneID string
 

--- a/internal/locality/locality.go
+++ b/internal/locality/locality.go
@@ -24,6 +24,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"slices"
 	"strings"
@@ -222,9 +223,7 @@ func ChooseDistributedProcesses(
 	currentLimits := make(map[string]int, len(fields))
 
 	if constraint.HardLimits != nil {
-		for field, limit := range constraint.HardLimits {
-			hardLimits[field] = limit
-		}
+		maps.Copy(hardLimits, constraint.HardLimits)
 	}
 
 	for _, field := range fields {

--- a/internal/locality/locality_test.go
+++ b/internal/locality/locality_test.go
@@ -130,7 +130,7 @@ func generateCandidates(dcIDs []string, processesPerDc int, numberOfZones int) [
 
 	idx := 0
 	for _, dcID := range dcIDs {
-		for i := 0; i < processesPerDc; i++ {
+		for i := range processesPerDc {
 			zoneIdx := i % numberOfZones
 			candidates[idx] = Info{
 				ID: dcID + strconv.Itoa(i),
@@ -301,7 +301,7 @@ var _ = Describe("Localities", func() {
 				})
 
 				for _, dcID := range dcIDs {
-					for i := 0; i < 3; i++ {
+					for i := range 3 {
 						pClass := fdbv1beta2.ProcessClassStorage
 						// The first locality will be a log process
 						if i == 0 {
@@ -859,7 +859,7 @@ var _ = Describe("Localities", func() {
 					candidates = make([]Info, 18)
 					idx := 0
 					for _, dcID := range []string{primaryID, primarySatelliteID, remoteID, remoteSatelliteID} {
-						for i := 0; i < 3; i++ {
+						for i := range 3 {
 							candidates[idx] = Info{
 								ID:    strconv.Itoa(idx),
 								Class: fdbv1beta2.ProcessClassLog,
@@ -879,7 +879,7 @@ var _ = Describe("Localities", func() {
 							continue
 						}
 
-						for i := 0; i < 3; i++ {
+						for i := range 3 {
 							candidates[idx] = Info{
 								ID:    strconv.Itoa(idx),
 								Class: fdbv1beta2.ProcessClassStorage,

--- a/internal/log_file_cleaner_test.go
+++ b/internal/log_file_cleaner_test.go
@@ -55,7 +55,7 @@ func (f dummyFileInfo) IsDir() bool {
 	return f.isDir
 }
 
-func (f dummyFileInfo) Sys() interface{} {
+func (f dummyFileInfo) Sys() any {
 	return nil
 }
 

--- a/internal/pod_helper.go
+++ b/internal/pod_helper.go
@@ -25,7 +25,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
+	"slices"
 	"strconv"
 
 	"k8s.io/utils/ptr"
@@ -107,7 +109,7 @@ func GetPodSpecHash(
 
 // GetJSONHash serializes an object to JSON and takes a hash of the resulting
 // JSON.
-func GetJSONHash(object interface{}) (string, error) {
+func GetJSONHash(object any) (string, error) {
 	hash := sha256.New()
 	encoder := json.NewEncoder(hash)
 	err := encoder.Encode(object)
@@ -126,9 +128,7 @@ func GetPodLabels(
 ) map[string]string {
 	labels := map[string]string{}
 
-	for key, value := range cluster.GetMatchLabels() {
-		labels[key] = value
-	}
+	maps.Copy(labels, cluster.GetMatchLabels())
 
 	if processClass != "" {
 		for _, label := range cluster.GetProcessClassLabels() {
@@ -153,9 +153,7 @@ func GetPodMatchLabels(
 ) map[string]string {
 	labels := map[string]string{}
 
-	for key, value := range cluster.GetMatchLabels() {
-		labels[key] = value
-	}
+	maps.Copy(labels, cluster.GetMatchLabels())
 
 	if processClass != "" {
 		labels[cluster.GetProcessClassLabel()] = string(processClass)
@@ -349,10 +347,8 @@ func GetIPFamily(pod *corev1.Pod) (int, error) {
 func PodHasSidecarTLS(pod *corev1.Pod) bool {
 	for _, container := range pod.Spec.Containers {
 		if container.Name == fdbv1beta2.SidecarContainerName {
-			for _, arg := range container.Args {
-				if arg == "--tls" {
-					return true
-				}
+			if slices.Contains(container.Args, "--tls") {
+				return true
 			}
 		}
 	}

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -1119,7 +1119,10 @@ func GetBackupDeployment(backup *fdbv1beta2.FoundationDBBackup) (*appsv1.Deploym
 
 	if backup.Spec.BackupDeploymentMetadata != nil {
 		maps.Copy(deployment.ObjectMeta.Labels, backup.Spec.BackupDeploymentMetadata.Labels)
-		maps.Copy(deployment.ObjectMeta.Annotations, backup.Spec.BackupDeploymentMetadata.Annotations)
+		maps.Copy(
+			deployment.ObjectMeta.Annotations,
+			backup.Spec.BackupDeploymentMetadata.Annotations,
+		)
 	}
 	deployment.ObjectMeta.Labels[fdbv1beta2.BackupDeploymentLabel] = string(backup.ObjectMeta.UID)
 

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -22,6 +22,7 @@ package internal
 
 import (
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -360,9 +361,7 @@ func setAffinityForFaultDomain(
 		}
 
 		labelSelectors := make(map[string]string, len(cluster.GetMatchLabels())+1)
-		for key, value := range cluster.GetMatchLabels() {
-			labelSelectors[key] = value
-		}
+		maps.Copy(labelSelectors, cluster.GetMatchLabels())
 
 		processClassLabel := cluster.GetProcessClassLabel()
 		labelSelectors[processClassLabel] = string(processClass)
@@ -1119,12 +1118,8 @@ func GetBackupDeployment(backup *fdbv1beta2.FoundationDBBackup) (*appsv1.Deploym
 	deployment.ObjectMeta.OwnerReferences = BuildOwnerReference(backup.TypeMeta, backup.ObjectMeta)
 
 	if backup.Spec.BackupDeploymentMetadata != nil {
-		for key, value := range backup.Spec.BackupDeploymentMetadata.Labels {
-			deployment.ObjectMeta.Labels[key] = value
-		}
-		for key, value := range backup.Spec.BackupDeploymentMetadata.Annotations {
-			deployment.ObjectMeta.Annotations[key] = value
-		}
+		maps.Copy(deployment.ObjectMeta.Labels, backup.Spec.BackupDeploymentMetadata.Labels)
+		maps.Copy(deployment.ObjectMeta.Annotations, backup.Spec.BackupDeploymentMetadata.Annotations)
 	}
 	deployment.ObjectMeta.Labels[fdbv1beta2.BackupDeploymentLabel] = string(backup.ObjectMeta.UID)
 
@@ -1413,13 +1408,9 @@ func GetObjectMetadata(
 		metadata.Labels = make(map[string]string)
 	}
 
-	for label, value := range GetPodLabels(cluster, processClass, string(id)) {
-		metadata.Labels[label] = value
-	}
+	maps.Copy(metadata.Labels, GetPodLabels(cluster, processClass, string(id)))
 
-	for label, value := range cluster.GetResourceLabels() {
-		metadata.Labels[label] = value
-	}
+	maps.Copy(metadata.Labels, cluster.GetResourceLabels())
 
 	return *metadata
 }

--- a/internal/replacements/replacements_test.go
+++ b/internal/replacements/replacements_test.go
@@ -1005,7 +1005,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 	When("using MaxConcurrentMisconfiguredReplacements", func() {
 		BeforeEach(func() {
 
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				_, id := cluster.GetProcessGroupID(fdbv1beta2.ProcessClassStorage, i)
 				processGroup := &fdbv1beta2.ProcessGroupStatus{
 					ProcessClass:   fdbv1beta2.ProcessClassStorage,
@@ -1026,7 +1026,7 @@ var _ = Describe("replace_misconfigured_pods", func() {
 				)
 			}
 
-			for i := 0; i < 1; i++ {
+			for i := range 1 {
 				_, id := cluster.GetProcessGroupID(fdbv1beta2.ProcessClassTransaction, i)
 				processGroup := &fdbv1beta2.ProcessGroupStatus{
 					ProcessClass:   fdbv1beta2.ProcessClassTransaction,

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -124,7 +124,7 @@ const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 // GenerateRandomString can be used to generate a random string with length n
 func GenerateRandomString(n int) string {
 	var res strings.Builder
-	for i := 0; i < n; i++ {
+	for range n {
 		res.WriteByte(letterBytes[rand.IntN(len(letterBytes))])
 	}
 


### PR DESCRIPTION
# Description

This is a follow up (but independent) PR to #2491 that applies Go 1.26+ fix modernizers to the codebase using `go fix`.

**What changed:**
- Ran `go fix` across the `fdbclient/` and `internal/` packages to apply Go 1.26+ modernizers

**Why:**
Go 1.26 introduced [fix modernizers](https://go.dev/doc/modules/fix) that automatically update code to use newer, more idiomatic Go patterns. These fixes improve code quality and maintainability.

Main changes here are:
- Use `fmt.Appendf` over `[]byte(fmt.Sprintf(...))`
- Replace the `interface{}` type with `any`
- Use `maps.Copy` over manual map copy loops
- Use `slices.Contains` over manual lookup loops
- Use `for range n` / `for i := range n` over index-based loops

## Type of change

- Other

Slight refactoring

## Testing

Eyeballed changes and it generally makes sense, this is a small change. All existing tests pass.
