### PR TITLE
Enforce Go 1.26+ `go fix` modernizers via `make fmt`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ endif
 
 all: deps generate fmt vet manager snapshot manifests samples documentation test_if_changed
 
-.PHONY: clean all manager samples documentation run install uninstall deploy manifests fmt vet generate container-build container-push container-push-if-remote rebuild-operator bounce lint check-license fix-license
+.PHONY: clean all manager samples documentation run install uninstall deploy manifests fmt vet generate container-build container-push container-push-if-remote rebuild-operator bounce lint check-license fix-license fix
 
 deps: $(BUILD_DEPS)
 
@@ -159,8 +159,12 @@ manifests: ${MANIFESTS}
 ${MANIFESTS}: ${CONTROLLER_GEN} ${GO_SRC}
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./api/..." paths="./controllers/..." applyconfiguration output:crd:artifacts:config=config/crd/bases
 
+# Run the Go fix modernizers against the code.
+fix:
+	go list ./... | grep -v '/e2e/chaos-mesh/' | xargs go fix
+
 # Run go fmt against code
-fmt: deps bin/fmt_check
+fmt: deps fix bin/fmt_check
 
 bin/fmt_check: ${GO_ALL}
 	# We make use of gofmt with golines because of: https://github.com/segmentio/golines/issues/155

--- a/cmd/check-license/main.go
+++ b/cmd/check-license/main.go
@@ -211,9 +211,9 @@ func fixFile(path, filename, bpRaw string) error {
 	// Strip existing leading block comment if present.
 	rest := s
 	if strings.HasPrefix(s, "/*") {
-		end := strings.Index(s, "*/")
-		if end >= 0 {
-			rest = strings.TrimLeft(s[end+2:], "\n")
+		_, after, ok := strings.Cut(s, "*/")
+		if ok {
+			rest = strings.TrimLeft(after, "\n")
 		}
 	}
 


### PR DESCRIPTION
# Description

Follow up to the `go fix` modernizer PRs (#2491, #2493, #2494, #2495). Adds a `fix` make target and runs it from `make fmt`, so the `build` job's existing `make clean all && git diff --exit-code` enforces modernizers going forward, with no new CI step.

- `e2e/chaos-mesh/api` is excluded since it is a vendored copy of upstream chaos-mesh. `go fix` only rewrites the packages it is passed, so filtering the package list is enough.
- Also applies the one outstanding modernizer (`strings.Cut` in `cmd/check-license/main.go`).
- Note: the check runs a fresh `go fix`, so code landing around this PR may need `make fix` re-run and committed at merge time.

## Type of change

- Other

## Testing

`go fix` produces no diff on the current tree, and `e2e/chaos-mesh` and generated files are left untouched. Relying on CI for the full `make fmt` / lint / test run.
