### PR TITLE
Enhance broken test that failed during release

### DIFF
--- a/controllers/update_status_test.go
+++ b/controllers/update_status_test.go
@@ -1810,7 +1810,7 @@ var _ = Describe("update_status", func() {
 			var unknownID fdbv1beta2.ProcessGroupID
 
 			BeforeEach(func() {
-				unknownID = "storage-99"
+				unknownID = "storage-999999"
 				pod := &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-%s", cluster.Name, unknownID),
@@ -1841,7 +1841,7 @@ var _ = Describe("update_status", func() {
 
 		When("a pod with an unknown process group ID is being deleted", func() {
 			BeforeEach(func() {
-				unknownID := fdbv1beta2.ProcessGroupID("storage-99")
+				unknownID := fdbv1beta2.ProcessGroupID("storage-999999")
 				pod := &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-%s", cluster.Name, unknownID),
@@ -1871,7 +1871,7 @@ var _ = Describe("update_status", func() {
 			var unknownID fdbv1beta2.ProcessGroupID
 
 			BeforeEach(func() {
-				unknownID = "storage-99"
+				unknownID = "storage-999999"
 				pvc := &corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-%s", cluster.Name, unknownID),
@@ -1902,7 +1902,7 @@ var _ = Describe("update_status", func() {
 
 		When("a PVC with an unknown process group ID is being deleted", func() {
 			BeforeEach(func() {
-				unknownID := fdbv1beta2.ProcessGroupID("storage-99")
+				unknownID := fdbv1beta2.ProcessGroupID("storage-999999")
 				pvc := &corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-%s", cluster.Name, unknownID),
@@ -1932,7 +1932,7 @@ var _ = Describe("update_status", func() {
 			var unknownID fdbv1beta2.ProcessGroupID
 
 			BeforeEach(func() {
-				unknownID = "storage-99"
+				unknownID = "storage-999999"
 				svc := &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-%s", cluster.Name, unknownID),
@@ -1984,7 +1984,7 @@ var _ = Describe("update_status", func() {
 
 		When("a service with an unknown process group ID is being deleted", func() {
 			BeforeEach(func() {
-				unknownID := fdbv1beta2.ProcessGroupID("storage-99")
+				unknownID := fdbv1beta2.ProcessGroupID("storage-999999")
 				svc := &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-%s", cluster.Name, unknownID),
@@ -2014,7 +2014,7 @@ var _ = Describe("update_status", func() {
 			var unknownID fdbv1beta2.ProcessGroupID
 
 			BeforeEach(func() {
-				unknownID = "storage-99"
+				unknownID = "storage-999999"
 				pod := &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-%s", cluster.Name, unknownID),


### PR DESCRIPTION
Fix flaky refreshProcessGroupStatus tests by using non-collidable ID. The hardcoded "storage-99" ID could collide with the cluster's randomly assigned process group IDs (range 1-99999), making the tests flaky in CI. Use "storage-999999" which is outside that range.

More context: During the release process for v2.29.0, the [Testing step failed in first attempt](https://github.com/FoundationDB/fdb-kubernetes-operator/actions/runs/27045360566/job/79830099831), it succeeded in 2nd attempt. 