### PR TITLE
Run `go fix` to apply Go 1.26+ modernizers to remaining packages

### DIFF
--- a/kubectl-fdb/cmd/deprecation.go
+++ b/kubectl-fdb/cmd/deprecation.go
@@ -190,7 +190,7 @@ func checkDeprecation(
 	return nil
 }
 
-func getDiff(objectA interface{}, objectB interface{}) (string, error) {
+func getDiff(objectA any, objectB any) (string, error) {
 	aYaml, err := getMinimalYAML(objectA)
 	if err != nil {
 		return "", err
@@ -204,12 +204,12 @@ func getDiff(objectA interface{}, objectB interface{}) (string, error) {
 	return cmp.Diff(aYaml, bYaml), nil
 }
 
-func getMinimalYAML(object interface{}) ([]byte, error) {
+func getMinimalYAML(object any) ([]byte, error) {
 	rawYAML, err := yaml.Marshal(object)
 	if err != nil {
 		return nil, err
 	}
-	genericObject := make(map[string]interface{})
+	genericObject := make(map[string]any)
 	err = yaml.Unmarshal(rawYAML, &genericObject)
 	if err != nil {
 		return nil, err
@@ -218,9 +218,9 @@ func getMinimalYAML(object interface{}) ([]byte, error) {
 	return yaml.Marshal(genericObject)
 }
 
-func removeEmptyFields(object map[string]interface{}) {
+func removeEmptyFields(object map[string]any) {
 	for field, value := range object {
-		mapValue, isMap := value.(map[string]interface{})
+		mapValue, isMap := value.(map[string]any)
 		if isMap {
 			removeEmptyFields(mapValue)
 			if len(mapValue) == 0 {

--- a/kubectl-fdb/cmd/exclusion_status.go
+++ b/kubectl-fdb/cmd/exclusion_status.go
@@ -136,7 +136,7 @@ kubectl fdb get exclusion-status c1 --interval=5m
 }
 
 // isTerminal checks if output is to a terminal (not piped)
-func isTerminal(out interface{}) bool {
+func isTerminal(out any) bool {
 	if f, ok := out.(*os.File); ok {
 		return term.IsTerminal(int(f.Fd()))
 	}
@@ -145,7 +145,7 @@ func isTerminal(out interface{}) bool {
 }
 
 // getTerminalWidth returns the width of the terminal, or a default if unavailable
-func getTerminalWidth(out interface{}) int {
+func getTerminalWidth(out any) int {
 	if f, ok := out.(*os.File); ok {
 		width, _, err := term.GetSize(int(f.Fd()))
 		if err != nil || width <= 0 {

--- a/kubectl-fdb/cmd/k8s_client.go
+++ b/kubectl-fdb/cmd/k8s_client.go
@@ -555,7 +555,7 @@ func chooseRandomPod(pods *corev1.PodList) (*corev1.Pod, error) {
 		return nil, fmt.Errorf("no pods available")
 	}
 
-	for tries := 0; tries < 10; tries++ {
+	for range 10 {
 		candidate := items[rand.IntN(len(items))]
 		if candidate.GetDeletionTimestamp().IsZero() {
 			return ptr.To(candidate), nil

--- a/kubectl-fdb/cmd/recover_multi_region_cluster.go
+++ b/kubectl-fdb/cmd/recover_multi_region_cluster.go
@@ -738,7 +738,7 @@ func checkIfClusterIsUnavailableAndMajorityOfCoordinatorsAreUnreachable(
 	}
 
 	log.Println("Getting the status from:", clientPod.Name)
-	for retry := 0; retry < 5; retry++ {
+	for range 5 {
 		err = getStatusAndCheckIfClusterShouldBeRecovered(ctx, kubeClient, config, clientPod)
 		if err == nil {
 			break

--- a/mock-kubernetes-client/client/client.go
+++ b/mock-kubernetes-client/client/client.go
@@ -258,13 +258,13 @@ func (client *MockClient) Delete(
 	return client.fakeClient.Delete(ctx, object, options...)
 }
 
-func getMapFromObject(object ctrlClient.Object) (map[string]interface{}, error) {
+func getMapFromObject(object ctrlClient.Object) (map[string]any, error) {
 	jsonData, err := json.Marshal(object)
 	if err != nil {
 		return nil, err
 	}
 
-	newMap := make(map[string]interface{})
+	newMap := make(map[string]any)
 	err = json.Unmarshal(jsonData, &newMap)
 	if err != nil {
 		return nil, err
@@ -467,7 +467,7 @@ func (client *MockClient) Eventf(
 	eventType string,
 	reason string,
 	messageFormat string,
-	args ...interface{},
+	args ...any,
 ) {
 	client.createEvent(buildEvent(object, eventType, reason, fmt.Sprintf(messageFormat, args...)))
 }
@@ -479,7 +479,7 @@ func (client *MockClient) PastEventf(
 	eventType string,
 	reason string,
 	messageFormat string,
-	args ...interface{},
+	args ...any,
 ) {
 	event := buildEvent(object, eventType, reason, fmt.Sprintf(messageFormat, args...))
 	event.EventTime = metav1.MicroTime(timestamp)
@@ -493,7 +493,7 @@ func (client *MockClient) AnnotatedEventf(
 	eventType string,
 	reason string,
 	messageFormat string,
-	args ...interface{},
+	args ...any,
 ) {
 	event := buildEvent(object, eventType, reason, fmt.Sprintf(messageFormat, args...))
 	event.ObjectMeta.Annotations = annotations

--- a/mock-kubernetes-client/client/client_test.go
+++ b/mock-kubernetes-client/client/client_test.go
@@ -558,7 +558,7 @@ var _ = Describe("[mock client]", func() {
 
 					expectedReplicas := ptr.Deref(replicaSet.Spec.Replicas, 1)
 
-					for i := int32(0); i < expectedReplicas; i++ {
+					for i := range expectedReplicas {
 						err := client.Create(ctx, &corev1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: replicaSet.Namespace,
@@ -616,7 +616,7 @@ var _ = Describe("[mock client]", func() {
 
 				expectedReplicas := ptr.Deref(replicaSet.Spec.Replicas, 1)
 
-				for i := int32(0); i < expectedReplicas; i++ {
+				for i := range expectedReplicas {
 					err := client.Create(ctx, &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: replicaSet.Namespace,

--- a/pkg/fdbadminclient/admin_client.go
+++ b/pkg/fdbadminclient/admin_client.go
@@ -117,7 +117,7 @@ type AdminClient interface {
 
 	// WithValues will update the logger used by the current AdminClient to contain the provided key value pairs. The provided
 	// arguments must be even.
-	WithValues(keysAndValues ...interface{})
+	WithValues(keysAndValues ...any)
 
 	// SetTimeout will overwrite the default timeout for interacting the FDB cluster.
 	SetTimeout(timeout time.Duration)

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -23,6 +23,7 @@ package mock
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"strings"
 	"sync"
@@ -277,9 +278,7 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 					fdbv1beta2.FDBLocalityDCIDKey:       client.Cluster.Spec.DataCenter,
 				}
 
-				for key, value := range client.localityInfo[processGroupID] {
-					locality[key] = value
-				}
+				maps.Copy(locality, client.localityInfo[processGroupID])
 
 				for _, container := range pod.Spec.Containers {
 					for _, envVar := range container.Env {
@@ -375,9 +374,7 @@ func (client *AdminClient) GetStatus() (*fdbv1beta2.FoundationDBStatus, error) {
 			fdbv1beta2.FDBLocalityZoneIDKey:     string(processGroup.ProcessGroupID),
 		}
 
-		for key, value := range client.localityInfo[processGroup.ProcessGroupID] {
-			locality[key] = value
-		}
+		maps.Copy(locality, client.localityInfo[processGroup.ProcessGroupID])
 
 		var uptimeSeconds float64 = 60000
 		underMaintenance := false
@@ -1237,7 +1234,7 @@ func (client *AdminClient) GetWorstDurabilityLag() (fdbv1beta2.FoundationDBStatu
 
 // WithValues will update the logger used by the current AdminClient to contain the provided key value pairs. The provided
 // arguments must be even.
-func (client *AdminClient) WithValues(_ ...interface{}) {}
+func (client *AdminClient) WithValues(_ ...any) {}
 
 // SetTimeout will overwrite the default timeout for interacting the FDB cluster.
 func (client *AdminClient) SetTimeout(_ time.Duration) {}
@@ -1248,9 +1245,7 @@ func (client *AdminClient) GetProcessesUnderMaintenance() (map[fdbv1beta2.Proces
 	// We have to create a copy here as the map will be a pointer.
 	res := make(map[fdbv1beta2.ProcessGroupID]int64, len(client.processesUnderMaintenance))
 
-	for processGroupID, timestamp := range client.processesUnderMaintenance {
-		res[processGroupID] = timestamp
-	}
+	maps.Copy(res, client.processesUnderMaintenance)
 
 	return res, nil
 }


### PR DESCRIPTION
# Description

This is a follow up (but independent) PR to #2491 that applies Go 1.26+ fix modernizers to the codebase using `go fix`.

**What changed:**
- Ran `go fix` across the `kubectl-fdb/`, `mock-kubernetes-client/` and `pkg/` packages to apply Go 1.26+ modernizers

**Why:**
Go 1.26 introduced [fix modernizers](https://go.dev/doc/modules/fix) that automatically update code to use newer, more idiomatic Go patterns. These fixes improve code quality and maintainability.

Main changes here are:
- Replace the `interface{}` type with `any` (mostly `map[string]interface{}` -> `map[string]any`)
- Use `maps.Copy` over manual map copy loops
- Use `for range n` / `for i := range n` over index-based loops

## Type of change

- Refactor

## Testing

Eyeballed changes and it generally makes sense, this is a small change. All existing tests pass.
