### PR TITLE
Add context.Context to all e2e test specs and remove the context.Background and context.TODO

### DIFF
--- a/e2e/fixtures/blobstore.go
+++ b/e2e/fixtures/blobstore.go
@@ -175,7 +175,7 @@ type blobstoreConfig struct {
 }
 
 // CreateBlobstoreIfAbsent creates the blobstore Deployment based on the template.
-func (factory *Factory) CreateBlobstoreIfAbsent(namespace string) {
+func (factory *Factory) CreateBlobstoreIfAbsent(ctx context.Context, namespace string) {
 	seaweedFSDeploymentTemplate, err := template.New("seaweedFSDeployment").
 		Parse(seaweedFSDeployment)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -204,24 +204,24 @@ func (factory *Factory) CreateBlobstoreIfAbsent(namespace string) {
 		unstructuredObj := &unstructured.Unstructured{Object: unstructuredMap}
 
 		gomega.Expect(
-			factory.CreateIfAbsent(unstructuredObj),
+			factory.CreateIfAbsent(ctx, unstructuredObj),
 		).NotTo(gomega.HaveOccurred())
 	}
 
 	// Make sure the blobstore Pods are running before moving forward.
-	factory.waitUntilBlobstorePodsRunning(namespace)
+	factory.waitUntilBlobstorePodsRunning(ctx, namespace)
 }
 
 // waitUntilBlobstorePodsRunning waits until the blobstore Pods are running.
-func (factory *Factory) waitUntilBlobstorePodsRunning(namespace string) {
+func (factory *Factory) waitUntilBlobstorePodsRunning(ctx context.Context, namespace string) {
 	deployment := &appsv1.Deployment{}
 	gomega.Expect(
 		factory.GetControllerRuntimeClient().
-			Get(context.Background(), client.ObjectKey{Name: seaweedFSName, Namespace: namespace}, deployment),
+			Get(ctx, client.ObjectKey{Name: seaweedFSName, Namespace: namespace}, deployment),
 	).NotTo(gomega.HaveOccurred())
 
 	factory.AddShutdownHook(func() error {
-		err := factory.GetControllerRuntimeClient().Delete(context.Background(), deployment)
+		err := factory.GetControllerRuntimeClient().Delete(ctx, deployment)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				return nil
@@ -235,7 +235,7 @@ func (factory *Factory) waitUntilBlobstorePodsRunning(namespace string) {
 
 	expectedReplicas := int(ptr.Deref(deployment.Spec.Replicas, 1))
 	gomega.Eventually(func(g gomega.Gomega) int {
-		pods := factory.getBlobstorePods(namespace)
+		pods := factory.getBlobstorePods(ctx, namespace)
 		var runningReplicas int
 		for _, pod := range pods.Items {
 			if pod.Status.Phase == corev1.PodRunning && pod.DeletionTimestamp.IsZero() {
@@ -251,7 +251,7 @@ func (factory *Factory) waitUntilBlobstorePodsRunning(namespace string) {
 					"not running after 120 seconds, going to delete this Pod, status:",
 					pod.Status,
 				)
-				err := factory.GetControllerRuntimeClient().Delete(context.Background(), &pod)
+				err := factory.GetControllerRuntimeClient().Delete(ctx, &pod)
 				if k8serrors.IsNotFound(err) {
 					continue
 				}
@@ -265,11 +265,11 @@ func (factory *Factory) waitUntilBlobstorePodsRunning(namespace string) {
 }
 
 // getBlobstorePods returns the blobstore Pods in the provided namespace.
-func (factory *Factory) getBlobstorePods(namespace string) *corev1.PodList {
+func (factory *Factory) getBlobstorePods(ctx context.Context, namespace string) *corev1.PodList {
 	pods := &corev1.PodList{}
 	gomega.Eventually(func() error {
 		return factory.GetControllerRuntimeClient().
-			List(context.Background(), pods, client.InNamespace(namespace), client.MatchingLabels(map[string]string{"app": seaweedFSName}))
+			List(ctx, pods, client.InNamespace(namespace), client.MatchingLabels(map[string]string{"app": seaweedFSName}))
 	}).WithTimeout(1 * time.Minute).WithPolling(1 * time.Second).ShouldNot(gomega.HaveOccurred())
 
 	return pods

--- a/e2e/fixtures/blobstore.go
+++ b/e2e/fixtures/blobstore.go
@@ -221,7 +221,7 @@ func (factory *Factory) waitUntilBlobstorePodsRunning(ctx context.Context, names
 	).NotTo(gomega.HaveOccurred())
 
 	factory.AddShutdownHook(func() error {
-		err := factory.GetControllerRuntimeClient().Delete(ctx, deployment)
+		err := factory.GetControllerRuntimeClient().Delete(context.Background(), deployment)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				return nil

--- a/e2e/fixtures/chaos_common.go
+++ b/e2e/fixtures/chaos_common.go
@@ -52,7 +52,7 @@ const ChaosDurationForever = "998h"
 
 // CleanupChaosMeshExperiments deletes any chaos experiments created by this handle.  Invoked at shutdown.  Tests
 // that need to delete experiments should invoke Delete on their ChaosMeshExperiment objects.
-func (factory *Factory) CleanupChaosMeshExperiments() error {
+func (factory *Factory) CleanupChaosMeshExperiments(ctx context.Context) error {
 	if len(factory.chaosExperiments) == 0 {
 		return nil
 	}
@@ -68,7 +68,7 @@ func (factory *Factory) CleanupChaosMeshExperiments() error {
 	for _, resource := range factory.chaosExperiments {
 		targetResource := resource // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
-			err := factory.deleteChaosMeshExperiment(&targetResource)
+			err := factory.deleteChaosMeshExperiment(ctx, &targetResource)
 			if err != nil {
 				log.Printf(
 					"error in cleaning up chaos experiement %s/%s: %s",
@@ -89,17 +89,28 @@ func (factory *Factory) CleanupChaosMeshExperiments() error {
 }
 
 // DeleteChaosMeshExperiment will delete a running Chaos Mesh experiment.
-func (factory *Factory) DeleteChaosMeshExperiment(experiment *ChaosMeshExperiment) {
-	gomega.Expect(factory.deleteChaosMeshExperiment(experiment)).ToNot(gomega.HaveOccurred())
+func (factory *Factory) DeleteChaosMeshExperiment(
+	ctx context.Context,
+	experiment *ChaosMeshExperiment,
+) {
+	gomega.Expect(factory.deleteChaosMeshExperiment(ctx, experiment)).ToNot(gomega.HaveOccurred())
 }
 
-func (factory *Factory) deleteChaosMeshExperiment(experiment *ChaosMeshExperiment) error {
+func (factory *Factory) deleteChaosMeshExperiment(
+	ctx context.Context,
+	experiment *ChaosMeshExperiment,
+) error {
 	if experiment == nil {
 		return nil
 	}
 
 	log.Println("Start deleting", experiment.name)
-	err := factory.getChaosExperiment(experiment.name, experiment.namespace, experiment.chaosObject)
+	err := factory.getChaosExperiment(
+		ctx,
+		experiment.name,
+		experiment.namespace,
+		experiment.chaosObject,
+	)
 	if err != nil {
 		// The experiment is already deleted.
 		if k8serrors.IsNotFound(err) {
@@ -119,24 +130,25 @@ func (factory *Factory) deleteChaosMeshExperiment(experiment *ChaosMeshExperimen
 	) // verbose compared to "true", but fixes annoying linter warning
 	experiment.chaosObject.SetAnnotations(annotations)
 
-	err = factory.GetControllerRuntimeClient().Update(context.Background(), experiment.chaosObject)
+	err = factory.GetControllerRuntimeClient().Update(ctx, experiment.chaosObject)
 	if err != nil {
 		log.Println("Could not update the annotation to set the experiment into pause state", err)
 	}
 
-	err = factory.GetControllerRuntimeClient().Delete(context.Background(), experiment.chaosObject)
+	err = factory.GetControllerRuntimeClient().Delete(ctx, experiment.chaosObject)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	}
 
 	log.Println("Chaos", experiment.name, "is deleted.")
 	err = wait.PollUntilContextTimeout(
-		context.Background(),
+		ctx,
 		1*time.Second,
 		5*time.Minute,
 		true,
 		func(_ context.Context) (done bool, err error) {
 			err = factory.getChaosExperiment(
+				ctx,
 				experiment.name,
 				experiment.namespace,
 				experiment.chaosObject,
@@ -158,20 +170,24 @@ func (factory *Factory) deleteChaosMeshExperiment(experiment *ChaosMeshExperimen
 
 // getChaosExperiment gets the chaos experiments in the cluster with specified name.
 func (factory *Factory) getChaosExperiment(
+	ctx context.Context,
 	name string,
 	namespace string,
 	chaosOut client.Object,
 ) error {
-	return factory.GetControllerRuntimeClient().Get(context.Background(), client.ObjectKey{
+	return factory.GetControllerRuntimeClient().Get(ctx, client.ObjectKey{
 		Name:      name,
 		Namespace: namespace,
 	}, chaosOut)
 }
 
 // CreateExperiment creates a chaos experiment in the cluster with specified type, name and chaos object.
-func (factory *Factory) CreateExperiment(chaos client.Object) *ChaosMeshExperiment {
+func (factory *Factory) CreateExperiment(
+	ctx context.Context,
+	chaos client.Object,
+) *ChaosMeshExperiment {
 	log.Printf("CreateExperiment name=%s, spec=%s", chaos.GetName(), ToJSON(chaos))
-	gomega.Expect(factory.CreateIfAbsent(chaos)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(factory.CreateIfAbsent(ctx, chaos)).NotTo(gomega.HaveOccurred())
 
 	experiment := ChaosMeshExperiment{
 		chaosObject: chaos,
@@ -180,23 +196,24 @@ func (factory *Factory) CreateExperiment(chaos client.Object) *ChaosMeshExperime
 	}
 	factory.addChaosExperiment(experiment)
 
-	gomega.Expect(factory.waitUntilExperimentRunning(experiment, chaos)).
+	gomega.Expect(factory.waitUntilExperimentRunning(ctx, experiment, chaos)).
 		NotTo(gomega.HaveOccurred())
 
 	return &experiment
 }
 
 func (factory *Factory) waitUntilExperimentRunning(
+	ctx context.Context,
 	experiment ChaosMeshExperiment,
 	out client.Object,
 ) error {
 	err := wait.PollUntilContextTimeout(
-		context.Background(),
+		ctx,
 		1*time.Second,
 		20*time.Minute,
 		true,
 		func(_ context.Context) (bool, error) {
-			err := factory.getChaosExperiment(experiment.name, experiment.namespace, out)
+			err := factory.getChaosExperiment(ctx, experiment.name, experiment.namespace, out)
 			if err != nil {
 				log.Println("error fetching chaos experiment", err)
 				return false, nil

--- a/e2e/fixtures/chaos_disk.go
+++ b/e2e/fixtures/chaos_disk.go
@@ -21,6 +21,8 @@
 package fixtures
 
 import (
+	"context"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	chaosmesh "github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/chaos-mesh/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,8 +30,12 @@ import (
 )
 
 // InjectDiskFailure injects a disk failure for all Pods selected by the selector.
-func (factory *Factory) InjectDiskFailure(selector chaosmesh.PodSelectorSpec) *ChaosMeshExperiment {
+func (factory *Factory) InjectDiskFailure(
+	ctx context.Context,
+	selector chaosmesh.PodSelectorSpec,
+) *ChaosMeshExperiment {
 	return factory.InjectDiskFailureWithPath(
+		ctx,
 		selector,
 		"/var/fdb/data",
 		"/var/fdb/data/**/*",
@@ -46,10 +52,12 @@ func (factory *Factory) InjectDiskFailure(selector chaosmesh.PodSelectorSpec) *C
 
 // InjectDiskFailureWithDuration injects a disk failure for all Pods selected by the selector for the specified duration.
 func (factory *Factory) InjectDiskFailureWithDuration(
+	ctx context.Context,
 	selector chaosmesh.PodSelectorSpec,
 	duration string,
 ) *ChaosMeshExperiment {
 	return factory.InjectDiskFailureWithPathAndDuration(
+		ctx,
 		selector,
 		"/var/fdb/data",
 		"/var/fdb/data/**/*",
@@ -68,6 +76,7 @@ func (factory *Factory) InjectDiskFailureWithDuration(
 // InjectDiskFailureWithPath injects a disk failure for all Pods selected by the selector. volumePath and path can be used to specify the affected files and methods
 // allow to specify the affected methods.
 func (factory *Factory) InjectDiskFailureWithPath(
+	ctx context.Context,
 	selector chaosmesh.PodSelectorSpec,
 	volumePath string,
 	path string,
@@ -75,6 +84,7 @@ func (factory *Factory) InjectDiskFailureWithPath(
 	containers []string,
 ) *ChaosMeshExperiment {
 	return factory.InjectDiskFailureWithPathAndDuration(
+		ctx,
 		selector,
 		volumePath,
 		path,
@@ -87,6 +97,7 @@ func (factory *Factory) InjectDiskFailureWithPath(
 // InjectDiskFailureWithPathAndDuration injects a disk failure for all Pods selected by the selector. volumePath and path can be used to specify the affected files and methods
 // allow to specify the affected methods. duration will define how long the chaos is injected.
 func (factory *Factory) InjectDiskFailureWithPathAndDuration(
+	ctx context.Context,
 	selector chaosmesh.PodSelectorSpec,
 	volumePath string,
 	path string,
@@ -94,62 +105,65 @@ func (factory *Factory) InjectDiskFailureWithPathAndDuration(
 	containers []string,
 	duration string,
 ) *ChaosMeshExperiment {
-	return factory.CreateExperiment(&chaosmesh.IOChaos{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      factory.RandStringRunes(32),
-			Namespace: factory.GetChaosNamespace(),
-			Labels:    factory.GetDefaultLabels(),
-		},
-		Spec: chaosmesh.IOChaosSpec{
-			Action:   chaosmesh.IoFaults,
-			Duration: ptr.To(duration),
-			ContainerSelector: chaosmesh.ContainerSelector{
-				ContainerNames: containers,
-				PodSelector: chaosmesh.PodSelector{
-					Selector: selector,
-					Mode:     chaosmesh.AllMode,
-				},
+	return factory.CreateExperiment(ctx,
+		&chaosmesh.IOChaos{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      factory.RandStringRunes(32),
+				Namespace: factory.GetChaosNamespace(),
+				Labels:    factory.GetDefaultLabels(),
 			},
-			VolumePath: volumePath,
-			Path:       path,
-			Errno:      5,
-			Percent:    100,
-			Methods:    methods,
-		},
-	})
+			Spec: chaosmesh.IOChaosSpec{
+				Action:   chaosmesh.IoFaults,
+				Duration: ptr.To(duration),
+				ContainerSelector: chaosmesh.ContainerSelector{
+					ContainerNames: containers,
+					PodSelector: chaosmesh.PodSelector{
+						Selector: selector,
+						Mode:     chaosmesh.AllMode,
+					},
+				},
+				VolumePath: volumePath,
+				Path:       path,
+				Errno:      5,
+				Percent:    100,
+				Methods:    methods,
+			},
+		})
 }
 
 // InjectIOLatency injects IOLatency for single pod.
 func (factory *Factory) InjectIOLatency(
+	ctx context.Context,
 	selector chaosmesh.PodSelectorSpec,
 	delay string,
 ) *ChaosMeshExperiment {
-	return factory.CreateExperiment(&chaosmesh.IOChaos{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      factory.RandStringRunes(32),
-			Namespace: factory.GetChaosNamespace(),
-			Labels:    factory.GetDefaultLabels(),
-		},
-		Spec: chaosmesh.IOChaosSpec{
-			Action:   chaosmesh.IoLatency,
-			Duration: ptr.To(ChaosDurationForever),
-			ContainerSelector: chaosmesh.ContainerSelector{
-				PodSelector: chaosmesh.PodSelector{
-					Selector: selector,
-					Mode:     chaosmesh.AllMode,
+	return factory.CreateExperiment(ctx,
+		&chaosmesh.IOChaos{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      factory.RandStringRunes(32),
+				Namespace: factory.GetChaosNamespace(),
+				Labels:    factory.GetDefaultLabels(),
+			},
+			Spec: chaosmesh.IOChaosSpec{
+				Action:   chaosmesh.IoLatency,
+				Duration: ptr.To(ChaosDurationForever),
+				ContainerSelector: chaosmesh.ContainerSelector{
+					PodSelector: chaosmesh.PodSelector{
+						Selector: selector,
+						Mode:     chaosmesh.AllMode,
+					},
+				},
+				VolumePath: "/var/fdb/data",
+				Path:       "/var/fdb/data/**/*",
+				Percent:    100,
+				Delay:      delay,
+				Methods: []chaosmesh.IoMethod{
+					chaosmesh.Write,
+					chaosmesh.Read,
+					chaosmesh.Open,
+					chaosmesh.Flush,
+					chaosmesh.Fsync,
 				},
 			},
-			VolumePath: "/var/fdb/data",
-			Path:       "/var/fdb/data/**/*",
-			Percent:    100,
-			Delay:      delay,
-			Methods: []chaosmesh.IoMethod{
-				chaosmesh.Write,
-				chaosmesh.Read,
-				chaosmesh.Open,
-				chaosmesh.Flush,
-				chaosmesh.Fsync,
-			},
-		},
-	})
+		})
 }

--- a/e2e/fixtures/chaos_http.go
+++ b/e2e/fixtures/chaos_http.go
@@ -21,6 +21,8 @@
 package fixtures
 
 import (
+	"context"
+
 	chaosmesh "github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/chaos-mesh/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -29,37 +31,39 @@ import (
 // InjectHTTPClientChaosWrongResultFdbMonitorConf  this method can be used to simulate a bad response from the operator to the sidecar. Currently this method returns as body the value "wrong"
 // when the operator does a request against the check_hash/fdbmonitor.conf endpoint, e.g. during upgrades.
 func (factory *Factory) InjectHTTPClientChaosWrongResultFdbMonitorConf(
+	ctx context.Context,
 	selector chaosmesh.PodSelectorSpec,
 	namespace string,
 ) *ChaosMeshExperiment {
-	return factory.CreateExperiment(&chaosmesh.HTTPChaos{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      factory.RandStringRunes(32),
-			Namespace: factory.GetChaosNamespace(),
-			Labels:    factory.GetDefaultLabels(),
-		},
-		Spec: chaosmesh.HTTPChaosSpec{
-			Target:   chaosmesh.PodHttpResponse,
-			Duration: ptr.To(ChaosDurationForever),
-			PodSelector: chaosmesh.PodSelector{
-				Selector: selector,
-				Mode:     chaosmesh.AllMode,
+	return factory.CreateExperiment(ctx,
+		&chaosmesh.HTTPChaos{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      factory.RandStringRunes(32),
+				Namespace: factory.GetChaosNamespace(),
+				Labels:    factory.GetDefaultLabels(),
 			},
-			Port:   8080,
-			Method: ptr.To("GET"),
-			Path:   ptr.To("check_hash/fdbmonitor.conf"),
-			PodHttpChaosActions: chaosmesh.PodHttpChaosActions{
-				Replace: &chaosmesh.PodHttpChaosReplaceActions{
-					Body: []byte("wrong"),
+			Spec: chaosmesh.HTTPChaosSpec{
+				Target:   chaosmesh.PodHttpResponse,
+				Duration: ptr.To(ChaosDurationForever),
+				PodSelector: chaosmesh.PodSelector{
+					Selector: selector,
+					Mode:     chaosmesh.AllMode,
+				},
+				Port:   8080,
+				Method: ptr.To("GET"),
+				Path:   ptr.To("check_hash/fdbmonitor.conf"),
+				PodHttpChaosActions: chaosmesh.PodHttpChaosActions{
+					Replace: &chaosmesh.PodHttpChaosReplaceActions{
+						Body: []byte("wrong"),
+					},
+				},
+				TLS: &chaosmesh.PodHttpChaosTLS{
+					SecretName:      factory.GetSecretName(),
+					SecretNamespace: namespace,
+					CertName:        "tls.crt",
+					KeyName:         "tls.key",
+					CAName:          ptr.To("ca.pem"),
 				},
 			},
-			TLS: &chaosmesh.PodHttpChaosTLS{
-				SecretName:      factory.GetSecretName(),
-				SecretNamespace: namespace,
-				CertName:        "tls.crt",
-				KeyName:         "tls.key",
-				CAName:          ptr.To("ca.pem"),
-			},
-		},
-	})
+		})
 }

--- a/e2e/fixtures/chaos_network.go
+++ b/e2e/fixtures/chaos_network.go
@@ -21,6 +21,7 @@
 package fixtures
 
 import (
+	"context"
 	"strconv"
 
 	"k8s.io/utils/ptr"
@@ -45,6 +46,7 @@ func ensurePodPhaseSelectorIsSet(selector *chaosmesh.PodSelectorSpec) {
 
 // InjectNetworkLoss injects network loss between the source and the target.
 func (factory *Factory) InjectNetworkLoss(
+	ctx context.Context,
 	lossPercentage string,
 	source chaosmesh.PodSelectorSpec,
 	target chaosmesh.PodSelectorSpec,
@@ -53,49 +55,54 @@ func (factory *Factory) InjectNetworkLoss(
 	ensurePodPhaseSelectorIsSet(&source)
 	ensurePodPhaseSelectorIsSet(&target)
 
-	return factory.CreateExperiment(&chaosmesh.NetworkChaos{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      factory.RandStringRunes(32),
-			Namespace: factory.GetChaosNamespace(),
-			Labels:    factory.GetDefaultLabels(),
-		},
-		Spec: chaosmesh.NetworkChaosSpec{
-			Action:   chaosmesh.LossAction,
-			Duration: ptr.To(ChaosDurationForever),
-			PodSelector: chaosmesh.PodSelector{
-				Selector: source,
-				Mode:     chaosmesh.AllMode,
+	return factory.CreateExperiment(ctx,
+		&chaosmesh.NetworkChaos{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      factory.RandStringRunes(32),
+				Namespace: factory.GetChaosNamespace(),
+				Labels:    factory.GetDefaultLabels(),
 			},
-			Target: &chaosmesh.PodSelector{
-				Mode:     chaosmesh.AllMode,
-				Selector: target,
-			},
-			Direction: direction,
-			TcParameter: chaosmesh.TcParameter{
-				Loss: &chaosmesh.LossSpec{
-					Loss:        lossPercentage,
-					Correlation: lossPercentage,
+			Spec: chaosmesh.NetworkChaosSpec{
+				Action:   chaosmesh.LossAction,
+				Duration: ptr.To(ChaosDurationForever),
+				PodSelector: chaosmesh.PodSelector{
+					Selector: source,
+					Mode:     chaosmesh.AllMode,
+				},
+				Target: &chaosmesh.PodSelector{
+					Mode:     chaosmesh.AllMode,
+					Selector: target,
+				},
+				Direction: direction,
+				TcParameter: chaosmesh.TcParameter{
+					Loss: &chaosmesh.LossSpec{
+						Loss:        lossPercentage,
+						Correlation: lossPercentage,
+					},
 				},
 			},
-		},
-	})
+		})
 }
 
 // InjectNetworkLossBetweenPods Injects network loss b/w each combination of podGroups.
 func (factory *Factory) InjectNetworkLossBetweenPods(
+	ctx context.Context,
 	pods []chaosmesh.PodSelectorSpec,
 	loss string,
 ) {
 	count := len(pods)
 	for i := range count {
 		for j := i + 1; j < count; j++ {
-			factory.InjectNetworkLoss(loss, pods[i], pods[j], chaosmesh.Both)
+			factory.InjectNetworkLoss(ctx, loss, pods[i], pods[j], chaosmesh.Both)
 		}
 	}
 }
 
 // InjectPartition injects a partition to the provided selector.
-func (factory *Factory) InjectPartition(selector chaosmesh.PodSelectorSpec) *ChaosMeshExperiment {
+func (factory *Factory) InjectPartition(
+	ctx context.Context,
+	selector chaosmesh.PodSelectorSpec,
+) *ChaosMeshExperiment {
 	namespaces := make([]string, 0, len(selector.Pods))
 	for namespace := range selector.Pods {
 		namespaces = append(namespaces, namespace)
@@ -108,38 +115,42 @@ func (factory *Factory) InjectPartition(selector chaosmesh.PodSelectorSpec) *Cha
 		},
 	}
 
-	return factory.InjectPartitionBetween(selector, target)
+	return factory.InjectPartitionBetween(ctx, selector, target)
 }
 
 // InjectPartitionWithExternalTargets injects a partition to the provided selector with the external targets
 func (factory *Factory) InjectPartitionWithExternalTargets(
+	ctx context.Context,
 	selector chaosmesh.PodSelectorSpec,
 	externalTargets []string,
 ) *ChaosMeshExperiment {
-	return factory.injectPartitionBetween(selector, nil, chaosmesh.Both, externalTargets)
+	return factory.injectPartitionBetween(ctx, selector, nil, chaosmesh.Both, externalTargets)
 }
 
 // InjectPartitionBetween injects a partition between the source and the target.
 func (factory *Factory) InjectPartitionBetween(
+	ctx context.Context,
 	source chaosmesh.PodSelectorSpec,
 	target chaosmesh.PodSelectorSpec,
 ) *ChaosMeshExperiment {
-	return factory.InjectPartitionBetweenWithDirection(source, target, chaosmesh.Both)
+	return factory.InjectPartitionBetweenWithDirection(ctx, source, target, chaosmesh.Both)
 }
 
 // InjectPartitionBetweenWithDirection injects a partition between the source and the target for the specified direction.
 func (factory *Factory) InjectPartitionBetweenWithDirection(
+	ctx context.Context,
 	source chaosmesh.PodSelectorSpec,
 	target chaosmesh.PodSelectorSpec,
 	direction chaosmesh.Direction,
 ) *ChaosMeshExperiment {
-	return factory.injectPartitionBetween(source, &chaosmesh.PodSelector{
+	return factory.injectPartitionBetween(ctx, source, &chaosmesh.PodSelector{
 		Mode:     chaosmesh.AllMode,
 		Selector: target,
 	}, direction, nil)
 }
 
 func (factory *Factory) injectPartitionBetween(
+	ctx context.Context,
 	source chaosmesh.PodSelectorSpec,
 	target *chaosmesh.PodSelector,
 	direction chaosmesh.Direction,
@@ -150,34 +161,36 @@ func (factory *Factory) injectPartitionBetween(
 		ensurePodPhaseSelectorIsSet(&target.Selector)
 	}
 
-	return factory.CreateExperiment(&chaosmesh.NetworkChaos{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      factory.RandStringRunes(32),
-			Namespace: factory.GetChaosNamespace(),
-			Labels:    factory.GetDefaultLabels(),
-		},
-		Spec: chaosmesh.NetworkChaosSpec{
-			Action:   chaosmesh.PartitionAction,
-			Duration: ptr.To(ChaosDurationForever),
-			PodSelector: chaosmesh.PodSelector{
-				Selector: source,
-				Mode:     chaosmesh.AllMode,
+	return factory.CreateExperiment(ctx,
+		&chaosmesh.NetworkChaos{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      factory.RandStringRunes(32),
+				Namespace: factory.GetChaosNamespace(),
+				Labels:    factory.GetDefaultLabels(),
 			},
-			Target:          target,
-			Direction:       direction,
-			ExternalTargets: externalTargets,
-		},
-	})
+			Spec: chaosmesh.NetworkChaosSpec{
+				Action:   chaosmesh.PartitionAction,
+				Duration: ptr.To(ChaosDurationForever),
+				PodSelector: chaosmesh.PodSelector{
+					Selector: source,
+					Mode:     chaosmesh.AllMode,
+				},
+				Target:          target,
+				Direction:       direction,
+				ExternalTargets: externalTargets,
+			},
+		})
 }
 
 // InjectPartitionOnSomeTargetPods injects a partition on some Pods instead of all Pods.
 // It picks a specific number of pods randomly. If the specified "fixedNumber" is greater than the number of all targets, all targets will be chosen.
 func (factory *Factory) InjectPartitionOnSomeTargetPods(
+	ctx context.Context,
 	source chaosmesh.PodSelectorSpec,
 	target chaosmesh.PodSelectorSpec,
 	fixedNumber int,
 ) *ChaosMeshExperiment {
-	return factory.injectPartitionBetween(source, &chaosmesh.PodSelector{
+	return factory.injectPartitionBetween(ctx, source, &chaosmesh.PodSelector{
 		Mode:     chaosmesh.FixedMode,
 		Value:    strconv.Itoa(fixedNumber),
 		Selector: target,
@@ -186,6 +199,7 @@ func (factory *Factory) InjectPartitionOnSomeTargetPods(
 
 // InjectNetworkLatency injects network latency between the source and the target.
 func (factory *Factory) InjectNetworkLatency(
+	ctx context.Context,
 	source chaosmesh.PodSelectorSpec,
 	target chaosmesh.PodSelectorSpec,
 	direction chaosmesh.Direction,
@@ -194,27 +208,28 @@ func (factory *Factory) InjectNetworkLatency(
 	ensurePodPhaseSelectorIsSet(&source)
 	ensurePodPhaseSelectorIsSet(&target)
 
-	return factory.CreateExperiment(&chaosmesh.NetworkChaos{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      factory.RandStringRunes(32),
-			Namespace: factory.GetChaosNamespace(),
-			Labels:    factory.GetDefaultLabels(),
-		},
-		Spec: chaosmesh.NetworkChaosSpec{
-			Action:   chaosmesh.DelayAction,
-			Duration: ptr.To(ChaosDurationForever),
-			PodSelector: chaosmesh.PodSelector{
-				Selector: source,
-				Mode:     chaosmesh.AllMode,
+	return factory.CreateExperiment(ctx,
+		&chaosmesh.NetworkChaos{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      factory.RandStringRunes(32),
+				Namespace: factory.GetChaosNamespace(),
+				Labels:    factory.GetDefaultLabels(),
 			},
-			Target: &chaosmesh.PodSelector{
-				Mode:     chaosmesh.AllMode,
-				Selector: target,
+			Spec: chaosmesh.NetworkChaosSpec{
+				Action:   chaosmesh.DelayAction,
+				Duration: ptr.To(ChaosDurationForever),
+				PodSelector: chaosmesh.PodSelector{
+					Selector: source,
+					Mode:     chaosmesh.AllMode,
+				},
+				Target: &chaosmesh.PodSelector{
+					Mode:     chaosmesh.AllMode,
+					Selector: target,
+				},
+				Direction: direction,
+				TcParameter: chaosmesh.TcParameter{
+					Delay: delay,
+				},
 			},
-			Direction: direction,
-			TcParameter: chaosmesh.TcParameter{
-				Delay: delay,
-			},
-		},
-	})
+		})
 }

--- a/e2e/fixtures/chaos_pod.go
+++ b/e2e/fixtures/chaos_pod.go
@@ -21,17 +21,21 @@
 package fixtures
 
 import (
+	"context"
+
 	chaosmesh "github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/chaos-mesh/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ScheduleInjectPodKill schedules a Pod Kill action.
 func (factory *Factory) ScheduleInjectPodKill(
+	ctx context.Context,
 	target chaosmesh.PodSelectorSpec,
 	schedule string,
 	mode chaosmesh.SelectorMode,
 ) *ChaosMeshExperiment {
 	return factory.scheduleInjectPod(
+		ctx,
 		chaosmesh.PodSelector{
 			Selector: target,
 			Mode:     mode,
@@ -43,12 +47,14 @@ func (factory *Factory) ScheduleInjectPodKill(
 
 // ScheduleInjectPodKillWithName schedules a Pod Kill action with the specified name.
 func (factory *Factory) ScheduleInjectPodKillWithName(
+	ctx context.Context,
 	target chaosmesh.PodSelectorSpec,
 	schedule string,
 	mode chaosmesh.SelectorMode,
 	name string,
 ) *ChaosMeshExperiment {
 	return factory.scheduleInjectPod(
+		ctx,
 		chaosmesh.PodSelector{
 			Selector: target,
 			Mode:     mode,
@@ -59,32 +65,34 @@ func (factory *Factory) ScheduleInjectPodKillWithName(
 }
 
 func (factory *Factory) scheduleInjectPod(
+	ctx context.Context,
 	target chaosmesh.PodSelector,
 	schedule string,
 	action chaosmesh.PodChaosAction,
 	name string,
 ) *ChaosMeshExperiment {
-	return factory.CreateExperiment(&chaosmesh.Schedule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: factory.GetChaosNamespace(),
-			Labels:    factory.GetDefaultLabels(),
-		},
-		Spec: chaosmesh.ScheduleSpec{
-			Schedule:          schedule,
-			ConcurrencyPolicy: chaosmesh.AllowConcurrent,
-			Type:              chaosmesh.ScheduleTypePodChaos,
-			HistoryLimit:      1,
-			ScheduleItem: chaosmesh.ScheduleItem{
-				EmbedChaos: chaosmesh.EmbedChaos{
-					PodChaos: &chaosmesh.PodChaosSpec{
-						Action: action,
-						ContainerSelector: chaosmesh.ContainerSelector{
-							PodSelector: target,
+	return factory.CreateExperiment(ctx,
+		&chaosmesh.Schedule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: factory.GetChaosNamespace(),
+				Labels:    factory.GetDefaultLabels(),
+			},
+			Spec: chaosmesh.ScheduleSpec{
+				Schedule:          schedule,
+				ConcurrencyPolicy: chaosmesh.AllowConcurrent,
+				Type:              chaosmesh.ScheduleTypePodChaos,
+				HistoryLimit:      1,
+				ScheduleItem: chaosmesh.ScheduleItem{
+					EmbedChaos: chaosmesh.EmbedChaos{
+						PodChaos: &chaosmesh.PodChaosSpec{
+							Action: action,
+							ContainerSelector: chaosmesh.ContainerSelector{
+								PodSelector: target,
+							},
 						},
 					},
 				},
 			},
-		},
-	})
+		})
 }

--- a/e2e/fixtures/chaos_stress.go
+++ b/e2e/fixtures/chaos_stress.go
@@ -21,6 +21,8 @@
 package fixtures
 
 import (
+	"context"
+
 	chaosmesh "github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/chaos-mesh/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -28,30 +30,32 @@ import (
 
 // InjectPodStress injects pod stress on the target.
 func (factory *Factory) InjectPodStress(
+	ctx context.Context,
 	target chaosmesh.PodSelectorSpec,
 	containerNames []string,
 	memoryStressor *chaosmesh.MemoryStressor,
 	cpuStressor *chaosmesh.CPUStressor,
 ) *ChaosMeshExperiment {
-	return factory.CreateExperiment(&chaosmesh.StressChaos{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      factory.RandStringRunes(32),
-			Namespace: factory.GetChaosNamespace(),
-			Labels:    factory.GetDefaultLabels(),
-		},
-		Spec: chaosmesh.StressChaosSpec{
-			Duration: ptr.To(ChaosDurationForever),
-			Stressors: &chaosmesh.Stressors{
-				MemoryStressor: memoryStressor,
-				CPUStressor:    cpuStressor,
+	return factory.CreateExperiment(ctx,
+		&chaosmesh.StressChaos{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      factory.RandStringRunes(32),
+				Namespace: factory.GetChaosNamespace(),
+				Labels:    factory.GetDefaultLabels(),
 			},
-			ContainerSelector: chaosmesh.ContainerSelector{
-				PodSelector: chaosmesh.PodSelector{
-					Selector: target,
-					Mode:     chaosmesh.AllMode,
+			Spec: chaosmesh.StressChaosSpec{
+				Duration: ptr.To(ChaosDurationForever),
+				Stressors: &chaosmesh.Stressors{
+					MemoryStressor: memoryStressor,
+					CPUStressor:    cpuStressor,
 				},
-				ContainerNames: containerNames,
+				ContainerSelector: chaosmesh.ContainerSelector{
+					PodSelector: chaosmesh.PodSelector{
+						Selector: target,
+						Mode:     chaosmesh.AllMode,
+					},
+					ContainerNames: containerNames,
+				},
 			},
-		},
-	})
+		})
 }

--- a/e2e/fixtures/cluster_config.go
+++ b/e2e/fixtures/cluster_config.go
@@ -21,6 +21,7 @@
 package fixtures
 
 import (
+	"context"
 	"log"
 	"math"
 	"strings"
@@ -150,14 +151,14 @@ func DefaultClusterConfig(debugSymbols bool) *ClusterConfig {
 }
 
 // SetDefaults will set all unset fields to the default values.
-func (config *ClusterConfig) SetDefaults(factory *Factory) {
+func (config *ClusterConfig) SetDefaults(ctx context.Context, factory *Factory) {
 	if config.Name == "" {
 		config.Name = factory.getClusterName()
 	}
 
 	// Only create the namespace for non HA clusters, otherwise the namespaces will be created in a different way.
 	if config.Namespace == "" && config.HaMode == HaModeNone {
-		config.Namespace = factory.SingleNamespace()
+		config.Namespace = factory.SingleNamespace(ctx)
 	}
 
 	if config.StorageEngine == "" {

--- a/e2e/fixtures/cluster_config_test.go
+++ b/e2e/fixtures/cluster_config_test.go
@@ -31,8 +31,8 @@ import (
 var _ = Describe("Cluster configuration", func() {
 	DescribeTable(
 		"when generating the Pod resources",
-		func(config *ClusterConfig, processClass fdbv1beta2.ProcessClass, expected corev1.ResourceList) {
-			config.SetDefaults(&Factory{options: &FactoryOptions{}})
+		func(ctx SpecContext, config *ClusterConfig, processClass fdbv1beta2.ProcessClass, expected corev1.ResourceList) {
+			config.SetDefaults(ctx, &Factory{options: &FactoryOptions{}})
 			generated := config.generatePodResources(processClass)
 			Expect(generated.Cpu().String()).To(Equal(expected.Cpu().String()))
 			Expect(generated.Memory().String()).To(Equal(expected.Memory().String()))

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -161,7 +161,7 @@ func (factory *Factory) GetEncryptionKeySecretName() string {
 }
 
 // CreateEncryptionKeySecret creates a 32-byte encryption key secret.
-func (factory *Factory) CreateEncryptionKeySecret(namespace string) {
+func (factory *Factory) CreateEncryptionKeySecret(ctx context.Context, namespace string) {
 	secretName := factory.GetEncryptionKeySecretName()
 
 	// Create 32-byte encryption key.
@@ -179,7 +179,7 @@ func (factory *Factory) CreateEncryptionKeySecret(namespace string) {
 		},
 	}
 
-	gomega.Expect(factory.CreateIfAbsent(secret)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(factory.CreateIfAbsent(ctx, secret)).NotTo(gomega.HaveOccurred())
 }
 
 func (factory *Factory) getConfig() *rest.Config {
@@ -187,15 +187,19 @@ func (factory *Factory) getConfig() *rest.Config {
 }
 
 // DeletePod deletes the provided Pod
-func (factory *Factory) DeletePod(pod *corev1.Pod) {
-	factory.Delete(pod)
+func (factory *Factory) DeletePod(ctx context.Context, pod *corev1.Pod) {
+	factory.Delete(ctx, pod)
 }
 
 // GetPod returns the Pod matching the namespace and name
-func (factory *Factory) GetPod(namespace string, name string) (*corev1.Pod, error) {
+func (factory *Factory) GetPod(
+	ctx context.Context,
+	namespace string,
+	name string,
+) (*corev1.Pod, error) {
 	pod := &corev1.Pod{}
 	err := factory.GetControllerRuntimeClient().
-		Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, pod)
+		Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, pod)
 
 	return pod, err
 }
@@ -212,24 +216,27 @@ func (factory *Factory) ChaosTestsEnabled() bool {
 
 // CreateFdbCluster creates a FDB cluster.
 func (factory *Factory) CreateFdbCluster(
+	ctx context.Context,
 	config *ClusterConfig,
 ) *FdbCluster {
 	return factory.CreateFdbClusterFromSpec(
-		factory.GenerateFDBClusterSpec(config),
+		ctx,
+		factory.GenerateFDBClusterSpec(ctx, config),
 		config)
 }
 
 // CreateFdbClusterFromSpec creates a FDB cluster. This method can be used in combination with the GenerateFDBClusterSpec method.
 // In general this should only be used for special cases that are not covered by changing the ClusterOptions or the ClusterConfig.
 func (factory *Factory) CreateFdbClusterFromSpec(
+	ctx context.Context,
 	spec *fdbv1beta2.FoundationDBCluster,
 	config *ClusterConfig,
 ) *FdbCluster {
 	startTime := time.Now()
-	config.SetDefaults(factory)
+	config.SetDefaults(ctx, factory)
 	log.Printf("create cluster: %s", ToJSON(spec))
 
-	cluster := factory.startFDBFromClusterSpec(spec, config)
+	cluster := factory.startFDBFromClusterSpec(ctx, spec, config)
 	log.Println(
 		"FoundationDB cluster created (at version",
 		cluster.cluster.Spec.Version,
@@ -242,12 +249,13 @@ func (factory *Factory) CreateFdbClusterFromSpec(
 
 // CreateFdbHaCluster creates a HA FDB Cluster based on the cluster config and cluster options
 func (factory *Factory) CreateFdbHaCluster(
+	ctx context.Context,
 	config *ClusterConfig,
 ) *HaFdbCluster {
 	startTime := time.Now()
-	config.SetDefaults(factory)
+	config.SetDefaults(ctx, factory)
 
-	cluster := factory.ensureHAFdbClusterExists(config)
+	cluster := factory.ensureHAFdbClusterExists(ctx, config)
 
 	log.Println(
 		"FoundationDB HA cluster created (at version",
@@ -304,7 +312,7 @@ func (factory *Factory) getClusterName() string {
 
 // GetDefaultStorageClass returns either the StorageClass provided by the command line or fetches the StorageClass passed on
 // the default Annotation.
-func (factory *Factory) GetDefaultStorageClass() string {
+func (factory *Factory) GetDefaultStorageClass(ctx context.Context) string {
 	flagStorageClass := factory.options.storageClass
 	// If a storage class is provided as parameter use that storage class.
 	if flagStorageClass != "" {
@@ -312,7 +320,7 @@ func (factory *Factory) GetDefaultStorageClass() string {
 	}
 
 	// If no storage class is provided use the default one in the cluster
-	storageClasses := factory.GetStorageClasses(nil)
+	storageClasses := factory.GetStorageClasses(ctx, nil)
 
 	for _, storageClass := range storageClasses.Items {
 		if _, ok := storageClass.Annotations["storageclass.kubernetes.io/is-default-class"]; ok {
@@ -335,18 +343,21 @@ func (factory *Factory) GetContext() string {
 }
 
 // GetStorageClasses returns all StorageClasses present in this Kubernetes cluster that have the label foundationdb.org/operator-testing=true.
-func (factory *Factory) GetStorageClasses(labels map[string]string) *storagev1.StorageClassList {
+func (factory *Factory) GetStorageClasses(
+	ctx context.Context,
+	labels map[string]string,
+) *storagev1.StorageClassList {
 	storageClasses := &storagev1.StorageClassList{}
 	gomega.Expect(
 		factory.GetControllerRuntimeClient().
-			List(context.Background(), storageClasses, client.MatchingLabels(labels)),
+			List(ctx, storageClasses, client.MatchingLabels(labels)),
 	).NotTo(gomega.HaveOccurred())
 
 	return storageClasses
 }
 
 // Shutdown executes all the shutdown handlers, usually called in afterSuite or afterTest depending on your scoping of the factory.
-func (factory *Factory) Shutdown() {
+func (factory *Factory) Shutdown(ctx context.Context) {
 	factory.shutdownInProgress = true
 	// If the cleanup flag is present don't do any cleanup
 	if !factory.options.cleanup {
@@ -355,7 +366,7 @@ func (factory *Factory) Shutdown() {
 
 	// Wait 15 seconds before running all shutdown handlers to ensure everything can catch up.
 	time.Sleep(15 * time.Second)
-	err := factory.CleanupChaosMeshExperiments()
+	err := factory.CleanupChaosMeshExperiments(ctx)
 	if err != nil {
 		log.Println("Could not delete chaos mesh experiments", err.Error())
 	}
@@ -371,12 +382,13 @@ func (factory *Factory) Shutdown() {
 // Get returns the (eventually consistent) status of this cluster.  This is used when bootstrapping an
 // FdbCluster object, so it's a member of FdbOperatorClient.
 func (factory *Factory) getClusterStatus(
+	ctx context.Context,
 	name string,
 	namespace string,
 ) (*fdbv1beta2.FoundationDBCluster, error) {
 	clusterRequest := &fdbv1beta2.FoundationDBCluster{}
 	err := factory.GetControllerRuntimeClient().
-		Get(context.Background(), client.ObjectKey{
+		Get(ctx, client.ObjectKey{
 			Name:      name,
 			Namespace: namespace}, clusterRequest)
 	if err != nil {
@@ -387,8 +399,8 @@ func (factory *Factory) getClusterStatus(
 }
 
 // DoesPodExist checks to see if Kubernetes still knows about this pod.
-func (factory *Factory) DoesPodExist(pod corev1.Pod) (bool, error) {
-	_, err := factory.GetPod(pod.Namespace, pod.Name)
+func (factory *Factory) DoesPodExist(ctx context.Context, pod corev1.Pod) (bool, error) {
+	_, err := factory.GetPod(ctx, pod.Namespace, pod.Name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
@@ -419,19 +431,20 @@ func (factory *Factory) logClusterInfo(spec *fdbv1beta2.FoundationDBCluster) {
 }
 
 func (factory *Factory) startFDBFromClusterSpec(
+	ctx context.Context,
 	spec *fdbv1beta2.FoundationDBCluster,
 	config *ClusterConfig,
 ) *FdbCluster {
 	factory.logClusterInfo(spec)
 
-	fdbCluster, err := factory.ensureFdbClusterExists(spec, config)
+	fdbCluster, err := factory.ensureFdbClusterExists(ctx, spec, config)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cluster was not created in the expected time")
 	factory.namespaces = append(
 		factory.namespaces,
 		fdbCluster.cluster.Namespace,
 	)
 
-	fdbCluster.WaitUntilAvailable()
+	fdbCluster.WaitUntilAvailable(ctx)
 	return fdbCluster
 }
 
@@ -534,9 +547,14 @@ func (factory *Factory) UploadFile(
 }
 
 // GetLogsForPod will fetch the logs for the specified Pod and container since the provided seconds.
-func (factory *Factory) GetLogsForPod(pod *corev1.Pod, container string, since *int64) string {
+func (factory *Factory) GetLogsForPod(
+	ctx context.Context,
+	pod *corev1.Pod,
+	container string,
+	since *int64,
+) string {
 	logs, err := kubeHelper.GetLogsFromPod(
-		context.Background(),
+		ctx,
 		factory.GetControllerRuntimeClient(),
 		factory.getConfig(),
 		pod,
@@ -701,12 +719,16 @@ func writePodInformation(pod corev1.Pod) string {
 
 // DumpStateWithLogsSince writes the state of the cluster to the log output. Useful for debugging test failures.
 // The logsSinceSeconds is used for the manager logs from the operator.
-func (factory *Factory) DumpStateWithLogsSince(fdbCluster *FdbCluster, logsSinceSeconds *int64) {
+func (factory *Factory) DumpStateWithLogsSince(
+	ctx context.Context,
+	fdbCluster *FdbCluster,
+	logsSinceSeconds *int64,
+) {
 	if fdbCluster == nil || !factory.options.dumpOperatorState {
 		return
 	}
 
-	cluster := fdbCluster.GetCluster()
+	cluster := fdbCluster.GetCluster(ctx)
 
 	// We write the whole information into a buffer to prevent having multiple log line prefixes.
 	var buffer strings.Builder
@@ -732,7 +754,7 @@ func (factory *Factory) DumpStateWithLogsSince(fdbCluster *FdbCluster, logsSince
 	// Printout all Pods for this namespace
 	pods := &corev1.PodList{}
 	err := factory.controllerRuntimeClient.List(
-		context.Background(),
+		ctx,
 		pods,
 		client.InNamespace(cluster.Namespace),
 	)
@@ -766,30 +788,31 @@ func (factory *Factory) DumpStateWithLogsSince(fdbCluster *FdbCluster, logsSince
 	// Printout the logs of the operator Pods for the last 300 seconds.
 	for _, pod := range operatorPods {
 		targetPod := pod
-		log.Println(factory.GetLogsForPod(&targetPod, "manager", logsSinceSeconds))
+		log.Println(factory.GetLogsForPod(ctx, &targetPod, "manager", logsSinceSeconds))
 	}
 }
 
 // DumpState writes the state of the cluster to the log output. Useful for debugging test failures.
-func (factory *Factory) DumpState(fdbCluster *FdbCluster) {
-	factory.DumpStateWithLogsSince(fdbCluster, ptr.To[int64](300))
+func (factory *Factory) DumpState(ctx context.Context, fdbCluster *FdbCluster) {
+	factory.DumpStateWithLogsSince(ctx, fdbCluster, ptr.To[int64](300))
 }
 
 // DumpStateHaCluster can be used to dump the state of the HA cluster. This includes the Kubernetes custom resource
 // information as well as the operator logs and the Pod state.
-func (factory *Factory) DumpStateHaCluster(fdbCluster *HaFdbCluster) {
-	factory.DumpStateHaClusterWithLogsSince(fdbCluster, ptr.To[int64](300))
+func (factory *Factory) DumpStateHaCluster(ctx context.Context, fdbCluster *HaFdbCluster) {
+	factory.DumpStateHaClusterWithLogsSince(ctx, fdbCluster, ptr.To[int64](300))
 }
 
 // DumpStateHaClusterWithLogsSince can be used to dump the state of the HA cluster. This includes the Kubernetes custom resource
 // information as well as the operator logs and the Pod state.
 // The logsSinceSeconds is used for the manager logs from the operator.
 func (factory *Factory) DumpStateHaClusterWithLogsSince(
+	ctx context.Context,
 	fdbCluster *HaFdbCluster,
 	logsSinceSeconds *int64,
 ) {
 	for _, cluster := range fdbCluster.clusters {
-		factory.DumpStateWithLogsSince(cluster, logsSinceSeconds)
+		factory.DumpStateWithLogsSince(ctx, cluster, logsSinceSeconds)
 	}
 }
 
@@ -820,7 +843,7 @@ func (factory *Factory) PrependRegistry(container string) string {
 }
 
 // CreateIfAbsent will create the provided resource if absent.
-func (factory *Factory) CreateIfAbsent(object client.Object) error {
+func (factory *Factory) CreateIfAbsent(ctx context.Context, object client.Object) error {
 	objectCopy, ok := object.DeepCopyObject().(client.Object)
 	if !ok {
 		return fmt.Errorf("cannot copy object")
@@ -829,7 +852,7 @@ func (factory *Factory) CreateIfAbsent(object client.Object) error {
 	ctrlClient := factory.GetControllerRuntimeClient()
 	err := ctrlClient.
 		Get(
-			context.Background(),
+			ctx,
 			client.ObjectKey{Namespace: object.GetNamespace(), Name: object.GetName()},
 			objectCopy,
 		)
@@ -843,7 +866,7 @@ func (factory *Factory) CreateIfAbsent(object client.Object) error {
 
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return ctrlClient.Create(context.Background(), object)
+			return ctrlClient.Create(ctx, object)
 		}
 
 		return err
@@ -853,8 +876,8 @@ func (factory *Factory) CreateIfAbsent(object client.Object) error {
 }
 
 // Delete will delete the provided resource if it exists.
-func (factory *Factory) Delete(object client.Object) {
-	err := factory.GetControllerRuntimeClient().Delete(context.Background(), object)
+func (factory *Factory) Delete(ctx context.Context, object client.Object) {
+	err := factory.GetControllerRuntimeClient().Delete(ctx, object)
 	if err == nil || k8serrors.IsNotFound(err) {
 		return
 	}
@@ -908,19 +931,19 @@ func (factory *Factory) UseUnifiedImage() bool {
 }
 
 // UpdateNode update node definition
-func (fdbCluster *FdbCluster) UpdateNode(node *corev1.Node) {
+func (fdbCluster *FdbCluster) UpdateNode(ctx context.Context, node *corev1.Node) {
 	gomega.Eventually(func() error {
-		return fdbCluster.getClient().Update(context.Background(), node)
+		return fdbCluster.getClient().Update(ctx, node)
 	}).WithTimeout(time.Duration(2) * time.Minute).WithPolling(2 * time.Second).Should(gomega.Succeed())
 }
 
 // GetNode return Node with the given name
-func (fdbCluster *FdbCluster) GetNode(name string) *corev1.Node {
+func (fdbCluster *FdbCluster) GetNode(ctx context.Context, name string) *corev1.Node {
 	// Retry if for some reason an error is returned
 	node := &corev1.Node{}
 	gomega.Eventually(func() error {
 		return fdbCluster.getClient().
-			Get(context.Background(), client.ObjectKey{Name: name}, node)
+			Get(ctx, client.ObjectKey{Name: name}, node)
 	}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).ShouldNot(gomega.HaveOccurred())
 
 	return node

--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -120,6 +120,9 @@ func (factory *Factory) StopInvariantCheck() {
 }
 
 // AddShutdownHook will add the provided shut down hook.
+// Methods that are called by AddShutdownHook should not use the provided SpecContext as the context will be canceled
+// after the Ginkgo node was executed. In another PR, we could pass a ctx to the invocation of the shutdown handlers.
+// Right now a generic context.Background() is used to ensure that the cleanup methods will always be executed.
 func (factory *Factory) AddShutdownHook(f func() error) {
 	factory.shutdownHooks.Defer(f)
 }

--- a/e2e/fixtures/fdb_backup.go
+++ b/e2e/fixtures/fdb_backup.go
@@ -222,7 +222,7 @@ func (factory *Factory) CreateBackupForClusterFromSpec(
 	}
 
 	factory.AddShutdownHook(func() error {
-		curBackup.Destroy(ctx)
+		curBackup.Destroy(context.Background())
 
 		return nil
 	})

--- a/e2e/fixtures/fdb_backup.go
+++ b/e2e/fixtures/fdb_backup.go
@@ -60,10 +60,12 @@ type FdbBackupConfiguration struct {
 
 // CreateBackupForCluster will create a FoundationDBBackup for the provided cluster.
 func (factory *Factory) CreateBackupForCluster(
+	ctx context.Context,
 	fdbCluster *FdbCluster,
 	config *FdbBackupConfiguration,
 ) *FdbBackup {
 	return factory.CreateBackupForClusterFromSpec(
+		ctx,
 		factory.GenerateBackupSpecForCluster(fdbCluster, config),
 		fdbCluster,
 	)
@@ -201,6 +203,7 @@ func (factory *Factory) GenerateBackupSpecForCluster(
 // CreateBackupForClusterFromSpec creates a FdbBackup. This method can be used in combination with the GenerateBackupSpecForCluster method.
 // In general this should only be used for special cases that are not covered by changing the FdbBackupConfiguration.
 func (factory *Factory) CreateBackupForClusterFromSpec(
+	ctx context.Context,
 	spec *fdbv1beta2.FoundationDBBackup,
 	fdbCluster *FdbCluster,
 ) *FdbBackup {
@@ -212,39 +215,39 @@ func (factory *Factory) CreateBackupForClusterFromSpec(
 		)
 	}()
 
-	gomega.Expect(factory.CreateIfAbsent(spec)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(factory.CreateIfAbsent(ctx, spec)).NotTo(gomega.HaveOccurred())
 	curBackup := &FdbBackup{
 		backup:     spec,
 		fdbCluster: fdbCluster,
 	}
 
 	factory.AddShutdownHook(func() error {
-		curBackup.Destroy()
+		curBackup.Destroy(ctx)
 
 		return nil
 	})
 
-	curBackup.WaitForReconciliation()
+	curBackup.WaitForReconciliation(ctx)
 
 	return curBackup
 }
 
 // GetBackup fetch the current state of the fdbv1beta2.FoundationDBBackup and return it.
-func (fdbBackup *FdbBackup) GetBackup() *fdbv1beta2.FoundationDBBackup {
+func (fdbBackup *FdbBackup) GetBackup(ctx context.Context) *fdbv1beta2.FoundationDBBackup {
 	objectKey := client.ObjectKeyFromObject(fdbBackup.backup)
 	foundationDBBackup := &fdbv1beta2.FoundationDBBackup{}
 	gomega.Expect(fdbBackup.fdbCluster.factory.GetControllerRuntimeClient().
-		Get(context.Background(), objectKey, foundationDBBackup)).NotTo(gomega.HaveOccurred())
+		Get(ctx, objectKey, foundationDBBackup)).NotTo(gomega.HaveOccurred())
 
 	fdbBackup.backup = foundationDBBackup
 	return fdbBackup.backup
 }
 
-func (fdbBackup *FdbBackup) setState(state fdbv1beta2.BackupState) {
+func (fdbBackup *FdbBackup) setState(ctx context.Context, state fdbv1beta2.BackupState) {
 	objectKey := client.ObjectKeyFromObject(fdbBackup.backup)
 	foundationDBBackup := &fdbv1beta2.FoundationDBBackup{}
 	gomega.Expect(fdbBackup.fdbCluster.factory.GetControllerRuntimeClient().
-		Get(context.Background(), objectKey, foundationDBBackup)).NotTo(gomega.HaveOccurred())
+		Get(ctx, objectKey, foundationDBBackup)).NotTo(gomega.HaveOccurred())
 
 	// Backup is already in desired state
 	if foundationDBBackup.Spec.BackupState == state {
@@ -253,44 +256,46 @@ func (fdbBackup *FdbBackup) setState(state fdbv1beta2.BackupState) {
 
 	foundationDBBackup.Spec.BackupState = state
 	gomega.Expect(fdbBackup.fdbCluster.factory.GetControllerRuntimeClient().
-		Update(context.Background(), foundationDBBackup)).NotTo(gomega.HaveOccurred())
+		Update(ctx, foundationDBBackup)).NotTo(gomega.HaveOccurred())
 	fdbBackup.backup = foundationDBBackup
-	fdbBackup.WaitForReconciliation()
+	fdbBackup.WaitForReconciliation(ctx)
 }
 
 // Stop will stop the FdbBackup.
-func (fdbBackup *FdbBackup) Stop() {
-	fdbBackup.setState(fdbv1beta2.BackupStateStopped)
+func (fdbBackup *FdbBackup) Stop(ctx context.Context) {
+	fdbBackup.setState(ctx, fdbv1beta2.BackupStateStopped)
 }
 
 // Start will start the FdbBackup.
-func (fdbBackup *FdbBackup) Start() {
-	fdbBackup.setState(fdbv1beta2.BackupStateRunning)
+func (fdbBackup *FdbBackup) Start(ctx context.Context) {
+	fdbBackup.setState(ctx, fdbv1beta2.BackupStateRunning)
 }
 
 // Pause will pause the FdbBackup.
-func (fdbBackup *FdbBackup) Pause() {
-	fdbBackup.setState(fdbv1beta2.BackupStatePaused)
+func (fdbBackup *FdbBackup) Pause(ctx context.Context) {
+	fdbBackup.setState(ctx, fdbv1beta2.BackupStatePaused)
 }
 
 // SetSnapshotInterval updates the snapshot interval of the current backup.
-func (fdbBackup *FdbBackup) SetSnapshotInterval(snapshotPeriodSeconds int) {
+func (fdbBackup *FdbBackup) SetSnapshotInterval(ctx context.Context, snapshotPeriodSeconds int) {
 	objectKey := client.ObjectKeyFromObject(fdbBackup.backup)
 	foundationDBBackup := &fdbv1beta2.FoundationDBBackup{}
 	gomega.Expect(fdbBackup.fdbCluster.factory.GetControllerRuntimeClient().
-		Get(context.Background(), objectKey, foundationDBBackup)).To(gomega.Succeed())
+		Get(ctx, objectKey, foundationDBBackup)).To(gomega.Succeed())
 
 	foundationDBBackup.Spec.SnapshotPeriodSeconds = &snapshotPeriodSeconds
 	gomega.Expect(fdbBackup.fdbCluster.factory.GetControllerRuntimeClient().
-		Update(context.Background(), foundationDBBackup)).To(gomega.Succeed())
+		Update(ctx, foundationDBBackup)).To(gomega.Succeed())
 	fdbBackup.backup = foundationDBBackup
-	fdbBackup.WaitForReconciliation()
+	fdbBackup.WaitForReconciliation(ctx)
 }
 
 // RunCommandOnBackupPod runs the provided command on a randomly chosen backup pod.
-func (fdbBackup *FdbBackup) RunCommandOnBackupPod(command string) string {
-	backupPod := fdbBackup.GetBackupPod()
+func (fdbBackup *FdbBackup) RunCommandOnBackupPod(ctx context.Context, command string) string {
+	backupPod := fdbBackup.GetBackupPod(ctx)
+	gomega.Expect(backupPod).NotTo(gomega.BeNil())
 	out, _, err := fdbBackup.fdbCluster.ExecuteCmdOnPod(
+		ctx,
 		*backupPod,
 		fdbv1beta2.MainContainerName,
 		command,
@@ -300,39 +305,41 @@ func (fdbBackup *FdbBackup) RunCommandOnBackupPod(command string) string {
 }
 
 // RunDescribeCommand runs the describe command on a randomly chosen backup pod.
-func (fdbBackup *FdbBackup) RunDescribeCommand() *fdbv1beta2.FDBBackupDescribe {
+func (fdbBackup *FdbBackup) RunDescribeCommand(ctx context.Context) *fdbv1beta2.FDBBackupDescribe {
 	backupURL, err := fdbBackup.backup.BackupURL()
 	gomega.Expect(err).To(gomega.Succeed())
 	command := fmt.Sprintf("fdbbackup describe -d \"%s\" --json", backupURL)
-	out := fdbBackup.RunCommandOnBackupPod(command)
+	out := fdbBackup.RunCommandOnBackupPod(ctx, command)
 	desc := &fdbv1beta2.FDBBackupDescribe{}
 	gomega.Expect(json.Unmarshal([]byte(out), desc)).To(gomega.Succeed())
 	return desc
 }
 
 // RunStatusCommand runs the status command on a randomly chosen backup pod.
-func (fdbBackup *FdbBackup) RunStatusCommand() *fdbv1beta2.FoundationDBLiveBackupStatus {
-	out := fdbBackup.RunCommandOnBackupPod("fdbbackup status --json")
+func (fdbBackup *FdbBackup) RunStatusCommand(
+	ctx context.Context,
+) *fdbv1beta2.FoundationDBLiveBackupStatus {
+	out := fdbBackup.RunCommandOnBackupPod(ctx, "fdbbackup status --json")
 	status := &fdbv1beta2.FoundationDBLiveBackupStatus{}
 	gomega.Expect(json.Unmarshal([]byte(out), status)).To(gomega.Succeed())
 	return status
 }
 
 // RunAbortCommand runs the abort command on a randomly chosen backup pod.
-func (fdbBackup *FdbBackup) RunAbortCommand() {
-	fdbBackup.RunCommandOnBackupPod("fdbbackup abort")
+func (fdbBackup *FdbBackup) RunAbortCommand(ctx context.Context) {
+	fdbBackup.RunCommandOnBackupPod(ctx, "fdbbackup abort")
 }
 
 // RunListCommand runs the list command on a randomly chosen backup pod.
-func (fdbBackup *FdbBackup) RunListCommand() []string {
+func (fdbBackup *FdbBackup) RunListCommand(ctx context.Context) []string {
 	backupURL, err := fdbBackup.backup.BaseURL()
 	gomega.Expect(err).To(gomega.Succeed())
 	command := fmt.Sprintf("fdbbackup list -b \"%s\"", backupURL)
-	return strings.Split(fdbBackup.RunCommandOnBackupPod(command), "\\n")
+	return strings.Split(fdbBackup.RunCommandOnBackupPod(ctx, command), "\\n")
 }
 
 // WaitForReconciliation waits until the FdbBackup resource is fully reconciled.
-func (fdbBackup *FdbBackup) WaitForReconciliation() {
+func (fdbBackup *FdbBackup) WaitForReconciliation(ctx context.Context) {
 	objectKey := client.ObjectKeyFromObject(fdbBackup.backup)
 
 	startTime := time.Now()
@@ -340,11 +347,11 @@ func (fdbBackup *FdbBackup) WaitForReconciliation() {
 	gomega.Eventually(func(g gomega.Gomega) bool {
 		curBackup := &fdbv1beta2.FoundationDBBackup{}
 		g.Expect(fdbBackup.fdbCluster.factory.GetControllerRuntimeClient().
-			Get(context.Background(), objectKey, curBackup)).NotTo(gomega.HaveOccurred())
+			Get(ctx, objectKey, curBackup)).NotTo(gomega.HaveOccurred())
 
 		// Dump the operator and cluster status after 5 minutes
 		if time.Since(startTime) > waitDuration {
-			fdbBackup.fdbCluster.factory.DumpState(fdbBackup.fdbCluster)
+			fdbBackup.fdbCluster.factory.DumpState(ctx, fdbBackup.fdbCluster)
 			startTime = time.Now()
 		}
 
@@ -353,10 +360,10 @@ func (fdbBackup *FdbBackup) WaitForReconciliation() {
 }
 
 // WaitForRestorableVersion will wait until the back is restorable.
-func (fdbBackup *FdbBackup) WaitForRestorableVersion(version uint64) uint64 {
+func (fdbBackup *FdbBackup) WaitForRestorableVersion(ctx context.Context, version uint64) uint64 {
 	var restorableVersion uint64
 	gomega.Eventually(func(g gomega.Gomega) uint64 {
-		status := fdbBackup.RunStatusCommand()
+		status := fdbBackup.RunStatusCommand(ctx)
 		var latestRestorableVersion uint64
 		if status.LatestRestorablePoint != nil {
 			latestRestorableVersion = ptr.Deref(status.LatestRestorablePoint.Version, 0)
@@ -379,15 +386,15 @@ func (fdbBackup *FdbBackup) WaitForRestorableVersion(version uint64) uint64 {
 }
 
 // GetBackupPod returns a random backup Pod for the provided backup.
-func (fdbBackup *FdbBackup) GetBackupPod() *corev1.Pod {
-	return fdbBackup.fdbCluster.factory.ChooseRandomPod(fdbBackup.GetBackupPods())
+func (fdbBackup *FdbBackup) GetBackupPod(ctx context.Context) *corev1.Pod {
+	return fdbBackup.fdbCluster.factory.ChooseRandomPod(fdbBackup.GetBackupPods(ctx))
 }
 
 // GetBackupPods returns a *corev1.PodList, which contains all pods for the provided backup.
-func (fdbBackup *FdbBackup) GetBackupPods() *corev1.PodList {
+func (fdbBackup *FdbBackup) GetBackupPods(ctx context.Context) *corev1.PodList {
 	podList := &corev1.PodList{}
 
-	gomega.Expect(fdbBackup.fdbCluster.factory.GetControllerRuntimeClient().List(context.Background(), podList,
+	gomega.Expect(fdbBackup.fdbCluster.factory.GetControllerRuntimeClient().List(ctx, podList,
 		client.InNamespace(fdbBackup.fdbCluster.Namespace()),
 		client.MatchingLabels(map[string]string{fdbv1beta2.BackupDeploymentPodLabel: fdbBackup.fdbCluster.Name() + "-backup-agents"}),
 	),
@@ -398,10 +405,10 @@ func (fdbBackup *FdbBackup) GetBackupPods() *corev1.PodList {
 }
 
 // Destroy will remove the underlying backup resources.
-func (fdbBackup *FdbBackup) Destroy() {
+func (fdbBackup *FdbBackup) Destroy(ctx context.Context) {
 	gomega.Eventually(func(g gomega.Gomega) {
 		err := fdbBackup.fdbCluster.getClient().
-			Delete(context.Background(), fdbBackup.backup)
+			Delete(ctx, fdbBackup.backup)
 		if k8serrors.IsNotFound(err) {
 			return
 		}
@@ -413,14 +420,14 @@ func (fdbBackup *FdbBackup) Destroy() {
 	gomega.Eventually(func(g gomega.Gomega) {
 		backup := &fdbv1beta2.FoundationDBBackup{}
 		err := fdbBackup.fdbCluster.getClient().
-			Get(context.Background(), client.ObjectKeyFromObject(fdbBackup.backup), backup)
+			Get(ctx, client.ObjectKeyFromObject(fdbBackup.backup), backup)
 		g.Expect(k8serrors.IsNotFound(err)).To(gomega.BeTrue())
 	}).WithTimeout(10 * time.Minute).WithPolling(1 * time.Second).To(gomega.Succeed())
 }
 
 // ForceReconcile will add an annotation with the current timestamp on the FoundationDBBackup resource to make sure
 // the operator reconciliation loop is triggered. This is used to speed up some test cases.
-func (fdbBackup *FdbBackup) ForceReconcile() {
+func (fdbBackup *FdbBackup) ForceReconcile(ctx context.Context) {
 	log.Printf("ForceReconcile: Status Generations=%s, Metadata Generation=%d",
 		ToJSON(fdbBackup.backup.Status.Generations),
 		fdbBackup.backup.ObjectMeta.Generation)
@@ -437,7 +444,7 @@ func (fdbBackup *FdbBackup) ForceReconcile() {
 	// This will apply an Annotation to the object which will trigger the reconcile loop.
 	// This should speed up the reconcile phase.
 	err := fdbBackup.fdbCluster.getClient().Patch(
-		context.Background(),
+		ctx,
 		fdbBackup.backup,
 		patch)
 	if err != nil {

--- a/e2e/fixtures/fdb_cluster.go
+++ b/e2e/fixtures/fdb_cluster.go
@@ -57,32 +57,36 @@ type FdbCluster struct {
 }
 
 // GetFDBImage return the FDB image used for the current version, defined in the FoundationDBClusterSpec.
-func (fdbCluster *FdbCluster) GetFDBImage() string {
-	return fdbv1beta2.SelectImageConfig(fdbCluster.GetClusterSpec().MainContainer.ImageConfigs, fdbCluster.cluster.Spec.Version).
+func (fdbCluster *FdbCluster) GetFDBImage(ctx context.Context) string {
+	return fdbv1beta2.SelectImageConfig(fdbCluster.GetClusterSpec(ctx).MainContainer.ImageConfigs, fdbCluster.cluster.Spec.Version).
 		Image()
 }
 
 // GetSidecarImageForVersion return the sidecar image used for the specified version.
-func (fdbCluster *FdbCluster) GetSidecarImageForVersion(version string) string {
+func (fdbCluster *FdbCluster) GetSidecarImageForVersion(
+	ctx context.Context,
+	version string,
+) string {
 	// In the case of the unified image the sidecar will also be the main container image.
 	if fdbCluster.cluster.UseUnifiedImage() {
-		return fdbv1beta2.SelectImageConfig(fdbCluster.GetClusterSpec().MainContainer.ImageConfigs, version).
+		return fdbv1beta2.SelectImageConfig(fdbCluster.GetClusterSpec(ctx).MainContainer.ImageConfigs, version).
 			Image()
 	}
 
-	return fdbv1beta2.SelectImageConfig(fdbCluster.GetClusterSpec().SidecarContainer.ImageConfigs, version).
+	return fdbv1beta2.SelectImageConfig(fdbCluster.GetClusterSpec(ctx).SidecarContainer.ImageConfigs, version).
 		Image()
 }
 
 // ExecuteCmdOnPod will run the provided command in a Shell.
 func (fdbCluster *FdbCluster) ExecuteCmdOnPod(
+	ctx context.Context,
 	pod corev1.Pod,
 	container string,
 	command string,
 	printOutput bool,
 ) (string, string, error) {
 	return fdbCluster.factory.ExecuteCmd(
-		context.Background(),
+		ctx,
 		pod.Namespace,
 		pod.Name,
 		container,
@@ -120,24 +124,24 @@ func (fdbCluster *FdbCluster) Namespace() string {
 }
 
 // WaitUntilExists synchronously waits until the cluster exists.  Usually called after Create().
-func (fdbCluster *FdbCluster) WaitUntilExists() {
+func (fdbCluster *FdbCluster) WaitUntilExists(ctx context.Context) {
 	clusterRequest := fdbv1beta2.FoundationDBCluster{}
 	key := client.ObjectKeyFromObject(fdbCluster.cluster)
 
 	gomega.Eventually(func() error {
 		return fdbCluster.getClient().
-			Get(context.Background(), key, &clusterRequest)
+			Get(ctx, key, &clusterRequest)
 	}).WithTimeout(2 * time.Minute).ShouldNot(gomega.HaveOccurred())
 }
 
 // Create asynchronously creates this FDB cluster.
-func (fdbCluster *FdbCluster) Create() error {
-	return fdbCluster.getClient().Create(context.Background(), fdbCluster.cluster)
+func (fdbCluster *FdbCluster) Create(ctx context.Context) error {
+	return fdbCluster.getClient().Create(ctx, fdbCluster.cluster)
 }
 
 // Update asynchronously updates this FDB cluster definition.
-func (fdbCluster *FdbCluster) Update() error {
-	return fdbCluster.getClient().Update(context.Background(), fdbCluster.cluster)
+func (fdbCluster *FdbCluster) Update(ctx context.Context) error {
+	return fdbCluster.getClient().Update(ctx, fdbCluster.cluster)
 }
 
 // ReconciliationOptions defines the different reconciliation options.
@@ -212,10 +216,14 @@ func MakeReconciliationOptionsStruct(
 }
 
 // WaitForReconciliation waits for the cluster to be reconciled based on the provided options.
-func (fdbCluster *FdbCluster) WaitForReconciliation(options ...func(*ReconciliationOptions)) error {
+func (fdbCluster *FdbCluster) WaitForReconciliation(
+	ctx context.Context,
+	options ...func(*ReconciliationOptions),
+) error {
 	reconciliationOptions := MakeReconciliationOptionsStruct(options...)
 
 	return fdbCluster.waitForReconciliationToGeneration(
+		ctx,
 		reconciliationOptions.minimumGeneration,
 		reconciliationOptions.allowSoftReconciliation,
 		reconciliationOptions.creationTrackerLogger,
@@ -226,6 +234,7 @@ func (fdbCluster *FdbCluster) WaitForReconciliation(options ...func(*Reconciliat
 
 // waitForReconciliationToGeneration waits for a specific generation to be reached.
 func (fdbCluster *FdbCluster) waitForReconciliationToGeneration(
+	ctx context.Context,
 	minimumGeneration int64,
 	softReconciliationAllowed bool,
 	creationTrackerLogger CreationTrackerLogger,
@@ -264,7 +273,7 @@ func (fdbCluster *FdbCluster) waitForReconciliationToGeneration(
 
 	checkIfReconciliationIsDone := func(cluster *fdbv1beta2.FoundationDBCluster) bool {
 		if creationTracker != nil {
-			creationTracker.trackProgress(cluster)
+			creationTracker.trackProgress(ctx, cluster)
 		}
 
 		var reconciled bool
@@ -295,6 +304,7 @@ func (fdbCluster *FdbCluster) waitForReconciliationToGeneration(
 	}
 
 	err := fdbCluster.WaitUntilWithForceReconcile(
+		ctx,
 		pollTimeInSeconds,
 		timeOutInSeconds,
 		checkIfReconciliationIsDone,
@@ -308,23 +318,24 @@ func (fdbCluster *FdbCluster) waitForReconciliationToGeneration(
 
 // WaitUntilWithForceReconcile will wait either until the checkMethod returns true or until the timeout is hit.
 func (fdbCluster *FdbCluster) WaitUntilWithForceReconcile(
+	ctx context.Context,
 	pollTimeInSeconds int,
 	timeOutInSeconds int,
 	checkMethod func(cluster *fdbv1beta2.FoundationDBCluster) bool,
 ) error {
 	// Printout the initial state of the cluster before we're moving forward waiting for the checkMethod to return true.
-	fdbCluster.factory.DumpState(fdbCluster)
+	fdbCluster.factory.DumpState(ctx, fdbCluster)
 
 	lastForcedReconciliationTime := time.Now()
 	forceReconcileDuration := 4 * time.Minute
 
 	// TODO (johscheuer): Convert this into a gomega statement.
-	return wait.PollUntilContextTimeout(context.Background(),
+	return wait.PollUntilContextTimeout(ctx,
 		time.Duration(pollTimeInSeconds)*time.Second,
 		time.Duration(timeOutInSeconds)*time.Second,
 		true,
 		func(_ context.Context) (bool, error) {
-			resCluster := fdbCluster.GetCluster()
+			resCluster := fdbCluster.GetCluster(ctx)
 
 			if checkMethod(resCluster) {
 				return true, nil
@@ -332,7 +343,7 @@ func (fdbCluster *FdbCluster) WaitUntilWithForceReconcile(
 
 			// Force a reconcile if needed.
 			if time.Since(lastForcedReconciliationTime) >= forceReconcileDuration {
-				fdbCluster.ForceReconcile()
+				fdbCluster.ForceReconcile(ctx)
 				lastForcedReconciliationTime = time.Now()
 			}
 
@@ -343,12 +354,12 @@ func (fdbCluster *FdbCluster) WaitUntilWithForceReconcile(
 
 // ForceReconcile will add an annotation with the current timestamp on the FoundationDBCluster resource to make sure
 // the operator reconciliation loop is triggered. This is used to speed up some test cases.
-func (fdbCluster *FdbCluster) ForceReconcile() {
+func (fdbCluster *FdbCluster) ForceReconcile(ctx context.Context) {
 	log.Printf("ForceReconcile: Status Generations=%s, Metadata Generation=%d",
 		ToJSON(fdbCluster.cluster.Status.Generations),
 		fdbCluster.cluster.ObjectMeta.Generation)
 
-	fdbCluster.factory.DumpState(fdbCluster)
+	fdbCluster.factory.DumpState(ctx, fdbCluster)
 	patch := client.MergeFrom(fdbCluster.cluster.DeepCopy())
 	if fdbCluster.cluster.Annotations == nil {
 		fdbCluster.cluster.Annotations = make(map[string]string)
@@ -361,7 +372,7 @@ func (fdbCluster *FdbCluster) ForceReconcile() {
 	// This will apply an Annotation to the object which will trigger the reconcile loop.
 	// This should speed up the reconcile phase.
 	err := fdbCluster.getClient().Patch(
-		context.Background(),
+		ctx,
 		fdbCluster.cluster,
 		patch)
 	if err != nil {
@@ -370,12 +381,13 @@ func (fdbCluster *FdbCluster) ForceReconcile() {
 }
 
 // GetCluster returns the FoundationDBCluster of the cluster. This will fetch the latest value from  the Kubernetes API.
-func (fdbCluster *FdbCluster) GetCluster() *fdbv1beta2.FoundationDBCluster {
+func (fdbCluster *FdbCluster) GetCluster(ctx context.Context) *fdbv1beta2.FoundationDBCluster {
 	var cluster *fdbv1beta2.FoundationDBCluster
 
 	gomega.Eventually(func() error {
 		var err error
 		cluster, err = fdbCluster.factory.getClusterStatus(
+			ctx,
 			fdbCluster.Name(),
 			fdbCluster.Namespace(),
 		)
@@ -408,23 +420,24 @@ func (fdbCluster *FdbCluster) GetCachedCluster() *fdbv1beta2.FoundationDBCluster
 
 // SetDatabaseConfiguration sets the provided DatabaseConfiguration for the FoundationDBCluster.
 func (fdbCluster *FdbCluster) SetDatabaseConfiguration(
+	ctx context.Context,
 	config fdbv1beta2.DatabaseConfiguration,
 	waitForReconcile bool,
 ) error {
 	fdbCluster.cluster.Spec.DatabaseConfiguration = config
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 
 	if !waitForReconcile {
 		return nil
 	}
 
-	return fdbCluster.WaitForReconciliation()
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // UpdateClusterStatus updates the FoundationDBCluster status. This method allows to modify the status sub-resource of
 // the FoundationDBCluster resource.
-func (fdbCluster *FdbCluster) UpdateClusterStatus() {
-	fdbCluster.UpdateClusterStatusWithStatus(fdbCluster.cluster.Status.DeepCopy())
+func (fdbCluster *FdbCluster) UpdateClusterStatus(ctx context.Context) {
+	fdbCluster.UpdateClusterStatusWithStatus(ctx, fdbCluster.cluster.Status.DeepCopy())
 }
 
 // UpdateClusterStatusWithStatus ensures that the FoundationDBCluster status will be updated in Kubernetes. This method has a retry mechanism
@@ -443,6 +456,7 @@ func (fdbCluster *FdbCluster) UpdateClusterStatus() {
 //		// Make sure the operator picks up the work again
 //		fdbCluster.SetSkipReconciliation(false)
 func (fdbCluster *FdbCluster) UpdateClusterStatusWithStatus(
+	ctx context.Context,
 	desiredStatus *fdbv1beta2.FoundationDBClusterStatus,
 ) {
 	fetchedCluster := &fdbv1beta2.FoundationDBCluster{}
@@ -451,7 +465,7 @@ func (fdbCluster *FdbCluster) UpdateClusterStatusWithStatus(
 	// Try a few times before giving up.
 	gomega.Eventually(func(g gomega.Gomega) bool {
 		err := fdbCluster.getClient().
-			Get(context.Background(), client.ObjectKeyFromObject(fdbCluster.cluster), fetchedCluster)
+			Get(ctx, client.ObjectKeyFromObject(fdbCluster.cluster), fetchedCluster)
 		g.Expect(err).NotTo(gomega.HaveOccurred(), "error fetching cluster")
 
 		updated := equality.Semantic.DeepEqual(fetchedCluster.Status, *desiredStatus)
@@ -461,7 +475,7 @@ func (fdbCluster *FdbCluster) UpdateClusterStatusWithStatus(
 		}
 
 		desiredStatus.DeepCopyInto(&fetchedCluster.Status)
-		err = fdbCluster.getClient().Status().Update(context.Background(), fetchedCluster)
+		err = fdbCluster.getClient().Status().Update(ctx, fetchedCluster)
 		g.Expect(err).NotTo(gomega.HaveOccurred(), "error updating cluster status")
 		// Retry here and let the method fetch the latest version of the cluster again until the spec is updated.
 		return false
@@ -472,8 +486,8 @@ func (fdbCluster *FdbCluster) UpdateClusterStatusWithStatus(
 
 // UpdateClusterSpec ensures that the FoundationDBCluster will be updated in Kubernetes. This method has a retry mechanism
 // implemented and ensures that the provided (local) Spec matches the Spec in Kubernetes.
-func (fdbCluster *FdbCluster) UpdateClusterSpec() {
-	fdbCluster.UpdateClusterSpecWithSpec(fdbCluster.cluster.Spec.DeepCopy())
+func (fdbCluster *FdbCluster) UpdateClusterSpec(ctx context.Context) {
+	fdbCluster.UpdateClusterSpecWithSpec(ctx, fdbCluster.cluster.Spec.DeepCopy())
 }
 
 // UpdateClusterSpecWithSpec ensures that the FoundationDBCluster will be updated in Kubernetes. This method has a retry mechanism
@@ -486,6 +500,7 @@ func (fdbCluster *FdbCluster) UpdateClusterSpec() {
 //
 //	fdbCluster.UpdateClusterSpecWithSpec(spec) // Update the spec.
 func (fdbCluster *FdbCluster) UpdateClusterSpecWithSpec(
+	ctx context.Context,
 	desiredSpec *fdbv1beta2.FoundationDBClusterSpec,
 ) {
 	fetchedCluster := &fdbv1beta2.FoundationDBCluster{}
@@ -494,7 +509,7 @@ func (fdbCluster *FdbCluster) UpdateClusterSpecWithSpec(
 	// Try a few times before giving up.
 	gomega.Eventually(func(g gomega.Gomega) bool {
 		err := fdbCluster.getClient().
-			Get(context.Background(), client.ObjectKeyFromObject(fdbCluster.cluster), fetchedCluster)
+			Get(ctx, client.ObjectKeyFromObject(fdbCluster.cluster), fetchedCluster)
 		g.Expect(err).NotTo(gomega.HaveOccurred(), "error fetching cluster")
 
 		specUpdated := equality.Semantic.DeepEqual(fetchedCluster.Spec, *desiredSpec)
@@ -504,7 +519,7 @@ func (fdbCluster *FdbCluster) UpdateClusterSpecWithSpec(
 		}
 
 		desiredSpec.DeepCopyInto(&fetchedCluster.Spec)
-		err = fdbCluster.getClient().Update(context.Background(), fetchedCluster)
+		err = fdbCluster.getClient().Update(ctx, fetchedCluster)
 		g.Expect(err).NotTo(gomega.HaveOccurred(), "error updating cluster spec")
 		// Retry here and let the method fetch the latest version of the cluster again until the spec is updated.
 		return false
@@ -514,23 +529,23 @@ func (fdbCluster *FdbCluster) UpdateClusterSpecWithSpec(
 }
 
 // GetAllPods returns all pods, even if not running.
-func (fdbCluster *FdbCluster) GetAllPods() *corev1.PodList {
+func (fdbCluster *FdbCluster) GetAllPods(ctx context.Context) *corev1.PodList {
 	podList := &corev1.PodList{}
 
 	gomega.Eventually(func() error {
 		return fdbCluster.getClient().
-			List(context.Background(), podList, client.MatchingLabels(fdbCluster.cluster.GetMatchLabels()))
+			List(ctx, podList, client.MatchingLabels(fdbCluster.cluster.GetMatchLabels()))
 	}).WithTimeout(1 * time.Minute).WithPolling(1 * time.Second).ShouldNot(gomega.HaveOccurred())
 
 	return podList
 }
 
 // GetPods returns only running Pods.
-func (fdbCluster *FdbCluster) GetPods() *corev1.PodList {
+func (fdbCluster *FdbCluster) GetPods(ctx context.Context) *corev1.PodList {
 	podList := &corev1.PodList{}
 
 	gomega.Eventually(func() error {
-		return fdbCluster.getClient().List(context.Background(), podList,
+		return fdbCluster.getClient().List(ctx, podList,
 			client.InNamespace(fdbCluster.Namespace()),
 			client.MatchingLabels(fdbCluster.cluster.GetMatchLabels()),
 			client.MatchingFields(map[string]string{"status.phase": string(corev1.PodRunning)}),
@@ -541,9 +556,9 @@ func (fdbCluster *FdbCluster) GetPods() *corev1.PodList {
 }
 
 // GetPodsNames GetS all Running Pods and return their names.
-func (fdbCluster *FdbCluster) GetPodsNames() []string {
+func (fdbCluster *FdbCluster) GetPodsNames(ctx context.Context) []string {
 	results := make([]string, 0)
-	podList := fdbCluster.GetPods()
+	podList := fdbCluster.GetPods(ctx)
 
 	for _, pod := range podList.Items {
 		results = append(results, pod.Name)
@@ -553,12 +568,13 @@ func (fdbCluster *FdbCluster) GetPodsNames() []string {
 }
 
 func (fdbCluster *FdbCluster) getPodsByProcessClass(
+	ctx context.Context,
 	processClass fdbv1beta2.ProcessClass,
 ) *corev1.PodList {
 	podList := &corev1.PodList{}
 
 	gomega.Eventually(func() error {
-		return fdbCluster.getClient().List(context.Background(), podList,
+		return fdbCluster.getClient().List(ctx, podList,
 			client.InNamespace(fdbCluster.Namespace()),
 			client.MatchingLabels(map[string]string{
 				fdbv1beta2.FDBClusterLabel:      fdbCluster.cluster.Name,
@@ -569,27 +585,27 @@ func (fdbCluster *FdbCluster) getPodsByProcessClass(
 }
 
 // GetLogPods returns all Pods of this cluster that have the process class log.
-func (fdbCluster *FdbCluster) GetLogPods() *corev1.PodList {
-	return fdbCluster.getPodsByProcessClass(fdbv1beta2.ProcessClassLog)
+func (fdbCluster *FdbCluster) GetLogPods(ctx context.Context) *corev1.PodList {
+	return fdbCluster.getPodsByProcessClass(ctx, fdbv1beta2.ProcessClassLog)
 }
 
 // GetStatelessPods returns all Pods of this cluster that have the process class stateless.
-func (fdbCluster *FdbCluster) GetStatelessPods() *corev1.PodList {
-	return fdbCluster.getPodsByProcessClass(fdbv1beta2.ProcessClassStateless)
+func (fdbCluster *FdbCluster) GetStatelessPods(ctx context.Context) *corev1.PodList {
+	return fdbCluster.getPodsByProcessClass(ctx, fdbv1beta2.ProcessClassStateless)
 }
 
 // GetStoragePods returns all Pods of this cluster that have the process class storage.
-func (fdbCluster *FdbCluster) GetStoragePods() *corev1.PodList {
-	return fdbCluster.getPodsByProcessClass(fdbv1beta2.ProcessClassStorage)
+func (fdbCluster *FdbCluster) GetStoragePods(ctx context.Context) *corev1.PodList {
+	return fdbCluster.getPodsByProcessClass(ctx, fdbv1beta2.ProcessClassStorage)
 }
 
 // GetPod returns the Pod with the given name that runs in the same namespace as the FoundationDBCluster.
-func (fdbCluster *FdbCluster) GetPod(name string) *corev1.Pod {
+func (fdbCluster *FdbCluster) GetPod(ctx context.Context, name string) *corev1.Pod {
 	pod := &corev1.Pod{}
-	// Retry if for some reasons an error is returned
+	// Retry if for some reason an error is returned
 	gomega.Eventually(func() error {
 		return fdbCluster.getClient().
-			Get(context.Background(), client.ObjectKey{Name: name, Namespace: fdbCluster.Namespace()}, pod)
+			Get(ctx, client.ObjectKey{Name: name, Namespace: fdbCluster.Namespace()}, pod)
 	}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).ShouldNot(gomega.HaveOccurred())
 
 	return pod
@@ -597,9 +613,10 @@ func (fdbCluster *FdbCluster) GetPod(name string) *corev1.Pod {
 
 // GetPodIDs returns all the process group IDs for all Pods of this cluster that have the matching process class.
 func (fdbCluster *FdbCluster) GetPodIDs(
+	ctx context.Context,
 	processClass fdbv1beta2.ProcessClass,
 ) map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None {
-	pods := fdbCluster.GetPods()
+	pods := fdbCluster.GetPods(ctx)
 
 	podIDs := make(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None, len(pods.Items))
 	for _, pod := range pods.Items {
@@ -617,12 +634,13 @@ func (fdbCluster *FdbCluster) GetPodIDs(
 
 // GetVolumeClaimsForProcesses returns a list of volume claims belonging to this cluster and the specific process class.
 func (fdbCluster *FdbCluster) GetVolumeClaimsForProcesses(
+	ctx context.Context,
 	processClass fdbv1beta2.ProcessClass,
 ) *corev1.PersistentVolumeClaimList {
 	volumeClaimList := &corev1.PersistentVolumeClaimList{}
 	gomega.Expect(
 		fdbCluster.getClient().
-			List(context.Background(), volumeClaimList,
+			List(ctx, volumeClaimList,
 				client.InNamespace(fdbCluster.Namespace()),
 				client.MatchingLabels(map[string]string{
 					fdbv1beta2.FDBClusterLabel:      fdbCluster.cluster.Name,
@@ -640,16 +658,17 @@ func (fdbCluster *FdbCluster) GetLogServersPerPod() int {
 
 // SetLogServersPerPod set the LogServersPerPod field in the cluster spec.
 func (fdbCluster *FdbCluster) SetLogServersPerPod(
+	ctx context.Context,
 	serverPerPod int,
 	waitForReconcile bool,
 ) error {
 	fdbCluster.cluster.Spec.LogServersPerPod = serverPerPod
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 
 	if !waitForReconcile {
 		return nil
 	}
-	return fdbCluster.WaitForReconciliation()
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // GetStorageServerPerPod returns the current expected storage server per pod.
@@ -658,66 +677,76 @@ func (fdbCluster *FdbCluster) GetStorageServerPerPod() int {
 }
 
 func (fdbCluster *FdbCluster) setStorageServerPerPod(
+	ctx context.Context,
 	serverPerPod int,
 	waitForReconcile bool,
 ) error {
 	fdbCluster.cluster.Spec.StorageServersPerPod = serverPerPod
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 
 	if !waitForReconcile {
 		return nil
 	}
-	return fdbCluster.WaitForReconciliation()
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // SetStorageServerPerPod set the SetStorageServerPerPod field in the cluster spec.
-func (fdbCluster *FdbCluster) SetStorageServerPerPod(serverPerPod int) error {
-	return fdbCluster.setStorageServerPerPod(serverPerPod, true)
+func (fdbCluster *FdbCluster) SetStorageServerPerPod(ctx context.Context, serverPerPod int) error {
+	return fdbCluster.setStorageServerPerPod(ctx, serverPerPod, true)
 }
 
 // ReplacePod replaces the provided Pod if it's part of the FoundationDBCluster.
-func (fdbCluster *FdbCluster) ReplacePod(pod corev1.Pod, waitForReconcile bool) {
-	cluster := fdbCluster.GetCluster()
+func (fdbCluster *FdbCluster) ReplacePod(
+	ctx context.Context,
+	pod corev1.Pod,
+	waitForReconcile bool,
+) {
+	cluster := fdbCluster.GetCluster(ctx)
 	fdbCluster.cluster.Spec.ProcessGroupsToRemove = []fdbv1beta2.ProcessGroupID{
 		GetProcessGroupID(pod),
 	}
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 
 	if !waitForReconcile {
 		return
 	}
 
-	gomega.Expect(fdbCluster.WaitForReconciliation(SoftReconcileOption(true), MinimumGenerationOption(cluster.Generation+1))).
+	gomega.Expect(fdbCluster.WaitForReconciliation(ctx, SoftReconcileOption(true), MinimumGenerationOption(cluster.Generation+1))).
 		NotTo(gomega.HaveOccurred())
 }
 
 // ReplacePods replaces the provided Pods in the current FoundationDBCluster.
-func (fdbCluster *FdbCluster) ReplacePods(pods []corev1.Pod, waitForReconcile bool) {
+func (fdbCluster *FdbCluster) ReplacePods(
+	ctx context.Context,
+	pods []corev1.Pod,
+	waitForReconcile bool,
+) {
 	for _, pod := range pods {
 		fdbCluster.cluster.Spec.ProcessGroupsToRemove = append(
 			fdbCluster.cluster.Spec.ProcessGroupsToRemove,
 			GetProcessGroupID(pod),
 		)
 	}
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 
 	if !waitForReconcile {
 		return
 	}
 
-	gomega.Expect(fdbCluster.WaitForReconciliation()).NotTo(gomega.HaveOccurred())
+	gomega.Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(gomega.HaveOccurred())
 }
 
 // ClearProcessGroupsToRemove clears the InstancesToRemove list in the cluster
 // spec.
-func (fdbCluster *FdbCluster) ClearProcessGroupsToRemove() error {
+func (fdbCluster *FdbCluster) ClearProcessGroupsToRemove(ctx context.Context) error {
 	fdbCluster.cluster.Spec.ProcessGroupsToRemove = nil
-	fdbCluster.UpdateClusterSpec()
-	return fdbCluster.WaitForReconciliation()
+	fdbCluster.UpdateClusterSpec(ctx)
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // SetVolumeSize updates the volume size for the specified process class.
 func (fdbCluster *FdbCluster) SetVolumeSize(
+	ctx context.Context,
 	processClass fdbv1beta2.ProcessClass,
 	size resource.Quantity,
 ) error {
@@ -739,8 +768,8 @@ func (fdbCluster *FdbCluster) SetVolumeSize(
 		processSettings.VolumeClaimTemplate.Spec.Resources.Requests[corev1.ResourceStorage] = size
 	}
 	fdbCluster.cluster.Spec.Processes[processClass] = *processSettings
-	fdbCluster.UpdateClusterSpec()
-	return fdbCluster.WaitForReconciliation()
+	fdbCluster.UpdateClusterSpec(ctx)
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // GetVolumeSize returns the volume size for the specified process class.
@@ -756,36 +785,43 @@ func (fdbCluster *FdbCluster) GetVolumeSize(
 }
 
 func (fdbCluster *FdbCluster) updateLogProcessCount(
+	ctx context.Context,
 	newLogProcessCount int,
 	waitForReconcile bool,
 ) error {
 	fdbCluster.cluster.Spec.ProcessCounts.Log = newLogProcessCount
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 	if !waitForReconcile {
 		return nil
 	}
-	return fdbCluster.WaitForReconciliation()
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // UpdateLogProcessCount updates the log process count in the cluster spec.
-func (fdbCluster *FdbCluster) UpdateLogProcessCount(newLogProcessCount int) error {
-	return fdbCluster.updateLogProcessCount(newLogProcessCount, true)
+func (fdbCluster *FdbCluster) UpdateLogProcessCount(
+	ctx context.Context,
+	newLogProcessCount int,
+) error {
+	return fdbCluster.updateLogProcessCount(ctx, newLogProcessCount, true)
 }
 
 // SetPodAsUnschedulable sets the provided Pod on the NoSchedule list of the current FoundationDBCluster. This will make
 // sure that the Pod is stuck in Pending.
-func (fdbCluster *FdbCluster) SetPodAsUnschedulable(pod corev1.Pod) {
-	fdbCluster.SetProcessGroupsAsUnschedulable([]fdbv1beta2.ProcessGroupID{GetProcessGroupID(pod)})
+func (fdbCluster *FdbCluster) SetPodAsUnschedulable(ctx context.Context, pod corev1.Pod) {
+	fdbCluster.SetProcessGroupsAsUnschedulable(
+		ctx,
+		[]fdbv1beta2.ProcessGroupID{GetProcessGroupID(pod)},
+	)
 
 	gomega.Eventually(func(g gomega.Gomega) string {
 		fetchedPod := &corev1.Pod{}
 		err := fdbCluster.getClient().
-			Get(context.Background(), client.ObjectKeyFromObject(&pod), fetchedPod)
+			Get(ctx, client.ObjectKeyFromObject(&pod), fetchedPod)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Try deleting the Pod as a workaround until the operator handle all cases.
 		if fetchedPod.Spec.NodeName != "" && fetchedPod.DeletionTimestamp.IsZero() {
-			g.Expect(fdbCluster.getClient().Delete(context.Background(), &pod)).
+			g.Expect(fdbCluster.getClient().Delete(ctx, &pod)).
 				NotTo(gomega.HaveOccurred())
 		}
 
@@ -796,38 +832,44 @@ func (fdbCluster *FdbCluster) SetPodAsUnschedulable(pod corev1.Pod) {
 // SetProcessGroupsAsUnschedulable sets the provided process groups on the NoSchedule list of the current FoundationDBCluster. This will make
 // sure that the Pod is stuck in Pending.
 func (fdbCluster *FdbCluster) SetProcessGroupsAsUnschedulable(
+	ctx context.Context,
 	processGroups []fdbv1beta2.ProcessGroupID,
 ) {
 	fdbCluster.cluster.Spec.Buggify.NoSchedule = processGroups
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 }
 
 // ClearBuggifyNoSchedule this will reset the NoSchedule setting for the current FoundationDBCluster.
-func (fdbCluster *FdbCluster) ClearBuggifyNoSchedule(waitForReconcile bool) error {
+func (fdbCluster *FdbCluster) ClearBuggifyNoSchedule(
+	ctx context.Context,
+	waitForReconcile bool,
+) error {
 	fdbCluster.cluster.Spec.Buggify.NoSchedule = nil
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 
 	if !waitForReconcile {
 		return nil
 	}
 
-	return fdbCluster.WaitForReconciliation()
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 func (fdbCluster *FdbCluster) setPublicIPSource(
+	ctx context.Context,
 	publicIPSource fdbv1beta2.PublicIPSource,
 	waitForReconcile bool,
 ) error {
 	fdbCluster.cluster.Spec.Routing.PublicIPSource = &publicIPSource
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 	if !waitForReconcile {
 		return nil
 	}
-	return fdbCluster.WaitForReconciliation()
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // SetTLS will enabled or disable the TLS setting in the current FoundationDBCluster.
 func (fdbCluster *FdbCluster) SetTLS(
+	ctx context.Context,
 	enableMainContainerTLS bool,
 	enableSidecarContainerTLS bool,
 ) error {
@@ -839,21 +881,24 @@ func (fdbCluster *FdbCluster) SetTLS(
 	)
 	fdbCluster.cluster.Spec.MainContainer.EnableTLS = enableMainContainerTLS
 	fdbCluster.cluster.Spec.SidecarContainer.EnableTLS = enableSidecarContainerTLS
-	fdbCluster.UpdateClusterSpec()
-	return fdbCluster.WaitForReconciliation()
+	fdbCluster.UpdateClusterSpec(ctx)
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // SetPublicIPSource will set the public IP source of the current FoundationDBCluster to the provided IP source.
-func (fdbCluster *FdbCluster) SetPublicIPSource(publicIPSource fdbv1beta2.PublicIPSource) error {
-	return fdbCluster.setPublicIPSource(publicIPSource, true)
+func (fdbCluster *FdbCluster) SetPublicIPSource(
+	ctx context.Context,
+	publicIPSource fdbv1beta2.PublicIPSource,
+) error {
+	return fdbCluster.setPublicIPSource(ctx, publicIPSource, true)
 }
 
 // GetServices returns the services associated with the current FoundationDBCluster.
-func (fdbCluster *FdbCluster) GetServices() *corev1.ServiceList {
+func (fdbCluster *FdbCluster) GetServices(ctx context.Context) *corev1.ServiceList {
 	serviceList := &corev1.ServiceList{}
 	gomega.Expect(
 		fdbCluster.getClient().List(
-			context.Background(),
+			ctx,
 			serviceList,
 			client.InNamespace(fdbCluster.Namespace()),
 			client.MatchingLabels(fdbCluster.GetResourceLabels())),
@@ -863,13 +908,18 @@ func (fdbCluster *FdbCluster) GetServices() *corev1.ServiceList {
 }
 
 // SetAutoReplacements will enabled or disable the auto replacement feature and allows to specify the detection time for a replacement.
-func (fdbCluster *FdbCluster) SetAutoReplacements(enabled bool, detectionTime time.Duration) error {
-	return fdbCluster.SetAutoReplacementsWithWait(enabled, detectionTime, true)
+func (fdbCluster *FdbCluster) SetAutoReplacements(
+	ctx context.Context,
+	enabled bool,
+	detectionTime time.Duration,
+) error {
+	return fdbCluster.SetAutoReplacementsWithWait(ctx, enabled, detectionTime, true)
 }
 
 // SetAutoReplacementsWithWait set the auto replacement setting on the operator and only waits for the cluster to reconcile
 // if wait is set to true.
 func (fdbCluster *FdbCluster) SetAutoReplacementsWithWait(
+	ctx context.Context,
 	enabled bool,
 	detectionTime time.Duration,
 	wait bool,
@@ -877,42 +927,43 @@ func (fdbCluster *FdbCluster) SetAutoReplacementsWithWait(
 	detectionTimeSec := int(detectionTime.Seconds())
 	fdbCluster.cluster.Spec.AutomationOptions.Replacements.Enabled = &enabled
 	fdbCluster.cluster.Spec.AutomationOptions.Replacements.FailureDetectionTimeSeconds = &detectionTimeSec
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 
 	if !wait {
 		return nil
 	}
 
-	return fdbCluster.WaitForReconciliation()
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // UpdateCoordinatorSelection allows to update the coordinator selection for the current FoundationDBCluster.
 func (fdbCluster *FdbCluster) UpdateCoordinatorSelection(
+	ctx context.Context,
 	setting []fdbv1beta2.CoordinatorSelectionSetting,
 ) error {
 	fdbCluster.cluster.Spec.CoordinatorSelection = setting
-	fdbCluster.UpdateClusterSpec()
-	return fdbCluster.WaitForReconciliation()
+	fdbCluster.UpdateClusterSpec(ctx)
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // SetProcessGroupPrefix will set the process group prefix setting.
-func (fdbCluster *FdbCluster) SetProcessGroupPrefix(prefix string) error {
+func (fdbCluster *FdbCluster) SetProcessGroupPrefix(ctx context.Context, prefix string) error {
 	fdbCluster.cluster.Spec.ProcessGroupIDPrefix = prefix
-	fdbCluster.UpdateClusterSpec()
-	return fdbCluster.WaitForReconciliation()
+	fdbCluster.UpdateClusterSpec(ctx)
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // SetSkipReconciliation will set the skip setting for the current FoundationDBCluster. This setting will make sure that
 // the operator is not taking any actions on this cluster.
-func (fdbCluster *FdbCluster) SetSkipReconciliation(skip bool) {
+func (fdbCluster *FdbCluster) SetSkipReconciliation(ctx context.Context, skip bool) {
 	fdbCluster.cluster.Spec.Skip = skip
 	// Skip wait for reconciliation since this spec update is in the operator itself and by setting it, the operator
 	// skips reconciliation.
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 }
 
 // WaitForPodRemoval will wait until the specified Pod is deleted.
-func (fdbCluster *FdbCluster) WaitForPodRemoval(pod *corev1.Pod) {
+func (fdbCluster *FdbCluster) WaitForPodRemoval(ctx context.Context, pod *corev1.Pod) {
 	if pod == nil {
 		return
 	}
@@ -928,7 +979,7 @@ func (fdbCluster *FdbCluster) WaitForPodRemoval(pod *corev1.Pod) {
 	fetchedPod := &corev1.Pod{}
 	gomega.Eventually(func() bool {
 		err := fdbCluster.getClient().
-			Get(context.Background(), client.ObjectKeyFromObject(pod), fetchedPod)
+			Get(ctx, client.ObjectKeyFromObject(pod), fetchedPod)
 		if err != nil && kubeErrors.IsNotFound(err) {
 			return true
 		}
@@ -939,7 +990,7 @@ func (fdbCluster *FdbCluster) WaitForPodRemoval(pod *corev1.Pod) {
 			return true
 		}
 
-		resCluster := fdbCluster.GetCluster()
+		resCluster := fdbCluster.GetCluster(ctx)
 		// We have to force a reconcile because the operator only reacts to events.
 		// The network partition of the Pod won't trigger any reconcile and we would have to wait for 10h.
 		if counter >= forceReconcile {
@@ -954,7 +1005,7 @@ func (fdbCluster *FdbCluster) WaitForPodRemoval(pod *corev1.Pod) {
 			// This will apply an Annotation to the object which will trigger the reconcile loop.
 			// This should speed up the reconcile phase.
 			_ = fdbCluster.getClient().Patch(
-				context.Background(),
+				ctx,
 				resCluster,
 				patch)
 			counter = -1
@@ -966,21 +1017,24 @@ func (fdbCluster *FdbCluster) WaitForPodRemoval(pod *corev1.Pod) {
 }
 
 // GetClusterSpec returns the current cluster spec.
-func (fdbCluster *FdbCluster) GetClusterSpec() fdbv1beta2.FoundationDBClusterSpec {
+func (fdbCluster *FdbCluster) GetClusterSpec(
+	ctx context.Context,
+) fdbv1beta2.FoundationDBClusterSpec {
 	// Ensure we fetch the latest state to ensure we return the latest spec and not a cached state.
-	_ = fdbCluster.GetCluster()
+	_ = fdbCluster.GetCluster(ctx)
 	return fdbCluster.cluster.Spec
 }
 
 // BounceClusterWithoutWait will restart all fdberver processes in the current FoundationDBCluster without waiting for the
 // cluster to become available again.
-func (fdbCluster *FdbCluster) BounceClusterWithoutWait() error {
+func (fdbCluster *FdbCluster) BounceClusterWithoutWait(ctx context.Context) error {
 	var retries int
 	var err error
 
 	// We try to execute the bounce command 5 times
 	for retries < 5 {
 		_, _, err = fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(
+			ctx,
 			"kill; kill all; sleep 5",
 			true,
 			30,
@@ -999,32 +1053,38 @@ func (fdbCluster *FdbCluster) BounceClusterWithoutWait() error {
 
 // SetFinalizerForPvc allows to set the finalizers for the provided PVC.
 func (fdbCluster *FdbCluster) SetFinalizerForPvc(
+	ctx context.Context,
 	finalizers []string,
 	pvc corev1.PersistentVolumeClaim,
 ) error {
 	patch := client.MergeFrom(pvc.DeepCopy())
 	pvc.SetFinalizers(finalizers)
-	return fdbCluster.getClient().Patch(context.Background(), &pvc, patch)
+	return fdbCluster.getClient().Patch(ctx, &pvc, patch)
 }
 
 // UpdateStorageClass this will set the StorageClass for the provided process class of the current FoundationDBCluster.
 func (fdbCluster *FdbCluster) UpdateStorageClass(
+	ctx context.Context,
 	storageClass string,
 	processClass fdbv1beta2.ProcessClass,
 ) error {
 	log.Println("Updating storage class for", processClass, "to", storageClass)
-	resCluster := fdbCluster.GetCluster()
+	resCluster := fdbCluster.GetCluster(ctx)
 	patch := client.MergeFrom(resCluster.DeepCopy())
 	resCluster.Spec.Processes[processClass].VolumeClaimTemplate.Spec.StorageClassName = &storageClass
-	_ = fdbCluster.getClient().Patch(context.Background(), resCluster, patch)
-	return fdbCluster.WaitForReconciliation()
+	_ = fdbCluster.getClient().Patch(ctx, resCluster, patch)
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // UpgradeCluster will upgrade the cluster to the specified version. If waitForReconciliation is set to true this method will
 // block until the cluster is fully upgraded and all Pods are running the new image version.
-func (fdbCluster *FdbCluster) UpgradeCluster(version string, waitForReconciliation bool) error {
+func (fdbCluster *FdbCluster) UpgradeCluster(
+	ctx context.Context,
+	version string,
+	waitForReconciliation bool,
+) error {
 	// Ensure we have pulled that latest state of the cluster.
-	_ = fdbCluster.GetCluster()
+	_ = fdbCluster.GetCluster(ctx)
 
 	log.Printf(
 		"Upgrading cluster from version %s to version %s",
@@ -1034,13 +1094,14 @@ func (fdbCluster *FdbCluster) UpgradeCluster(version string, waitForReconciliati
 
 	fdbCluster.cluster.Spec.Version = version
 	log.Println("Spec version", fdbCluster.cluster.Spec.Version)
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 	// Ensure the version is actually upgraded.
 	gomega.Expect(fdbCluster.cluster.Spec.Version).To(gomega.Equal(version))
 
 	if waitForReconciliation {
 		log.Println("Waiting for generation:", fdbCluster.cluster.Generation)
 		return fdbCluster.WaitForReconciliation(
+			ctx,
 			MinimumGenerationOption(fdbCluster.cluster.Generation),
 		)
 	}
@@ -1050,13 +1111,14 @@ func (fdbCluster *FdbCluster) UpgradeCluster(version string, waitForReconciliati
 
 // SetClusterTaintConfig set fdbCluster's TaintReplacementOptions
 func (fdbCluster *FdbCluster) SetClusterTaintConfig(
+	ctx context.Context,
 	taintOption []fdbv1beta2.TaintReplacementOption,
 	taintReplacementTimeSeconds *int,
 ) {
-	curClusterSpec := fdbCluster.GetCluster().Spec.DeepCopy()
+	curClusterSpec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 	curClusterSpec.AutomationOptions.Replacements.TaintReplacementOptions = taintOption
 	curClusterSpec.AutomationOptions.Replacements.TaintReplacementTimeSeconds = taintReplacementTimeSeconds
-	fdbCluster.UpdateClusterSpecWithSpec(curClusterSpec)
+	fdbCluster.UpdateClusterSpecWithSpec(ctx, curClusterSpec)
 }
 
 // GetProcessCounts returns the process counts of the current FoundationDBCluster.
@@ -1071,10 +1133,11 @@ func (fdbCluster *FdbCluster) HasHeadlessService() bool {
 
 // SetCustomParameters allows to set the custom parameters of the provided process class.
 func (fdbCluster *FdbCluster) SetCustomParameters(
+	ctx context.Context,
 	customParameters map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters,
 	waitForReconcile bool,
 ) error {
-	cluster := fdbCluster.GetCluster()
+	cluster := fdbCluster.GetCluster(ctx)
 
 	for processClass, parameters := range customParameters {
 		setting, ok := cluster.Spec.Processes[processClass]
@@ -1086,12 +1149,12 @@ func (fdbCluster *FdbCluster) SetCustomParameters(
 		cluster.Spec.Processes[processClass] = setting
 	}
 
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 	if !waitForReconcile {
 		return nil
 	}
 
-	return fdbCluster.WaitForReconciliation()
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // GetCustomParameters returns the current custom parameters for the specified process class.
@@ -1103,6 +1166,7 @@ func (fdbCluster *FdbCluster) GetCustomParameters(
 
 // SetPodTemplateSpec allows to set the pod template spec of the provided process class.
 func (fdbCluster *FdbCluster) SetPodTemplateSpec(
+	ctx context.Context,
 	processClass fdbv1beta2.ProcessClass,
 	podTemplateSpec *corev1.PodSpec,
 	waitForReconcile bool,
@@ -1114,12 +1178,12 @@ func (fdbCluster *FdbCluster) SetPodTemplateSpec(
 	setting.PodTemplate.Spec = *podTemplateSpec
 
 	fdbCluster.cluster.Spec.Processes[processClass] = setting
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 	if !waitForReconcile {
 		return nil
 	}
 
-	return fdbCluster.WaitForReconciliation()
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // GetPodTemplateSpec returns the current pod template spec for the specified process class.
@@ -1146,10 +1210,10 @@ func (fdbCluster *FdbCluster) GetProcessSettings(
 }
 
 // CheckPodIsDeleted return true if Pod no longer exists at the executed time point
-func (fdbCluster *FdbCluster) CheckPodIsDeleted(podName string) bool {
+func (fdbCluster *FdbCluster) CheckPodIsDeleted(ctx context.Context, podName string) bool {
 	pod := &corev1.Pod{}
 	err := fdbCluster.getClient().
-		Get(context.Background(), client.ObjectKey{Namespace: fdbCluster.Namespace(), Name: podName}, pod)
+		Get(ctx, client.ObjectKey{Namespace: fdbCluster.Namespace(), Name: podName}, pod)
 
 	if err != nil {
 		if kubeErrors.IsNotFound(err) {
@@ -1163,6 +1227,7 @@ func (fdbCluster *FdbCluster) CheckPodIsDeleted(podName string) bool {
 // EnsurePodIsDeletedWithCustomTimeout validates that a Pod is either not existing or is marked as deleted with a non-zero deletion timestamp.
 // It times out after timeoutMinutes.
 func (fdbCluster *FdbCluster) EnsurePodIsDeletedWithCustomTimeout(
+	ctx context.Context,
 	podName string,
 	timeoutMinutes int,
 ) {
@@ -1171,36 +1236,42 @@ func (fdbCluster *FdbCluster) EnsurePodIsDeletedWithCustomTimeout(
 		// Force a reconciliation every minute to ensure the deletion will be done in a more timely manner (without
 		// the reconciliation getting delayed by the requeue mechanism).
 		if time.Since(lastForceReconcile) > 1*time.Minute {
-			fdbCluster.ForceReconcile()
+			fdbCluster.ForceReconcile(ctx)
 			lastForceReconcile = time.Now()
 		}
 
-		return fdbCluster.CheckPodIsDeleted(podName)
+		return fdbCluster.CheckPodIsDeleted(ctx, podName)
 	}).WithTimeout(time.Duration(timeoutMinutes) * time.Minute).WithPolling(1 * time.Second).Should(gomega.BeTrue())
 }
 
 // EnsurePodIsDeleted validates that a Pod is either not existing or is marked as deleted with a non-zero deletion timestamp.
-func (fdbCluster *FdbCluster) EnsurePodIsDeleted(podName string) {
-	fdbCluster.EnsurePodIsDeletedWithCustomTimeout(podName, 5)
+func (fdbCluster *FdbCluster) EnsurePodIsDeleted(ctx context.Context, podName string) {
+	fdbCluster.EnsurePodIsDeletedWithCustomTimeout(ctx, podName, 5)
 }
 
 // SetUseDNSInClusterFile enables DNS in the cluster file. Enable this setting to use DNS instead of IP addresses in
 // the connection string.
-func (fdbCluster *FdbCluster) SetUseDNSInClusterFile(useDNSInClusterFile bool) error {
+func (fdbCluster *FdbCluster) SetUseDNSInClusterFile(
+	ctx context.Context,
+	useDNSInClusterFile bool,
+) error {
 	fdbCluster.cluster.Spec.Routing.UseDNSInClusterFile = ptr.To(useDNSInClusterFile)
-	fdbCluster.UpdateClusterSpec()
-	return fdbCluster.WaitForReconciliation()
+	fdbCluster.UpdateClusterSpec(ctx)
+	return fdbCluster.WaitForReconciliation(ctx)
 }
 
 // Destroy will remove the underlying cluster.
-func (fdbCluster *FdbCluster) Destroy() error {
-	return fdbCluster.DestroyWithWaitForTearDown(false)
+func (fdbCluster *FdbCluster) Destroy(ctx context.Context) error {
+	return fdbCluster.DestroyWithWaitForTearDown(ctx, false)
 }
 
 // DestroyWithWaitForTearDown will remove the underlying cluster and wait for the resources to be removed.
-func (fdbCluster *FdbCluster) DestroyWithWaitForTearDown(waitForTearDown bool) error {
+func (fdbCluster *FdbCluster) DestroyWithWaitForTearDown(
+	ctx context.Context,
+	waitForTearDown bool,
+) error {
 	err := fdbCluster.getClient().
-		Delete(context.Background(), fdbCluster.cluster)
+		Delete(ctx, fdbCluster.cluster)
 	if err != nil {
 		return err
 	}
@@ -1213,7 +1284,7 @@ func (fdbCluster *FdbCluster) DestroyWithWaitForTearDown(waitForTearDown bool) e
 	gomega.Eventually(func(g gomega.Gomega) {
 		podList := &corev1.PodList{}
 
-		g.Expect(fdbCluster.getClient().List(context.Background(), podList,
+		g.Expect(fdbCluster.getClient().List(ctx, podList,
 			client.InNamespace(fdbCluster.cluster.Namespace),
 			client.MatchingLabels(fdbCluster.cluster.GetMatchLabels()),
 		)).To(gomega.Succeed())
@@ -1225,32 +1296,36 @@ func (fdbCluster *FdbCluster) DestroyWithWaitForTearDown(waitForTearDown bool) e
 }
 
 // SetIgnoreMissingProcessesSeconds sets the IgnoreMissingProcessesSeconds setting.
-func (fdbCluster *FdbCluster) SetIgnoreMissingProcessesSeconds(duration time.Duration) {
+func (fdbCluster *FdbCluster) SetIgnoreMissingProcessesSeconds(
+	ctx context.Context,
+	duration time.Duration,
+) {
 	fdbCluster.cluster.Spec.AutomationOptions.IgnoreMissingProcessesSeconds = ptr.To(
 		int(duration.Seconds()),
 	)
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 }
 
 // SetKillProcesses sets the automation option to allow the operator to restart processes or not.
-func (fdbCluster *FdbCluster) SetKillProcesses(allowKill bool, wait bool) {
+func (fdbCluster *FdbCluster) SetKillProcesses(ctx context.Context, allowKill bool, wait bool) {
 	fdbCluster.cluster.Spec.AutomationOptions.KillProcesses = ptr.To(allowKill)
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 
 	if !wait {
 		return
 	}
 
-	gomega.Expect(fdbCluster.WaitForReconciliation()).NotTo(gomega.HaveOccurred())
+	gomega.Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(gomega.HaveOccurred())
 }
 
 // AllProcessGroupsHaveCondition returns true if all process groups have the specified condition. If allowOtherConditions is
 // set to true only this condition is allowed.
 func (fdbCluster *FdbCluster) AllProcessGroupsHaveCondition(
+	ctx context.Context,
 	condition fdbv1beta2.ProcessGroupConditionType,
 	ignoreMissing bool,
 ) bool {
-	cluster := fdbCluster.GetCluster()
+	cluster := fdbCluster.GetCluster(ctx)
 
 	for _, processGroup := range cluster.Status.ProcessGroups {
 		if processGroup.IsMarkedForRemoval() {
@@ -1275,26 +1350,31 @@ func (fdbCluster *FdbCluster) AllProcessGroupsHaveCondition(
 
 // SetCrashLoopContainers sets the crashLoopContainers of the FoundationDBCluster spec.
 func (fdbCluster *FdbCluster) SetCrashLoopContainers(
+	ctx context.Context,
 	crashLoopContainers []fdbv1beta2.CrashLoopContainerObject,
 	waitForReconcile bool,
 ) {
 	fdbCluster.cluster.Spec.Buggify.CrashLoopContainers = crashLoopContainers
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 	if !waitForReconcile {
 		return
 	}
-	gomega.Expect(fdbCluster.WaitForReconciliation()).NotTo(gomega.HaveOccurred())
+	gomega.Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(gomega.HaveOccurred())
 }
 
 // SetIgnoreDuringRestart sets the buggify option for the operator.
-func (fdbCluster *FdbCluster) SetIgnoreDuringRestart(processes []fdbv1beta2.ProcessGroupID) {
+func (fdbCluster *FdbCluster) SetIgnoreDuringRestart(
+	ctx context.Context,
+	processes []fdbv1beta2.ProcessGroupID,
+) {
 	fdbCluster.cluster.Spec.Buggify.IgnoreDuringRestart = processes
-	fdbCluster.UpdateClusterSpec()
-	gomega.Expect(fdbCluster.WaitForReconciliation()).NotTo(gomega.HaveOccurred())
+	fdbCluster.UpdateClusterSpec(ctx)
+	gomega.Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(gomega.HaveOccurred())
 }
 
 // UpdateContainerImage sets the image for the provided Pod for the provided container.
 func (fdbCluster *FdbCluster) UpdateContainerImage(
+	ctx context.Context,
 	pod *corev1.Pod,
 	containerName string,
 	image string,
@@ -1302,7 +1382,7 @@ func (fdbCluster *FdbCluster) UpdateContainerImage(
 	gomega.Eventually(func(g gomega.Gomega) error {
 		updatePod := &corev1.Pod{}
 
-		g.Expect(fdbCluster.getClient().Get(context.Background(), client.ObjectKeyFromObject(pod), updatePod)).
+		g.Expect(fdbCluster.getClient().Get(ctx, client.ObjectKeyFromObject(pod), updatePod)).
 			To(gomega.Succeed())
 
 		for idx, container := range updatePod.Spec.Containers {
@@ -1314,14 +1394,17 @@ func (fdbCluster *FdbCluster) UpdateContainerImage(
 		}
 
 		return fdbCluster.factory.GetControllerRuntimeClient().
-			Update(context.Background(), updatePod)
+			Update(ctx, updatePod)
 	}).ShouldNot(gomega.HaveOccurred())
 }
 
 // SetBuggifyBlockRemoval will set the provided list of process group IDs to be blocked for removal.
-func (fdbCluster *FdbCluster) SetBuggifyBlockRemoval(blockRemovals []fdbv1beta2.ProcessGroupID) {
+func (fdbCluster *FdbCluster) SetBuggifyBlockRemoval(
+	ctx context.Context,
+	blockRemovals []fdbv1beta2.ProcessGroupID,
+) {
 	fdbCluster.cluster.Spec.Buggify.BlockRemoval = blockRemovals
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 }
 
 // GetAutomationOptions return the fdbCluster's AutomationOptions
@@ -1332,13 +1415,14 @@ func (fdbCluster *FdbCluster) GetAutomationOptions() fdbv1beta2.FoundationDBClus
 // ValidateProcessesCount will make sure that the cluster has the expected count of ProcessGroups and processes running
 // with the provided ProcessClass.
 func (fdbCluster *FdbCluster) ValidateProcessesCount(
+	ctx context.Context,
 	processClass fdbv1beta2.ProcessClass,
 	countProcessGroups int,
 	countServer int,
 ) {
 	gomega.Eventually(func() int {
 		var cnt int
-		for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+		for _, processGroup := range fdbCluster.GetCluster(ctx).Status.ProcessGroups {
 			if processGroup.ProcessClass != processClass {
 				continue
 			}
@@ -1354,11 +1438,11 @@ func (fdbCluster *FdbCluster) ValidateProcessesCount(
 	}).Should(gomega.BeNumerically("==", countProcessGroups))
 
 	gomega.Eventually(func() int {
-		return fdbCluster.GetProcessCountByProcessClass(processClass)
+		return fdbCluster.GetProcessCountByProcessClass(ctx, processClass)
 	}).Should(gomega.BeNumerically("==", countServer))
 
 	// Make sure that all process group have a fault domain set.
-	for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+	for _, processGroup := range fdbCluster.GetCluster(ctx).Status.ProcessGroups {
 		gomega.Expect(processGroup.FaultDomain).NotTo(gomega.BeEmpty())
 	}
 }
@@ -1377,6 +1461,7 @@ func (fdbCluster *FdbCluster) ValidateProcessesCount(
 
 */
 func (fdbCluster *FdbCluster) UpdateAnnotationsAndLabels(
+	ctx context.Context,
 	annotations map[string]string,
 	labels map[string]string,
 ) {
@@ -1384,7 +1469,7 @@ func (fdbCluster *FdbCluster) UpdateAnnotationsAndLabels(
 	gomega.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		fetchedCluster := &fdbv1beta2.FoundationDBCluster{}
 		err := fdbCluster.getClient().
-			Get(context.Background(), client.ObjectKeyFromObject(fdbCluster.cluster), fetchedCluster)
+			Get(ctx, client.ObjectKeyFromObject(fdbCluster.cluster), fetchedCluster)
 		if err != nil {
 			return err
 		}
@@ -1394,21 +1479,21 @@ func (fdbCluster *FdbCluster) UpdateAnnotationsAndLabels(
 		fetchedCluster.Labels = labels
 
 		return fdbCluster.getClient().Patch(
-			context.Background(),
+			ctx,
 			fetchedCluster,
 			patch)
 	})).NotTo(gomega.HaveOccurred())
 
 	// Make sure the current reference is updated.
-	fdbCluster.GetCluster()
+	fdbCluster.GetCluster(ctx)
 }
 
 // VerifyVersion Checks if cluster is running at the expectedVersion. This is done by checking the status of the FoundationDBCluster status.
 // Before that we checked the cluster status json by checking the reported version of all processes. This approach only worked for
 // version compatible upgrades, since incompatible processes won't be part of the cluster anyway. To simplify the check
 // we verify the reported running version from the operator.
-func (fdbCluster *FdbCluster) VerifyVersion(version string) {
-	gomega.Expect(fdbCluster.WaitUntilWithForceReconcile(2, 600, func(cluster *fdbv1beta2.FoundationDBCluster) bool {
+func (fdbCluster *FdbCluster) VerifyVersion(ctx context.Context, version string) {
+	gomega.Expect(fdbCluster.WaitUntilWithForceReconcile(ctx, 2, 600, func(cluster *fdbv1beta2.FoundationDBCluster) bool {
 		return cluster.Status.RunningVersion == version
 	})).
 		NotTo(gomega.HaveOccurred())
@@ -1416,30 +1501,30 @@ func (fdbCluster *FdbCluster) VerifyVersion(version string) {
 
 // UpgradeAndVerify will upgrade the cluster to the new version and perform a check at the end that the running version
 // matched the new version.
-func (fdbCluster *FdbCluster) UpgradeAndVerify(version string) {
+func (fdbCluster *FdbCluster) UpgradeAndVerify(ctx context.Context, version string) {
 	startTime := time.Now()
 	defer func() {
 		log.Println("Upgrade took:", time.Since(startTime).String())
 	}()
 
-	gomega.Expect(fdbCluster.UpgradeCluster(version, true)).NotTo(gomega.HaveOccurred())
-	fdbCluster.VerifyVersion(version)
+	gomega.Expect(fdbCluster.UpgradeCluster(ctx, version, true)).NotTo(gomega.HaveOccurred())
+	fdbCluster.VerifyVersion(ctx, version)
 }
 
 // EnsureTeamTrackersAreHealthy will check if the machine-readable status suggest that the team trackers are healthy
 // and all data is present.
-func (fdbCluster *FdbCluster) EnsureTeamTrackersAreHealthy() {
+func (fdbCluster *FdbCluster) EnsureTeamTrackersAreHealthy(ctx context.Context) {
 	gomega.Eventually(func(g gomega.Gomega) bool {
 		// If the status is initializing the team trackers will be missing. This can happen in cases where e.g.
 		// the DD is restarted or when the SS are restarted. This state is only intermediate and will change once the
 		// DD is done analyzing the current state. If we are not checking for this state, we might see intermediate failures
 		// because of a short period where the DD is restarted and therefore the team trackers are empty.
-		if fdbCluster.GetStatus().Cluster.Data.State.Name == "initializing" {
+		if fdbCluster.GetStatus(ctx).Cluster.Data.State.Name == "initializing" {
 			return true
 		}
 
 		// Make sure that the team trackers are reporting.
-		teamTrackers := fdbCluster.GetStatus().Cluster.Data.TeamTrackers
+		teamTrackers := fdbCluster.GetStatus(ctx).Cluster.Data.TeamTrackers
 		g.Expect(teamTrackers).NotTo(gomega.BeEmpty())
 		for _, tracker := range teamTrackers {
 			if !tracker.State.Healthy {
@@ -1453,10 +1538,10 @@ func (fdbCluster *FdbCluster) EnsureTeamTrackersAreHealthy() {
 
 // EnsureTeamTrackersHaveMinReplicas will check if the machine-readable status suggest that the team trackers min_replicas
 // match the expected replicas.
-func (fdbCluster *FdbCluster) EnsureTeamTrackersHaveMinReplicas() {
+func (fdbCluster *FdbCluster) EnsureTeamTrackersHaveMinReplicas(ctx context.Context) {
 	desiredFaultTolerance := fdbCluster.GetCachedCluster().DesiredFaultTolerance()
 	gomega.Eventually(func(g gomega.Gomega) int {
-		status := fdbCluster.GetStatus()
+		status := fdbCluster.GetStatus(ctx)
 		// If the status is initializing the team trackers will be missing. This can happen in cases where e.g.
 		// the DD is restarted or when the SS are restarted. This state is only intermediate and will change once the
 		// DD is done analyzing the current state. If we are not checking for this state, we might see intermediate failures
@@ -1480,9 +1565,10 @@ func (fdbCluster *FdbCluster) EnsureTeamTrackersHaveMinReplicas() {
 
 // GetListOfUIDsFromVolumeClaims will return of list of UIDs for the current volume claims for the provided processes class.
 func (fdbCluster *FdbCluster) GetListOfUIDsFromVolumeClaims(
+	ctx context.Context,
 	processClass fdbv1beta2.ProcessClass,
 ) []types.UID {
-	volumesClaims := fdbCluster.GetVolumeClaimsForProcesses(processClass)
+	volumesClaims := fdbCluster.GetVolumeClaimsForProcesses(ctx, processClass)
 
 	uids := make([]types.UID, 0, len(volumesClaims.Items))
 	for _, volumeClaim := range volumesClaims.Items {
@@ -1493,21 +1579,24 @@ func (fdbCluster *FdbCluster) GetListOfUIDsFromVolumeClaims(
 }
 
 // UpdateConnectionString will update the connection string in the ConfigMap and the SeedConnectionString of the custer.
-func (fdbCluster *FdbCluster) UpdateConnectionString(connectionString string) {
+func (fdbCluster *FdbCluster) UpdateConnectionString(ctx context.Context, connectionString string) {
 	fdbCluster.cluster.Spec.SeedConnectionString = connectionString
-	fdbCluster.UpdateClusterSpec()
+	fdbCluster.UpdateClusterSpec(ctx)
 
 	cm := &corev1.ConfigMap{}
-	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Get(context.Background(), client.ObjectKey{Namespace: fdbCluster.Namespace(), Name: fdbCluster.Name() + "-config"}, cm)).
+	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Get(ctx, client.ObjectKey{Namespace: fdbCluster.Namespace(), Name: fdbCluster.Name() + "-config"}, cm)).
 		NotTo(gomega.HaveOccurred())
 	gomega.Expect(cm.Data).To(gomega.HaveKey(fdbv1beta2.ClusterFileKey))
 	cm.Data[fdbv1beta2.ClusterFileKey] = connectionString
-	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Update(context.Background(), cm)).
+	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Update(ctx, cm)).
 		NotTo(gomega.HaveOccurred())
 }
 
 // CreateTesterDeployment will create a deployment that runs tester processes with the specified number of replicas.
-func (fdbCluster *FdbCluster) CreateTesterDeployment(replicas int) *appsv1.Deployment {
+func (fdbCluster *FdbCluster) CreateTesterDeployment(
+	ctx context.Context,
+	replicas int,
+) *appsv1.Deployment {
 	deploymentName := fdbCluster.Name() + "-tester"
 
 	deploymentLabels := map[string]string{
@@ -1739,12 +1828,12 @@ func (fdbCluster *FdbCluster) CreateTesterDeployment(replicas int) *appsv1.Deplo
 		},
 	}
 
-	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Create(context.Background(), deploy)).
+	gomega.Expect(fdbCluster.factory.controllerRuntimeClient.Create(ctx, deploy)).
 		NotTo(gomega.HaveOccurred())
 	gomega.Eventually(func(g gomega.Gomega) int {
 		pods := &corev1.PodList{}
 
-		err := fdbCluster.factory.controllerRuntimeClient.List(context.Background(), pods,
+		err := fdbCluster.factory.controllerRuntimeClient.List(ctx, pods,
 			client.InNamespace(fdbCluster.Namespace()),
 			client.MatchingLabels(map[string]string{"app": deploymentName}))
 		g.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1764,8 +1853,13 @@ func (fdbCluster *FdbCluster) CreateTesterDeployment(replicas int) *appsv1.Deplo
 }
 
 // GetClusterVersion returns the cluster's version
-func (fdbCluster *FdbCluster) GetClusterVersion() uint64 {
-	stdout, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry("getversion", false, 30)
+func (fdbCluster *FdbCluster) GetClusterVersion(ctx context.Context) uint64 {
+	stdout, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(
+		ctx,
+		"getversion",
+		false,
+		30,
+	)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	version, err := strconv.ParseUint(strings.TrimSpace(stdout), 10, 64)
@@ -1775,12 +1869,12 @@ func (fdbCluster *FdbCluster) GetClusterVersion() uint64 {
 }
 
 // ClearRange will delete the provided range.
-func (fdbCluster *FdbCluster) ClearRange(prefixBytes []byte, timeout int) {
+func (fdbCluster *FdbCluster) ClearRange(ctx context.Context, prefixBytes []byte, timeout int) {
 	begin := FdbPrintable(prefixBytes)
 	endBytes, err := FdbStrinc(prefixBytes)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	end := FdbPrintable(endBytes)
-	_, stderr, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(fmt.Sprintf(
+	_, stderr, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(ctx, fmt.Sprintf(
 		"writemode on; option on ACCESS_SYSTEM_KEYS; clearrange %s %s",
 		begin,
 		end,
@@ -1807,6 +1901,7 @@ func (keyValue *KeyValue) GetValue() string {
 
 // GetRange will return the values of the provided range.
 func (fdbCluster *FdbCluster) GetRange(
+	ctx context.Context,
 	prefixBytes []byte,
 	limit int,
 	timeout int,
@@ -1814,7 +1909,7 @@ func (fdbCluster *FdbCluster) GetRange(
 	endBytes, err := FdbStrinc(prefixBytes)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	stdout, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(fmt.Sprintf(
+	stdout, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(ctx, fmt.Sprintf(
 		"option on ACCESS_SYSTEM_KEYS; getrange %s %s %d",
 		FdbPrintable(prefixBytes),
 		FdbPrintable(endBytes),
@@ -1863,11 +1958,13 @@ func (fdbCluster *FdbCluster) GenerateRandomValues(
 
 // WriteKeyValue writes a single key value pair into FDB.
 func (fdbCluster *FdbCluster) WriteKeyValue(
+	ctx context.Context,
 	keyValue KeyValue,
 	timeout int,
 ) {
 	gomega.Eventually(func(g gomega.Gomega) {
 		_, stderr, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(
+			ctx,
 			fmt.Sprintf("writemode on; set %s %s", keyValue.GetKey(), keyValue.GetValue()),
 			false,
 			timeout,
@@ -1878,13 +1975,17 @@ func (fdbCluster *FdbCluster) WriteKeyValue(
 }
 
 // WriteKeyValuesWithTimeout writes multiples key values into FDB with the specified timeout.
-func (fdbCluster *FdbCluster) WriteKeyValuesWithTimeout(keyValues []KeyValue, timeout int) {
+func (fdbCluster *FdbCluster) WriteKeyValuesWithTimeout(
+	ctx context.Context,
+	keyValues []KeyValue,
+	timeout int,
+) {
 	for _, kv := range keyValues {
-		fdbCluster.WriteKeyValue(kv, timeout)
+		fdbCluster.WriteKeyValue(ctx, kv, timeout)
 	}
 }
 
 // WriteKeyValues writes multiples key values into FDB.
-func (fdbCluster *FdbCluster) WriteKeyValues(keyValues []KeyValue) {
-	fdbCluster.WriteKeyValuesWithTimeout(keyValues, 30)
+func (fdbCluster *FdbCluster) WriteKeyValues(ctx context.Context, keyValues []KeyValue) {
+	fdbCluster.WriteKeyValuesWithTimeout(ctx, keyValues, 30)
 }

--- a/e2e/fixtures/fdb_cluster_creation_tracker.go
+++ b/e2e/fixtures/fdb_cluster_creation_tracker.go
@@ -137,8 +137,9 @@ func (tracker *fdbClusterCreationTracker) nextStep() {
 	})).NotTo(gomega.HaveOccurred())
 }
 
-// checkStep will check if the current step is full filled and if the state machine should move to the next step.
+// checkStep will check if the current step is fulfilled and if the state machine should move to the next step.
 func (tracker *fdbClusterCreationTracker) checkStep(
+	ctx context.Context,
 	step creationStep,
 	cluster *fdbv1beta2.FoundationDBCluster,
 ) {
@@ -155,7 +156,7 @@ func (tracker *fdbClusterCreationTracker) checkStep(
 		}
 	case creationStepProcessGroupsCreated:
 		podList := &corev1.PodList{}
-		gomega.Expect(tracker.ctrlClient.List(context.TODO(), podList,
+		gomega.Expect(tracker.ctrlClient.List(ctx, podList,
 			client.InNamespace(cluster.Namespace),
 			client.MatchingLabels(cluster.GetMatchLabels()))).ToNot(gomega.HaveOccurred())
 
@@ -165,7 +166,7 @@ func (tracker *fdbClusterCreationTracker) checkStep(
 		}
 	case creationStepPodsCreated:
 		podList := &corev1.PodList{}
-		gomega.Expect(tracker.ctrlClient.List(context.TODO(), podList,
+		gomega.Expect(tracker.ctrlClient.List(ctx, podList,
 			client.InNamespace(cluster.Namespace),
 			client.MatchingLabels(cluster.GetMatchLabels()))).ToNot(gomega.HaveOccurred())
 
@@ -223,13 +224,16 @@ func (tracker *fdbClusterCreationTracker) checkStep(
 }
 
 // trackProgress will check the current step until the state machine cannot make progress.
-func (tracker *fdbClusterCreationTracker) trackProgress(cluster *fdbv1beta2.FoundationDBCluster) {
+func (tracker *fdbClusterCreationTracker) trackProgress(
+	ctx context.Context,
+	cluster *fdbv1beta2.FoundationDBCluster,
+) {
 	curStep := -1
 
 	// Check as many steps as possible.
 	for curStep != int(tracker.currentStep) {
 		curStep = int(tracker.currentStep)
-		tracker.checkStep(tracker.currentStep, cluster)
+		tracker.checkStep(ctx, tracker.currentStep, cluster)
 	}
 }
 

--- a/e2e/fixtures/fdb_cluster_specs.go
+++ b/e2e/fixtures/fdb_cluster_specs.go
@@ -21,6 +21,8 @@
 package fixtures
 
 import (
+	"context"
+
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,17 +32,20 @@ import (
 
 // GenerateFDBClusterSpec will generate a *fdbv1beta2.FoundationDBCluster based on the input ClusterConfig.
 func (factory *Factory) GenerateFDBClusterSpec(
+	ctx context.Context,
 	config *ClusterConfig,
 ) *fdbv1beta2.FoundationDBCluster {
-	config.SetDefaults(factory)
+	config.SetDefaults(ctx, factory)
 
 	return factory.createFDBClusterSpec(
+		ctx,
 		config,
 		config.CreateDatabaseConfiguration())
 }
 
 // High Level Cluster Spec Supplied by Operator.
 func (factory *Factory) createFDBClusterSpec(
+	ctx context.Context,
 	config *ClusterConfig,
 	databaseConfiguration fdbv1beta2.DatabaseConfiguration,
 ) *fdbv1beta2.FoundationDBCluster {
@@ -76,7 +81,7 @@ func (factory *Factory) createFDBClusterSpec(
 		Spec: fdbv1beta2.FoundationDBClusterSpec{
 			MinimumUptimeSecondsForBounce: 30,
 			Version:                       config.GetVersion(),
-			Processes:                     factory.createProcesses(config),
+			Processes:                     factory.createProcesses(ctx, config),
 			DatabaseConfiguration:         databaseConfiguration,
 			StorageServersPerPod:          config.StorageServerPerPod,
 			LogServersPerPod:              config.LogServersPerPod,
@@ -321,9 +326,10 @@ func (factory *Factory) createPodTemplate(
 
 // createProcesses will generate the ProcessSettings for the cluster configuration.
 func (factory *Factory) createProcesses(
+	ctx context.Context,
 	config *ClusterConfig,
 ) map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings {
-	claimTemplate := config.generateVolumeClaimTemplate(factory.GetDefaultStorageClass())
+	claimTemplate := config.generateVolumeClaimTemplate(factory.GetDefaultStorageClass(ctx))
 	return map[fdbv1beta2.ProcessClass]fdbv1beta2.ProcessSettings{
 		fdbv1beta2.ProcessClassGeneral: {
 			PodTemplate: factory.createPodTemplate(

--- a/e2e/fixtures/fdb_cluster_test.go
+++ b/e2e/fixtures/fdb_cluster_test.go
@@ -28,7 +28,7 @@ import (
 var _ = Describe("FDB Cluster", func() {
 	DescribeTable(
 		"when generating the reconciliation options",
-		func(expected *ReconciliationOptions, options ...func(*ReconciliationOptions)) {
+		func(_ SpecContext, expected *ReconciliationOptions, options ...func(*ReconciliationOptions)) {
 			reconciliationOptions := MakeReconciliationOptionsStruct(options...)
 			Expect(reconciliationOptions).To(Equal(expected))
 		},

--- a/e2e/fixtures/fdb_data_loader.go
+++ b/e2e/fixtures/fdb_data_loader.go
@@ -365,13 +365,14 @@ func getDefaultDataLoaderOptions() *DataLoaderOptions {
 }
 
 // CreateDataLoaderIfAbsent will create the data loader for the provided cluster and load some random data into the cluster.
-func (factory *Factory) CreateDataLoaderIfAbsent(cluster *FdbCluster) {
-	factory.CreateDataLoaderIfAbsentWithOptions(cluster, getDefaultDataLoaderOptions())
+func (factory *Factory) CreateDataLoaderIfAbsent(ctx context.Context, cluster *FdbCluster) {
+	factory.CreateDataLoaderIfAbsentWithOptions(ctx, cluster, getDefaultDataLoaderOptions())
 }
 
 // CreateDataLoaderIfAbsentWithOptions will create the data loader for the provided cluster and load some random data into the cluster.
 // If wait is true, the method will wait until the data loader has finished.
 func (factory *Factory) CreateDataLoaderIfAbsentWithOptions(
+	ctx context.Context,
 	cluster *FdbCluster,
 	options *DataLoaderOptions,
 ) {
@@ -413,7 +414,7 @@ func (factory *Factory) CreateDataLoaderIfAbsentWithOptions(
 		unstructuredObj := &unstructured.Unstructured{Object: unstructuredMap}
 
 		gomega.Expect(
-			factory.CreateIfAbsent(unstructuredObj),
+			factory.CreateIfAbsent(ctx, unstructuredObj),
 		).NotTo(gomega.HaveOccurred())
 	}
 
@@ -421,14 +422,14 @@ func (factory *Factory) CreateDataLoaderIfAbsentWithOptions(
 		return
 	}
 
-	factory.WaitUntilDataLoaderIsDone(cluster)
-	factory.DeleteDataLoader(cluster)
+	factory.WaitUntilDataLoaderIsDone(ctx, cluster)
+	factory.DeleteDataLoader(ctx, cluster)
 }
 
 // DeleteDataLoader will delete the data loader job
-func (factory *Factory) DeleteDataLoader(cluster *FdbCluster) {
+func (factory *Factory) DeleteDataLoader(ctx context.Context, cluster *FdbCluster) {
 	// Remove data loader Pods again, as the loading was done.
-	err := factory.controllerRuntimeClient.Delete(context.Background(), &batchv1.Job{
+	err := factory.controllerRuntimeClient.Delete(ctx, &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dataLoaderName,
 			Namespace: cluster.Namespace(),
@@ -439,20 +440,20 @@ func (factory *Factory) DeleteDataLoader(cluster *FdbCluster) {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
-	gomega.Expect(factory.controllerRuntimeClient.DeleteAllOf(context.Background(), &corev1.Pod{},
+	gomega.Expect(factory.controllerRuntimeClient.DeleteAllOf(ctx, &corev1.Pod{},
 		client.InNamespace(cluster.Namespace()),
 		client.MatchingLabels(map[string]string{"job-name": dataLoaderName}),
 	)).NotTo(gomega.HaveOccurred())
 }
 
 // WaitUntilDataLoaderIsDone will wait until the data loader Job has finished.
-func (factory *Factory) WaitUntilDataLoaderIsDone(cluster *FdbCluster) {
+func (factory *Factory) WaitUntilDataLoaderIsDone(ctx context.Context, cluster *FdbCluster) {
 	printTime := time.Now()
 	gomega.Eventually(func(g gomega.Gomega) int {
 		pods := &corev1.PodList{}
 		g.Expect(
 			factory.controllerRuntimeClient.List(
-				context.Background(),
+				ctx,
 				pods,
 				client.InNamespace(cluster.Namespace()),
 				client.MatchingLabels(map[string]string{"job-name": dataLoaderName}),
@@ -466,7 +467,7 @@ func (factory *Factory) WaitUntilDataLoaderIsDone(cluster *FdbCluster) {
 			job := &batchv1.Job{}
 			g.Expect(
 				factory.controllerRuntimeClient.Get(
-					context.Background(),
+					ctx,
 					client.ObjectKey{
 						Namespace: cluster.Namespace(),
 						Name:      dataLoaderName,
@@ -515,7 +516,7 @@ func (factory *Factory) WaitUntilDataLoaderIsDone(cluster *FdbCluster) {
 		job := &batchv1.Job{}
 		g.Expect(
 			factory.controllerRuntimeClient.Get(
-				context.Background(),
+				ctx,
 				client.ObjectKey{
 					Namespace: cluster.Namespace(),
 					Name:      dataLoaderName,

--- a/e2e/fixtures/fdb_data_loader_test.go
+++ b/e2e/fixtures/fdb_data_loader_test.go
@@ -35,7 +35,7 @@ var _ = Describe("FDB Data Loader", func() {
 		var factory *Factory
 		var k8sClient *mockclient.MockClient
 
-		BeforeEach(func() {
+		BeforeEach(func(_ SpecContext) {
 			Expect(scheme.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 			Expect(fdbv1beta2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 
@@ -62,8 +62,8 @@ var _ = Describe("FDB Data Loader", func() {
 		})
 
 		When("passing empty arguments options", func() {
-			It("should generate a decoder without errors", func() {
-				factory.CreateDataLoaderIfAbsentWithOptions(&FdbCluster{
+			It("should generate a decoder without errors", func(ctx SpecContext) {
+				factory.CreateDataLoaderIfAbsentWithOptions(ctx, &FdbCluster{
 					cluster: &fdbv1beta2.FoundationDBCluster{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test-cluster",
@@ -80,8 +80,8 @@ var _ = Describe("FDB Data Loader", func() {
 		})
 
 		When("passing custom arguments options", func() {
-			It("should generate a decoder without errors", func() {
-				factory.CreateDataLoaderIfAbsentWithOptions(&FdbCluster{
+			It("should generate a decoder without errors", func(ctx SpecContext) {
+				factory.CreateDataLoaderIfAbsentWithOptions(ctx, &FdbCluster{
 					cluster: &fdbv1beta2.FoundationDBCluster{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test-cluster",

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -633,13 +633,13 @@ func (factory *Factory) getOperatorConfig(namespace string) *operatorConfig {
 	}
 }
 
-func (factory *Factory) ensureFDBOperatorExists(namespace string) error {
+func (factory *Factory) ensureFDBOperatorExists(ctx context.Context, namespace string) error {
 	// TODO: we also want to ensure that the CRDs are installed as an option
-	return factory.CreateFDBOperatorIfAbsent(namespace)
+	return factory.CreateFDBOperatorIfAbsent(ctx, namespace)
 }
 
 // CreateFDBOperatorIfAbsent creates the operator Deployment based on the template.
-func (factory *Factory) CreateFDBOperatorIfAbsent(namespace string) error {
+func (factory *Factory) CreateFDBOperatorIfAbsent(ctx context.Context, namespace string) error {
 	operatorRBACTemplate, err := template.New("operatorRBAC").Parse(operatorRBAC)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	buf := bytes.Buffer{}
@@ -665,20 +665,20 @@ func (factory *Factory) CreateFDBOperatorIfAbsent(namespace string) error {
 		unstructuredObj := &unstructured.Unstructured{Object: unstructuredMap}
 
 		gomega.Expect(
-			factory.CreateIfAbsent(unstructuredObj),
+			factory.CreateIfAbsent(ctx, unstructuredObj),
 		).NotTo(gomega.HaveOccurred())
 	}
 
 	// Make sure we delete the cluster scoped objects.
 	factory.AddShutdownHook(func() error {
-		factory.Delete(&rbacv1.ClusterRole{
+		factory.Delete(ctx, &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      namespace + "-operator-manager-clusterrole",
 				Namespace: namespace,
 			},
 		})
 
-		factory.Delete(&rbacv1.ClusterRoleBinding{
+		factory.Delete(ctx, &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      namespace + "-operator-manager-clusterrolebinding",
 				Namespace: namespace,
@@ -718,18 +718,19 @@ func (factory *Factory) CreateFDBOperatorIfAbsent(namespace string) error {
 		unstructuredObj := &unstructured.Unstructured{Object: unstructuredMap}
 
 		gomega.Expect(
-			factory.CreateIfAbsent(unstructuredObj),
+			factory.CreateIfAbsent(ctx, unstructuredObj),
 		).NotTo(gomega.HaveOccurred())
 	}
 
 	// Make sure the Operator Pods are running before moving forward.
-	factory.WaitUntilOperatorPodsRunning(namespace)
+	factory.WaitUntilOperatorPodsRunning(ctx, namespace)
 	return nil
 }
 
 // GetOperatorPods returns the operator Pods in the provided namespace.
-func (factory *Factory) GetOperatorPods(namespace string) *corev1.PodList {
+func (factory *Factory) GetOperatorPods(ctx context.Context, namespace string) *corev1.PodList {
 	return factory.GetOperatorPodsWithOptions(
+		ctx,
 		namespace,
 		client.MatchingFields(map[string]string{"status.phase": string(corev1.PodRunning)}),
 	)
@@ -738,6 +739,7 @@ func (factory *Factory) GetOperatorPods(namespace string) *corev1.PodList {
 // GetOperatorPodsWithOptions returns the operator Pods in the provided namespace with the additional list options.
 // The default list options contain the namespace selector and the label selector for the operator pods.
 func (factory *Factory) GetOperatorPodsWithOptions(
+	ctx context.Context,
 	namespace string,
 	options ...client.ListOption,
 ) *corev1.PodList {
@@ -752,18 +754,18 @@ func (factory *Factory) GetOperatorPodsWithOptions(
 	}
 
 	gomega.Eventually(func() error {
-		return factory.GetControllerRuntimeClient().List(context.TODO(), pods, listOptions...)
+		return factory.GetControllerRuntimeClient().List(ctx, pods, listOptions...)
 	}).WithTimeout(1 * time.Minute).WithPolling(1 * time.Second).ShouldNot(gomega.HaveOccurred())
 
 	return pods
 }
 
 // WaitUntilOperatorPodsRunning waits until the Operator Pods are running.
-func (factory *Factory) WaitUntilOperatorPodsRunning(namespace string) {
+func (factory *Factory) WaitUntilOperatorPodsRunning(ctx context.Context, namespace string) {
 	deployment := &appsv1.Deployment{}
 	gomega.Expect(
 		factory.GetControllerRuntimeClient().
-			Get(context.TODO(), client.ObjectKey{Name: operatorDeploymentName, Namespace: namespace}, deployment),
+			Get(ctx, client.ObjectKey{Name: operatorDeploymentName, Namespace: namespace}, deployment),
 	).NotTo(gomega.HaveOccurred())
 
 	expectedReplicas := int(ptr.Deref(deployment.Spec.Replicas, 1))
@@ -773,7 +775,7 @@ func (factory *Factory) WaitUntilOperatorPodsRunning(namespace string) {
 		deployment = &appsv1.Deployment{}
 		g.Expect(
 			factory.GetControllerRuntimeClient().
-				Get(context.TODO(), client.ObjectKey{Name: operatorDeploymentName, Namespace: namespace}, deployment),
+				Get(ctx, client.ObjectKey{Name: operatorDeploymentName, Namespace: namespace}, deployment),
 		).To(gomega.Succeed())
 		g.Expect(deployment.Status.UpdatedReplicas).To(gomega.BeNumerically(">=", expectedReplicas))
 
@@ -785,7 +787,7 @@ func (factory *Factory) WaitUntilOperatorPodsRunning(namespace string) {
 			log.Println("deployment status:", string(statusBytes))
 		}
 
-		pods := factory.GetOperatorPodsWithOptions(namespace)
+		pods := factory.GetOperatorPodsWithOptions(ctx, namespace)
 		var runningReplicas int
 		for _, pod := range pods.Items {
 			if pod.Status.Phase == corev1.PodRunning && pod.DeletionTimestamp.IsZero() {
@@ -805,7 +807,7 @@ func (factory *Factory) WaitUntilOperatorPodsRunning(namespace string) {
 					string(statusBytes),
 				)
 
-				err = factory.GetControllerRuntimeClient().Delete(context.TODO(), &pod)
+				err = factory.GetControllerRuntimeClient().Delete(ctx, &pod)
 				if k8serrors.IsNotFound(err) {
 					continue
 				}
@@ -820,12 +822,12 @@ func (factory *Factory) WaitUntilOperatorPodsRunning(namespace string) {
 
 // RecreateOperatorPods will recreate all operator Pods in the specified namespace and wait until the new Pods are
 // up and running.
-func (factory *Factory) RecreateOperatorPods(namespace string) {
+func (factory *Factory) RecreateOperatorPods(ctx context.Context, namespace string) {
 	restartAnnotation := "foundationdb.org/restart-deployment"
 
 	gomega.Eventually(func(g gomega.Gomega) {
 		deployment := &appsv1.Deployment{}
-		g.Expect(factory.GetControllerRuntimeClient().Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: operatorDeploymentName}, deployment)).
+		g.Expect(factory.GetControllerRuntimeClient().Get(ctx, client.ObjectKey{Namespace: namespace, Name: operatorDeploymentName}, deployment)).
 			To(gomega.Succeed())
 
 		patch := client.MergeFrom(deployment.DeepCopy())
@@ -834,9 +836,9 @@ func (factory *Factory) RecreateOperatorPods(namespace string) {
 		}
 		deployment.Spec.Template.Annotations[restartAnnotation] = time.Now().String()
 		log.Println("Update deployment")
-		g.Expect(factory.GetControllerRuntimeClient().Patch(context.Background(), deployment, patch)).
+		g.Expect(factory.GetControllerRuntimeClient().Patch(ctx, deployment, patch)).
 			To(gomega.Succeed())
 	}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
 
-	factory.WaitUntilOperatorPodsRunning(namespace)
+	factory.WaitUntilOperatorPodsRunning(ctx, namespace)
 }

--- a/e2e/fixtures/fdb_operator_client.go
+++ b/e2e/fixtures/fdb_operator_client.go
@@ -671,14 +671,14 @@ func (factory *Factory) CreateFDBOperatorIfAbsent(ctx context.Context, namespace
 
 	// Make sure we delete the cluster scoped objects.
 	factory.AddShutdownHook(func() error {
-		factory.Delete(ctx, &rbacv1.ClusterRole{
+		factory.Delete(context.Background(), &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      namespace + "-operator-manager-clusterrole",
 				Namespace: namespace,
 			},
 		})
 
-		factory.Delete(ctx, &rbacv1.ClusterRoleBinding{
+		factory.Delete(context.Background(), &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      namespace + "-operator-manager-clusterrolebinding",
 				Namespace: namespace,

--- a/e2e/fixtures/fdb_operator_fixtures.go
+++ b/e2e/fixtures/fdb_operator_fixtures.go
@@ -21,6 +21,7 @@
 package fixtures
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -32,10 +33,11 @@ import (
 )
 
 func (factory *Factory) ensureFdbClusterExists(
+	ctx context.Context,
 	clusterSpec *fdbv1beta2.FoundationDBCluster,
 	config *ClusterConfig,
 ) (*FdbCluster, error) {
-	clusterStatus, err := factory.getClusterStatus(clusterSpec.Name, clusterSpec.Namespace)
+	clusterStatus, err := factory.getClusterStatus(ctx, clusterSpec.Name, clusterSpec.Namespace)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return nil, fmt.Errorf("could not look up FDB cluster: %w", err)
 	}
@@ -46,7 +48,7 @@ func (factory *Factory) ensureFdbClusterExists(
 
 	log.Printf("preparing to create fdb cluster: %s/%s", clusterSpec.Namespace, clusterSpec.Name)
 	fdbCluster := factory.createFdbClusterObject(clusterSpec)
-	err = fdbCluster.Create()
+	err = fdbCluster.Create(ctx)
 	if err != nil {
 		// consider checking k8serrors.IsAlreadyExists(err), but if that's
 		// the case, we're probably running concurrently with another
@@ -54,10 +56,10 @@ func (factory *Factory) ensureFdbClusterExists(
 		return nil, err
 	}
 	// Wait until the cluster CRD object exists. The caller should wait for whatever state they care about.
-	fdbCluster.WaitUntilExists()
+	fdbCluster.WaitUntilExists(ctx)
 	// Wait until cluster is reconciled -- otherwise, the operator may not have
 	// assigned pods, etc.
-	err = fdbCluster.WaitForReconciliation(CreationTrackerLoggerOption(config.CreationTracker))
+	err = fdbCluster.WaitForReconciliation(ctx, CreationTrackerLoggerOption(config.CreationTracker))
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +70,7 @@ func (factory *Factory) ensureFdbClusterExists(
 }
 
 func (factory *Factory) ensureHaMemberClusterExists(
+	ctx context.Context,
 	haFdbCluster *HaFdbCluster,
 	config *ClusterConfig,
 	dcID string,
@@ -87,6 +90,7 @@ func (factory *Factory) ensureHaMemberClusterExists(
 	)
 
 	spec := factory.createHaFdbClusterSpec(
+		ctx,
 		config,
 		dcID,
 		seedConnection,
@@ -96,7 +100,7 @@ func (factory *Factory) ensureHaMemberClusterExists(
 	curCluster := factory.createFdbClusterObject(spec)
 	factory.logClusterInfo(spec)
 	// We have to trigger here an update since the cluster already exists!
-	fetchedClusterStatus, err := factory.getClusterStatus(config.Name, config.Namespace)
+	fetchedClusterStatus, err := factory.getClusterStatus(ctx, config.Name, config.Namespace)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			log.Printf(
@@ -104,7 +108,7 @@ func (factory *Factory) ensureHaMemberClusterExists(
 				curCluster.cluster.Namespace,
 				curCluster.cluster.Name,
 			)
-			err = curCluster.Create()
+			err = curCluster.Create(ctx)
 			if err != nil && !k8serrors.IsAlreadyExists(err) {
 				return err
 			}
@@ -114,7 +118,7 @@ func (factory *Factory) ensureHaMemberClusterExists(
 				curCluster.cluster.Name,
 			)
 
-			curCluster.WaitUntilExists()
+			curCluster.WaitUntilExists(ctx)
 			return haFdbCluster.addCluster(curCluster)
 		}
 		return err
@@ -133,13 +137,14 @@ func (factory *Factory) ensureHaMemberClusterExists(
 		fetchedCluster.cluster.Spec.DatabaseConfiguration = curCluster.cluster.Spec.DatabaseConfiguration
 		fetchedCluster.cluster.Spec.SeedConnectionString = seedConnection
 		log.Printf("update cluster: %s/%s", curCluster.cluster.Namespace, curCluster.cluster.Name)
-		fetchedCluster.UpdateClusterSpec()
+		fetchedCluster.UpdateClusterSpec(ctx)
 	}
 
 	return haFdbCluster.addCluster(fetchedCluster)
 }
 
 func (factory *Factory) ensureHAFdbClusterExists(
+	ctx context.Context,
 	config *ClusterConfig,
 ) *HaFdbCluster {
 	fdb := &HaFdbCluster{}
@@ -159,7 +164,7 @@ func (factory *Factory) ensureHAFdbClusterExists(
 		},
 	}
 
-	namespaces := factory.MultipleNamespaces(config, dcIDs)
+	namespaces := factory.MultipleNamespaces(ctx, config, dcIDs)
 	log.Printf("ensureHAFDBClusterExists namespaces=%s", namespaces)
 
 	newConfig := config.Copy()
@@ -167,6 +172,7 @@ func (factory *Factory) ensureHAFdbClusterExists(
 	newConfig.Namespace = namespaces[0]
 
 	err := factory.ensureHaMemberClusterExists(
+		ctx,
 		fdb,
 		newConfig,
 		dcIDs[0],
@@ -174,11 +180,15 @@ func (factory *Factory) ensureHAFdbClusterExists(
 		initialDatabaseConfiguration,
 	)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	gomega.Expect(fdb.WaitForReconciliation(CreationTrackerLoggerOption(config.CreationTracker))).
+	gomega.Expect(fdb.WaitForReconciliation(ctx, CreationTrackerLoggerOption(config.CreationTracker))).
 		ToNot(gomega.HaveOccurred())
 	log.Printf("primary cluster is reconciled in namespaces=%s", namespaces)
 
-	cluster, err := factory.getClusterStatus(fdb.GetPrimary().Name(), fdb.GetPrimary().Namespace())
+	cluster, err := factory.getClusterStatus(
+		ctx,
+		fdb.GetPrimary().Name(),
+		fdb.GetPrimary().Namespace(),
+	)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	for idx := range dcIDs {
@@ -187,6 +197,7 @@ func (factory *Factory) ensureHAFdbClusterExists(
 		currentConfig.Namespace = namespaces[idx]
 
 		err = factory.ensureHaMemberClusterExists(
+			ctx,
 			fdb,
 			currentConfig,
 			dcIDs[idx],
@@ -197,7 +208,7 @@ func (factory *Factory) ensureHAFdbClusterExists(
 	}
 
 	// Wait until clusters are ready
-	gomega.Expect(fdb.WaitForReconciliation(CreationTrackerLoggerOption(config.CreationTracker))).
+	gomega.Expect(fdb.WaitForReconciliation(ctx, CreationTrackerLoggerOption(config.CreationTracker))).
 		ToNot(gomega.HaveOccurred())
 
 	config.CreationCallback(fdb.GetPrimary())

--- a/e2e/fixtures/fdb_restore.go
+++ b/e2e/fixtures/fdb_restore.go
@@ -70,7 +70,7 @@ func (factory *Factory) CreateRestoreForCluster(
 	gomega.Expect(factory.CreateIfAbsent(ctx, restore.restore)).NotTo(gomega.HaveOccurred())
 
 	factory.AddShutdownHook(func() error {
-		restore.Destroy(ctx)
+		restore.Destroy(context.Background())
 		return nil
 	})
 

--- a/e2e/fixtures/fdb_restore.go
+++ b/e2e/fixtures/fdb_restore.go
@@ -45,6 +45,7 @@ type FdbRestore struct {
 // For more information how the backup system with the operator is working please look at
 // the operator documentation: https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/docs/manual/backup.md
 func (factory *Factory) CreateRestoreForCluster(
+	ctx context.Context,
 	backup *FdbBackup,
 	backupVersion *uint64,
 ) *FdbRestore {
@@ -66,26 +67,26 @@ func (factory *Factory) CreateRestoreForCluster(
 		fdbCluster: backup.fdbCluster,
 	}
 
-	gomega.Expect(factory.CreateIfAbsent(restore.restore)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(factory.CreateIfAbsent(ctx, restore.restore)).NotTo(gomega.HaveOccurred())
 
 	factory.AddShutdownHook(func() error {
-		restore.Destroy()
+		restore.Destroy(ctx)
 		return nil
 	})
 
-	restore.waitForRestoreToComplete(backup)
+	restore.waitForRestoreToComplete(ctx, backup)
 
 	return restore
 }
 
 // waitForRestoreToComplete waits until the restore completed.
-func (restore *FdbRestore) waitForRestoreToComplete(backup *FdbBackup) {
+func (restore *FdbRestore) waitForRestoreToComplete(ctx context.Context, backup *FdbBackup) {
 	ctrlClient := restore.fdbCluster.getClient()
 
 	lastReconcile := time.Now()
 	gomega.Eventually(func(g gomega.Gomega) fdbv1beta2.FoundationDBRestoreState {
 		currentRestore := &fdbv1beta2.FoundationDBRestore{}
-		g.Expect(ctrlClient.Get(context.Background(), client.ObjectKeyFromObject(restore.restore), currentRestore)).
+		g.Expect(ctrlClient.Get(ctx, client.ObjectKeyFromObject(restore.restore), currentRestore)).
 			To(gomega.Succeed())
 		log.Println("restore state:", currentRestore.Status.State)
 
@@ -103,12 +104,13 @@ func (restore *FdbRestore) waitForRestoreToComplete(backup *FdbBackup) {
 			// This will apply an Annotation to the object which will trigger the reconcile loop.
 			// This should speed up the reconcile phase.
 			gomega.Expect(ctrlClient.Patch(
-				context.Background(),
+				ctx,
 				currentRestore,
 				patch)).To(gomega.Succeed())
 
 			out, _, err := restore.fdbCluster.ExecuteCmdOnPod(
-				*backup.GetBackupPod(),
+				ctx,
+				*backup.GetBackupPod(ctx),
 				fdbv1beta2.MainContainerName,
 				"fdbrestore status --dest_cluster_file $FDB_CLUSTER_FILE",
 				false,
@@ -123,10 +125,10 @@ func (restore *FdbRestore) waitForRestoreToComplete(backup *FdbBackup) {
 }
 
 // Destroy will delete the FoundationDBRestore for the associated FdbBackup if it exists.
-func (restore *FdbRestore) Destroy() {
+func (restore *FdbRestore) Destroy(ctx context.Context) {
 	gomega.Eventually(func(g gomega.Gomega) {
 		err := restore.fdbCluster.factory.GetControllerRuntimeClient().
-			Delete(context.Background(), restore.restore)
+			Delete(ctx, restore.restore)
 		if k8serrors.IsNotFound(err) {
 			return
 		}
@@ -138,7 +140,7 @@ func (restore *FdbRestore) Destroy() {
 	gomega.Eventually(func(g gomega.Gomega) {
 		currentRestore := &fdbv1beta2.FoundationDBRestore{}
 		err := restore.fdbCluster.getClient().
-			Get(context.Background(), client.ObjectKeyFromObject(restore.restore), currentRestore)
+			Get(ctx, client.ObjectKeyFromObject(restore.restore), currentRestore)
 		g.Expect(k8serrors.IsNotFound(err)).To(gomega.BeTrue())
 	}).WithTimeout(10 * time.Minute).WithPolling(1 * time.Second).To(gomega.Succeed())
 }

--- a/e2e/fixtures/ha_fdb_cluster.go
+++ b/e2e/fixtures/ha_fdb_cluster.go
@@ -21,6 +21,7 @@
 package fixtures
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math/rand/v2"
@@ -170,23 +171,25 @@ func (haFDBCluster *HaFdbCluster) GetNamespaceSelector() chaosmesh.PodSelectorSp
 
 // SetDatabaseConfiguration sets the new DatabaseConfiguration, without waiting for reconciliation.
 func (haFDBCluster *HaFdbCluster) SetDatabaseConfiguration(
+	ctx context.Context,
 	config fdbv1beta2.DatabaseConfiguration,
 ) {
 	for _, fdbCluster := range haFDBCluster.clusters {
-		gomega.Expect(fdbCluster.SetDatabaseConfiguration(config, false)).
+		gomega.Expect(fdbCluster.SetDatabaseConfiguration(ctx, config, false)).
 			NotTo(gomega.HaveOccurred())
 	}
 }
 
 // WaitForReconciliation waits for all associated FoundationDBClusters to be reconciled
 func (haFDBCluster *HaFdbCluster) WaitForReconciliation(
+	ctx context.Context,
 	options ...func(*ReconciliationOptions),
 ) error {
 	g := new(errgroup.Group)
 	for _, cluster := range haFDBCluster.GetAllClusters() {
 		singleCluster := cluster // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
-			return singleCluster.WaitForReconciliation(options...)
+			return singleCluster.WaitForReconciliation(ctx, options...)
 		})
 	}
 
@@ -194,12 +197,14 @@ func (haFDBCluster *HaFdbCluster) WaitForReconciliation(
 }
 
 func (factory *Factory) createHaFdbClusterSpec(
+	ctx context.Context,
 	config *ClusterConfig,
 	dcID string,
 	seedConnection string,
 	databaseConfiguration *fdbv1beta2.DatabaseConfiguration,
 ) *fdbv1beta2.FoundationDBCluster {
 	cluster := factory.createFDBClusterSpec(
+		ctx,
 		config,
 		*databaseConfiguration,
 	)
@@ -212,19 +217,24 @@ func (factory *Factory) createHaFdbClusterSpec(
 }
 
 // Delete removes all Clusters associated FoundationDBClusters.
-func (haFDBCluster *HaFdbCluster) Delete() {
+func (haFDBCluster *HaFdbCluster) Delete(ctx context.Context) {
 	for _, cluster := range haFDBCluster.GetAllClusters() {
-		gomega.Expect(cluster.Destroy()).NotTo(gomega.HaveOccurred())
+		gomega.Expect(cluster.Destroy(ctx)).NotTo(gomega.HaveOccurred())
 	}
 }
 
 // UpgradeCluster upgrades the HA FoundationDBCluster to the specified version.
-func (haFDBCluster *HaFdbCluster) UpgradeCluster(version string, waitForReconciliation bool) error {
-	return haFDBCluster.UpgradeClusterWithTimeout(version, waitForReconciliation, 0)
+func (haFDBCluster *HaFdbCluster) UpgradeCluster(
+	ctx context.Context,
+	version string,
+	waitForReconciliation bool,
+) error {
+	return haFDBCluster.UpgradeClusterWithTimeout(ctx, version, waitForReconciliation, 0)
 }
 
 // UpgradeClusterWithTimeout upgrades the HA FoundationDBCluster to the specified version with the provided timeout.
 func (haFDBCluster *HaFdbCluster) UpgradeClusterWithTimeout(
+	ctx context.Context,
 	version string,
 	waitForReconciliation bool,
 	timeout int,
@@ -238,7 +248,7 @@ func (haFDBCluster *HaFdbCluster) UpgradeClusterWithTimeout(
 	})
 
 	for _, cluster := range clusters {
-		curCluster := cluster.GetCluster()
+		curCluster := cluster.GetCluster(ctx)
 
 		generation := curCluster.ObjectMeta.Generation
 		// Only increase the expected generation if the cluster is not already upgraded.
@@ -249,7 +259,7 @@ func (haFDBCluster *HaFdbCluster) UpgradeClusterWithTimeout(
 		expectedGenerations[cluster.Name()] = generation
 		cluster.cluster = curCluster
 
-		err := cluster.UpgradeCluster(version, false)
+		err := cluster.UpgradeCluster(ctx, version, false)
 		if err != nil {
 			return err
 		}
@@ -268,6 +278,7 @@ func (haFDBCluster *HaFdbCluster) UpgradeClusterWithTimeout(
 		singleCluster := cluster // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
 			return singleCluster.WaitForReconciliation(
+				ctx,
 				MinimumGenerationOption(expectedGenerations[singleCluster.Name()]),
 				TimeOutInSecondsOption(timeout),
 				PollTimeInSecondsOption(30),
@@ -279,14 +290,15 @@ func (haFDBCluster *HaFdbCluster) UpgradeClusterWithTimeout(
 }
 
 // DumpState logs the current state of all FoundationDBClusters.
-func (haFDBCluster *HaFdbCluster) DumpState() {
+func (haFDBCluster *HaFdbCluster) DumpState(ctx context.Context) {
 	for _, cluster := range haFDBCluster.clusters {
-		cluster.factory.DumpState(cluster)
+		cluster.factory.DumpState(ctx, cluster)
 	}
 }
 
 // SetCustomParameters sets the custom parameters for the provided process class.
 func (haFDBCluster *HaFdbCluster) SetCustomParameters(
+	ctx context.Context,
 	customParameters map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters,
 	waitForReconcile bool,
 ) error {
@@ -294,7 +306,7 @@ func (haFDBCluster *HaFdbCluster) SetCustomParameters(
 	for _, cluster := range haFDBCluster.clusters {
 		clusterCopy := cluster
 		wg.Go(func() error {
-			return clusterCopy.SetCustomParameters(customParameters, false)
+			return clusterCopy.SetCustomParameters(ctx, customParameters, false)
 		})
 	}
 
@@ -311,7 +323,7 @@ func (haFDBCluster *HaFdbCluster) SetCustomParameters(
 	for _, cluster := range haFDBCluster.clusters {
 		clusterCopy := cluster
 		reconcileWg.Go(func() error {
-			return clusterCopy.WaitForReconciliation()
+			return clusterCopy.WaitForReconciliation(ctx)
 		})
 	}
 
@@ -322,12 +334,13 @@ func (haFDBCluster *HaFdbCluster) SetCustomParameters(
 // Before that we checked the cluster status json by checking the reported version of all processes. This approach only worked for
 // version compatible upgrades, since incompatible processes won't be part of the cluster anyway. To simplify the check
 // we verify the reported running version from the operator.
-func (haFDBCluster *HaFdbCluster) VerifyVersion(version string) {
+func (haFDBCluster *HaFdbCluster) VerifyVersion(ctx context.Context, version string) {
 	g := new(errgroup.Group)
 	for _, cluster := range haFDBCluster.GetAllClusters() {
 		singleCluster := cluster // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
 			return singleCluster.WaitUntilWithForceReconcile(
+				ctx,
 				2,
 				600,
 				func(cluster *fdbv1beta2.FoundationDBCluster) bool {

--- a/e2e/fixtures/images_test.go
+++ b/e2e/fixtures/images_test.go
@@ -30,7 +30,7 @@ import (
 var _ = Describe("image setup", func() {
 	DescribeTable(
 		"when generating the sidecar image configuration",
-		func(factory *Factory, config *ClusterConfig, expected fdbv1beta2.ContainerOverrides) {
+		func(_ SpecContext, factory *Factory, config *ClusterConfig, expected fdbv1beta2.ContainerOverrides) {
 			result := factory.GetSidecarContainerOverrides(config)
 			Expect(result.ImageConfigs).To(ConsistOf(expected.ImageConfigs))
 		},
@@ -253,7 +253,7 @@ var _ = Describe("image setup", func() {
 
 	DescribeTable(
 		"when generating the main image configuration",
-		func(factory *Factory, config *ClusterConfig, expected fdbv1beta2.ContainerOverrides) {
+		func(_ SpecContext, factory *Factory, config *ClusterConfig, expected fdbv1beta2.ContainerOverrides) {
 			result := factory.GetMainContainerOverrides(config)
 			Expect(result.ImageConfigs).To(ConsistOf(expected.ImageConfigs))
 		},

--- a/e2e/fixtures/kubernetes_fixtures.go
+++ b/e2e/fixtures/kubernetes_fixtures.go
@@ -54,7 +54,11 @@ func (factory *Factory) getRandomizedNamespaceName() string {
 }
 
 // MultipleNamespaces creates multiple namespaces for HA testing.
-func (factory *Factory) MultipleNamespaces(config *ClusterConfig, dcIDs []string) []string {
+func (factory *Factory) MultipleNamespaces(
+	ctx context.Context,
+	config *ClusterConfig,
+	dcIDs []string,
+) []string {
 	// If a namespace is provided in the config we will use this name as prefix.
 	if config.Namespace != "" {
 		factory.namespace = config.Namespace
@@ -65,19 +69,19 @@ func (factory *Factory) MultipleNamespaces(config *ClusterConfig, dcIDs []string
 
 	factory.namespaces = make([]string, len(dcIDs))
 	for idx, dcID := range dcIDs {
-		factory.namespaces[idx] = factory.createNamespace(dcID)
+		factory.namespaces[idx] = factory.createNamespace(ctx, dcID)
 	}
 
 	return factory.namespaces
 }
 
 // SingleNamespace returns a single namespace.
-func (factory *Factory) SingleNamespace() string {
+func (factory *Factory) SingleNamespace(ctx context.Context) string {
 	if len(factory.namespaces) > 0 {
 		return factory.namespaces[0]
 	}
 
-	namespace := factory.createNamespace("")
+	namespace := factory.createNamespace(ctx, "")
 	if len(factory.namespaces) == 0 {
 		factory.namespaces = append(factory.namespaces, namespace)
 	}
@@ -85,7 +89,7 @@ func (factory *Factory) SingleNamespace() string {
 	return namespace
 }
 
-func (factory *Factory) createNamespace(suffix string) string {
+func (factory *Factory) createNamespace(ctx context.Context, suffix string) string {
 	var namespace string
 	gomega.Eventually(func(g gomega.Gomega) error {
 		namespace = factory.namespace
@@ -100,15 +104,15 @@ func (factory *Factory) createNamespace(suffix string) string {
 
 		g.Expect(len(namespace)).To(gomega.BeNumerically("<=", 63))
 
-		err := factory.checkIfNamespaceIsTerminating(namespace)
+		err := factory.checkIfNamespaceIsTerminating(ctx, namespace)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
-		err = factory.ensureNamespaceExists(namespace)
+		err = factory.ensureNamespaceExists(ctx, namespace)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		namespaceResource := &corev1.Namespace{}
 		err = factory.controllerRuntimeClient.Get(
-			context.Background(),
+			ctx,
 			client.ObjectKey{Namespace: "", Name: namespace},
 			namespaceResource,
 		)
@@ -133,7 +137,7 @@ func (factory *Factory) createNamespace(suffix string) string {
 	secret := factory.getCertificate()
 	secret.SetNamespace(namespace)
 	secret.SetResourceVersion("")
-	gomega.Expect(factory.CreateIfAbsent(secret)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(factory.CreateIfAbsent(ctx, secret)).NotTo(gomega.HaveOccurred())
 
 	// Create the backup credentials for backup related operations.
 	backupCredentials := &corev1.Secret{
@@ -154,13 +158,13 @@ func (factory *Factory) createNamespace(suffix string) string {
 }`,
 		},
 	}
-	gomega.Expect(factory.CreateIfAbsent(backupCredentials)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(factory.CreateIfAbsent(ctx, backupCredentials)).NotTo(gomega.HaveOccurred())
 
 	// Create the encryption key secret for backup encryption operations.
-	factory.CreateEncryptionKeySecret(namespace)
+	factory.CreateEncryptionKeySecret(ctx, namespace)
 
-	factory.ensureRBACSetupExists(namespace)
-	gomega.Expect(factory.ensureFDBOperatorExists(namespace)).ToNot(gomega.HaveOccurred())
+	factory.ensureRBACSetupExists(ctx, namespace)
+	gomega.Expect(factory.ensureFDBOperatorExists(ctx, namespace)).ToNot(gomega.HaveOccurred())
 	log.Printf("using namespace %s for testing", namespace)
 	factory.AddShutdownHook(func() error {
 		log.Printf("finished all tests, start deleting namespace %s\n", namespace)
@@ -168,7 +172,7 @@ func (factory *Factory) createNamespace(suffix string) string {
 		gomega.Eventually(func(g gomega.Gomega) {
 			podList := &corev1.PodList{}
 			err := factory.controllerRuntimeClient.List(
-				context.Background(),
+				ctx,
 				podList,
 				client.InNamespace(namespace),
 			)
@@ -177,13 +181,13 @@ func (factory *Factory) createNamespace(suffix string) string {
 			for _, pod := range podList.Items {
 				if len(pod.Finalizers) > 0 {
 					log.Printf("Removing finalizer from Pod %s/%s\n", namespace, pod.Name)
-					factory.SetFinalizerForPod(&pod, []string{})
+					factory.SetFinalizerForPod(ctx, &pod, []string{})
 				}
 			}
 
 			backupList := &fdbv1beta2.FoundationDBBackupList{}
 			err = factory.controllerRuntimeClient.List(
-				context.Background(),
+				ctx,
 				backupList,
 				client.InNamespace(namespace),
 			)
@@ -195,7 +199,7 @@ func (factory *Factory) createNamespace(suffix string) string {
 					gomega.Eventually(func(g gomega.Gomega) {
 						fetchedBackup := &fdbv1beta2.FoundationDBBackup{}
 						err = factory.controllerRuntimeClient.Get(
-							context.Background(),
+							ctx,
 							client.ObjectKeyFromObject(ptr.To(backup)),
 							fetchedBackup,
 						)
@@ -206,7 +210,7 @@ func (factory *Factory) createNamespace(suffix string) string {
 						g.Expect(err).NotTo(gomega.HaveOccurred())
 						if len(fetchedBackup.Finalizers) > 0 {
 							fetchedBackup.SetFinalizers([]string{})
-							g.Expect(factory.controllerRuntimeClient.Update(context.Background(), fetchedBackup)).
+							g.Expect(factory.controllerRuntimeClient.Update(ctx, fetchedBackup)).
 								NotTo(gomega.HaveOccurred())
 						}
 
@@ -216,7 +220,7 @@ func (factory *Factory) createNamespace(suffix string) string {
 			}
 		}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(gomega.Succeed())
 
-		factory.Delete(&corev1.Namespace{
+		factory.Delete(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespace,
 			},
@@ -230,11 +234,11 @@ func (factory *Factory) createNamespace(suffix string) string {
 
 // checkIfNamespaceIsTerminating will check if the namespace has a deletionTimestamp set. If so this method will wait
 // up to 5 minutes until the namespace is deleted to prevent race conditions.
-func (factory *Factory) checkIfNamespaceIsTerminating(name string) error {
+func (factory *Factory) checkIfNamespaceIsTerminating(ctx context.Context, name string) error {
 	controllerClient := factory.GetControllerRuntimeClient()
 
 	namespace := &corev1.Namespace{}
-	err := controllerClient.Get(context.Background(), client.ObjectKey{Name: name}, namespace)
+	err := controllerClient.Get(ctx, client.ObjectKey{Name: name}, namespace)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
@@ -262,7 +266,7 @@ func (factory *Factory) checkIfNamespaceIsTerminating(name string) error {
 		deletionTimestamp.String(),
 	)
 	podList := &corev1.PodList{}
-	err = controllerClient.List(context.Background(), podList, client.InNamespace(name))
+	err = controllerClient.List(ctx, podList, client.InNamespace(name))
 	if err != nil {
 		return err
 	}
@@ -270,7 +274,7 @@ func (factory *Factory) checkIfNamespaceIsTerminating(name string) error {
 	for _, pod := range podList.Items {
 		if len(pod.Finalizers) > 0 {
 			log.Printf("Removing finalizer from Pod %s/%s\n", namespace, pod.Name)
-			factory.SetFinalizerForPod(&pod, []string{})
+			factory.SetFinalizerForPod(ctx, &pod, []string{})
 		}
 	}
 
@@ -281,8 +285,8 @@ func (factory *Factory) checkIfNamespaceIsTerminating(name string) error {
 	)
 }
 
-func (factory *Factory) ensureNamespaceExists(namespace string) error {
-	return factory.CreateIfAbsent(&corev1.Namespace{
+func (factory *Factory) ensureNamespaceExists(ctx context.Context, namespace string) error {
+	return factory.CreateIfAbsent(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   namespace,
 			Labels: factory.GetDefaultLabels(),
@@ -293,8 +297,8 @@ func (factory *Factory) ensureNamespaceExists(namespace string) error {
 	})
 }
 
-func (factory *Factory) ensureRBACSetupExists(namespace string) {
-	gomega.Expect(factory.CreateIfAbsent(&corev1.ServiceAccount{
+func (factory *Factory) ensureRBACSetupExists(ctx context.Context, namespace string) {
+	gomega.Expect(factory.CreateIfAbsent(ctx, &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      foundationdbServiceAccount,
 			Labels:    factory.GetDefaultLabels(),
@@ -302,7 +306,7 @@ func (factory *Factory) ensureRBACSetupExists(namespace string) {
 		},
 	})).ToNot(gomega.HaveOccurred())
 
-	gomega.Expect(factory.CreateIfAbsent(&rbacv1.Role{
+	gomega.Expect(factory.CreateIfAbsent(ctx, &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      foundationdbServiceAccount,
 			Labels:    factory.GetDefaultLabels(),
@@ -327,7 +331,7 @@ func (factory *Factory) ensureRBACSetupExists(namespace string) {
 		},
 	})).ToNot(gomega.HaveOccurred())
 
-	gomega.Expect(factory.CreateIfAbsent(&rbacv1.RoleBinding{
+	gomega.Expect(factory.CreateIfAbsent(ctx, &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      foundationdbServiceAccount,
 			Labels:    factory.GetDefaultLabels(),
@@ -347,7 +351,7 @@ func (factory *Factory) ensureRBACSetupExists(namespace string) {
 	})).ToNot(gomega.HaveOccurred())
 
 	nodeRoleName := namespace + "-" + foundationdbNodeRole
-	gomega.Expect(factory.CreateIfAbsent(&rbacv1.ClusterRole{
+	gomega.Expect(factory.CreateIfAbsent(ctx, &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodeRoleName,
 			Labels:    factory.GetDefaultLabels(),
@@ -370,7 +374,7 @@ func (factory *Factory) ensureRBACSetupExists(namespace string) {
 		},
 	})).ToNot(gomega.HaveOccurred())
 
-	gomega.Expect(factory.CreateIfAbsent(&rbacv1.ClusterRoleBinding{
+	gomega.Expect(factory.CreateIfAbsent(ctx, &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodeRoleName,
 			Labels:    factory.GetDefaultLabels(),
@@ -391,14 +395,14 @@ func (factory *Factory) ensureRBACSetupExists(namespace string) {
 	})).ToNot(gomega.HaveOccurred())
 
 	factory.AddShutdownHook(func() error {
-		factory.Delete(&rbacv1.ClusterRole{
+		factory.Delete(ctx, &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nodeRoleName,
 				Namespace: namespace,
 			},
 		})
 
-		factory.Delete(&rbacv1.ClusterRoleBinding{
+		factory.Delete(ctx, &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nodeRoleName,
 				Namespace: namespace,

--- a/e2e/fixtures/kubernetes_fixtures.go
+++ b/e2e/fixtures/kubernetes_fixtures.go
@@ -172,7 +172,7 @@ func (factory *Factory) createNamespace(ctx context.Context, suffix string) stri
 		gomega.Eventually(func(g gomega.Gomega) {
 			podList := &corev1.PodList{}
 			err := factory.controllerRuntimeClient.List(
-				ctx,
+				context.Background(),
 				podList,
 				client.InNamespace(namespace),
 			)
@@ -181,13 +181,13 @@ func (factory *Factory) createNamespace(ctx context.Context, suffix string) stri
 			for _, pod := range podList.Items {
 				if len(pod.Finalizers) > 0 {
 					log.Printf("Removing finalizer from Pod %s/%s\n", namespace, pod.Name)
-					factory.SetFinalizerForPod(ctx, &pod, []string{})
+					factory.SetFinalizerForPod(context.Background(), &pod, []string{})
 				}
 			}
 
 			backupList := &fdbv1beta2.FoundationDBBackupList{}
 			err = factory.controllerRuntimeClient.List(
-				ctx,
+				context.Background(),
 				backupList,
 				client.InNamespace(namespace),
 			)
@@ -199,7 +199,7 @@ func (factory *Factory) createNamespace(ctx context.Context, suffix string) stri
 					gomega.Eventually(func(g gomega.Gomega) {
 						fetchedBackup := &fdbv1beta2.FoundationDBBackup{}
 						err = factory.controllerRuntimeClient.Get(
-							ctx,
+							context.Background(),
 							client.ObjectKeyFromObject(ptr.To(backup)),
 							fetchedBackup,
 						)
@@ -210,7 +210,7 @@ func (factory *Factory) createNamespace(ctx context.Context, suffix string) stri
 						g.Expect(err).NotTo(gomega.HaveOccurred())
 						if len(fetchedBackup.Finalizers) > 0 {
 							fetchedBackup.SetFinalizers([]string{})
-							g.Expect(factory.controllerRuntimeClient.Update(ctx, fetchedBackup)).
+							g.Expect(factory.controllerRuntimeClient.Update(context.Background(), fetchedBackup)).
 								NotTo(gomega.HaveOccurred())
 						}
 
@@ -220,7 +220,7 @@ func (factory *Factory) createNamespace(ctx context.Context, suffix string) stri
 			}
 		}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(gomega.Succeed())
 
-		factory.Delete(ctx, &corev1.Namespace{
+		factory.Delete(context.Background(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespace,
 			},
@@ -395,14 +395,14 @@ func (factory *Factory) ensureRBACSetupExists(ctx context.Context, namespace str
 	})).ToNot(gomega.HaveOccurred())
 
 	factory.AddShutdownHook(func() error {
-		factory.Delete(ctx, &rbacv1.ClusterRole{
+		factory.Delete(context.Background(), &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nodeRoleName,
 				Namespace: namespace,
 			},
 		})
 
-		factory.Delete(ctx, &rbacv1.ClusterRoleBinding{
+		factory.Delete(context.Background(), &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nodeRoleName,
 				Namespace: namespace,

--- a/e2e/fixtures/pods.go
+++ b/e2e/fixtures/pods.go
@@ -126,7 +126,11 @@ func (factory *Factory) RandomPickOneCluster(input []*FdbCluster) *FdbCluster {
 }
 
 // SetFinalizerForPod will set the provided finalizer slice for the Pods
-func (factory *Factory) SetFinalizerForPod(pod *corev1.Pod, finalizers []string) {
+func (factory *Factory) SetFinalizerForPod(
+	ctx context.Context,
+	pod *corev1.Pod,
+	finalizers []string,
+) {
 	if pod == nil {
 		return
 	}
@@ -134,12 +138,12 @@ func (factory *Factory) SetFinalizerForPod(pod *corev1.Pod, finalizers []string)
 	controllerClient := factory.GetControllerRuntimeClient()
 	gomega.Eventually(func(g gomega.Gomega) {
 		fetchedPod := &corev1.Pod{}
-		g.Expect(controllerClient.Get(context.Background(), client.ObjectKeyFromObject(pod), fetchedPod)).
+		g.Expect(controllerClient.Get(ctx, client.ObjectKeyFromObject(pod), fetchedPod)).
 			NotTo(gomega.HaveOccurred())
 
 		if !equality.Semantic.DeepEqual(finalizers, fetchedPod.Finalizers) {
 			fetchedPod.SetFinalizers(finalizers)
-			g.Expect(controllerClient.Update(context.Background(), fetchedPod)).
+			g.Expect(controllerClient.Update(ctx, fetchedPod)).
 				NotTo(gomega.HaveOccurred())
 		}
 

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -38,7 +38,9 @@ import (
 )
 
 // getStatusFromOperatorPod returns fdb status queried through the operator Pod.
-func (fdbCluster *FdbCluster) getStatusFromOperatorPod() *fdbv1beta2.FoundationDBStatus {
+func (fdbCluster *FdbCluster) getStatusFromOperatorPod(
+	ctx context.Context,
+) *fdbv1beta2.FoundationDBStatus {
 	status := &fdbv1beta2.FoundationDBStatus{}
 
 	if fdbCluster.factory.shutdownInProgress {
@@ -46,7 +48,12 @@ func (fdbCluster *FdbCluster) getStatusFromOperatorPod() *fdbv1beta2.FoundationD
 	}
 
 	gomega.Eventually(func() error {
-		out, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry("status json", false, 30)
+		out, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(
+			ctx,
+			"status json",
+			false,
+			30,
+		)
 		if err != nil {
 			return err
 		}
@@ -60,6 +67,7 @@ func (fdbCluster *FdbCluster) getStatusFromOperatorPod() *fdbv1beta2.FoundationD
 
 // RunFdbCliCommandInOperator allows to run a command with fdbcli in the operator Pod.
 func (fdbCluster *FdbCluster) RunFdbCliCommandInOperator(
+	ctx context.Context,
 	command string,
 	printOutput bool,
 	timeout int,
@@ -71,6 +79,7 @@ func (fdbCluster *FdbCluster) RunFdbCliCommandInOperator(
 		// Ensure we fetch everything if we have to retry it e.g. because the connection string has changed or
 		// because the operator Pod was killed.
 		stdout, stderr, err = fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(
+			ctx,
 			command,
 			printOutput,
 			timeout,
@@ -93,11 +102,13 @@ func (fdbCluster *FdbCluster) RunFdbCliCommandInOperator(
 
 // RunFdbCliCommandInOperatorWithoutRetry allows to run a command with fdbcli in the operator Pod without doing any retries.
 func (fdbCluster *FdbCluster) RunFdbCliCommandInOperatorWithoutRetry(
+	ctx context.Context,
 	command string,
 	printOutput bool,
 	timeout int,
 ) (string, string, error) {
 	return fdbCluster.runCommandInOperatorWithoutRetry(
+		ctx,
 		fmt.Sprintf("--exec '%s'", command),
 		printOutput,
 		timeout,
@@ -107,20 +118,22 @@ func (fdbCluster *FdbCluster) RunFdbCliCommandInOperatorWithoutRetry(
 
 // RunFdbBackupCommandInOperatorWithoutRetry allows to run a command with fdbbackup in the operator Pod without doing any retries.
 func (fdbCluster *FdbCluster) RunFdbBackupCommandInOperatorWithoutRetry(
+	ctx context.Context,
 	command string,
 	printOutput bool,
 ) (string, string, error) {
-	return fdbCluster.runCommandInOperatorWithoutRetry(command, printOutput, 0, "fdbbackup")
+	return fdbCluster.runCommandInOperatorWithoutRetry(ctx, command, printOutput, 0, "fdbbackup")
 }
 
 // runCommandInOperatorWithoutRetry can be used to run commands with a FDB binary like fdbcli or fdbbackup.
 func (fdbCluster *FdbCluster) runCommandInOperatorWithoutRetry(
+	ctx context.Context,
 	command string,
 	printOutput bool,
 	timeout int,
 	binary string,
 ) (string, string, error) {
-	operatorPods := fdbCluster.factory.GetOperatorPods(fdbCluster.Namespace())
+	operatorPods := fdbCluster.factory.GetOperatorPods(ctx, fdbCluster.Namespace())
 	pod := fdbCluster.factory.ChooseRandomPod(operatorPods)
 	if pod == nil {
 		log.Println("current operator pods:", operatorPods.Items)
@@ -128,6 +141,7 @@ func (fdbCluster *FdbCluster) runCommandInOperatorWithoutRetry(
 	}
 
 	cluster, err := fdbCluster.factory.getClusterStatus(
+		ctx,
 		fdbCluster.Name(),
 		fdbCluster.Namespace(),
 	)
@@ -192,7 +206,7 @@ func (fdbCluster *FdbCluster) runCommandInOperatorWithoutRetry(
 			log.Println(cmd)
 		}
 		stdout, stderr, err = fdbCluster.factory.ExecuteCmd(
-			context.Background(),
+			ctx,
 			pod.Namespace,
 			pod.Name,
 			"manager",
@@ -252,20 +266,21 @@ func parseStatusOutput(rawStatus string) (*fdbv1beta2.FoundationDBStatus, error)
 }
 
 // IsAvailable returns true if the database is available.
-func (fdbCluster *FdbCluster) IsAvailable() bool {
-	return fdbCluster.GetStatus().Client.DatabaseStatus.Available
+func (fdbCluster *FdbCluster) IsAvailable(ctx context.Context) bool {
+	return fdbCluster.GetStatus(ctx).Client.DatabaseStatus.Available
 }
 
 // WaitUntilAvailable waits until the cluster is available.
-func (fdbCluster *FdbCluster) WaitUntilAvailable() {
+func (fdbCluster *FdbCluster) WaitUntilAvailable(ctx context.Context) {
 	gomega.Eventually(func() bool {
-		return fdbCluster.IsAvailable()
+		return fdbCluster.IsAvailable(ctx)
 	}).To(gomega.BeTrue())
 }
 
 // StatusInvariantChecker provides a way to check an invariant for the cluster status.
 // nolint:nilerr
 func (fdbCluster *FdbCluster) StatusInvariantChecker(
+	ctx context.Context,
 	name string,
 	threshold time.Duration,
 	f func(status *fdbv1beta2.FoundationDBStatus) error,
@@ -282,6 +297,7 @@ func (fdbCluster *FdbCluster) StatusInvariantChecker(
 			}
 
 			cluster, err := fdbCluster.factory.getClusterStatus(
+				ctx,
 				fdbCluster.Name(),
 				fdbCluster.Namespace(),
 			)
@@ -295,6 +311,7 @@ func (fdbCluster *FdbCluster) StatusInvariantChecker(
 			}
 
 			out, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(
+				ctx,
 				"status json",
 				false,
 				30,
@@ -337,9 +354,11 @@ func checkAvailability(status *fdbv1beta2.FoundationDBStatus) error {
 
 // InvariantClusterStatusAvailableWithThreshold checks if the database is at a maximum unavailable for the provided threshold.
 func (fdbCluster *FdbCluster) InvariantClusterStatusAvailableWithThreshold(
+	ctx context.Context,
 	availabilityThreshold time.Duration,
 ) error {
 	return fdbCluster.StatusInvariantChecker(
+		ctx,
 		"InvariantClusterStatusAvailable",
 		availabilityThreshold,
 		checkAvailability,
@@ -347,16 +366,20 @@ func (fdbCluster *FdbCluster) InvariantClusterStatusAvailableWithThreshold(
 }
 
 // InvariantClusterStatusAvailable checks if the cluster is available the whole test with the default unavailable threshold.
-func (fdbCluster *FdbCluster) InvariantClusterStatusAvailable() error {
+func (fdbCluster *FdbCluster) InvariantClusterStatusAvailable(ctx context.Context) error {
 	return fdbCluster.InvariantClusterStatusAvailableWithThreshold(
+		ctx,
 		fdbCluster.factory.GetDefaultUnavailableThreshold(),
 	)
 }
 
 // GetProcessCount returns the number of processes having the specified role
-func (fdbCluster *FdbCluster) GetProcessCount(targetRole fdbv1beta2.ProcessRole) int {
+func (fdbCluster *FdbCluster) GetProcessCount(
+	ctx context.Context,
+	targetRole fdbv1beta2.ProcessRole,
+) int {
 	pCounter := 0
-	status := fdbCluster.GetStatus()
+	status := fdbCluster.GetStatus(ctx)
 
 	for _, process := range status.Cluster.Processes {
 		for _, role := range process.Roles {
@@ -370,9 +393,12 @@ func (fdbCluster *FdbCluster) GetProcessCount(targetRole fdbv1beta2.ProcessRole)
 }
 
 // GetProcessCountByProcessClass returns the number of processes based on process class
-func (fdbCluster *FdbCluster) GetProcessCountByProcessClass(pClass fdbv1beta2.ProcessClass) int {
+func (fdbCluster *FdbCluster) GetProcessCountByProcessClass(
+	ctx context.Context,
+	pClass fdbv1beta2.ProcessClass,
+) int {
 	pCounter := 0
-	status := fdbCluster.GetStatus()
+	status := fdbCluster.GetStatus(ctx)
 
 	for _, process := range status.Cluster.Processes {
 		if process.ProcessClass == pClass {
@@ -384,8 +410,8 @@ func (fdbCluster *FdbCluster) GetProcessCountByProcessClass(pClass fdbv1beta2.Pr
 }
 
 // HasTLSEnabled returns true if the cluster is running with TLS enabled.
-func (fdbCluster *FdbCluster) HasTLSEnabled() bool {
-	status := fdbCluster.GetStatus()
+func (fdbCluster *FdbCluster) HasTLSEnabled(ctx context.Context) bool {
+	status := fdbCluster.GetStatus(ctx)
 
 	if len(status.Cluster.Processes) == 0 {
 		return false
@@ -421,14 +447,14 @@ func (fdbCluster *FdbCluster) HasTLSEnabled() bool {
 }
 
 // GetCoordinators returns the Pods of the FoundationDBCluster that are having the coordinator role.
-func (fdbCluster *FdbCluster) GetCoordinators() []corev1.Pod {
-	return fdbCluster.GetPodsWithRole(fdbv1beta2.ProcessRoleCoordinator)
+func (fdbCluster *FdbCluster) GetCoordinators(ctx context.Context) []corev1.Pod {
+	return fdbCluster.GetPodsWithRole(ctx, fdbv1beta2.ProcessRoleCoordinator)
 }
 
 // GetCoordinatorsOnLogProcesses returns the Pods of the FoundationDBCluster that have the coordinator role and have the
 // process class log.
-func (fdbCluster *FdbCluster) GetCoordinatorsOnLogProcesses() []corev1.Pod {
-	coordinators := fdbCluster.GetPodsWithRole(fdbv1beta2.ProcessRoleCoordinator)
+func (fdbCluster *FdbCluster) GetCoordinatorsOnLogProcesses(ctx context.Context) []corev1.Pod {
+	coordinators := fdbCluster.GetPodsWithRole(ctx, fdbv1beta2.ProcessRoleCoordinator)
 	gomega.Expect(coordinators).NotTo(gomega.BeEmpty())
 
 	coordinatorsOnLogProcesses := make([]corev1.Pod, 0, len(coordinators))
@@ -442,12 +468,12 @@ func (fdbCluster *FdbCluster) GetCoordinatorsOnLogProcesses() []corev1.Pod {
 
 	if len(coordinatorsOnLogProcesses) == 0 {
 		pickedPod := fdbCluster.factory.RandomPickOnePod(coordinators)
-		fdbCluster.factory.DeletePod(&pickedPod)
+		fdbCluster.factory.DeletePod(ctx, &pickedPod)
 		// Wait for new coordinators
 		time.Sleep(1 * time.Minute)
 		// Fetch all coordinators again
 
-		coordinators = fdbCluster.GetPodsWithRole(fdbv1beta2.ProcessRoleCoordinator)
+		coordinators = fdbCluster.GetPodsWithRole(ctx, fdbv1beta2.ProcessRoleCoordinator)
 		gomega.Expect(coordinators).NotTo(gomega.BeEmpty())
 		for _, coordinator := range coordinators {
 			if !GetProcessClass(coordinator).IsTransaction() {
@@ -462,8 +488,8 @@ func (fdbCluster *FdbCluster) GetCoordinatorsOnLogProcesses() []corev1.Pod {
 }
 
 // GetStatus returns fdb status queried from a random operator Pod in this clusters namespace.
-func (fdbCluster *FdbCluster) GetStatus() *fdbv1beta2.FoundationDBStatus {
-	return fdbCluster.getStatusFromOperatorPod()
+func (fdbCluster *FdbCluster) GetStatus(ctx context.Context) *fdbv1beta2.FoundationDBStatus {
+	return fdbCluster.getStatusFromOperatorPod(ctx)
 }
 
 // RoleInfo stores information for one particular worker role.
@@ -473,9 +499,11 @@ type RoleInfo struct {
 }
 
 // GetPodRoleMap returns a map with the process group ID as key and all associated roles.
-func (fdbCluster *FdbCluster) GetPodRoleMap() map[fdbv1beta2.ProcessGroupID][]RoleInfo {
+func (fdbCluster *FdbCluster) GetPodRoleMap(
+	ctx context.Context,
+) map[fdbv1beta2.ProcessGroupID][]RoleInfo {
 	ret := make(map[fdbv1beta2.ProcessGroupID][]RoleInfo)
-	status := fdbCluster.GetStatus()
+	status := fdbCluster.GetStatus(ctx)
 
 	for _, process := range status.Cluster.Processes {
 		podName := fdbv1beta2.ProcessGroupID(process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey])
@@ -489,9 +517,12 @@ func (fdbCluster *FdbCluster) GetPodRoleMap() map[fdbv1beta2.ProcessGroupID][]Ro
 }
 
 // GetPodsWithRole returns all Pods that have the provided role.
-func (fdbCluster *FdbCluster) GetPodsWithRole(role fdbv1beta2.ProcessRole) []corev1.Pod {
-	roleMap := fdbCluster.GetPodRoleMap()
-	pods := fdbCluster.GetPods()
+func (fdbCluster *FdbCluster) GetPodsWithRole(
+	ctx context.Context,
+	role fdbv1beta2.ProcessRole,
+) []corev1.Pod {
+	roleMap := fdbCluster.GetPodRoleMap(ctx)
+	pods := fdbCluster.GetPods(ctx)
 
 	var matches []corev1.Pod
 	for _, p := range pods.Items {
@@ -511,8 +542,10 @@ func (fdbCluster *FdbCluster) GetPodsWithRole(role fdbv1beta2.ProcessRole) []cor
 }
 
 // GetCommandlineForProcessesPerClass fetches the commandline args for all processes except of the specified class.
-func (fdbCluster *FdbCluster) GetCommandlineForProcessesPerClass() map[fdbv1beta2.ProcessClass][]string {
-	return fdbCluster.GetCommandlineForProcessesPerClassWithStatus(fdbCluster.GetStatus())
+func (fdbCluster *FdbCluster) GetCommandlineForProcessesPerClass(
+	ctx context.Context,
+) map[fdbv1beta2.ProcessClass][]string {
+	return fdbCluster.GetCommandlineForProcessesPerClassWithStatus(fdbCluster.GetStatus(ctx))
 }
 
 // GetCommandlineForProcessesPerClassWithStatus fetches the commandline args for all processes except of the specified class.

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -31,7 +31,6 @@ This cluster will be used for all tests.
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -67,22 +66,26 @@ func init() {
 	testOptions = fixtures.InitFlags()
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	factory = fixtures.CreateFactory(testOptions)
-	fdbCluster = factory.CreateFdbCluster(
+	fdbCluster = factory.CreateFdbCluster(ctx,
 		fixtures.DefaultClusterConfig(false),
 	)
 
 	// Make sure that the test suite is able to fetch logs from Pods.
-	operatorPod := factory.RandomPickOnePod(factory.GetOperatorPods(fdbCluster.Namespace()).Items)
-	Expect(factory.GetLogsForPod(&operatorPod, "manager", nil)).NotTo(BeEmpty())
+	operatorPod := factory.RandomPickOnePod(
+		factory.GetOperatorPods(ctx, fdbCluster.Namespace()).Items,
+	)
+	Expect(
+		factory.GetLogsForPod(ctx, &operatorPod, "manager", nil),
+	).NotTo(BeEmpty())
 
 	// Load some data async into the cluster. We will only block as long as the Job is created.
-	factory.CreateDataLoaderIfAbsent(fdbCluster)
+	factory.CreateDataLoaderIfAbsent(ctx, fdbCluster)
 
 	// In order to test the robustness of the operator we try to kill the operator Pods every minute.
 	if factory.ChaosTestsEnabled() {
-		scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(
+		scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(ctx,
 			fixtures.GetOperatorSelector(fdbCluster.Namespace()),
 			"*/2 * * * *",
 			chaosmesh.OneMode,
@@ -91,33 +94,32 @@ var _ = BeforeSuite(func() {
 	}
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx SpecContext) {
 	if CurrentSpecReport().Failed() {
 		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
 	}
-	factory.Shutdown()
+	factory.Shutdown(ctx)
 })
 
 var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	var availabilityCheck bool
 
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		// Reset availabilityCheck if a test case removes this check.
 		availabilityCheck = true
 		if CurrentSpecReport().Failed() {
-			factory.DumpState(fdbCluster)
+			factory.DumpState(ctx, fdbCluster)
 		}
-		Expect(fdbCluster.WaitForReconciliation()).ToNot(HaveOccurred())
+		Expect(fdbCluster.WaitForReconciliation(ctx)).ToNot(HaveOccurred())
 		factory.StopInvariantCheck()
 		// Make sure all data is present in the cluster
-		fdbCluster.EnsureTeamTrackersAreHealthy()
-		fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+		fdbCluster.EnsureTeamTrackersAreHealthy(ctx)
+		fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		if availabilityCheck {
-			err := fdbCluster.InvariantClusterStatusAvailable()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(fdbCluster.InvariantClusterStatusAvailable(ctx)).To(Succeed())
 		}
 	})
 
@@ -133,19 +135,19 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		numNodesTainted := 2 // TODO: Change to higher number 5
 		ensurePodIsDeletedTimeoutMinutes := 20
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// Cleanup tainted nodes in case previous test fails which will leave tainted nodes behind
 			for nodeName := range historyTaintedNodes {
 				log.Printf("BeforeEach Reset node as untainted:%s\n", nodeName)
-				node := fdbCluster.GetNode(nodeName)
+				node := fdbCluster.GetNode(ctx, nodeName)
 				node.Spec.Taints = []corev1.Taint{}
-				fdbCluster.UpdateNode(node)
+				fdbCluster.UpdateNode(ctx, node)
 			}
 
-			initialPods = fdbCluster.GetStatelessPods()
+			initialPods = fdbCluster.GetStatelessPods(ctx)
 
 			// Setup cluster's taint config and wait for long enough
-			fdbCluster.SetClusterTaintConfig([]fdbv1beta2.TaintReplacementOption{
+			fdbCluster.SetClusterTaintConfig(ctx, []fdbv1beta2.TaintReplacementOption{
 				{
 					Key:               &taintKeyMaintenance,
 					DurationInSeconds: &taintKeyMaintenanceDuration,
@@ -154,41 +156,43 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			Expect(
 				len(
-					fdbCluster.GetCluster().Spec.AutomationOptions.Replacements.TaintReplacementOptions,
+					fdbCluster.GetCluster(
+						ctx,
+					).Spec.AutomationOptions.Replacements.TaintReplacementOptions,
 				),
 			).To(BeNumerically(">=", 1))
 
 			Expect(*fdbCluster.GetAutomationOptions().Replacements.Enabled).To(BeTrue())
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.ClearProcessGroupsToRemove(ctx)).NotTo(HaveOccurred())
 			// Reset taint related options to default value in e2e test
-			fdbCluster.SetClusterTaintConfig(
+			fdbCluster.SetClusterTaintConfig(ctx,
 				[]fdbv1beta2.TaintReplacementOption{},
 				ptr.To(150),
 			)
 			// untaint the nodes
 			log.Printf("AfterEach Cleanup: Untaint the single node:%s\n", taintedNode.Name)
 			historyTaintedNodes[taintedNode.Name] = fdbv1beta2.None{}
-			taintedNode = fdbCluster.GetNode(taintedNode.Name)
+			taintedNode = fdbCluster.GetNode(ctx, taintedNode.Name)
 			taintedNode.Spec.Taints = []corev1.Taint{}
-			fdbCluster.UpdateNode(taintedNode)
+			fdbCluster.UpdateNode(ctx, taintedNode)
 			for i, node := range taintedNodes {
 				historyTaintedNodes[node.Name] = fdbv1beta2.None{}
 				log.Printf("Cleanup: Untaint the %dth node:%s\n", i, node.Name)
-				node = fdbCluster.GetNode(node.Name)
+				node = fdbCluster.GetNode(ctx, node.Name)
 				node.Spec.Taints = []corev1.Taint{}
-				fdbCluster.UpdateNode(node)
+				fdbCluster.UpdateNode(ctx, node)
 			}
 			taintedNodes = []*corev1.Node{}
 		})
 
 		When("cluster enables taint feature on focused maintenance taint key", func() {
-			It("should remove the targeted Pod whose Node is tainted", func() {
+			It("should remove the targeted Pod whose Node is tainted", func(ctx SpecContext) {
 				replacedPod := factory.RandomPickOnePod(initialPods.Items)
 				// Taint replacePod's node
-				taintedNode = fdbCluster.GetNode(replacedPod.Spec.NodeName)
+				taintedNode = fdbCluster.GetNode(ctx, replacedPod.Spec.NodeName)
 				taintedNode.Spec.Taints = []corev1.Taint{
 					{
 						Key:    taintKeyMaintenance,
@@ -208,22 +212,23 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					taintedNode.Spec.Taints[0].TimeAdded.Time,
 					time.Now(),
 				)
-				fdbCluster.UpdateNode(taintedNode)
+				fdbCluster.UpdateNode(ctx, taintedNode)
 
-				err := fdbCluster.WaitForReconciliation()
+				err := fdbCluster.WaitForReconciliation(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
 				fdbCluster.EnsurePodIsDeletedWithCustomTimeout(
+					ctx,
 					replacedPod.Name,
 					ensurePodIsDeletedTimeoutMinutes,
 				)
 			})
 
-			It("should remove all Pods whose Nodes are tainted", func() {
+			It("should remove all Pods whose Nodes are tainted", func(ctx SpecContext) {
 				replacedPods := factory.RandomPickPod(initialPods.Items, numNodesTainted)
 				for _, pod := range replacedPods {
 					// Taint replacePod's node
-					node := fdbCluster.GetNode(pod.Spec.NodeName)
+					node := fdbCluster.GetNode(ctx, pod.Spec.NodeName)
 					node.Spec.Taints = []corev1.Taint{
 						{
 							Key:    taintKeyMaintenance,
@@ -243,16 +248,17 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 						node.Spec.Taints[0].TimeAdded.Time,
 						time.Now(),
 					)
-					fdbCluster.UpdateNode(node)
+					fdbCluster.UpdateNode(ctx, node)
 					taintedNodes = append(taintedNodes, node)
 				}
 
-				err := fdbCluster.WaitForReconciliation()
+				err := fdbCluster.WaitForReconciliation(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
 				for i, pod := range replacedPods {
 					log.Printf("Ensure %dth pod:%s is deleted\n", i, pod.Name)
 					fdbCluster.EnsurePodIsDeletedWithCustomTimeout(
+						ctx,
 						pod.Name,
 						ensurePodIsDeletedTimeoutMinutes,
 					)
@@ -265,9 +271,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			taintKeyStar = "*"
 			taintKeyStarDuration = int64(5)
 
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				// Custom TaintReplacementOptions to taintKeyStar
-				fdbCluster.SetClusterTaintConfig([]fdbv1beta2.TaintReplacementOption{
+				fdbCluster.SetClusterTaintConfig(ctx, []fdbv1beta2.TaintReplacementOption{
 					{
 						Key:               &taintKeyStar,
 						DurationInSeconds: &taintKeyStarDuration,
@@ -282,45 +288,49 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			})
 
-			It("should eventually remove the targeted Pod whose Node is tainted", func() {
-				replacedPod := factory.RandomPickOnePod(initialPods.Items)
-				// Taint replacePod's node
-				node := fdbCluster.GetNode(replacedPod.Spec.NodeName)
-				node.Spec.Taints = []corev1.Taint{
-					{
-						Key:    taintKeyMaintenance,
-						Value:  "rack_maintenance",
-						Effect: corev1.TaintEffectPreferNoSchedule,
-						TimeAdded: &metav1.Time{
-							Time: time.Now().
-								Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1)),
+			It(
+				"should eventually remove the targeted Pod whose Node is tainted",
+				func(ctx SpecContext) {
+					replacedPod := factory.RandomPickOnePod(initialPods.Items)
+					// Taint replacePod's node
+					node := fdbCluster.GetNode(ctx, replacedPod.Spec.NodeName)
+					node.Spec.Taints = []corev1.Taint{
+						{
+							Key:    taintKeyMaintenance,
+							Value:  "rack_maintenance",
+							Effect: corev1.TaintEffectPreferNoSchedule,
+							TimeAdded: &metav1.Time{
+								Time: time.Now().
+									Add(-time.Second * time.Duration(taintKeyMaintenanceDuration+1)),
+							},
 						},
-					},
-				}
-				log.Printf(
-					"Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n",
-					replacedPod.Name,
-					node.Name,
-					node.Spec.Taints,
-					node.Spec.Taints[0].TimeAdded.Time,
-					time.Now(),
-				)
-				fdbCluster.UpdateNode(node)
+					}
+					log.Printf(
+						"Taint node: Pod name:%s Node name:%s Node taints:%+v TaintTime:%+v Now:%+v\n",
+						replacedPod.Name,
+						node.Name,
+						node.Spec.Taints,
+						node.Spec.Taints[0].TimeAdded.Time,
+						time.Now(),
+					)
+					fdbCluster.UpdateNode(ctx, node)
 
-				err := fdbCluster.WaitForReconciliation()
-				Expect(err).NotTo(HaveOccurred())
+					err := fdbCluster.WaitForReconciliation(ctx)
+					Expect(err).NotTo(HaveOccurred())
 
-				fdbCluster.EnsurePodIsDeletedWithCustomTimeout(
-					replacedPod.Name,
-					ensurePodIsDeletedTimeoutMinutes,
-				)
-			})
+					fdbCluster.EnsurePodIsDeletedWithCustomTimeout(
+						ctx,
+						replacedPod.Name,
+						ensurePodIsDeletedTimeoutMinutes,
+					)
+				},
+			)
 
-			It("should eventually remove all Pods whose Nodes are tainted", func() {
+			It("should eventually remove all Pods whose Nodes are tainted", func(ctx SpecContext) {
 				replacedPods := factory.RandomPickPod(initialPods.Items, numNodesTainted)
 				for _, pod := range replacedPods {
 					// Taint replacePod's node
-					node := fdbCluster.GetNode(pod.Spec.NodeName)
+					node := fdbCluster.GetNode(ctx, pod.Spec.NodeName)
 					node.Spec.Taints = []corev1.Taint{
 						{
 							Key:    taintKeyMaintenance,
@@ -340,15 +350,16 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 						node.Spec.Taints[0].TimeAdded.Time,
 						time.Now(),
 					)
-					fdbCluster.UpdateNode(node)
+					fdbCluster.UpdateNode(ctx, node)
 				}
 
-				err := fdbCluster.WaitForReconciliation()
+				err := fdbCluster.WaitForReconciliation(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
 				for i, pod := range replacedPods {
 					log.Printf("Ensure %dth pod:%s is deleted\n", i, pod.Name)
 					fdbCluster.EnsurePodIsDeletedWithCustomTimeout(
+						ctx,
 						pod.Name,
 						ensurePodIsDeletedTimeoutMinutes,
 					)
@@ -360,9 +371,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			taintKeyMaintenanceDuration = int64(1)
 			taintKeyStar = "*"
 
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				// Custom TaintReplacementOptions to taintKeyStar
-				fdbCluster.SetClusterTaintConfig(
+				fdbCluster.SetClusterTaintConfig(ctx,
 					[]fdbv1beta2.TaintReplacementOption{},
 					ptr.To(1),
 				)
@@ -375,16 +386,19 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			})
 
-			It("should not remove any Pod whose Nodes are tainted", func() {
+			It("should not remove any Pod whose Nodes are tainted", func(ctx SpecContext) {
 				targetPods := factory.RandomPickPod(initialPods.Items, numNodesTainted)
 				var targetPodProcessGroupIDs []fdbv1beta2.ProcessGroupID
 				for _, pod := range targetPods {
 					targetPodProcessGroupIDs = append(
 						targetPodProcessGroupIDs,
-						internal.GetProcessGroupIDFromMeta(fdbCluster.GetCluster(), pod.ObjectMeta),
+						internal.GetProcessGroupIDFromMeta(
+							fdbCluster.GetCluster(ctx),
+							pod.ObjectMeta,
+						),
 					)
 					// Taint replacePod's node
-					node := fdbCluster.GetNode(pod.Spec.NodeName)
+					node := fdbCluster.GetNode(ctx, pod.Spec.NodeName)
 					node.Spec.Taints = []corev1.Taint{
 						{
 							Key:    taintKeyMaintenance,
@@ -404,13 +418,13 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 						node.Spec.Taints[0].TimeAdded.Time,
 						time.Now(),
 					)
-					fdbCluster.UpdateNode(node)
+					fdbCluster.UpdateNode(ctx, node)
 				}
 
 				Consistently(func() bool {
 					for _, groupID := range targetPodProcessGroupIDs {
 						processGroupStatus := fdbv1beta2.FindProcessGroupByID(
-							fdbCluster.GetCluster().Status.ProcessGroups,
+							fdbCluster.GetCluster(ctx).Status.ProcessGroups,
 							groupID,
 						)
 						Expect(processGroupStatus).NotTo(BeNil())
@@ -427,20 +441,20 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 						*fdbCluster.GetAutomationOptions().Replacements.TaintReplacementTimeSeconds+1,
 					),
 				)
-				err := fdbCluster.WaitForReconciliation()
+				err := fdbCluster.WaitForReconciliation(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
 				for i, pod := range targetPods {
 					log.Printf("Ensure %dth pod:%s is not deleted\n", i, pod.Name)
-					deleted := fdbCluster.CheckPodIsDeleted(pod.Name)
+					deleted := fdbCluster.CheckPodIsDeleted(ctx, pod.Name)
 					Expect(deleted).To(BeFalse())
 				}
 			})
 		})
 	})
 
-	It("should set the fault domain for all process groups", func() {
-		for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+	It("should set the fault domain for all process groups", func(ctx SpecContext) {
+		for _, processGroup := range fdbCluster.GetCluster(ctx).Status.ProcessGroups {
 			Expect(processGroup.FaultDomain).NotTo(BeEmpty())
 		}
 
@@ -449,15 +463,16 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	})
 
 	When("the cluster is unavailable", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			if factory.ChaosTestsEnabled() {
 				Skip("test needs chaos mesh for fault injection")
 			}
 			// Prevent chaos-mesh from deleting the operator pods, this would remove the partition.
-			factory.DeleteChaosMeshExperiment(scheduleInjectPodKill)
+			factory.DeleteChaosMeshExperiment(ctx, scheduleInjectPodKill)
 			// Partition the operator pods from the cluster, so that the cluster seems unavailable from the operator
 			// perspective.
 			factory.InjectPartitionBetween(
+				ctx,
 				fixtures.GetOperatorSelector(fdbCluster.GetCachedCluster().GetNamespace()),
 				chaosmesh.PodSelectorSpec{
 					GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
@@ -468,17 +483,17 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			)
 		})
 
-		AfterEach(func() {
-			Expect(factory.CleanupChaosMeshExperiments()).To(Succeed())
+		AfterEach(func(ctx SpecContext) {
+			Expect(factory.CleanupChaosMeshExperiments(ctx)).To(Succeed())
 			// Ensure that the status is reset after the partition is deleted.
-			fdbCluster.ForceReconcile()
+			fdbCluster.ForceReconcile(ctx)
 			Eventually(func(g Gomega) {
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 				g.Expect(cluster.Status.Health.Available).To(BeTrue())
 				g.Expect(cluster.Status.Health.Healthy).To(BeTrue())
 			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
 
-			scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(
+			scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(ctx,
 				fixtures.GetOperatorSelector(fdbCluster.Namespace()),
 				"*/2 * * * *",
 				chaosmesh.OneMode,
@@ -486,11 +501,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			)
 		})
 
-		It("should set the cluster.status.health to false", func() {
+		It("should set the cluster.status.health to false", func(ctx SpecContext) {
 			// Start a force reconcile to ensure the operator picks up the "change".
-			fdbCluster.ForceReconcile()
+			fdbCluster.ForceReconcile(ctx)
 			Eventually(func(g Gomega) {
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 				g.Expect(cluster.Status.Health.Available).To(BeFalse())
 				g.Expect(cluster.Status.Health.Healthy).To(BeFalse())
 			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
@@ -501,9 +516,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var replacedPod corev1.Pod
 		var useLocalitiesForExclusion bool
 
-		JustBeforeEach(func() {
-			initialPods := fdbCluster.GetPods()
-			coordinators := fdbstatus.GetCoordinatorsFromStatus(fdbCluster.GetStatus())
+		JustBeforeEach(func(ctx SpecContext) {
+			initialPods := fdbCluster.GetPods(ctx)
+			coordinators := fdbstatus.GetCoordinatorsFromStatus(fdbCluster.GetStatus(ctx))
 
 			for _, pod := range initialPods.Items {
 				_, isCoordinator := coordinators[string(fixtures.GetProcessGroupID(pod))]
@@ -519,36 +534,36 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}
 
 			log.Println("coordinators:", coordinators, "replacedPod", replacedPod.Name)
-			fdbCluster.ReplacePod(replacedPod, true)
+			fdbCluster.ReplacePod(ctx, replacedPod, true)
 		})
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// Until the race condition is resolved in the FDB go bindings make sure the operator is not restarted.
 			// See: https://github.com/apple/foundationdb/issues/11222
 			// We can remove this once 7.1 is the default version.
-			factory.DeleteChaosMeshExperiment(scheduleInjectPodKill)
-			useLocalitiesForExclusion = fdbCluster.GetCluster().UseLocalitiesForExclusion()
+			factory.DeleteChaosMeshExperiment(ctx, scheduleInjectPodKill)
+			useLocalitiesForExclusion = fdbCluster.GetCluster(ctx).UseLocalitiesForExclusion()
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.ClearProcessGroupsToRemove(ctx)).NotTo(HaveOccurred())
 			// Make sure we reset the previous behaviour.
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.AutomationOptions.UseLocalitiesForExclusion = ptr.To(
 				useLocalitiesForExclusion,
 			)
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 			Expect(
-				fdbCluster.GetCluster().UseLocalitiesForExclusion(),
+				fdbCluster.GetCluster(ctx).UseLocalitiesForExclusion(),
 			).To(Equal(useLocalitiesForExclusion))
 
 			// Making sure we included back all the process groups after exclusion is complete.
 			Expect(
-				fdbCluster.GetStatus().Cluster.DatabaseConfiguration.ExcludedServers,
+				fdbCluster.GetStatus(ctx).Cluster.DatabaseConfiguration.ExcludedServers,
 			).To(BeEmpty())
 
 			if factory.ChaosTestsEnabled() {
-				scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(
+				scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(ctx,
 					fixtures.GetOperatorSelector(fdbCluster.Namespace()),
 					"*/2 * * * *",
 					chaosmesh.OneMode,
@@ -558,20 +573,20 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		When("IP addresses are used for exclusion", func() {
-			BeforeEach(func() {
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			BeforeEach(func(ctx SpecContext) {
+				spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 				spec.AutomationOptions.UseLocalitiesForExclusion = ptr.To(false)
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 			})
 
-			It("should remove the targeted Pod", func() {
-				fdbCluster.EnsurePodIsDeleted(replacedPod.Name)
+			It("should remove the targeted Pod", func(ctx SpecContext) {
+				fdbCluster.EnsurePodIsDeleted(ctx, replacedPod.Name)
 			})
 		})
 
 		When("localities are used for exclusion", func() {
-			BeforeEach(func() {
-				cluster := fdbCluster.GetCluster()
+			BeforeEach(func(ctx SpecContext) {
+				cluster := fdbCluster.GetCluster(ctx)
 
 				fdbVersion, err := fdbv1beta2.ParseFdbVersion(cluster.GetRunningVersion())
 				Expect(err).NotTo(HaveOccurred())
@@ -584,18 +599,18 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 				spec := cluster.Spec.DeepCopy()
 				spec.AutomationOptions.UseLocalitiesForExclusion = ptr.To(true)
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
-				Expect(fdbCluster.GetCluster().UseLocalitiesForExclusion()).To(BeTrue())
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+				Expect(fdbCluster.GetCluster(ctx).UseLocalitiesForExclusion()).To(BeTrue())
 			})
 
-			It("should remove the targeted Pod", func() {
+			It("should remove the targeted Pod", func(ctx SpecContext) {
 				Expect(
 					ptr.Deref(
-						fdbCluster.GetCluster().Spec.AutomationOptions.UseLocalitiesForExclusion,
+						fdbCluster.GetCluster(ctx).Spec.AutomationOptions.UseLocalitiesForExclusion,
 						false,
 					),
 				).To(BeTrue())
-				fdbCluster.EnsurePodIsDeleted(replacedPod.Name)
+				fdbCluster.EnsurePodIsDeleted(ctx, replacedPod.Name)
 			})
 		})
 	})
@@ -603,9 +618,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	When("setting storageServersPerPod", func() {
 		var initialStorageServerPerPod, expectedPodCnt, expectedStorageProcessesCnt int
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			initialStorageServerPerPod = fdbCluster.GetStorageServerPerPod()
-			initialPods := fdbCluster.GetStoragePods()
+			initialPods := fdbCluster.GetStoragePods(ctx)
 			expectedPodCnt = len(initialPods.Items)
 			expectedStorageProcessesCnt = expectedPodCnt * initialStorageServerPerPod
 			log.Printf(
@@ -613,40 +628,40 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				expectedPodCnt,
 				expectedStorageProcessesCnt,
 			)
-			fdbCluster.ValidateProcessesCount(
+			fdbCluster.ValidateProcessesCount(ctx,
 				fdbv1beta2.ProcessClassStorage,
 				expectedPodCnt,
 				expectedStorageProcessesCnt,
 			)
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			log.Printf("set storage server per pod to %d", initialStorageServerPerPod)
 			Expect(
-				fdbCluster.SetStorageServerPerPod(initialStorageServerPerPod),
+				fdbCluster.SetStorageServerPerPod(ctx, initialStorageServerPerPod),
 			).ShouldNot(HaveOccurred())
 			log.Printf(
 				"expectedPodCnt: %d, expectedStorageProcessesCnt: %d",
 				expectedPodCnt,
 				expectedPodCnt*initialStorageServerPerPod,
 			)
-			fdbCluster.ValidateProcessesCount(fdbv1beta2.ProcessClassStorage,
+			fdbCluster.ValidateProcessesCount(ctx, fdbv1beta2.ProcessClassStorage,
 				expectedPodCnt,
 				expectedPodCnt*initialStorageServerPerPod,
 			)
 		})
 
-		It("should update the storage servers to the expected amount", func() {
+		It("should update the storage servers to the expected amount", func(ctx SpecContext) {
 			// Update to double the SS per Disk
 			serverPerPod := initialStorageServerPerPod * 2
 			log.Printf("set storage server per Pod to %d", serverPerPod)
-			Expect(fdbCluster.SetStorageServerPerPod(serverPerPod)).ShouldNot(HaveOccurred())
+			Expect(fdbCluster.SetStorageServerPerPod(ctx, serverPerPod)).ShouldNot(HaveOccurred())
 			log.Printf(
 				"expectedPodCnt: %d, expectedStorageProcessesCnt: %d",
 				expectedPodCnt,
 				expectedPodCnt*serverPerPod,
 			)
-			fdbCluster.ValidateProcessesCount(
+			fdbCluster.ValidateProcessesCount(ctx,
 				fdbv1beta2.ProcessClassStorage,
 				expectedPodCnt,
 				expectedPodCnt*serverPerPod,
@@ -657,22 +672,24 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	When("Shrinking the number of log processes by one", func() {
 		var initialLogPodCount int
 
-		BeforeEach(func() {
-			initialLogPodCount = len(fdbCluster.GetLogPods().Items)
+		BeforeEach(func(ctx SpecContext) {
+			initialLogPodCount = len(fdbCluster.GetLogPods(ctx).Items)
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			// Set the log process count back to the default value
-			Expect(fdbCluster.UpdateLogProcessCount(initialLogPodCount)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpdateLogProcessCount(ctx, initialLogPodCount)).NotTo(HaveOccurred())
 			Eventually(func() int {
-				return len(fdbCluster.GetLogPods().Items)
+				return len(fdbCluster.GetLogPods(ctx).Items)
 			}).Should(BeNumerically("==", initialLogPodCount))
 		})
 
-		It("should reduce the number of log processes by one", func() {
-			Expect(fdbCluster.UpdateLogProcessCount(initialLogPodCount - 1)).NotTo(HaveOccurred())
+		It("should reduce the number of log processes by one", func(ctx SpecContext) {
+			Expect(
+				fdbCluster.UpdateLogProcessCount(ctx, initialLogPodCount-1),
+			).NotTo(HaveOccurred())
 			Eventually(func() int {
-				return len(fdbCluster.GetLogPods().Items)
+				return len(fdbCluster.GetLogPods(ctx).Items)
 			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(BeNumerically("==", initialLogPodCount-1))
 		})
 	})
@@ -680,21 +697,21 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	When("a Pod is in a failed scheduling state", func() {
 		var failedPod corev1.Pod
 
-		BeforeEach(func() {
-			initialPods := fdbCluster.GetStatelessPods()
+		BeforeEach(func(ctx SpecContext) {
+			initialPods := fdbCluster.GetStatelessPods(ctx)
 			failedPod = factory.RandomPickOnePod(initialPods.Items)
 			log.Printf("Setting pod %s to unschedulable.", failedPod.Name)
-			fdbCluster.SetPodAsUnschedulable(failedPod)
-			fdbCluster.ReplacePod(failedPod, true)
+			fdbCluster.SetPodAsUnschedulable(ctx, failedPod)
+			fdbCluster.ReplacePod(ctx, failedPod, true)
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.ClearBuggifyNoSchedule(true)).NotTo(HaveOccurred())
-			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.ClearBuggifyNoSchedule(ctx, true)).NotTo(HaveOccurred())
+			Expect(fdbCluster.ClearProcessGroupsToRemove(ctx)).NotTo(HaveOccurred())
 		})
 
-		It("should remove the targeted Pod", func() {
-			fdbCluster.EnsurePodIsDeletedWithCustomTimeout(failedPod.Name, 15)
+		It("should remove the targeted Pod", func(ctx SpecContext) {
+			fdbCluster.EnsurePodIsDeletedWithCustomTimeout(ctx, failedPod.Name, 15)
 		})
 	})
 
@@ -702,55 +719,58 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var failedPod *corev1.Pod
 		var podToReplace *corev1.Pod
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// We bring down two pods, which could cause some recoveries.
 			availabilityCheck = false
-			failedPod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
-			podToReplace = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
+			failedPod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods(ctx))
+			podToReplace = factory.ChooseRandomPod(fdbCluster.GetStatelessPods(ctx))
 			log.Println(
 				"Failed (unscheduled) Pod:",
 				failedPod.Name,
 				", Pod to replace:",
 				podToReplace.Name,
 			)
-			fdbCluster.SetPodAsUnschedulable(*failedPod)
-			fdbCluster.ReplacePod(*podToReplace, false)
+			fdbCluster.SetPodAsUnschedulable(ctx, *failedPod)
+			fdbCluster.ReplacePod(ctx, *podToReplace, false)
 		})
 		// 2024/11/26 01:41:00 Failed (unscheduled) Pod: operator-test-fdnhokqf-stateless-42898 , Pod to replace: operator-test-fdnhokqf-stateless-93723
-		AfterEach(func() {
-			Expect(fdbCluster.ClearBuggifyNoSchedule(false)).NotTo(HaveOccurred())
-			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.ClearBuggifyNoSchedule(ctx, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.ClearProcessGroupsToRemove(ctx)).NotTo(HaveOccurred())
 		})
 
-		It("should remove the targeted Pod", func() {
-			fdbCluster.EnsurePodIsDeletedWithCustomTimeout(podToReplace.Name, 15)
+		It("should remove the targeted Pod", func(ctx SpecContext) {
+			fdbCluster.EnsurePodIsDeletedWithCustomTimeout(ctx, podToReplace.Name, 15)
 		})
 	})
 
 	When("Skipping a cluster for reconciliation", func() {
 		var initialGeneration int64
 
-		BeforeEach(func() {
-			fdbCluster.SetSkipReconciliation(true)
-			initialGeneration = fdbCluster.GetCluster().Status.Generations.Reconciled
+		BeforeEach(func(ctx SpecContext) {
+			fdbCluster.SetSkipReconciliation(ctx, true)
+			initialGeneration = fdbCluster.GetCluster(ctx).Status.Generations.Reconciled
 		})
 
-		It("should not reconcile and keep the cluster in the same generation", func() {
-			initialStoragePods := fdbCluster.GetStoragePods()
-			podToDelete := factory.ChooseRandomPod(initialStoragePods)
-			log.Printf("deleting storage pod %s/%s", podToDelete.Namespace, podToDelete.Name)
-			factory.DeletePod(podToDelete)
-			Eventually(func() int {
-				return len(fdbCluster.GetStoragePods().Items)
-			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(BeNumerically("==", len(initialStoragePods.Items)-1))
+		It(
+			"should not reconcile and keep the cluster in the same generation",
+			func(ctx SpecContext) {
+				initialStoragePods := fdbCluster.GetStoragePods(ctx)
+				podToDelete := factory.ChooseRandomPod(initialStoragePods)
+				log.Printf("deleting storage pod %s/%s", podToDelete.Namespace, podToDelete.Name)
+				factory.DeletePod(ctx, podToDelete)
+				Eventually(func() int {
+					return len(fdbCluster.GetStoragePods(ctx).Items)
+				}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(BeNumerically("==", len(initialStoragePods.Items)-1))
 
-			Consistently(func() int64 {
-				return fdbCluster.GetCluster().Status.Generations.Reconciled
-			}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(BeNumerically("==", initialGeneration))
-		})
+				Consistently(func() int64 {
+					return fdbCluster.GetCluster(ctx).Status.Generations.Reconciled
+				}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(BeNumerically("==", initialGeneration))
+			},
+		)
 
-		AfterEach(func() {
-			fdbCluster.SetSkipReconciliation(false)
+		AfterEach(func(ctx SpecContext) {
+			fdbCluster.SetSkipReconciliation(ctx, false)
 		})
 	})
 
@@ -758,17 +778,17 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var podToDelete corev1.Pod
 		var deleteTime time.Time
 
-		BeforeEach(func() {
-			podToDelete = factory.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
+		BeforeEach(func(ctx SpecContext) {
+			podToDelete = factory.RandomPickOnePod(fdbCluster.GetStoragePods(ctx).Items)
 			log.Printf("deleting storage pod %s/%s", podToDelete.Namespace, podToDelete.Name)
 			// Add some buffer here to reduce the risk of a race condition.
 			deleteTime = time.Now().Add(-15 * time.Second)
-			factory.DeletePod(&podToDelete)
+			factory.DeletePod(ctx, &podToDelete)
 		})
 
-		It("Should recreate the storage Pod", func() {
+		It("Should recreate the storage Pod", func(ctx SpecContext) {
 			Eventually(func() bool {
-				return fdbCluster.GetPod(podToDelete.Name).CreationTimestamp.After(deleteTime)
+				return fdbCluster.GetPod(ctx, podToDelete.Name).CreationTimestamp.After(deleteTime)
 			}, 3*time.Minute, 1*time.Second).Should(BeTrue())
 		})
 	})
@@ -777,25 +797,30 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var exp *fixtures.ChaosMeshExperiment
 		var initialReplaceTime time.Duration
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			if !factory.ChaosTestsEnabled() {
 				Skip("Chaos tests are skipped for the operator")
 			}
 			availabilityCheck = false
 			initialReplaceTime = time.Duration(ptr.Deref(
-				fdbCluster.GetClusterSpec().AutomationOptions.Replacements.FailureDetectionTimeSeconds,
+				fdbCluster.GetClusterSpec(
+					ctx,
+				).AutomationOptions.Replacements.FailureDetectionTimeSeconds,
 				90,
 			)) * time.Second
-			Expect(fdbCluster.SetAutoReplacements(true, 30*time.Second)).ShouldNot(HaveOccurred())
+			Expect(
+				fdbCluster.SetAutoReplacements(ctx, true, 30*time.Second),
+			).ShouldNot(HaveOccurred())
 		})
 
 		When("a Pod gets partitioned", func() {
 			var partitionedPod *corev1.Pod
 
-			BeforeEach(func() {
-				partitionedPod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
+			BeforeEach(func(ctx SpecContext) {
+				partitionedPod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods(ctx))
 				log.Printf("partition Pod: %s", partitionedPod.Name)
 				exp = factory.InjectPartitionBetween(
+					ctx,
 					fixtures.PodSelector(partitionedPod),
 					chaosmesh.PodSelectorSpec{
 						GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
@@ -807,13 +832,13 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 				// Make sure the operator picks up the changes to the environment. This is not really needed but will
 				// speed up the tests.
-				fdbCluster.ForceReconcile()
+				fdbCluster.ForceReconcile(ctx)
 			})
 
-			It("should replace the partitioned Pod", func() {
+			It("should replace the partitioned Pod", func(ctx SpecContext) {
 				log.Printf("waiting for pod removal: %s", partitionedPod.Name)
-				fdbCluster.WaitForPodRemoval(partitionedPod)
-				exists, err := factory.DoesPodExist(*partitionedPod)
+				fdbCluster.WaitForPodRemoval(ctx, partitionedPod)
+				exists, err := factory.DoesPodExist(ctx, *partitionedPod)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(exists).To(BeFalse())
 			})
@@ -827,26 +852,30 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				var experiments []*fixtures.ChaosMeshExperiment
 				creationTimestamps := map[string]metav1.Time{}
 
-				BeforeEach(func() {
-					concurrentReplacements = fdbCluster.GetCluster().
+				BeforeEach(func(ctx SpecContext) {
+					concurrentReplacements = fdbCluster.GetCluster(ctx).
 						GetMaxConcurrentAutomaticReplacements()
 					// Allow to replace 1 Pod concurrently
-					spec := fdbCluster.GetCluster().Spec.DeepCopy()
+					spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 					spec.AutomationOptions.Replacements.MaxConcurrentReplacements = ptr.To(1)
-					fdbCluster.UpdateClusterSpecWithSpec(spec)
+					fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 
 					// Make sure we disable automatic replacements to prevent the case that the operator replaces one Pod
 					// before the partitioned is injected.
 					Expect(
-						fdbCluster.SetAutoReplacements(false, 30*time.Second),
+						fdbCluster.SetAutoReplacements(ctx, false, 30*time.Second),
 					).ShouldNot(HaveOccurred())
 
 					// Pick 2 Pods, so the operator has to replace them one after another
-					partitionedPods = factory.RandomPickPod(fdbCluster.GetStatelessPods().Items, 3)
+					partitionedPods = factory.RandomPickPod(
+						fdbCluster.GetStatelessPods(ctx).Items,
+						3,
+					)
 					for _, partitionedPod := range partitionedPods {
 						pod := partitionedPod
 						log.Printf("partition Pod: %s", pod.Name)
 						experiments = append(experiments, factory.InjectPartitionBetween(
+							ctx,
 							fixtures.PodSelector(&pod),
 							chaosmesh.PodSelectorSpec{
 								GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
@@ -864,25 +893,25 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 					// Now we can enable the replacements.
 					Expect(
-						fdbCluster.SetAutoReplacements(true, 30*time.Second),
+						fdbCluster.SetAutoReplacements(ctx, true, 30*time.Second),
 					).ShouldNot(HaveOccurred())
 				})
 
-				AfterEach(func() {
-					spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				AfterEach(func(ctx SpecContext) {
+					spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 					spec.AutomationOptions.Replacements.MaxConcurrentReplacements = ptr.To(
 						concurrentReplacements,
 					)
-					fdbCluster.UpdateClusterSpecWithSpec(spec)
+					fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 					for _, experiment := range experiments {
-						factory.DeleteChaosMeshExperiment(experiment)
+						factory.DeleteChaosMeshExperiment(ctx, experiment)
 					}
 				})
 
-				It("should replace the all partitioned Pod", func() {
+				It("should replace the all partitioned Pod", func(ctx SpecContext) {
 					Eventually(func() bool {
 						allUpdatedOrRemoved := true
-						for _, pod := range fdbCluster.GetStatelessPods().Items {
+						for _, pod := range fdbCluster.GetStatelessPods(ctx).Items {
 							creationTime, exists := creationTimestamps[pod.Name]
 							// If the Pod doesn't exist we can assume it was updated.
 							if !exists {
@@ -912,15 +941,15 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		When("a Pod has a bad disk", func() {
 			var podWithIOError corev1.Pod
 
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				if !factory.ChaosTestsEnabled() {
 					Skip("Chaos tests are skipped for the operator")
 				}
 				availabilityCheck = false
-				initialPods := fdbCluster.GetStoragePods()
+				initialPods := fdbCluster.GetStoragePods(ctx)
 				podWithIOError = factory.RandomPickOnePod(initialPods.Items)
 				log.Printf("Injecting I/O chaos to %s for 1 minute", podWithIOError.Name)
-				exp = factory.InjectDiskFailureWithDuration(
+				exp = factory.InjectDiskFailureWithDuration(ctx,
 					fixtures.PodSelector(&podWithIOError),
 					"1m",
 				)
@@ -928,8 +957,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				log.Printf("iochaos injected to %s", podWithIOError.Name)
 				// File creation should fail due to I/O error
 				Eventually(func() error {
-					_, _, err := factory.ExecuteCmdOnPod(
-						context.Background(),
+					_, _, err := factory.ExecuteCmdOnPod(ctx,
 						&podWithIOError,
 						fdbv1beta2.MainContainerName,
 						"touch /var/fdb/data/test",
@@ -940,7 +968,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 				processGroupID := string(fixtures.GetProcessGroupID(podWithIOError))
 				Eventually(func(g Gomega) []string {
-					status := fdbCluster.GetStatus()
+					status := fdbCluster.GetStatus(ctx)
 
 					for _, process := range status.Cluster.Processes {
 						processID, ok := process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]
@@ -963,14 +991,14 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					return nil
 				}).WithPolling(1 * time.Second).WithTimeout(5 * time.Minute).Should(Or(ContainElement("io_error"), ContainElement("io_timeout")))
 
-				fdbCluster.ForceReconcile()
+				fdbCluster.ForceReconcile(ctx)
 			})
 
-			It("should remove the targeted process", func() {
+			It("should remove the targeted process", func(ctx SpecContext) {
 				processGroupID := fixtures.GetProcessGroupID(podWithIOError)
 				// Wait until the process group is marked to be removed.
 				Expect(
-					fdbCluster.WaitUntilWithForceReconcile(
+					fdbCluster.WaitUntilWithForceReconcile(ctx,
 						1,
 						600,
 						func(cluster *fdbv1beta2.FoundationDBCluster) bool {
@@ -989,7 +1017,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 				// Wait until the process group is removed
 				Expect(
-					fdbCluster.WaitUntilWithForceReconcile(
+					fdbCluster.WaitUntilWithForceReconcile(ctx,
 						1,
 						1200,
 						func(cluster *fdbv1beta2.FoundationDBCluster) bool {
@@ -1009,11 +1037,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			})
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			Expect(
-				fdbCluster.SetAutoReplacements(true, initialReplaceTime),
+				fdbCluster.SetAutoReplacements(ctx, true, initialReplaceTime),
 			).ShouldNot(HaveOccurred())
-			factory.DeleteChaosMeshExperiment(exp)
+			factory.DeleteChaosMeshExperiment(ctx, exp)
 		})
 	})
 
@@ -1021,49 +1049,49 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var podWithIOError corev1.Pod
 		var exp *fixtures.ChaosMeshExperiment
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			if !factory.ChaosTestsEnabled() {
 				Skip("Chaos tests are skipped for the operator")
 			}
 			availabilityCheck = false
-			initialPods := fdbCluster.GetStoragePods()
+			initialPods := fdbCluster.GetStoragePods(ctx)
 			podWithIOError = factory.RandomPickOnePod(initialPods.Items)
 			log.Printf("injecting iochaos to %s", podWithIOError.Name)
-			exp = factory.InjectIOLatency(fixtures.PodSelector(&podWithIOError), "2s")
+			exp = factory.InjectIOLatency(ctx, fixtures.PodSelector(&podWithIOError), "2s")
 			log.Printf("iochaos injected to %s", podWithIOError.Name)
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
-			factory.DeleteChaosMeshExperiment(exp)
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.ClearProcessGroupsToRemove(ctx)).NotTo(HaveOccurred())
+			factory.DeleteChaosMeshExperiment(ctx, exp)
 		})
 
-		It("should remove the targeted process", func() {
-			fdbCluster.ReplacePod(podWithIOError, true)
-			fdbCluster.EnsurePodIsDeleted(podWithIOError.Name)
+		It("should remove the targeted process", func(ctx SpecContext) {
+			fdbCluster.ReplacePod(ctx, podWithIOError, true)
+			fdbCluster.EnsurePodIsDeleted(ctx, podWithIOError.Name)
 		})
 	})
 
 	When("we change the process group prefix", func() {
 		prefix := "banana"
 
-		BeforeEach(func() {
-			Expect(fdbCluster.SetProcessGroupPrefix(prefix)).NotTo(HaveOccurred())
+		BeforeEach(func(ctx SpecContext) {
+			Expect(fdbCluster.SetProcessGroupPrefix(ctx, prefix)).NotTo(HaveOccurred())
 		})
 
-		It("should add the prefix to all instances", func() {
+		It("should add the prefix to all instances", func(ctx SpecContext) {
 			lastForcedReconciliationTime := time.Now()
 			forceReconcileDuration := 4 * time.Minute
 
 			Eventually(func(g Gomega) bool {
 				// Force a reconcile if needed to make sure we speed up the reconciliation if needed.
 				if time.Since(lastForcedReconciliationTime) >= forceReconcileDuration {
-					fdbCluster.ForceReconcile()
+					fdbCluster.ForceReconcile(ctx)
 					lastForcedReconciliationTime = time.Now()
 				}
 
 				// Check if all process groups are migrated
-				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+				for _, processGroup := range fdbCluster.GetCluster(ctx).Status.ProcessGroups {
 					if processGroup.IsMarkedForRemoval() && processGroup.IsExcluded() {
 						continue
 					}
@@ -1078,19 +1106,19 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	When("replacing multiple Pods", func() {
 		var replacedPods []corev1.Pod
 
-		BeforeEach(func() {
-			fdbCluster.ReplacePods(
-				factory.RandomPickPod(fdbCluster.GetStatelessPods().Items, 4),
+		BeforeEach(func(ctx SpecContext) {
+			fdbCluster.ReplacePods(ctx,
+				factory.RandomPickPod(fdbCluster.GetStatelessPods(ctx).Items, 4),
 				true,
 			)
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.ClearProcessGroupsToRemove(ctx)).NotTo(HaveOccurred())
 		})
 
-		It("should replace all the targeted Pods", func() {
-			currentPodsNames := fdbCluster.GetPodsNames()
+		It("should replace all the targeted Pods", func(ctx SpecContext) {
+			currentPodsNames := fdbCluster.GetPodsNames(ctx)
 			for _, replacedPod := range replacedPods {
 				Expect(currentPodsNames).ShouldNot(ContainElement(replacedPod.Name))
 			}
@@ -1101,37 +1129,39 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var podsBeforeReplacement []string
 		var replacePod *corev1.Pod
 
-		BeforeEach(func() {
-			podsBeforeReplacement = fdbCluster.GetPodsNames()
-			replacePod = factory.ChooseRandomPod(fdbCluster.GetPods())
-			factory.SetFinalizerForPod(replacePod, []string{"foundationdb.org/test"})
-			fdbCluster.ReplacePod(*replacePod, true)
+		BeforeEach(func(ctx SpecContext) {
+			podsBeforeReplacement = fdbCluster.GetPodsNames(ctx)
+			replacePod = factory.ChooseRandomPod(fdbCluster.GetPods(ctx))
+			factory.SetFinalizerForPod(ctx, replacePod, []string{"foundationdb.org/test"})
+			fdbCluster.ReplacePod(ctx, *replacePod, true)
 		})
 
-		AfterEach(func() {
-			factory.SetFinalizerForPod(replacePod, []string{})
-			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			factory.SetFinalizerForPod(ctx, replacePod, []string{})
+			Expect(fdbCluster.ClearProcessGroupsToRemove(ctx)).NotTo(HaveOccurred())
 		})
 
-		It("should replace the Pod stuck in Terminating state", func() {
+		It("should replace the Pod stuck in Terminating state", func(ctx SpecContext) {
 			Expect(
-				fdbCluster.GetPodsNames(),
+				fdbCluster.GetPodsNames(ctx),
 			).Should(Or(HaveLen(len(podsBeforeReplacement)+1), HaveLen(len(podsBeforeReplacement))))
 		})
 	})
 
 	When("changing coordinator selection", func() {
-		AfterEach(func() {
-			Expect(fdbCluster.UpdateCoordinatorSelection(
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.UpdateCoordinatorSelection(ctx,
 				[]fdbv1beta2.CoordinatorSelectionSetting{},
 			)).ShouldNot(HaveOccurred())
 		})
 
 		DescribeTable(
 			"changing coordinator selection",
-			func(setting []fdbv1beta2.CoordinatorSelectionSetting, expectedProcessClassList []fdbv1beta2.ProcessClass) {
-				Expect(fdbCluster.UpdateCoordinatorSelection(setting)).ShouldNot(HaveOccurred())
-				pods := fdbCluster.GetCoordinators()
+			func(ctx SpecContext, setting []fdbv1beta2.CoordinatorSelectionSetting, expectedProcessClassList []fdbv1beta2.ProcessClass) {
+				Expect(
+					fdbCluster.UpdateCoordinatorSelection(ctx, setting),
+				).ShouldNot(HaveOccurred())
+				pods := fdbCluster.GetCoordinators(ctx)
 				for _, pod := range pods {
 					log.Println(pod.Name)
 					Expect(
@@ -1179,21 +1209,23 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	When("increasing the number of log Pods by one", func() {
 		var initialPodCount int
 
-		BeforeEach(func() {
-			initialPodCount = len(fdbCluster.GetLogPods().Items)
+		BeforeEach(func(ctx SpecContext) {
+			initialPodCount = len(fdbCluster.GetLogPods(ctx).Items)
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.UpdateLogProcessCount(initialPodCount)).ShouldNot(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.UpdateLogProcessCount(ctx, initialPodCount)).ShouldNot(HaveOccurred())
 			Eventually(func() int {
-				return len(fdbCluster.GetLogPods().Items)
+				return len(fdbCluster.GetLogPods(ctx).Items)
 			}).Should(BeNumerically("==", initialPodCount))
 		})
 
-		It("should increase the count of log Pods by one", func() {
-			Expect(fdbCluster.UpdateLogProcessCount(initialPodCount + 1)).ShouldNot(HaveOccurred())
+		It("should increase the count of log Pods by one", func(ctx SpecContext) {
+			Expect(
+				fdbCluster.UpdateLogProcessCount(ctx, initialPodCount+1),
+			).ShouldNot(HaveOccurred())
 			Eventually(func() int {
-				return len(fdbCluster.GetLogPods().Items)
+				return len(fdbCluster.GetLogPods(ctx).Items)
 			}).Should(BeNumerically("==", initialPodCount+1))
 		})
 	})
@@ -1201,9 +1233,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	When("setting 2 logs per disk", func() {
 		var initialLogServerPerPod, expectedPodCnt, expectedLogProcessesCnt, serverPerPod int
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			initialLogServerPerPod = fdbCluster.GetLogServersPerPod()
-			initialPods := fdbCluster.GetLogPods()
+			initialPods := fdbCluster.GetLogPods(ctx)
 			expectedPodCnt = len(initialPods.Items)
 			expectedLogProcessesCnt = expectedPodCnt * initialLogServerPerPod
 			log.Printf(
@@ -1212,17 +1244,17 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				expectedLogProcessesCnt,
 			)
 			Eventually(func() int {
-				return len(fdbCluster.GetLogPods().Items)
+				return len(fdbCluster.GetLogPods(ctx).Items)
 			}).Should(BeNumerically("==", expectedPodCnt))
 
 			serverPerPod = initialLogServerPerPod * 2
 			log.Printf("new log servers per Pod: %d", serverPerPod)
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			log.Printf("set log servers per Pod to %d", initialLogServerPerPod)
 			Expect(
-				fdbCluster.SetLogServersPerPod(initialLogServerPerPod, true),
+				fdbCluster.SetLogServersPerPod(ctx, initialLogServerPerPod, true),
 			).ShouldNot(HaveOccurred())
 
 			log.Printf(
@@ -1231,23 +1263,27 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				expectedPodCnt*initialLogServerPerPod,
 			)
 			Eventually(func() int {
-				return len(fdbCluster.GetLogPods().Items)
+				return len(fdbCluster.GetLogPods(ctx).Items)
 			}).Should(BeNumerically("==", expectedPodCnt))
 		})
 
 		When("when using log servers", func() {
-			BeforeEach(func() {
-				Expect(fdbCluster.SetLogServersPerPod(serverPerPod, true)).ShouldNot(HaveOccurred())
+			BeforeEach(func(ctx SpecContext) {
+				Expect(
+					fdbCluster.SetLogServersPerPod(ctx, serverPerPod, true),
+				).ShouldNot(HaveOccurred())
 			})
 
-			It("should update the log servers to the expected amount", func() {
-				Expect(fdbCluster.SetLogServersPerPod(serverPerPod, true)).ShouldNot(HaveOccurred())
+			It("should update the log servers to the expected amount", func(ctx SpecContext) {
+				Expect(
+					fdbCluster.SetLogServersPerPod(ctx, serverPerPod, true),
+				).ShouldNot(HaveOccurred())
 				log.Printf(
 					"expectedPodCnt: %d, expectedProcessesCnt: %d",
 					expectedPodCnt,
 					expectedPodCnt*serverPerPod,
 				)
-				fdbCluster.ValidateProcessesCount(
+				fdbCluster.ValidateProcessesCount(ctx,
 					fdbv1beta2.ProcessClassLog,
 					expectedPodCnt,
 					expectedPodCnt*serverPerPod,
@@ -1256,10 +1292,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		})
 
 		When("migrating from log processes to transaction processes", func() {
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				// Change the servers per pod and change the transaction process counts and set the log process counts
 				// to -1.
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 				spec := cluster.Spec.DeepCopy()
 				spec.LogServersPerPod = serverPerPod
 
@@ -1270,13 +1306,13 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 				// process counts with default?
 				log.Println(spec.ProcessCounts)
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
-				Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+				Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 			})
 
-			AfterEach(func() {
+			AfterEach(func(ctx SpecContext) {
 				// Reset the transaction process class changes and make sure we create log pods again.
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 				spec := cluster.Spec.DeepCopy()
 				spec.LogServersPerPod = initialLogServerPerPod
 
@@ -1285,19 +1321,19 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				spec.ProcessCounts.Log = processCounts.Transaction
 				spec.ProcessCounts.Transaction = -1
 				log.Println(spec.ProcessCounts)
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
-				Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+				Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 			})
 
 			It(
 				"should update the log servers to the expected amount and should create transaction Pods",
-				func() {
+				func(ctx SpecContext) {
 					log.Printf(
 						"expectedPodCnt: %d, expectedProcessesCnt: %d",
 						expectedPodCnt,
 						expectedPodCnt*serverPerPod,
 					)
-					fdbCluster.ValidateProcessesCount(
+					fdbCluster.ValidateProcessesCount(ctx,
 						fdbv1beta2.ProcessClassTransaction,
 						expectedPodCnt,
 						expectedPodCnt*serverPerPod,
@@ -1312,10 +1348,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var initialVolumeClaims *corev1.PersistentVolumeClaimList
 		var pvc corev1.PersistentVolumeClaim
 
-		BeforeEach(func() {
-			replacePod = factory.ChooseRandomPod(fdbCluster.GetLogPods())
+		BeforeEach(func(ctx SpecContext) {
+			replacePod = factory.ChooseRandomPod(fdbCluster.GetLogPods(ctx))
 			volClaimName := fixtures.GetPvc(replacePod)
-			initialVolumeClaims = fdbCluster.GetVolumeClaimsForProcesses(
+			initialVolumeClaims = fdbCluster.GetVolumeClaimsForProcesses(ctx,
 				fdbv1beta2.ProcessClassLog,
 			)
 			for _, volumeClaim := range initialVolumeClaims.Items {
@@ -1326,19 +1362,19 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}
 			log.Printf("adding finalizer to pvc: %s", volClaimName)
 			Expect(
-				fdbCluster.SetFinalizerForPvc([]string{"foundationdb.org/test"}, pvc),
+				fdbCluster.SetFinalizerForPvc(ctx, []string{"foundationdb.org/test"}, pvc),
 			).ShouldNot(HaveOccurred())
-			fdbCluster.ReplacePod(*replacePod, true)
+			fdbCluster.ReplacePod(ctx, *replacePod, true)
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.SetFinalizerForPvc([]string{}, pvc)).ShouldNot(HaveOccurred())
-			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.SetFinalizerForPvc(ctx, []string{}, pvc)).ShouldNot(HaveOccurred())
+			Expect(fdbCluster.ClearProcessGroupsToRemove(ctx)).NotTo(HaveOccurred())
 		})
 
-		It("should replace the PVC stuck in Terminating state", func() {
-			fdbCluster.EnsurePodIsDeleted(replacePod.Name)
-			volumeClaims := fdbCluster.GetVolumeClaimsForProcesses(
+		It("should replace the PVC stuck in Terminating state", func(ctx SpecContext) {
+			fdbCluster.EnsurePodIsDeleted(ctx, replacePod.Name)
+			volumeClaims := fdbCluster.GetVolumeClaimsForProcesses(ctx,
 				fdbv1beta2.ProcessClassLog,
 			)
 			volumeClaimNames := make([]string, 0, len(volumeClaims.Items))
@@ -1355,7 +1391,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var newKnob string
 		var pickedPod *corev1.Pod
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// Disable the availability check to prevent flaky tests if the small cluster takes longer to be restarted
 			availabilityCheck = false
 			initialGeneralCustomParameters = fdbCluster.GetCustomParameters(
@@ -1368,14 +1404,14 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				fdbv1beta2.FoundationDBCustomParameter(newKnob),
 			)
 
-			pickedPod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
+			pickedPod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods(ctx))
 			log.Println("Selected Pod:", pickedPod.Name, " to be skipped during the restart")
-			fdbCluster.SetIgnoreDuringRestart(
+			fdbCluster.SetIgnoreDuringRestart(ctx,
 				[]fdbv1beta2.ProcessGroupID{fixtures.GetProcessGroupID(*pickedPod)},
 			)
 
 			Expect(
-				fdbCluster.SetCustomParameters(
+				fdbCluster.SetCustomParameters(ctx,
 					map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 						fdbv1beta2.ProcessClassGeneral: newGeneralCustomParameters,
 					},
@@ -1384,22 +1420,22 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			).NotTo(HaveOccurred())
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.SetCustomParameters(
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.SetCustomParameters(ctx,
 				map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 					fdbv1beta2.ProcessClassGeneral: initialGeneralCustomParameters,
 				},
 				false,
 			)).NotTo(HaveOccurred())
-			fdbCluster.SetIgnoreDuringRestart(nil)
+			fdbCluster.SetIgnoreDuringRestart(ctx, nil)
 		})
 
-		It("should not restart the process on the ignore list", func() {
+		It("should not restart the process on the ignore list", func(ctx SpecContext) {
 			processGroupID := fixtures.GetProcessGroupID(*pickedPod)
 
 			// Ensure that the process group has the condition IncorrectCommandLine and is kept in that state for 1 minute.
 			Eventually(func() bool {
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					if processGroup.ProcessGroupID != processGroupID {
 						continue
@@ -1419,8 +1455,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var podMarkedForRemoval corev1.Pod
 		var processGroupID fdbv1beta2.ProcessGroupID
 
-		BeforeEach(func() {
-			initialPods := fdbCluster.GetStatelessPods()
+		BeforeEach(func(ctx SpecContext) {
+			initialPods := fdbCluster.GetStatelessPods(ctx)
 			podMarkedForRemoval = factory.RandomPickOnePod(initialPods.Items)
 			log.Println(
 				"Setting Pod",
@@ -1428,18 +1464,18 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				"to be blocked to be removed and mark it for removal.",
 			)
 			processGroupID = fixtures.GetProcessGroupID(podMarkedForRemoval)
-			fdbCluster.SetBuggifyBlockRemoval([]fdbv1beta2.ProcessGroupID{processGroupID})
-			fdbCluster.ReplacePod(podMarkedForRemoval, false)
+			fdbCluster.SetBuggifyBlockRemoval(ctx, []fdbv1beta2.ProcessGroupID{processGroupID})
+			fdbCluster.ReplacePod(ctx, podMarkedForRemoval, false)
 		})
 
-		AfterEach(func() {
-			fdbCluster.SetBuggifyBlockRemoval(nil)
-			fdbCluster.EnsurePodIsDeleted(podMarkedForRemoval.Name)
+		AfterEach(func(ctx SpecContext) {
+			fdbCluster.SetBuggifyBlockRemoval(ctx, nil)
+			fdbCluster.EnsurePodIsDeleted(ctx, podMarkedForRemoval.Name)
 		})
 
-		It("should exclude the Pod but not remove the resources", func() {
+		It("should exclude the Pod but not remove the resources", func(ctx SpecContext) {
 			Eventually(func() bool {
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					if processGroup.ProcessGroupID != processGroupID {
@@ -1453,7 +1489,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				return false
 			}).WithTimeout(5 * time.Minute).WithPolling(15 * time.Second).ShouldNot(BeTrue())
 			Consistently(func() *corev1.Pod {
-				return fdbCluster.GetPod(podMarkedForRemoval.Name)
+				return fdbCluster.GetPod(ctx, podMarkedForRemoval.Name)
 			}).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).ShouldNot(BeNil())
 		})
 	})
@@ -1463,18 +1499,18 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var podName string
 		var initialReplacementDuration time.Duration
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			initialReplacementDuration = time.Duration(
 				fdbCluster.GetCachedCluster().GetFailureDetectionTimeSeconds(),
 			) * time.Second
 			// Get the current Process Group ID numbers that are in use.
-			_, processGroupIDs, err := fdbCluster.GetCluster().
+			_, processGroupIDs, err := fdbCluster.GetCluster(ctx).
 				GetCurrentProcessGroupsAndProcessCounts()
 			Expect(err).NotTo(HaveOccurred())
 
 			// Make sure the operator doesn't modify the status.
-			fdbCluster.SetSkipReconciliation(true)
-			cluster := fdbCluster.GetCluster()
+			fdbCluster.SetSkipReconciliation(ctx, true)
+			cluster := fdbCluster.GetCluster(ctx)
 			status := cluster.Status.DeepCopy() // Fetch the current status.
 			processGroupID = cluster.GetNextRandomProcessGroupID(
 				fdbv1beta2.ProcessClassStateless,
@@ -1488,7 +1524,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					nil,
 				),
 			)
-			fdbCluster.UpdateClusterStatusWithStatus(status)
+			fdbCluster.UpdateClusterStatusWithStatus(ctx, status)
 
 			log.Println(
 				"Next process group ID",
@@ -1498,19 +1534,22 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			)
 
 			// Make sure the new Pod will be stuck in unschedulable.
-			fdbCluster.SetProcessGroupsAsUnschedulable([]fdbv1beta2.ProcessGroupID{processGroupID})
+			fdbCluster.SetProcessGroupsAsUnschedulable(
+				ctx,
+				[]fdbv1beta2.ProcessGroupID{processGroupID},
+			)
 			// Now replace a random Pod for replacement to force the cluster to create a new Pod.
-			fdbCluster.ReplacePod(
-				factory.RandomPickOnePod(fdbCluster.GetStatelessPods().Items),
+			fdbCluster.ReplacePod(ctx,
+				factory.RandomPickOnePod(fdbCluster.GetStatelessPods(ctx).Items),
 				false,
 			)
 
 			// Allow the operator again to reconcile.
-			fdbCluster.SetSkipReconciliation(false)
+			fdbCluster.SetSkipReconciliation(ctx, false)
 
 			// Wait until the new Pod is actually created.
 			Eventually(func() bool {
-				for _, pod := range fdbCluster.GetStatelessPods().Items {
+				for _, pod := range fdbCluster.GetStatelessPods(ctx).Items {
 					if fixtures.GetProcessGroupID(pod) == processGroupID {
 						podName = pod.Name
 						return pod.DeletionTimestamp.IsZero()
@@ -1521,24 +1560,24 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}).WithPolling(2 * time.Second).WithTimeout(5 * time.Minute).MustPassRepeatedly(2).Should(BeTrue())
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			// Clear the buggify list, this should allow the operator to move forward and delete the Pod
-			Expect(fdbCluster.ClearBuggifyNoSchedule(true)).NotTo(HaveOccurred())
+			Expect(fdbCluster.ClearBuggifyNoSchedule(ctx, true)).NotTo(HaveOccurred())
 			// Make sure we cleaned up the process groups to remove.
-			Expect(fdbCluster.ClearProcessGroupsToRemove())
+			Expect(fdbCluster.ClearProcessGroupsToRemove(ctx))
 			Expect(
-				fdbCluster.SetAutoReplacements(true, initialReplacementDuration),
+				fdbCluster.SetAutoReplacements(ctx, true, initialReplacementDuration),
 			).NotTo(HaveOccurred())
 		})
 
 		When("automatic replacements are disabled", func() {
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				Expect(
-					fdbCluster.SetAutoReplacementsWithWait(false, 10*time.Hour, false),
+					fdbCluster.SetAutoReplacementsWithWait(ctx, false, 10*time.Hour, false),
 				).NotTo(HaveOccurred())
 			})
 
-			It("should not remove the Pod as long as it is unschedulable", func() {
+			It("should not remove the Pod as long as it is unschedulable", func(ctx SpecContext) {
 				log.Println(
 					"Make sure process group",
 					processGroupID,
@@ -1547,19 +1586,19 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				)
 				// Make sure the Pod is stuck in pending for 2 minutes
 				Consistently(func() corev1.PodPhase {
-					return fdbCluster.GetPod(podName).Status.Phase
+					return fdbCluster.GetPod(ctx, podName).Status.Phase
 				}).WithTimeout(2 * time.Minute).WithPolling(15 * time.Second).Should(Equal(corev1.PodPending))
 			})
 		})
 
 		When("automatic replacements are enabled", func() {
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				Expect(
-					fdbCluster.SetAutoReplacementsWithWait(true, 1*time.Minute, false),
+					fdbCluster.SetAutoReplacementsWithWait(ctx, true, 1*time.Minute, false),
 				).NotTo(HaveOccurred())
 			})
 
-			It("should remove the Pod", func() {
+			It("should remove the Pod", func(ctx SpecContext) {
 				log.Println(
 					"Make sure process group",
 					processGroupID,
@@ -1569,14 +1608,14 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				// Make sure the process group is removed after some time.
 				Eventually(func() *fdbv1beta2.ProcessGroupStatus {
 					return fdbv1beta2.FindProcessGroupByID(
-						fdbCluster.GetCluster().Status.ProcessGroups,
+						fdbCluster.GetCluster(ctx).Status.ProcessGroups,
 						processGroupID,
 					)
 				}).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).Should(BeNil())
 
 				// Make sure the Pod is actually deleted after some time.
 				Eventually(func() bool {
-					return fdbCluster.CheckPodIsDeleted(podName)
+					return fdbCluster.CheckPodIsDeleted(ctx, podName)
 				}).WithTimeout(2 * time.Minute).WithPolling(15 * time.Second).Should(BeTrue())
 			})
 		})
@@ -1590,7 +1629,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			var originalPodSpec, modifiedPodSpec, originalStoragePodSpec *corev1.PodSpec
 			var initialPodUpdateStrategy fdbv1beta2.PodUpdateStrategy
 
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				originalPodSpec = fdbCluster.GetPodTemplateSpec(fdbv1beta2.ProcessClassGeneral)
 				originalStoragePodSpec = fdbCluster.GetPodTemplateSpec(
 					fdbv1beta2.ProcessClassStorage,
@@ -1604,24 +1643,24 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					).NotTo(Equal(corev1.FSGroupChangeOnRootMismatch))
 				}
 				modifiedPodSpec.SecurityContext.FSGroupChangePolicy = &[]corev1.PodFSGroupChangePolicy{corev1.FSGroupChangeOnRootMismatch}[0]
-				for _, logPod := range fdbCluster.GetLogPods().Items {
+				for _, logPod := range fdbCluster.GetLogPods(ctx).Items {
 					podsToReplace = append(podsToReplace, logPod.Name)
 				}
-				for _, statelessPod := range fdbCluster.GetStatelessPods().Items {
+				for _, statelessPod := range fdbCluster.GetStatelessPods(ctx).Items {
 					podsToReplace = append(podsToReplace, statelessPod.Name)
 				}
-				for _, storagePod := range fdbCluster.GetStoragePods().Items {
+				for _, storagePod := range fdbCluster.GetStoragePods(ctx).Items {
 					podsToReplace = append(podsToReplace, storagePod.Name)
 				}
 				// if we do not set the PodUpdateStrategy to delete, then the pods will get replaced for the spec change,
 				// meaning we cannot test the security context change on non-storage pods unless we use PodUpdateStrategyDelete
 				// (and storage pod use would make the test take ~5min longer)
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 				initialPodUpdateStrategy = spec.AutomationOptions.PodUpdateStrategy
 				spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyDelete
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 				Expect(
-					fdbCluster.SetPodTemplateSpec(
+					fdbCluster.SetPodTemplateSpec(ctx,
 						fdbv1beta2.ProcessClassGeneral,
 						modifiedPodSpec,
 						false,
@@ -1629,12 +1668,12 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				).NotTo(HaveOccurred())
 			})
 
-			AfterEach(func() {
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			AfterEach(func(ctx SpecContext) {
+				spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 				spec.AutomationOptions.PodUpdateStrategy = initialPodUpdateStrategy
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 				Expect(
-					fdbCluster.SetPodTemplateSpec(
+					fdbCluster.SetPodTemplateSpec(ctx,
 						fdbv1beta2.ProcessClassGeneral,
 						originalPodSpec,
 						true,
@@ -1642,50 +1681,53 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				).NotTo(HaveOccurred())
 			})
 
-			It("should replace all the log pods (which had the securityContext change)", func() {
-				lastForcedReconciliationTime := time.Now()
-				forceReconcileDuration := 4 * time.Minute
-				Eventually(func(g Gomega) {
-					// Force a reconcile if needed to make sure we speed up the reconciliation if needed.
-					if time.Since(lastForcedReconciliationTime) >= forceReconcileDuration {
-						fdbCluster.ForceReconcile()
-						lastForcedReconciliationTime = time.Now()
-					}
+			It(
+				"should replace all the log pods (which had the securityContext change)",
+				func(ctx SpecContext) {
+					lastForcedReconciliationTime := time.Now()
+					forceReconcileDuration := 4 * time.Minute
+					Eventually(func(g Gomega) {
+						// Force a reconcile if needed to make sure we speed up the reconciliation if needed.
+						if time.Since(lastForcedReconciliationTime) >= forceReconcileDuration {
+							fdbCluster.ForceReconcile(ctx)
+							lastForcedReconciliationTime = time.Now()
+						}
 
-					// check that we replaced the pods we should have and did not replace others
-					currentPods := fdbCluster.GetPodsNames()
-					g.Expect(currentPods).NotTo(ContainElements(podsToReplace))
-					g.Expect(currentPods).To(ContainElements(podsNotToReplace))
-					// check that General template pods (Log + Stateless) are replaced with the new security context
-					logPods := fdbCluster.GetLogPods()
-					for _, pod := range logPods.Items {
-						g.Expect(pod.Spec.SecurityContext.FSGroupChangePolicy).ToNot(BeNil())
-						g.Expect(*pod.Spec.SecurityContext.FSGroupChangePolicy).
-							To(Equal(corev1.FSGroupChangeOnRootMismatch))
-					}
-					statelessPods := fdbCluster.GetStatelessPods()
-					for _, pod := range statelessPods.Items {
-						g.Expect(pod.Spec.SecurityContext.FSGroupChangePolicy).ToNot(BeNil())
-						g.Expect(*pod.Spec.SecurityContext.FSGroupChangePolicy).
-							To(Equal(corev1.FSGroupChangeOnRootMismatch))
-					}
-					// ensure that we only changed pods that are expected to be changed (i.e. don't touch storage)
-					storagePods := fdbCluster.GetStoragePods()
-					for _, pod := range storagePods.Items {
-						g.Expect(pod.Spec.SecurityContext).
-							To(Equal(originalStoragePodSpec.SecurityContext))
-					}
-				}).WithTimeout(15 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
-			})
+						// check that we replaced the pods we should have and did not replace others
+						currentPods := fdbCluster.GetPodsNames(ctx)
+						g.Expect(currentPods).NotTo(ContainElements(podsToReplace))
+						g.Expect(currentPods).To(ContainElements(podsNotToReplace))
+						// check that General template pods (Log + Stateless) are replaced with the new security context
+						logPods := fdbCluster.GetLogPods(ctx)
+						for _, pod := range logPods.Items {
+							g.Expect(pod.Spec.SecurityContext.FSGroupChangePolicy).ToNot(BeNil())
+							g.Expect(*pod.Spec.SecurityContext.FSGroupChangePolicy).
+								To(Equal(corev1.FSGroupChangeOnRootMismatch))
+						}
+						statelessPods := fdbCluster.GetStatelessPods(ctx)
+						for _, pod := range statelessPods.Items {
+							g.Expect(pod.Spec.SecurityContext.FSGroupChangePolicy).ToNot(BeNil())
+							g.Expect(*pod.Spec.SecurityContext.FSGroupChangePolicy).
+								To(Equal(corev1.FSGroupChangeOnRootMismatch))
+						}
+						// ensure that we only changed pods that are expected to be changed (i.e. don't touch storage)
+						storagePods := fdbCluster.GetStoragePods(ctx)
+						for _, pod := range storagePods.Items {
+							g.Expect(pod.Spec.SecurityContext).
+								To(Equal(originalStoragePodSpec.SecurityContext))
+						}
+					}).WithTimeout(15 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+				},
+			)
 		},
 	)
 
 	// This test is pending, as all Pods will be restarted at the same time, which will lead to unavailability without
 	// using DNS.
 	PWhen("crash looping the sidecar for all Pods", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			availabilityCheck = false
-			fdbCluster.SetCrashLoopContainers([]fdbv1beta2.CrashLoopContainerObject{
+			fdbCluster.SetCrashLoopContainers(ctx, []fdbv1beta2.CrashLoopContainerObject{
 				{
 					ContainerName: fdbv1beta2.SidecarContainerName,
 					Targets:       []fdbv1beta2.ProcessGroupID{"*"},
@@ -1693,12 +1735,12 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}, false)
 		})
 
-		AfterEach(func() {
-			fdbCluster.SetCrashLoopContainers(nil, true)
+		AfterEach(func(ctx SpecContext) {
+			fdbCluster.SetCrashLoopContainers(ctx, nil, true)
 
 			Eventually(func() bool {
 				allCrashLooping := true
-				for _, pod := range fdbCluster.GetPods().Items {
+				for _, pod := range fdbCluster.GetPods(ctx).Items {
 					for _, container := range pod.Spec.Containers {
 						if container.Name == fdbv1beta2.SidecarContainerName {
 							if allCrashLooping {
@@ -1712,10 +1754,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}).WithPolling(4 * time.Second).WithTimeout(2 * time.Minute).MustPassRepeatedly(10).Should(BeTrue())
 		})
 
-		It("should set all sidecar containers into crash looping state", func() {
+		It("should set all sidecar containers into crash looping state", func(ctx SpecContext) {
 			Eventually(func() bool {
 				allCrashLooping := true
-				for _, pod := range fdbCluster.GetPods().Items {
+				for _, pod := range fdbCluster.GetPods(ctx).Items {
 					for _, container := range pod.Spec.Containers {
 						if container.Name == fdbv1beta2.SidecarContainerName {
 							if allCrashLooping {
@@ -1734,37 +1776,41 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var initialReplaceTime time.Duration
 		var pod *corev1.Pod
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			availabilityCheck = false
 			initialReplaceTime = time.Duration(ptr.Deref(
-				fdbCluster.GetClusterSpec().AutomationOptions.Replacements.FailureDetectionTimeSeconds,
+				fdbCluster.GetClusterSpec(
+					ctx,
+				).AutomationOptions.Replacements.FailureDetectionTimeSeconds,
 				90,
 			)) * time.Second
-			Expect(fdbCluster.SetAutoReplacements(true, 30*time.Second)).ShouldNot(HaveOccurred())
+			Expect(
+				fdbCluster.SetAutoReplacements(ctx, true, 30*time.Second),
+			).ShouldNot(HaveOccurred())
 
-			pod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods())
+			pod = factory.ChooseRandomPod(fdbCluster.GetStatelessPods(ctx))
 			log.Printf("exclude Pod: %s", pod.Name)
 			Expect(pod.Status.PodIP).NotTo(BeEmpty())
-			_, _ = fdbCluster.RunFdbCliCommandInOperator(
+			_, _ = fdbCluster.RunFdbCliCommandInOperator(ctx,
 				fmt.Sprintf("exclude %s", pod.Status.PodIP),
 				false,
 				30,
 			)
 			// Make sure we trigger a reconciliation to speed up the exclusion detection.
-			fdbCluster.ForceReconcile()
+			fdbCluster.ForceReconcile(ctx)
 		})
 
-		It("should replace the excluded Pod", func() {
+		It("should replace the excluded Pod", func(ctx SpecContext) {
 			log.Printf("waiting for pod removal: %s", pod.Name)
-			fdbCluster.WaitForPodRemoval(pod)
-			exists, err := factory.DoesPodExist(*pod)
+			fdbCluster.WaitForPodRemoval(ctx, pod)
+			exists, err := factory.DoesPodExist(ctx, *pod)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(exists).To(BeFalse())
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			Expect(
-				fdbCluster.SetAutoReplacements(true, initialReplaceTime),
+				fdbCluster.SetAutoReplacements(ctx, true, initialReplaceTime),
 			).ShouldNot(HaveOccurred())
 		})
 	})
@@ -1775,13 +1821,17 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var exp *fixtures.ChaosMeshExperiment
 		var targetProcessGroup *fdbv1beta2.ProcessGroupStatus
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			availabilityCheck = false
 			initialReplaceTime = time.Duration(ptr.Deref(
-				fdbCluster.GetClusterSpec().AutomationOptions.Replacements.FailureDetectionTimeSeconds,
+				fdbCluster.GetClusterSpec(
+					ctx,
+				).AutomationOptions.Replacements.FailureDetectionTimeSeconds,
 				90,
 			)) * time.Second
-			Expect(fdbCluster.SetAutoReplacements(true, 30*time.Second)).ShouldNot(HaveOccurred())
+			Expect(
+				fdbCluster.SetAutoReplacements(ctx, true, 30*time.Second),
+			).ShouldNot(HaveOccurred())
 			for _, processGroup := range fdbCluster.GetCachedCluster().Status.ProcessGroups {
 				if processGroup.ProcessClass != fdbv1beta2.ProcessClassStorage {
 					continue
@@ -1792,15 +1842,19 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}
 
 			log.Println("targeted process group:", targetProcessGroup.ProcessGroupID)
-			_, _ = fdbCluster.RunFdbCliCommandInOperator(
+			_, _ = fdbCluster.RunFdbCliCommandInOperator(ctx,
 				fmt.Sprintf("maintenance on %s 600", targetProcessGroup.FaultDomain),
 				false,
 				30,
 			)
 
 			// Partition the Pod from the rest of the FoundationDB cluster.
-			pod := fdbCluster.GetPod(targetProcessGroup.GetPodName(fdbCluster.GetCachedCluster()))
+			pod := fdbCluster.GetPod(
+				ctx,
+				targetProcessGroup.GetPodName(fdbCluster.GetCachedCluster()),
+			)
 			exp = factory.InjectPartitionBetween(
+				ctx,
 				fixtures.PodSelector(pod),
 				chaosmesh.PodSelectorSpec{
 					GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
@@ -1811,12 +1865,12 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			)
 
 			// Make sure the operator notices that the process is not reporting
-			fdbCluster.ForceReconcile()
+			fdbCluster.ForceReconcile(ctx)
 		})
 
-		It("should not replace the process group", func() {
+		It("should not replace the process group", func(ctx SpecContext) {
 			Consistently(func() bool {
-				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+				for _, processGroup := range fdbCluster.GetCluster(ctx).Status.ProcessGroups {
 					if processGroup.ProcessGroupID != targetProcessGroup.ProcessGroupID {
 						continue
 					}
@@ -1828,14 +1882,14 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(BeFalse())
 		})
 
-		AfterEach(func() {
-			factory.DeleteChaosMeshExperiment(exp)
+		AfterEach(func(ctx SpecContext) {
+			factory.DeleteChaosMeshExperiment(ctx, exp)
 			// First reset the maintenance zone. Otherwise the reconciliation will be blocked until the maintenance mode
 			// is timed out because the update status reconciler will skip process groups under the maintenance zone to
 			// prevent misleading condition changes.
-			fdbCluster.RunFdbCliCommandInOperator("maintenance off", false, 30)
+			fdbCluster.RunFdbCliCommandInOperator(ctx, "maintenance off", false, 30)
 			Expect(
-				fdbCluster.SetAutoReplacements(true, initialReplaceTime),
+				fdbCluster.SetAutoReplacements(ctx, true, initialReplaceTime),
 			).ShouldNot(HaveOccurred())
 
 		})
@@ -1844,8 +1898,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	When("using proxies instead of grv and commit proxies", func() {
 		var originalRoleCounts fdbv1beta2.RoleCounts
 
-		BeforeEach(func() {
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+		BeforeEach(func(ctx SpecContext) {
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			originalRoleCounts = spec.DatabaseConfiguration.RoleCounts
 			spec.DatabaseConfiguration.RoleCounts.Proxies = spec.DatabaseConfiguration.RoleCounts.GrvProxies + spec.DatabaseConfiguration.RoleCounts.CommitProxies
 			// Reset the more specific GRV and Commit proxy count.
@@ -1858,22 +1912,22 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				"new roleCounts:",
 				fixtures.ToJSON(spec.DatabaseConfiguration.RoleCounts),
 			)
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+			Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 		})
 
-		AfterEach(func() {
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+		AfterEach(func(ctx SpecContext) {
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.DatabaseConfiguration.RoleCounts = originalRoleCounts
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+			Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 		})
 
 		It(
 			"should configure the database to run with GRV and commit proxies but keep the proxies in the status field of the FoundationDB resource",
-			func() {
+			func(ctx SpecContext) {
 				// Make sure GRV and commit proxies are configured.
-				status := fdbCluster.GetStatus()
+				status := fdbCluster.GetStatus(ctx)
 				Expect(
 					status.Cluster.DatabaseConfiguration.RoleCounts.CommitProxies,
 				).To(BeNumerically(">", 0))
@@ -1887,7 +1941,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					fixtures.ToJSON(status.Cluster.DatabaseConfiguration),
 				)
 				// Verify the FoundationDB Cluster resource
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 				// Make sure that the spec of the FoundationDB resource only has proxies defined.
 				Expect(cluster.Spec.DatabaseConfiguration.RoleCounts.GrvProxies).To(BeZero())
 				Expect(cluster.Spec.DatabaseConfiguration.RoleCounts.CommitProxies).To(BeZero())
@@ -1901,23 +1955,23 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	})
 
 	When("adding and removing a test process", func() {
-		BeforeEach(func() {
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+		BeforeEach(func(ctx SpecContext) {
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.ProcessCounts.Test = 1
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+			Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 		})
 
-		AfterEach(func() {
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+		AfterEach(func(ctx SpecContext) {
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.ProcessCounts.Test = 0
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+			Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 		})
 
-		It("should create the test Pod", func() {
+		It("should create the test Pod", func(ctx SpecContext) {
 			Eventually(func(g Gomega) bool {
-				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+				for _, processGroup := range fdbCluster.GetCluster(ctx).Status.ProcessGroups {
 					if processGroup.ProcessClass != fdbv1beta2.ProcessClassTest {
 						continue
 					}
@@ -1940,12 +1994,12 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			Expect(podName).NotTo(BeEmpty())
 			Eventually(func() corev1.PodPhase {
-				return fdbCluster.GetPod(podName).Status.Phase
+				return fdbCluster.GetPod(ctx, podName).Status.Phase
 			}).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).Should(Equal(corev1.PodRunning))
 
 			Eventually(func() int {
 				var count int
-				processes := fdbCluster.GetStatus().Cluster.Processes
+				processes := fdbCluster.GetStatus(ctx).Cluster.Processes
 				for _, process := range processes {
 					if process.ProcessClass != fdbv1beta2.ProcessClassTest {
 						continue
@@ -1963,14 +2017,14 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var faultDomain fdbv1beta2.FaultDomain
 		var pickedProcessGroup *fdbv1beta2.ProcessGroupStatus
 
-		BeforeEach(func() {
-			cluster := fdbCluster.GetCluster()
+		BeforeEach(func(ctx SpecContext) {
+			cluster := fdbCluster.GetCluster(ctx)
 			spec := cluster.Spec.DeepCopy()
 			// TODO (johscheuer): Once the new CRD is available change this to ResetMaintenanceMode.
 			spec.AutomationOptions.MaintenanceModeOptions.UseMaintenanceModeChecker = ptr.To(
 				true,
 			)
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 
 			for _, processGroup := range cluster.Status.ProcessGroups {
 				if processGroup.ProcessClass != fdbv1beta2.ProcessClassStorage {
@@ -1995,53 +2049,53 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 					fixtures.FdbPrintable([]byte(key)),
 					fixtures.FdbHexString(timestampByteBuffer.Bytes()),
 				)
-				_, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(cmd, true, 20)
+				_, _, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(ctx, cmd, true, 20)
 
 				return err
 			}).WithTimeout(5 * time.Minute).WithPolling(15 * time.Second).ShouldNot(HaveOccurred())
 
 			command := fmt.Sprintf("maintenance on %s %s", pickedProcessGroup.FaultDomain, "3600")
-			_, _ = fdbCluster.RunFdbCliCommandInOperator(command, false, 20)
+			_, _ = fdbCluster.RunFdbCliCommandInOperator(ctx, command, false, 20)
 		})
 
-		It("should reset the maintenance mode once the Pod was restarted", func() {
+		It("should reset the maintenance mode once the Pod was restarted", func(ctx SpecContext) {
 			// Make sure the operator sees the maintenance mode.
-			fdbCluster.ForceReconcile()
+			fdbCluster.ForceReconcile(ctx)
 			// Make sure the maintenance mode is not reset until the Pod is recreated
 			Consistently(func() fdbv1beta2.FaultDomain {
-				return fdbCluster.GetStatus().Cluster.MaintenanceZone
+				return fdbCluster.GetStatus(ctx).Cluster.MaintenanceZone
 			}).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(Equal(faultDomain))
 
-			podName := pickedProcessGroup.GetPodName(fdbCluster.GetCluster())
+			podName := pickedProcessGroup.GetPodName(fdbCluster.GetCluster(ctx))
 			log.Println("Delete Pod", podName)
-			factory.DeletePod(fdbCluster.GetPod(podName))
+			factory.DeletePod(ctx, fdbCluster.GetPod(ctx, podName))
 
 			lastForceReconcile := time.Now()
 			// Make sure the maintenance mode is reset
 			Eventually(func() fdbv1beta2.FaultDomain {
 				// Make sure we speed up the reconciliation and allow the operator to remove the maintenance mode.
 				if time.Since(lastForceReconcile) > 1*time.Minute {
-					fdbCluster.ForceReconcile()
+					fdbCluster.ForceReconcile(ctx)
 					lastForceReconcile = time.Now()
 				}
-				return fdbCluster.GetStatus().Cluster.MaintenanceZone
+				return fdbCluster.GetStatus(ctx).Cluster.MaintenanceZone
 			}).WithTimeout(10 * time.Minute).WithPolling(2 * time.Second).MustPassRepeatedly(10).Should(Equal(fdbv1beta2.FaultDomain("")))
 		})
 
-		AfterEach(func() {
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+		AfterEach(func(ctx SpecContext) {
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			// TODO (johscheuer): Once the new CRD is available change this to ResetMaintenanceMode.
 			spec.AutomationOptions.MaintenanceModeOptions.UseMaintenanceModeChecker = ptr.To(
 				false,
 			)
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 		})
 	})
 
 	When("setting a locality that is using an environment variable", func() {
 		var initialGeneralCustomParameters fdbv1beta2.FoundationDBCustomParameters
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// Disable the availability check to prevent flaky tests if the small cluster takes longer to be restarted
 			availabilityCheck = false
 			initialGeneralCustomParameters = fdbCluster.GetCustomParameters(
@@ -2054,7 +2108,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			)
 
 			Expect(
-				fdbCluster.SetCustomParameters(
+				fdbCluster.SetCustomParameters(ctx,
 					map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 						fdbv1beta2.ProcessClassGeneral: newGeneralCustomParameters,
 					},
@@ -2063,8 +2117,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			).NotTo(HaveOccurred())
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.SetCustomParameters(
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.SetCustomParameters(ctx,
 				map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 					fdbv1beta2.ProcessClassGeneral: initialGeneralCustomParameters,
 				},
@@ -2072,25 +2126,28 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			)).NotTo(HaveOccurred())
 		})
 
-		It("should update the locality with the substituted environment variable", func() {
-			localityKey := "testing"
-			Eventually(func(g Gomega) bool {
-				for _, process := range fdbCluster.GetStatus().Cluster.Processes {
-					// We change the knob only for stateless processes.
-					if process.ProcessClass != fdbv1beta2.ProcessClassStateless {
-						continue
+		It(
+			"should update the locality with the substituted environment variable",
+			func(ctx SpecContext) {
+				localityKey := "testing"
+				Eventually(func(g Gomega) bool {
+					for _, process := range fdbCluster.GetStatus(ctx).Cluster.Processes {
+						// We change the knob only for stateless processes.
+						if process.ProcessClass != fdbv1beta2.ProcessClassStateless {
+							continue
+						}
+
+						g.Expect(process.Locality).NotTo(BeEmpty())
+						g.Expect(process.Locality).To(HaveKey(localityKey))
+						g.Expect(process.Locality).To(HaveKey(fdbv1beta2.FDBLocalityInstanceIDKey))
+						g.Expect(process.Locality[localityKey]).
+							To(Equal(process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]))
 					}
 
-					g.Expect(process.Locality).NotTo(BeEmpty())
-					g.Expect(process.Locality).To(HaveKey(localityKey))
-					g.Expect(process.Locality).To(HaveKey(fdbv1beta2.FDBLocalityInstanceIDKey))
-					g.Expect(process.Locality[localityKey]).
-						To(Equal(process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey]))
-				}
-
-				return true
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
-		})
+					return true
+				}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
+			},
+		)
 	})
 
 	When("a FDB pod is partitioned from the Kubernetes API", func() {
@@ -2100,9 +2157,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var initialCustomParameters fdbv1beta2.FoundationDBCustomParameters
 		var initialRestarts int
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// If we are not using the unified image, we can skip this test.
-			if !fdbCluster.GetCluster().UseUnifiedImage() {
+			if !fdbCluster.GetCluster(ctx).UseUnifiedImage() {
 				Skip("The sidecar image doesn't require connectivity to the Kubernetes API")
 			}
 
@@ -2110,7 +2167,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				Skip("Chaos tests are skipped for the operator")
 			}
 
-			selectedPod = factory.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
+			selectedPod = factory.RandomPickOnePod(fdbCluster.GetStoragePods(ctx).Items)
 			for _, status := range selectedPod.Status.ContainerStatuses {
 				initialRestarts += int(status.RestartCount)
 			}
@@ -2119,8 +2176,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			var kubernetesServiceHost string
 			Eventually(func(g Gomega) error {
-				std, _, err := factory.ExecuteCmdOnPod(
-					context.Background(),
+				std, _, err := factory.ExecuteCmdOnPod(ctx,
 					&selectedPod,
 					fdbv1beta2.MainContainerName,
 					"printenv KUBERNETES_SERVICE_HOST",
@@ -2133,14 +2189,13 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				return err
 			}, 5*time.Minute).ShouldNot(HaveOccurred())
 
-			exp = factory.InjectPartitionWithExternalTargets(
+			exp = factory.InjectPartitionWithExternalTargets(ctx,
 				fixtures.PodSelector(&selectedPod),
 				[]string{kubernetesServiceHost},
 			)
 			// Make sure that the partition takes effect.
 			Eventually(func() error {
-				_, _, err := factory.ExecuteCmdOnPod(
-					context.Background(),
+				_, _, err := factory.ExecuteCmdOnPod(ctx,
 					&selectedPod,
 					fdbv1beta2.MainContainerName,
 					fmt.Sprintf("nc -vz -w 2 %s 443", kubernetesServiceHost),
@@ -2155,7 +2210,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				fdbv1beta2.ProcessClassStorage,
 			)
 			Expect(
-				fdbCluster.SetCustomParameters(
+				fdbCluster.SetCustomParameters(ctx,
 					map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 						fdbv1beta2.ProcessClassStorage: append(
 							initialCustomParameters,
@@ -2167,11 +2222,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			).NotTo(HaveOccurred())
 		})
 
-		It("should keep the pod up and running", func() {
+		It("should keep the pod up and running", func(ctx SpecContext) {
 			selectedProcessGroupID := fixtures.GetProcessGroupID(selectedPod)
 			// Make sure the partitioned Pod is not able to update its annotation.
 			Eventually(func() *int64 {
-				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+				for _, processGroup := range fdbCluster.GetCluster(ctx).Status.ProcessGroups {
 					if processGroup.ProcessGroupID != selectedProcessGroupID {
 						continue
 					}
@@ -2182,10 +2237,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				return nil
 			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).MustPassRepeatedly(10).ShouldNot(BeNil())
 
-			expectedStorageServersPerPod := fdbCluster.GetCluster().GetStorageServersPerPod()
+			expectedStorageServersPerPod := fdbCluster.GetCluster(ctx).GetStorageServersPerPod()
 			// Make sure the processes are still reporting the whole time.
 			Consistently(func() int {
-				status := fdbCluster.GetStatus()
+				status := fdbCluster.GetStatus(ctx)
 
 				var runningProcesses int
 				for _, process := range status.Cluster.Processes {
@@ -2202,7 +2257,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(BeNumerically("==", expectedStorageServersPerPod))
 
 			// Make sure the Pod was not restarted because of the partition.
-			pod, err := factory.GetPod(fdbCluster.Namespace(), selectedPod.Name)
+			pod, err := factory.GetPod(ctx, fdbCluster.Namespace(), selectedPod.Name)
 			Expect(err).NotTo(HaveOccurred())
 
 			var restarts int
@@ -2213,7 +2268,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			Expect(restarts).To(BeNumerically("==", initialRestarts))
 
 			// Restart all the processes, to ensure they are running with the expected parameters.
-			stdout, stderr, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(
+			stdout, stderr, err := fdbCluster.RunFdbCliCommandInOperatorWithoutRetry(ctx,
 				"kill; kill all; sleep 10",
 				true,
 				60,
@@ -2221,19 +2276,19 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			log.Println("stdout", stdout, "stderr", stderr, "err", err)
 
 			// Delete the partition, this allows the partitioned Pod to update its annotations again.
-			factory.DeleteChaosMeshExperiment(exp)
+			factory.DeleteChaosMeshExperiment(ctx, exp)
 
-			fdbCluster.ForceReconcile()
+			fdbCluster.ForceReconcile(ctx)
 
 			// Ensure the partitioned Pod was able to update its annotations.
 			Eventually(func() string {
-				return fdbCluster.GetPod(selectedPod.Name).Annotations[api.CurrentConfigurationAnnotation]
+				return fdbCluster.GetPod(ctx, selectedPod.Name).Annotations[api.CurrentConfigurationAnnotation]
 			}).WithTimeout(10 * time.Minute).WithPolling(1 * time.Second).ShouldNot(Equal(initialConfiguration))
 		})
 
-		AfterEach(func() {
-			factory.DeleteChaosMeshExperiment(exp)
-			Expect(fdbCluster.SetCustomParameters(
+		AfterEach(func(ctx SpecContext) {
+			factory.DeleteChaosMeshExperiment(ctx, exp)
+			Expect(fdbCluster.SetCustomParameters(ctx,
 				map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 					fdbv1beta2.ProcessClassStorage: initialCustomParameters,
 				},
@@ -2245,9 +2300,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	When("enabling the node watch feature", func() {
 		var initialParameters fdbv1beta2.FoundationDBCustomParameters
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// If we are not using the unified image, we can skip this test.
-			if !fdbCluster.GetCluster().UseUnifiedImage() {
+			if !fdbCluster.GetCluster(ctx).UseUnifiedImage() {
 				Skip("The sidecar image doesn't support reading node labels")
 			}
 
@@ -2281,17 +2336,17 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}
 
 			Expect(
-				fdbCluster.SetPodTemplateSpec(fdbv1beta2.ProcessClassStorage, spec, true),
+				fdbCluster.SetPodTemplateSpec(ctx, fdbv1beta2.ProcessClassStorage, spec, true),
 			).NotTo(HaveOccurred())
 		})
 
-		It("should have enabled the node watch feature on all Pods", func() {
+		It("should have enabled the node watch feature on all Pods", func(ctx SpecContext) {
 			initialParameters = fdbCluster.GetCustomParameters(
 				fdbv1beta2.ProcessClassStorage,
 			)
 
 			// Update the storage processes to have the new locality.
-			Expect(fdbCluster.SetCustomParameters(
+			Expect(fdbCluster.SetCustomParameters(ctx,
 				map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 					fdbv1beta2.ProcessClassStorage: append(
 						initialParameters,
@@ -2302,7 +2357,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			)).NotTo(HaveOccurred())
 
 			Eventually(func(g Gomega) bool {
-				status := fdbCluster.GetStatus()
+				status := fdbCluster.GetStatus(ctx)
 				for _, process := range status.Cluster.Processes {
 					if process.ProcessClass != fdbv1beta2.ProcessClassStorage {
 						continue
@@ -2315,8 +2370,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			})
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.SetCustomParameters(
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.SetCustomParameters(ctx,
 				map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 					fdbv1beta2.ProcessClassStorage: initialParameters,
 				},
@@ -2328,25 +2383,25 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	When("the Pod is set into isolate mode", func() {
 		var isolatedPod corev1.Pod
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// If we are not using the unified image, we can skip this test.
-			if !fdbCluster.GetCluster().UseUnifiedImage() {
+			if !fdbCluster.GetCluster(ctx).UseUnifiedImage() {
 				Skip("The sidecar image doesn't support reading node labels")
 			}
 
-			isolatedPod = factory.RandomPickOnePod(fdbCluster.GetStatelessPods().Items)
+			isolatedPod = factory.RandomPickOnePod(fdbCluster.GetStatelessPods(ctx).Items)
 			isolatedPod.Annotations[fdbv1beta2.IsolateProcessGroupAnnotation] = "true"
 			Expect(
-				factory.GetControllerRuntimeClient().Update(context.Background(), &isolatedPod),
+				factory.GetControllerRuntimeClient().Update(ctx, &isolatedPod),
 			).NotTo(HaveOccurred())
-			fdbCluster.ReplacePod(isolatedPod, false)
+			fdbCluster.ReplacePod(ctx, isolatedPod, false)
 		})
 
-		It("should shutdown the fdbserver processes of this Pod", func() {
+		It("should shutdown the fdbserver processes of this Pod", func(ctx SpecContext) {
 			processGroupID := string(fixtures.GetProcessGroupID(isolatedPod))
 			// Make sure the process is not reporting to the cluster.
 			Eventually(func(g Gomega) bool {
-				status := fdbCluster.GetStatus()
+				status := fdbCluster.GetStatus(ctx)
 				for _, process := range status.Cluster.Processes {
 					if process.ProcessClass != fdbv1beta2.ProcessClassStateless {
 						continue
@@ -2360,22 +2415,22 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(BeTrue())
 
 			Consistently(func(g Gomega) *metav1.Time {
-				pod, err := factory.GetPod(isolatedPod.Namespace, isolatedPod.Name)
+				pod, err := factory.GetPod(ctx, isolatedPod.Namespace, isolatedPod.Name)
 				g.Expect(err).NotTo(HaveOccurred())
 
 				return pod.DeletionTimestamp
 			}).WithTimeout(1 * time.Minute).WithPolling(1 * time.Second).Should(BeNil())
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			pod := &corev1.Pod{}
 			Expect(
 				factory.GetControllerRuntimeClient().
-					Get(context.Background(), ctrlClient.ObjectKey{Name: isolatedPod.Name, Namespace: isolatedPod.Namespace}, pod),
+					Get(ctx, ctrlClient.ObjectKey{Name: isolatedPod.Name, Namespace: isolatedPod.Namespace}, pod),
 			).NotTo(HaveOccurred())
 			pod.Annotations[fdbv1beta2.IsolateProcessGroupAnnotation] = "false"
 			Expect(
-				factory.GetControllerRuntimeClient().Update(context.Background(), pod),
+				factory.GetControllerRuntimeClient().Update(ctx, pod),
 			).NotTo(HaveOccurred())
 		})
 	})
@@ -2383,13 +2438,13 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 	When("a new knob for storage servers is rolled out to the cluster", func() {
 		var initialCustomParameters fdbv1beta2.FoundationDBCustomParameters
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			initialCustomParameters = fdbCluster.GetCustomParameters(
 				fdbv1beta2.ProcessClassStorage,
 			)
 
 			Expect(
-				fdbCluster.SetCustomParameters(
+				fdbCluster.SetCustomParameters(ctx,
 					map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 						fdbv1beta2.ProcessClassStorage: append(
 							initialCustomParameters,
@@ -2401,8 +2456,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			).NotTo(HaveOccurred())
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.SetCustomParameters(
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.SetCustomParameters(ctx,
 				map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 					fdbv1beta2.ProcessClassStorage: initialCustomParameters,
 				},
@@ -2410,20 +2465,24 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			)).NotTo(HaveOccurred())
 		})
 
-		It("should update the locality with the substituted environment variable", func() {
-			Eventually(func(g Gomega) bool {
-				for _, process := range fdbCluster.GetStatus().Cluster.Processes {
-					// We change the knob only for storage processes.
-					if process.ProcessClass != fdbv1beta2.ProcessClassStorage {
-						continue
+		It(
+			"should update the locality with the substituted environment variable",
+			func(ctx SpecContext) {
+				Eventually(func(g Gomega) bool {
+					for _, process := range fdbCluster.GetStatus(ctx).Cluster.Processes {
+						// We change the knob only for storage processes.
+						if process.ProcessClass != fdbv1beta2.ProcessClassStorage {
+							continue
+						}
+
+						g.Expect(process.CommandLine).
+							To(ContainSubstring("knob_read_sampling_enabled"))
 					}
 
-					g.Expect(process.CommandLine).To(ContainSubstring("knob_read_sampling_enabled"))
-				}
-
-				return true
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
-		})
+					return true
+				}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(BeTrue())
+			},
+		)
 	})
 
 	When("a process is marked for removal and was excluded", func() {
@@ -2431,8 +2490,8 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		var initialExclusionTimestamp *metav1.Time
 		var pickedPod corev1.Pod
 
-		BeforeEach(func() {
-			pickedPod = factory.RandomPickOnePod(fdbCluster.GetStatelessPods().Items)
+		BeforeEach(func(ctx SpecContext) {
+			pickedPod = factory.RandomPickOnePod(fdbCluster.GetStatelessPods(ctx).Items)
 			pickedProcessGroupID = fixtures.GetProcessGroupID(pickedPod)
 			log.Println(
 				"pickedProcessGroupID",
@@ -2441,14 +2500,14 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				pickedPod.Status.PodIP,
 			)
 
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.AutomationOptions.RemovalMode = fdbv1beta2.PodUpdateModeNone
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 
-			fdbCluster.ReplacePod(pickedPod, false)
+			fdbCluster.ReplacePod(ctx, pickedPod, false)
 			var pickedProcessGroup *fdbv1beta2.ProcessGroupStatus
 			Expect(
-				fdbCluster.WaitUntilWithForceReconcile(
+				fdbCluster.WaitUntilWithForceReconcile(ctx,
 					1,
 					900,
 					func(cluster *fdbv1beta2.FoundationDBCluster) bool {
@@ -2469,7 +2528,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			).NotTo(HaveOccurred(), "process group is missing the exclusion timestamp")
 
 			var excludedServer fdbv1beta2.ExcludedServers
-			if fdbCluster.GetCluster().UseLocalitiesForExclusion() {
+			if fdbCluster.GetCluster(ctx).UseLocalitiesForExclusion() {
 				Expect(pickedProcessGroup).NotTo(BeNil())
 				excludedServer = fdbv1beta2.ExcludedServers{
 					Locality: pickedProcessGroup.GetExclusionString(),
@@ -2480,27 +2539,27 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 
 			// Ensure that the IP is excluded
 			Expect(
-				fdbCluster.GetStatus().Cluster.DatabaseConfiguration.ExcludedServers,
+				fdbCluster.GetStatus(ctx).Cluster.DatabaseConfiguration.ExcludedServers,
 			).To(ContainElements(excludedServer))
 		})
 
-		AfterEach(func() {
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+		AfterEach(func(ctx SpecContext) {
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.AutomationOptions.RemovalMode = fdbv1beta2.PodUpdateModeZone
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+			Expect(fdbCluster.ClearProcessGroupsToRemove(ctx)).NotTo(HaveOccurred())
 		})
 
 		When("the process gets included again", func() {
-			BeforeEach(func() {
-				fdbCluster.RunFdbCliCommandInOperator("include all", false, 60)
+			BeforeEach(func(ctx SpecContext) {
+				fdbCluster.RunFdbCliCommandInOperator(ctx, "include all", false, 60)
 			})
 
-			It("should be excluded a second time", func() {
+			It("should be excluded a second time", func(ctx SpecContext) {
 				var newExclusionTimestamp *metav1.Time
 
 				Expect(
-					fdbCluster.WaitUntilWithForceReconcile(
+					fdbCluster.WaitUntilWithForceReconcile(ctx,
 						1,
 						900,
 						func(cluster *fdbv1beta2.FoundationDBCluster) bool {
@@ -2531,22 +2590,22 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 			var processGroupID fdbv1beta2.ProcessGroupID
 			var initialCustomParameters fdbv1beta2.FoundationDBCustomParameters
 
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				availabilityCheck = false
 
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 				spec.AutomationOptions.DeletionMode = fdbv1beta2.PodUpdateModeNone
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 
-				storagePod := factory.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
+				storagePod := factory.RandomPickOnePod(fdbCluster.GetStoragePods(ctx).Items)
 				log.Println("Selected Pod:", storagePod.Name, " to be replaced")
-				fdbCluster.ReplacePod(storagePod, false)
+				fdbCluster.ReplacePod(ctx, storagePod, false)
 				processGroupID = fixtures.GetProcessGroupID(storagePod)
 
 				// Wait until the process group is marked for removal.
 				Eventually(func(g Gomega) {
 					processGroup := fdbv1beta2.FindProcessGroupByID(
-						fdbCluster.GetCluster().Status.ProcessGroups,
+						fdbCluster.GetCluster(ctx).Status.ProcessGroups,
 						processGroupID,
 					)
 
@@ -2566,10 +2625,10 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				)
 
 				// Disable the operator bounce feature to ensure the targeted process group sees the changes.
-				fdbCluster.SetKillProcesses(false, false)
+				fdbCluster.SetKillProcesses(ctx, false, false)
 
 				Expect(
-					fdbCluster.SetCustomParameters(
+					fdbCluster.SetCustomParameters(ctx,
 						map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 							fdbv1beta2.ProcessClassStorage: newCustomParameters,
 						},
@@ -2580,7 +2639,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				// Wait until the process group has the incorrect command line
 				Eventually(func(g Gomega) {
 					processGroup := fdbv1beta2.FindProcessGroupByID(
-						fdbCluster.GetCluster().Status.ProcessGroups,
+						fdbCluster.GetCluster(ctx).Status.ProcessGroups,
 						processGroupID,
 					)
 
@@ -2593,12 +2652,12 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				}).WithTimeout(10 * time.Minute).WithPolling(1 * time.Second).To(Succeed())
 			})
 
-			AfterEach(func() {
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			AfterEach(func(ctx SpecContext) {
+				spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 				spec.AutomationOptions.DeletionMode = fdbv1beta2.PodUpdateModeZone
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 
-				Expect(fdbCluster.SetCustomParameters(
+				Expect(fdbCluster.SetCustomParameters(ctx,
 					map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 						fdbv1beta2.ProcessClassStorage: initialCustomParameters,
 					},
@@ -2606,7 +2665,7 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				)).NotTo(HaveOccurred())
 			})
 
-			It("should update the pod that is marked for removal", func() {
+			It("should update the pod that is marked for removal", func(ctx SpecContext) {
 				log.Println(
 					"Make sure process group",
 					processGroupID,
@@ -2614,11 +2673,11 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 				)
 
 				// Enable the kill feature again.
-				fdbCluster.SetKillProcesses(true, false)
+				fdbCluster.SetKillProcesses(ctx, true, false)
 				// Make sure the process group is updated after some time.
 				Eventually(func(g Gomega) {
 					processGroup := fdbv1beta2.FindProcessGroupByID(
-						fdbCluster.GetCluster().Status.ProcessGroups,
+						fdbCluster.GetCluster(ctx).Status.ProcessGroups,
 						processGroupID,
 					)
 

--- a/e2e/test_operator_backups/operator_backup_test.go
+++ b/e2e/test_operator_backups/operator_backup_test.go
@@ -46,7 +46,7 @@ func init() {
 	testOptions = fixtures.InitFlags()
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	factory = fixtures.CreateFactory(testOptions)
 
 	badBackupVersion, err := fdbv1beta2.ParseFdbVersion("7.3.50")
@@ -64,14 +64,14 @@ var _ = BeforeSuite(func() {
 	}
 
 	// Create a blobstore for testing backups and restore.
-	factory.CreateBlobstoreIfAbsent(factory.SingleNamespace())
+	factory.CreateBlobstoreIfAbsent(ctx, factory.SingleNamespace(ctx))
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx SpecContext) {
 	if CurrentSpecReport().Failed() {
 		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
 	}
-	factory.Shutdown()
+	factory.Shutdown(ctx)
 })
 
 var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func() {
@@ -81,26 +81,26 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 		var backup *fixtures.FdbBackup
 		var restore *fixtures.FdbRestore
 
-		BeforeEach(func() {
-			fdbCluster = factory.CreateFdbCluster(
+		BeforeEach(func(ctx SpecContext) {
+			fdbCluster = factory.CreateFdbCluster(ctx,
 				fixtures.DefaultClusterConfig(false),
 			)
 		})
 
 		// Delete the backup and restore resource after each test. And make sure that the data in the cluster is cleared.
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			if backup != nil {
-				backup.Destroy()
+				backup.Destroy(ctx)
 			}
 			if restore != nil {
-				restore.Destroy()
+				restore.Destroy(ctx)
 			}
 
 			namespace := fdbCluster.Namespace()
 			// Delete the FDB cluster to have a clean start.
-			Expect(fdbCluster.DestroyWithWaitForTearDown(true)).To(Succeed())
+			Expect(fdbCluster.DestroyWithWaitForTearDown(ctx, true)).To(Succeed())
 			// Restart the operator pods.
-			factory.RecreateOperatorPods(namespace)
+			factory.RecreateOperatorPods(ctx, namespace)
 		})
 
 		When("the default backup system is used", func() {
@@ -112,7 +112,7 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 			var backupConfiguration *fixtures.FdbBackupConfiguration
 			var currentRestorableVersion *uint64
 
-			JustBeforeEach(func() {
+			JustBeforeEach(func(ctx SpecContext) {
 				log.Printf(
 					"creating backup for cluster, skipRestore: %t, useRestorableVersion: %t\n",
 					skipRestore,
@@ -127,42 +127,44 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 				) {
 				case fdbv1beta2.BackupModeContinuous:
 					// For the continuous backup we want to start the backup first and then write some data.
-					backup = factory.CreateBackupForCluster(fdbCluster, backupConfiguration)
-					fdbCluster.WriteKeyValues(keyValues)
-					if backup.GetBackup().GetBackupType() != fdbv1beta2.BackupTypeUnmanaged {
+					backup = factory.CreateBackupForCluster(ctx, fdbCluster, backupConfiguration)
+					fdbCluster.WriteKeyValues(ctx, keyValues)
+					if backup.GetBackup(ctx).GetBackupType() != fdbv1beta2.BackupTypeUnmanaged {
 						restorableVersion = backup.WaitForRestorableVersion(
-							fdbCluster.GetClusterVersion(),
+							ctx,
+							fdbCluster.GetClusterVersion(ctx),
 						)
 						if shouldPauseBackup {
-							backup.Pause()
+							backup.Pause(ctx)
 						} else {
-							backup.Stop()
+							backup.Stop(ctx)
 						}
 					}
 				case fdbv1beta2.BackupModeOneTime:
 					// In case of the one time backup we have to first write the keys and then do the backup.
-					fdbCluster.WriteKeyValues(keyValues)
-					currentVersion := fdbCluster.GetClusterVersion()
-					backup = factory.CreateBackupForCluster(fdbCluster, backupConfiguration)
-					if backup.GetBackup().GetBackupType() != fdbv1beta2.BackupTypeUnmanaged {
+					fdbCluster.WriteKeyValues(ctx, keyValues)
+					currentVersion := fdbCluster.GetClusterVersion(ctx)
+					backup = factory.CreateBackupForCluster(ctx, fdbCluster, backupConfiguration)
+					if backup.GetBackup(ctx).GetBackupType() != fdbv1beta2.BackupTypeUnmanaged {
 						restorableVersion = backup.WaitForRestorableVersion(
+							ctx,
 							currentVersion,
 						)
 					}
 				}
 
 				// Delete the data and restore it again.
-				fdbCluster.ClearRange([]byte{prefix}, 60)
+				fdbCluster.ClearRange(ctx, []byte{prefix}, 60)
 				if useRestorableVersion {
 					currentRestorableVersion = ptr.To(restorableVersion)
 				}
 				if !skipRestore {
-					restore = factory.CreateRestoreForCluster(backup, currentRestorableVersion)
+					restore = factory.CreateRestoreForCluster(ctx, backup, currentRestorableVersion)
 				}
 			})
 
 			When("the backup should not be managed", func() {
-				BeforeEach(func() {
+				BeforeEach(func(_ SpecContext) {
 					// The backup is not managed by the operator, so we can skip it.
 					skipRestore = true
 					backupConfiguration = &fixtures.FdbBackupConfiguration{
@@ -172,9 +174,8 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 
 				When("the backup was not started externally", func() {
 					It(
-						"should only have data for the backup deployment",
-						func() {
-							currentBackup := backup.GetBackup()
+						"should only have data for the backup deployment", func(ctx SpecContext) {
+							currentBackup := backup.GetBackup(ctx)
 							Expect(currentBackup.Status.DeploymentConfigured).Should(BeTrue())
 							Expect(currentBackup.Status.BackupDetails.Running).Should(BeFalse())
 							Expect(currentBackup.Status.BackupDetails.Restorable).Should(BeFalse())
@@ -184,7 +185,7 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 			})
 
 			When("the continuous backup mode is used", func() {
-				BeforeEach(func() {
+				BeforeEach(func(_ SpecContext) {
 					skipRestore = false
 					backupConfiguration = &fixtures.FdbBackupConfiguration{
 						BackupType: ptr.To(fdbv1beta2.BackupTypeDefault),
@@ -193,9 +194,9 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 				})
 
 				When("no restorable version is specified", func() {
-					JustBeforeEach(func() {
+					JustBeforeEach(func(ctx SpecContext) {
 						// running describe command
-						describeCommandOutput := backup.RunDescribeCommand()
+						describeCommandOutput := backup.RunDescribeCommand(ctx)
 						if factory.GetFDBVersion().SupportsBackupEncryption() {
 							Expect(*describeCommandOutput.FileLevelEncryption).To(BeFalse())
 						}
@@ -203,13 +204,18 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 						Expect(*describeCommandOutput.Partitioned).To(BeFalse())
 					})
 
-					It("should restore the cluster successfully with a restorable version", func() {
-						Expect(fdbCluster.GetRange([]byte{prefix}, 25, 60)).Should(Equal(keyValues))
-					})
+					It(
+						"should restore the cluster successfully with a restorable version",
+						func(ctx SpecContext) {
+							Expect(
+								fdbCluster.GetRange(ctx, []byte{prefix}, 25, 60),
+							).Should(Equal(keyValues))
+						},
+					)
 				})
 
 				When("encryption is enabled", func() {
-					BeforeEach(func() {
+					BeforeEach(func(_ SpecContext) {
 						if !factory.GetFDBVersion().SupportsBackupEncryption() {
 							Skip(
 								"version doesn't support the encryption feature",
@@ -219,16 +225,16 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 						backupConfiguration.EncryptionEnabled = true
 					})
 
-					AfterEach(func() {
+					AfterEach(func(ctx SpecContext) {
 						if backup == nil {
 							return
 						}
 
-						backup.Start()
+						backup.Start(ctx)
 
 						var statusBeforeAbort *fdbv1beta2.FoundationDBLiveBackupStatus
 						Eventually(func(g Gomega) {
-							statusBeforeAbort = backup.RunStatusCommand()
+							statusBeforeAbort = backup.RunStatusCommand(ctx)
 							g.Expect(statusBeforeAbort.Status.Running).To(BeTrue())
 							g.Expect(statusBeforeAbort.Status.Name).
 								To(Equal("RunningDifferentially"))
@@ -238,10 +244,10 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 						}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
 						uidBeforeAbort := *statusBeforeAbort.UID
 
-						backup.RunAbortCommand()
+						backup.RunAbortCommand(ctx)
 
 						Eventually(func(g Gomega) {
-							statusAfterAbort := backup.RunStatusCommand()
+							statusAfterAbort := backup.RunStatusCommand(ctx)
 							g.Expect(statusAfterAbort.Status.Running).To(BeFalse())
 							g.Expect(statusAfterAbort.Status.Name).To(Equal("Aborted"))
 							g.Expect(statusAfterAbort.UID).NotTo(BeNil())
@@ -250,38 +256,38 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 					})
 
 					When("running fdbbackup commands", func() {
-						BeforeEach(func() {
+						BeforeEach(func(_ SpecContext) {
 							skipRestore = true
 							shouldPauseBackup = true
 						})
 
-						JustBeforeEach(func() {
+						JustBeforeEach(func(ctx SpecContext) {
 							// running status command
-							statusCommandOutput := backup.RunStatusCommand()
+							statusCommandOutput := backup.RunStatusCommand(ctx)
 							Expect(statusCommandOutput.SnapshotIntervalSeconds).To(Equal(864000))
 							Expect(statusCommandOutput.UID).NotTo(BeNil())
 							backupUID := *statusCommandOutput.UID
 
 							// running list command
-							listCommandOutput := backup.RunListCommand()
+							listCommandOutput := backup.RunListCommand(ctx)
 							Expect(listCommandOutput).To(HaveLen(1))
 
 							// running modify command to change the snapshot period
 							// restart the backup before modifying since the backup is paused
 							modifiedSnapshotPeriod := 900000
-							backup.Start()
-							backup.SetSnapshotInterval(modifiedSnapshotPeriod)
+							backup.Start(ctx)
+							backup.SetSnapshotInterval(ctx, modifiedSnapshotPeriod)
 							// validating snapshot interval changed and the backup UID is same
-							statusCommandOutput = backup.RunStatusCommand()
+							statusCommandOutput = backup.RunStatusCommand(ctx)
 							Expect(
 								statusCommandOutput.SnapshotIntervalSeconds,
 							).To(Equal(modifiedSnapshotPeriod))
 							Expect(statusCommandOutput.UID).NotTo(BeNil())
 							Expect(*statusCommandOutput.UID).To(Equal(backupUID))
-							backup.Stop()
+							backup.Stop(ctx)
 
 							// running describe command
-							describeCommandOutput := backup.RunDescribeCommand()
+							describeCommandOutput := backup.RunDescribeCommand(ctx)
 							Expect(*describeCommandOutput.FileLevelEncryption).To(BeTrue())
 							Expect(*describeCommandOutput.Restorable).To(BeTrue())
 							Expect(*describeCommandOutput.Partitioned).To(BeFalse())
@@ -289,13 +295,14 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 
 						It(
 							"should be able to restore the cluster successfully with a restorable version",
-							func() {
+							func(ctx SpecContext) {
 								restore = factory.CreateRestoreForCluster(
+									ctx,
 									backup,
 									currentRestorableVersion,
 								)
 								Expect(
-									fdbCluster.GetRange([]byte{prefix}, 25, 60),
+									fdbCluster.GetRange(ctx, []byte{prefix}, 25, 60),
 								).Should(Equal(keyValues))
 							},
 						)
@@ -304,18 +311,23 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 
 				// TODO (johscheuer): Enable test once the CRD in CI is updated.
 				PWhen("using a restorable version", func() {
-					BeforeEach(func() {
+					BeforeEach(func(_ SpecContext) {
 						useRestorableVersion = true
 					})
 
-					It("should restore the cluster successfully with a restorable version", func() {
-						Expect(fdbCluster.GetRange([]byte{prefix}, 25, 60)).Should(Equal(keyValues))
-					})
+					It(
+						"should restore the cluster successfully with a restorable version",
+						func(ctx SpecContext) {
+							Expect(
+								fdbCluster.GetRange(ctx, []byte{prefix}, 25, 60),
+							).Should(Equal(keyValues))
+						},
+					)
 				})
 			})
 
 			When("the one time backup mode is used", func() {
-				BeforeEach(func() {
+				BeforeEach(func(_ SpecContext) {
 					skipRestore = false
 					backupConfiguration = &fixtures.FdbBackupConfiguration{
 						BackupType: ptr.To(fdbv1beta2.BackupTypeDefault),
@@ -324,13 +336,18 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 				})
 
 				When("no restorable version is specified", func() {
-					It("should restore the cluster successfully with a restorable version", func() {
-						Expect(fdbCluster.GetRange([]byte{prefix}, 25, 60)).Should(Equal(keyValues))
-					})
+					It(
+						"should restore the cluster successfully with a restorable version",
+						func(ctx SpecContext) {
+							Expect(
+								fdbCluster.GetRange(ctx, []byte{prefix}, 25, 60),
+							).Should(Equal(keyValues))
+						},
+					)
 				})
 
 				When("encryption is enabled", func() {
-					BeforeEach(func() {
+					BeforeEach(func(_ SpecContext) {
 						if !factory.GetFDBVersion().SupportsBackupEncryption() {
 							Skip(
 								"version doesn't support the encryption feature",
@@ -340,26 +357,36 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 						backupConfiguration.EncryptionEnabled = true
 					})
 
-					It("should restore the cluster successfully with a restorable version", func() {
-						Expect(fdbCluster.GetRange([]byte{prefix}, 25, 60)).Should(Equal(keyValues))
-					})
+					It(
+						"should restore the cluster successfully with a restorable version",
+						func(ctx SpecContext) {
+							Expect(
+								fdbCluster.GetRange(ctx, []byte{prefix}, 25, 60),
+							).Should(Equal(keyValues))
+						},
+					)
 				})
 
 				// TODO (johscheuer): Enable test once the CRD in CI is updated.
 				PWhen("using a restorable version", func() {
-					BeforeEach(func() {
+					BeforeEach(func(_ SpecContext) {
 						useRestorableVersion = true
 					})
 
-					It("should restore the cluster successfully with a restorable version", func() {
-						Expect(fdbCluster.GetRange([]byte{prefix}, 25, 60)).Should(Equal(keyValues))
-					})
+					It(
+						"should restore the cluster successfully with a restorable version",
+						func(ctx SpecContext) {
+							Expect(
+								fdbCluster.GetRange(ctx, []byte{prefix}, 25, 60),
+							).Should(Equal(keyValues))
+						},
+					)
 				})
 			})
 		})
 
 		When("the partitioned backup system is used", func() {
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				// Versions before 7.4 have a few issues and will not work properly with the experimental feature.
 				requiredFdbVersion, err := fdbv1beta2.ParseFdbVersion("7.4.5")
 				Expect(err).NotTo(HaveOccurred())
@@ -372,7 +399,7 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 				// Add additional backup workers to the cluster. Those will be used by the partitioned backup system.
 				// The backup worker(not to be confused with the backup agent) will be used to back up the lof mutations.
 				// We still need the backup agents to back up the key ranges.
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 				spec := cluster.Spec.DeepCopy()
 				processCounts, err := cluster.GetProcessCountsWithDefaults()
 				Expect(err).NotTo(HaveOccurred())
@@ -417,38 +444,38 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 					break
 				}
 				spec.Processes[fdbv1beta2.ProcessClassBackup] = *processSpec
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
-				Expect(fdbCluster.WaitForReconciliation()).To(Succeed())
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+				Expect(fdbCluster.WaitForReconciliation(ctx)).To(Succeed())
 
-				backup = factory.CreateBackupForCluster(
+				backup = factory.CreateBackupForCluster(ctx,
 					fdbCluster,
 					&fixtures.FdbBackupConfiguration{
 						BackupType: ptr.To(fdbv1beta2.BackupTypePartitionedLog),
 					},
 				)
 				keyValues = fdbCluster.GenerateRandomValues(10, prefix)
-				fdbCluster.WriteKeyValues(keyValues)
-				backup.WaitForRestorableVersion(fdbCluster.GetClusterVersion())
-				backup.Stop()
+				fdbCluster.WriteKeyValues(ctx, keyValues)
+				backup.WaitForRestorableVersion(ctx, fdbCluster.GetClusterVersion(ctx))
+				backup.Stop(ctx)
 			})
 
-			It("should restore the cluster successfully", func() {
-				fdbCluster.ClearRange([]byte{prefix}, 60)
-				factory.CreateRestoreForCluster(backup, nil)
-				Expect(fdbCluster.GetRange([]byte{prefix}, 25, 60)).Should(Equal(keyValues))
+			It("should restore the cluster successfully", func(ctx SpecContext) {
+				fdbCluster.ClearRange(ctx, []byte{prefix}, 60)
+				factory.CreateRestoreForCluster(ctx, backup, nil)
+				Expect(fdbCluster.GetRange(ctx, []byte{prefix}, 25, 60)).Should(Equal(keyValues))
 			})
 
-			AfterEach(func() {
+			AfterEach(func(ctx SpecContext) {
 				// We have to make sure that the backup is deleted before proceeding.
-				backup.Destroy()
+				backup.Destroy(ctx)
 				// Remove additional backup workers from the cluster.
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 				spec := cluster.Spec.DeepCopy()
 				spec.ProcessCounts.BackupWorker = -1
 				delete(spec.Processes, fdbv1beta2.ProcessClassBackup)
 
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
-				Expect(fdbCluster.WaitForReconciliation()).To(Succeed())
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+				Expect(fdbCluster.WaitForReconciliation(ctx)).To(Succeed())
 			})
 		})
 	})

--- a/e2e/test_operator_creation_velocity/operator_creation_velocity_test.go
+++ b/e2e/test_operator_creation_velocity/operator_creation_velocity_test.go
@@ -60,23 +60,23 @@ var (
 	testOptions *fixtures.FactoryOptions
 )
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	factory = fixtures.CreateFactory(testOptions)
 	// Create a namespace and wait until the operator Pods are running. We don't want to measure that time.
-	namespace = factory.SingleNamespace()
-	factory.WaitUntilOperatorPodsRunning(namespace)
+	namespace = factory.SingleNamespace(ctx)
+	factory.WaitUntilOperatorPodsRunning(ctx, namespace)
 })
 
-var _ = AfterSuite(func() {
-	factory.Shutdown()
+var _ = AfterSuite(func(ctx SpecContext) {
+	factory.Shutdown(ctx)
 })
 
 var _ = Describe("Test Operator Velocity", Label("e2e"), func() {
 	When("creating a single FDB cluster", func() {
-		It("should roll out knob changes within expected time", func() {
+		It("should roll out knob changes within expected time", func(ctx SpecContext) {
 			startTime := time.Now()
 
-			fdbCluster := factory.CreateFdbCluster(
+			fdbCluster := factory.CreateFdbCluster(ctx,
 				&fixtures.ClusterConfig{
 					Namespace:       namespace,
 					CreationTracker: fixtures.NewDefaultCreationTrackerLogger(),
@@ -85,15 +85,15 @@ var _ = Describe("Test Operator Velocity", Label("e2e"), func() {
 
 			runTime := time.Since(startTime)
 			log.Println("Single-DC cluster creation took: ", runTime.String())
-			Expect(fdbCluster.Destroy()).ToNot(HaveOccurred())
+			Expect(fdbCluster.Destroy(ctx)).ToNot(HaveOccurred())
 		})
 	})
 
 	When("creating a multi-DC FDB cluster", func() {
-		It("benchmark multi-DC cluster creation", func() {
+		It("benchmark multi-DC cluster creation", func(ctx SpecContext) {
 			startTime := time.Now()
 
-			haCluster := factory.CreateFdbHaCluster(
+			haCluster := factory.CreateFdbHaCluster(ctx,
 				&fixtures.ClusterConfig{
 					HaMode:          fixtures.HaFourZoneSingleSat,
 					CreationTracker: fixtures.NewDefaultCreationTrackerLogger(),
@@ -102,7 +102,7 @@ var _ = Describe("Test Operator Velocity", Label("e2e"), func() {
 
 			runTime := time.Since(startTime)
 			log.Println("Multi-DC cluster creation took: ", runTime.String())
-			haCluster.Delete()
+			haCluster.Delete(ctx)
 		})
 	})
 })

--- a/e2e/test_operator_ha/operator_ha_test.go
+++ b/e2e/test_operator_ha/operator_ha_test.go
@@ -30,7 +30,6 @@ This cluster will be used for all tests.
 */
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strconv"
@@ -63,18 +62,19 @@ func init() {
 	testOptions = fixtures.InitFlags()
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	factory = fixtures.CreateFactory(testOptions)
-	fdbCluster = factory.CreateFdbHaCluster(
+	fdbCluster = factory.CreateFdbHaCluster(ctx,
 		fixtures.DefaultClusterConfigWithHaMode(fixtures.HaFourZoneSingleSat, false))
 
 	// Load some data into the cluster.
-	factory.CreateDataLoaderIfAbsent(fdbCluster.GetPrimary())
+	factory.CreateDataLoaderIfAbsent(ctx, fdbCluster.GetPrimary())
 
 	// In order to test the robustness of the operator we try to kill the operator Pods every minute.
 	if factory.ChaosTestsEnabled() {
 		for _, cluster := range fdbCluster.GetAllClusters() {
 			factory.ScheduleInjectPodKill(
+				ctx,
 				fixtures.GetOperatorSelector(cluster.Namespace()),
 				"*/2 * * * *",
 				chaosmesh.OneMode,
@@ -83,32 +83,34 @@ var _ = BeforeSuite(func() {
 	}
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx SpecContext) {
 	if CurrentSpecReport().Failed() {
 		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
 	}
-	factory.Shutdown()
+	factory.Shutdown(ctx)
 })
 
 var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 	var availabilityCheck bool
 
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		// Reset availabilityCheck if a test case removes this check.
 		availabilityCheck = true
 		if CurrentSpecReport().Failed() {
-			factory.DumpStateHaCluster(fdbCluster)
+			factory.DumpStateHaCluster(ctx, fdbCluster)
 		}
-		Expect(fdbCluster.WaitForReconciliation()).ToNot(HaveOccurred())
+		Expect(fdbCluster.WaitForReconciliation(ctx)).ToNot(HaveOccurred())
 		factory.StopInvariantCheck()
 		// Make sure all data is present in the cluster
-		fdbCluster.GetPrimary().EnsureTeamTrackersAreHealthy()
-		fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas()
+		fdbCluster.GetPrimary().EnsureTeamTrackersAreHealthy(ctx)
+		fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas(ctx)
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		if availabilityCheck {
-			Expect(fdbCluster.GetPrimary().InvariantClusterStatusAvailable()).NotTo(HaveOccurred())
+			Expect(
+				fdbCluster.GetPrimary().InvariantClusterStatusAvailable(ctx),
+			).NotTo(HaveOccurred())
 		}
 	})
 
@@ -116,13 +118,13 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 		var initialConnectionString string
 		var initialCoordinators map[string]fdbv1beta2.None
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			primary := fdbCluster.GetPrimary()
-			status := primary.GetStatus()
+			status := primary.GetStatus(ctx)
 			initialConnectionString = status.Cluster.ConnectionString
 
 			initialCoordinators = fdbstatus.GetCoordinatorsFromStatus(status)
-			primaryPods := primary.GetPods()
+			primaryPods := primary.GetPods(ctx)
 
 			coordinatorPods := make([]corev1.Pod, 0, len(initialCoordinators))
 			for _, pod := range primaryPods.Items {
@@ -140,16 +142,17 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 			}
 
 			_ = factory.InjectPartitionBetween(
+				ctx,
 				fdbCluster.GetNamespaceSelector(),
 				fixtures.PodsSelector(coordinatorPods),
 			)
 		})
 
-		AfterEach(func() {
-			Expect(factory.CleanupChaosMeshExperiments()).To(Succeed())
+		AfterEach(func(ctx SpecContext) {
+			Expect(factory.CleanupChaosMeshExperiments(ctx)).To(Succeed())
 		})
 
-		It("should change the coordinators", func() {
+		It("should change the coordinators", func(ctx SpecContext) {
 			primary := fdbCluster.GetPrimary()
 
 			lastForceReconcile := time.Now()
@@ -157,13 +160,13 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 				// Ensure that the coordinators are changed in a timely manner for the test case.
 				if time.Since(lastForceReconcile) > 1*time.Minute {
 					for _, cluster := range fdbCluster.GetAllClusters() {
-						cluster.ForceReconcile()
+						cluster.ForceReconcile(ctx)
 					}
 
 					lastForceReconcile = time.Now()
 				}
 
-				status := primary.GetStatus()
+				status := primary.GetStatus(ctx)
 
 				// Make sure we have the same count of coordinators again and the deleted
 				coordinators := fdbstatus.GetCoordinatorsFromStatus(status)
@@ -179,13 +182,13 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 					// The unified image has a mechanism to propagate changes in the cluster file, this allows multi-region
 					// clusters to reconcile faster. In the case of the split image we need "external" events in Kubernetes
 					// to trigger a reconciliation.
-					if !cluster.GetCluster().UseUnifiedImage() ||
+					if !cluster.GetCluster(ctx).UseUnifiedImage() ||
 						time.Since(lastForceReconcile) > 3*time.Minute {
-						cluster.ForceReconcile()
+						cluster.ForceReconcile(ctx)
 						lastForceReconcile = time.Now()
 					}
 
-					g.Expect(cluster.GetCluster().Status.ConnectionString).
+					g.Expect(cluster.GetCluster(ctx).Status.ConnectionString).
 						NotTo(Equal(initialConnectionString), fmt.Sprintf("expected for cluster \"%s\" to get the updated connection string in time", cluster.Name()))
 				}
 			}).WithTimeout(5 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
@@ -196,9 +199,9 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 		var desiredRunningPods int
 		var quota *corev1.ResourceQuota
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			satellite := fdbCluster.GetPrimarySatellite()
-			satelliteCluster := satellite.GetCluster()
+			satelliteCluster := satellite.GetCluster(ctx)
 
 			processCounts, err := satelliteCluster.GetProcessCountsWithDefaults()
 			Expect(err).NotTo(HaveOccurred())
@@ -215,28 +218,30 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 					},
 				},
 			}
-			Expect(factory.CreateIfAbsent(quota)).NotTo(HaveOccurred())
+			Expect(factory.CreateIfAbsent(ctx, quota)).NotTo(HaveOccurred())
 
 			desiredRunningPods = processCounts.Log - satelliteCluster.DesiredFaultTolerance()
 
 			// Replace all Pods for this cluster.
-			satellite.ReplacePods(satellite.GetAllPods().Items, false)
+			satellite.ReplacePods(ctx, satellite.GetAllPods(ctx).Items, false)
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			// Make sure that the quota is deleted and new PVCs can be created.
-			factory.Delete(quota)
-			Expect(fdbCluster.GetPrimarySatellite().WaitForReconciliation()).NotTo(HaveOccurred())
+			factory.Delete(ctx, quota)
+			Expect(
+				fdbCluster.GetPrimarySatellite().WaitForReconciliation(ctx),
+			).NotTo(HaveOccurred())
 		})
 
-		It("should not replace too many Pods and bring down the satellite", func() {
+		It("should not replace too many Pods and bring down the satellite", func(ctx SpecContext) {
 			satellite := fdbCluster.GetPrimarySatellite()
 			primary := fdbCluster.GetPrimary()
-			primaryDCID := primary.GetCluster().Spec.DataCenter
+			primaryDCID := primary.GetCluster(ctx).Spec.DataCenter
 
 			Consistently(func(g Gomega) int {
 				var runningPods int
-				for _, pod := range satellite.GetAllPods().Items {
+				for _, pod := range satellite.GetAllPods(ctx).Items {
 					if pod.Status.Phase != corev1.PodRunning {
 						continue
 					}
@@ -244,7 +249,7 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 					runningPods++
 				}
 
-				status := fdbCluster.GetPrimary().GetStatus()
+				status := fdbCluster.GetPrimary().GetStatus(ctx)
 				if status.Client.DatabaseStatus.Available {
 					g.Expect(status.Cluster.DatabaseConfiguration.GetPrimaryDCID()).
 						To(Equal(primaryDCID))
@@ -257,12 +262,12 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 
 			// Add enough quota, so that the log processes can be updated after some time.
 			processCounts, err := fdbCluster.GetPrimarySatellite().
-				GetCluster().
+				GetCluster(ctx).
 				GetProcessCountsWithDefaults()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(
 				factory.GetControllerRuntimeClient().
-					Update(context.Background(), &corev1.ResourceQuota{
+					Update(ctx, &corev1.ResourceQuota{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "testing-quota",
 							Namespace: satellite.Namespace(),
@@ -278,29 +283,29 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 			).To(Succeed())
 
 			// Wait until the cluster has replaced all the log processes.
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 		})
 	})
 
 	When("locality based exclusions are enabled", func() {
 		var initialUseLocalitiesForExclusion bool
 
-		BeforeEach(func() {
-			spec := fdbCluster.GetRemote().GetCluster().Spec.DeepCopy()
+		BeforeEach(func(ctx SpecContext) {
+			spec := fdbCluster.GetRemote().GetCluster(ctx).Spec.DeepCopy()
 			initialUseLocalitiesForExclusion = fdbCluster.GetRemote().
-				GetCluster().
+				GetCluster(ctx).
 				UseLocalitiesForExclusion()
 			spec.AutomationOptions.UseLocalitiesForExclusion = ptr.To(true)
-			fdbCluster.GetRemote().UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.GetRemote().GetCluster().UseLocalitiesForExclusion()).To(BeTrue())
+			fdbCluster.GetRemote().UpdateClusterSpecWithSpec(ctx, spec)
+			Expect(fdbCluster.GetRemote().GetCluster(ctx).UseLocalitiesForExclusion()).To(BeTrue())
 		})
 
-		AfterEach(func() {
-			spec := fdbCluster.GetRemote().GetCluster().Spec.DeepCopy()
+		AfterEach(func(ctx SpecContext) {
+			spec := fdbCluster.GetRemote().GetCluster(ctx).Spec.DeepCopy()
 			spec.AutomationOptions.UseLocalitiesForExclusion = ptr.To(
 				initialUseLocalitiesForExclusion,
 			)
-			fdbCluster.GetRemote().UpdateClusterSpecWithSpec(spec)
+			fdbCluster.GetRemote().UpdateClusterSpecWithSpec(ctx, spec)
 		})
 
 		When("a remote log has network latency issues and gets replaced", func() {
@@ -308,16 +313,16 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 			var processGroupID fdbv1beta2.ProcessGroupID
 			var replacedPod corev1.Pod
 
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				// Ensure the other clusters are not interacting.
 				for _, cluster := range fdbCluster.GetAllClusters() {
-					cluster.SetSkipReconciliation(true)
+					cluster.SetSkipReconciliation(ctx, true)
 				}
 
 				remote := fdbCluster.GetRemote()
-				remote.SetSkipReconciliation(false)
-				dcID := remote.GetCluster().Spec.DataCenter
-				status := remote.GetStatus()
+				remote.SetSkipReconciliation(ctx, false)
+				dcID := remote.GetCluster(ctx).Spec.DataCenter
+				status := remote.GetStatus(ctx)
 				for _, process := range status.Cluster.Processes {
 					dc, ok := process.Locality[fdbv1beta2.FDBLocalityDCIDKey]
 					if !ok || dc != dcID {
@@ -343,7 +348,7 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 				}
 
 				log.Println("Will inject chaos into", processGroupID, "and replace it")
-				for _, pod := range remote.GetLogPods().Items {
+				for _, pod := range remote.GetLogPods(ctx).Items {
 					if fixtures.GetProcessGroupID(pod) != processGroupID {
 						continue
 					}
@@ -353,7 +358,7 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 				}
 
 				log.Println("Inject latency chaos")
-				experiment = factory.InjectNetworkLatency(
+				experiment = factory.InjectNetworkLatency(ctx,
 					fixtures.PodSelector(&replacedPod),
 					chaosmesh.PodSelectorSpec{
 						GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
@@ -369,6 +374,7 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 
 				// TODO (johscheuer): Allow to have this as a long running task until the test is done.
 				factory.CreateDataLoaderIfAbsentWithOptions(
+					ctx,
 					fdbCluster.GetPrimary(),
 					&fixtures.DataLoaderOptions{Wait: true},
 				)
@@ -378,24 +384,24 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 					"replace Pod",
 					replacedPod.Name,
 					"useLocalitiesForExclusion",
-					fdbCluster.GetPrimary().GetCluster().UseLocalitiesForExclusion(),
+					fdbCluster.GetPrimary().GetCluster(ctx).UseLocalitiesForExclusion(),
 				)
-				remote.ReplacePod(replacedPod, true)
+				remote.ReplacePod(ctx, replacedPod, true)
 			})
 
-			It("should exclude and remove the pod", func() {
+			It("should exclude and remove the pod", func(ctx SpecContext) {
 				excludedServer := fdbv1beta2.ExcludedServers{
 					Locality: processGroupID.GetExclusionString(),
 				}
 
 				Eventually(func(g Gomega) []fdbv1beta2.ExcludedServers {
-					status := fdbCluster.GetPrimary().GetStatus()
+					status := fdbCluster.GetPrimary().GetStatus(ctx)
 					excludedServers := status.Cluster.DatabaseConfiguration.ExcludedServers
 					log.Println("excludedServers", excludedServers)
 
 					pod := &corev1.Pod{}
 					err := factory.GetControllerRuntimeClient().
-						Get(context.Background(), ctrlClient.ObjectKeyFromObject(&replacedPod), pod)
+						Get(ctx, ctrlClient.ObjectKeyFromObject(&replacedPod), pod)
 					g.Expect(err).To(HaveOccurred())
 					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 
@@ -403,13 +409,13 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 				}).WithTimeout(15 * time.Minute).WithPolling(1 * time.Second).ShouldNot(ContainElement(excludedServer))
 			})
 
-			AfterEach(func() {
+			AfterEach(func(ctx SpecContext) {
 				for _, cluster := range fdbCluster.GetAllClusters() {
-					cluster.SetSkipReconciliation(false)
+					cluster.SetSkipReconciliation(ctx, false)
 				}
-				Expect(fdbCluster.GetRemote().ClearProcessGroupsToRemove()).To(Succeed())
-				factory.DeleteChaosMeshExperiment(experiment)
-				factory.DeleteDataLoader(fdbCluster.GetPrimary())
+				Expect(fdbCluster.GetRemote().ClearProcessGroupsToRemove(ctx)).To(Succeed())
+				factory.DeleteChaosMeshExperiment(ctx, experiment)
+				factory.DeleteDataLoader(ctx, fdbCluster.GetPrimary())
 			})
 		})
 
@@ -426,10 +432,10 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 			*/
 			var experiment *fixtures.ChaosMeshExperiment
 
-			BeforeEach(func() {
-				dcID := fdbCluster.GetRemote().GetCluster().Spec.DataCenter
+			BeforeEach(func(ctx SpecContext) {
+				dcID := fdbCluster.GetRemote().GetCluster(ctx).Spec.DataCenter
 
-				status := fdbCluster.GetPrimary().GetStatus()
+				status := fdbCluster.GetPrimary().GetStatus(ctx)
 
 				var processGroupID fdbv1beta2.ProcessGroupID
 				for _, process := range status.Cluster.Processes {
@@ -458,7 +464,7 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 
 				log.Println("Will inject chaos into", processGroupID, "and replace it")
 				var replacedPod corev1.Pod
-				for _, pod := range fdbCluster.GetRemote().GetLogPods().Items {
+				for _, pod := range fdbCluster.GetRemote().GetLogPods(ctx).Items {
 					if fixtures.GetProcessGroupID(pod) != processGroupID {
 						continue
 					}
@@ -468,7 +474,7 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 				}
 
 				log.Println("Inject latency chaos")
-				experiment = factory.InjectNetworkLatency(
+				experiment = factory.InjectNetworkLatency(ctx,
 					chaosmesh.PodSelectorSpec{
 						GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
 							Namespaces: []string{fdbCluster.GetRemote().Namespace()},
@@ -501,6 +507,7 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 
 				// TODO (johscheuer): Allow to have this as a long running task until the test is done.
 				factory.CreateDataLoaderIfAbsentWithOptions(
+					ctx,
 					fdbCluster.GetPrimary(),
 					&fixtures.DataLoaderOptions{Wait: true},
 				)
@@ -510,30 +517,30 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 					"replacedPod",
 					replacedPod.Name,
 					"useLocalitiesForExclusion",
-					fdbCluster.GetPrimary().GetCluster().UseLocalitiesForExclusion(),
+					fdbCluster.GetPrimary().GetCluster(ctx).UseLocalitiesForExclusion(),
 				)
-				fdbCluster.GetRemote().ReplacePod(replacedPod, true)
+				fdbCluster.GetRemote().ReplacePod(ctx, replacedPod, true)
 			})
 
-			It("should exclude and remove the pod", func() {
+			It("should exclude and remove the pod", func(ctx SpecContext) {
 				Eventually(func() []fdbv1beta2.ExcludedServers {
-					status := fdbCluster.GetPrimary().GetStatus()
+					status := fdbCluster.GetPrimary().GetStatus(ctx)
 					excludedServers := status.Cluster.DatabaseConfiguration.ExcludedServers
 					log.Println("excludedServers", excludedServers)
 					return excludedServers
 				}).WithTimeout(15 * time.Minute).WithPolling(1 * time.Second).Should(BeEmpty())
 			})
 
-			AfterEach(func() {
-				Expect(fdbCluster.GetRemote().ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
-				factory.DeleteChaosMeshExperiment(experiment)
+			AfterEach(func(ctx SpecContext) {
+				Expect(fdbCluster.GetRemote().ClearProcessGroupsToRemove(ctx)).NotTo(HaveOccurred())
+				factory.DeleteChaosMeshExperiment(ctx, experiment)
 				// Making sure we included back all the process groups after exclusion is complete.
 				Expect(
 					fdbCluster.GetPrimary().
-						GetStatus().
+						GetStatus(ctx).
 						Cluster.DatabaseConfiguration.ExcludedServers,
 				).To(BeEmpty())
-				factory.DeleteDataLoader(fdbCluster.GetPrimary())
+				factory.DeleteDataLoader(ctx, fdbCluster.GetPrimary())
 			})
 		})
 	})

--- a/e2e/test_operator_ha_failure/operator_ha_failure_test.go
+++ b/e2e/test_operator_ha_failure/operator_ha_failure_test.go
@@ -25,7 +25,6 @@ This test suite contains destructive test cases for a multi-region FDB cluster (
 */
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"time"
@@ -47,15 +46,16 @@ func init() {
 	testOptions = fixtures.InitFlags()
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	factory = fixtures.CreateFactory(testOptions)
-	fdbCluster = factory.CreateFdbHaCluster(
+	fdbCluster = factory.CreateFdbHaCluster(ctx,
 		fixtures.DefaultClusterConfigWithHaMode(fixtures.HaFourZoneSingleSat, false))
 
 	// In order to test the robustness of the operator we try to kill the operator Pods every minute.
 	if factory.ChaosTestsEnabled() {
 		for _, cluster := range fdbCluster.GetAllClusters() {
 			factory.ScheduleInjectPodKill(
+				ctx,
 				fixtures.GetOperatorSelector(cluster.Namespace()),
 				"*/2 * * * *",
 				chaosmesh.OneMode,
@@ -64,11 +64,11 @@ var _ = BeforeSuite(func() {
 	}
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx SpecContext) {
 	if CurrentSpecReport().Failed() {
 		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
 	}
-	factory.Shutdown()
+	factory.Shutdown(ctx)
 })
 
 // This test suite contains destructive tests which will break the cluster after the test is done.
@@ -80,7 +80,7 @@ var _ = Describe("Operator HA Failure tests", Label("e2e"), func() {
 		var keyValues []fixtures.KeyValue
 		var prefix byte = 'a'
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			if factory.ChaosTestsEnabled() {
 				Skip("chaos tests are required for this test suite")
 			}
@@ -96,6 +96,7 @@ var _ = Describe("Operator HA Failure tests", Label("e2e"), func() {
 			experiments = make([]*fixtures.ChaosMeshExperiment, 0, 2)
 			// Inject a partition between primary and the remote + remote satellite
 			experiments = append(experiments, factory.InjectPartitionBetween(
+				ctx,
 				chaosmesh.PodSelectorSpec{
 					GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
 						Namespaces:     []string{primary.Namespace()},
@@ -113,6 +114,7 @@ var _ = Describe("Operator HA Failure tests", Label("e2e"), func() {
 
 			// Inject a partition between primary satellite and the remote + remote satellite
 			experiments = append(experiments, factory.InjectPartitionBetween(
+				ctx,
 				chaosmesh.PodSelectorSpec{
 					GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
 						Namespaces:     []string{primarySatellite.Namespace()},
@@ -131,21 +133,21 @@ var _ = Describe("Operator HA Failure tests", Label("e2e"), func() {
 			time.Sleep(10 * time.Second)
 
 			keyValues = primary.GenerateRandomValues(10, prefix)
-			primary.WriteKeyValuesWithTimeout(keyValues, 120)
+			primary.WriteKeyValuesWithTimeout(ctx, keyValues, 120)
 			// Destroy primary and primary satellite (should have mutations that are not present in the remote side).
-			primary.SetSkipReconciliation(true)
-			primarySatellite.SetSkipReconciliation(true)
+			primary.SetSkipReconciliation(ctx, true)
+			primarySatellite.SetSkipReconciliation(ctx, true)
 			// We also destroy the remote satellite, it shouldn't matter in this case as the remote satellite
 			// has no data anyways. But the idea here is to reduce the possible interaction between the remote
 			// and the remote satellite during the forced fail-over.
-			remoteSatellite.SetSkipReconciliation(true)
+			remoteSatellite.SetSkipReconciliation(ctx, true)
 
 			// We could probably simulate that with the suspend command, but destroying the pods is a more robust solution.
 			var wg errgroup.Group
 			log.Println("Delete Pods in primary")
 			wg.Go(func() error {
-				for _, pod := range primary.GetPods().Items {
-					factory.DeletePod(&pod)
+				for _, pod := range primary.GetPods(ctx).Items {
+					factory.DeletePod(ctx, &pod)
 				}
 
 				return nil
@@ -153,8 +155,8 @@ var _ = Describe("Operator HA Failure tests", Label("e2e"), func() {
 
 			log.Println("Delete Pods in primary satellite")
 			wg.Go(func() error {
-				for _, pod := range primarySatellite.GetPods().Items {
-					factory.DeletePod(&pod)
+				for _, pod := range primarySatellite.GetPods(ctx).Items {
+					factory.DeletePod(ctx, &pod)
 				}
 
 				return nil
@@ -162,8 +164,8 @@ var _ = Describe("Operator HA Failure tests", Label("e2e"), func() {
 
 			log.Println("Delete Pods in remote satellite")
 			wg.Go(func() error {
-				for _, pod := range remoteSatellite.GetPods().Items {
-					factory.DeletePod(&pod)
+				for _, pod := range remoteSatellite.GetPods(ctx).Items {
+					factory.DeletePod(ctx, &pod)
 				}
 
 				return nil
@@ -175,25 +177,25 @@ var _ = Describe("Operator HA Failure tests", Label("e2e"), func() {
 
 			// Ensure the cluster is unavailable.
 			Eventually(func() bool {
-				return remote.GetStatus().Client.DatabaseStatus.Available
+				return remote.GetStatus(ctx).Client.DatabaseStatus.Available
 			}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(BeFalse())
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			for _, experiment := range experiments {
-				factory.DeleteChaosMeshExperiment(experiment)
+				factory.DeleteChaosMeshExperiment(ctx, experiment)
 			}
 		})
 
-		It("should fail-over and cause data loss", func() {
+		It("should fail-over and cause data loss", func(ctx SpecContext) {
 			remote := fdbCluster.GetRemote()
 			// Pick one operator pod and execute the recovery command
 			operatorPod := factory.RandomPickOnePod(
-				factory.GetOperatorPods(remote.Namespace()).Items,
+				factory.GetOperatorPods(ctx, remote.Namespace()).Items,
 			)
 			log.Println("operatorPod:", operatorPod.Name)
 			stdout, stderr, err := factory.ExecuteCmdOnPod(
-				context.Background(),
+				ctx,
 				&operatorPod,
 				"manager",
 				fmt.Sprintf(
@@ -208,11 +210,11 @@ var _ = Describe("Operator HA Failure tests", Label("e2e"), func() {
 
 			// Ensure the cluster is available again.
 			Eventually(func() bool {
-				return remote.GetStatus().Client.DatabaseStatus.Available
+				return remote.GetStatus(ctx).Client.DatabaseStatus.Available
 			}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(BeTrue())
 
 			// Ensure we lost some data.
-			Expect(remote.GetRange([]byte{prefix}, 25, 60)).Should(BeEmpty())
+			Expect(remote.GetRange(ctx, []byte{prefix}, 25, 60)).Should(BeEmpty())
 		})
 	})
 })

--- a/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
+++ b/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
@@ -27,6 +27,7 @@ Each test will create a new HA FoundationDB cluster which will be upgraded.
 */
 
 import (
+	"context"
 	"log"
 
 	"k8s.io/utils/ptr"
@@ -55,6 +56,7 @@ var _ = AfterSuite(func() {
 })
 
 func clusterSetupWithHealthCheckOption(
+	ctx context.Context,
 	beforeVersion string,
 	enableOperatorPodChaos bool,
 	enableHealthCheck bool,
@@ -62,16 +64,17 @@ func clusterSetupWithHealthCheckOption(
 	config := fixtures.DefaultClusterConfigWithHaMode(fixtures.HaFourZoneSingleSat, false)
 	config.Version = ptr.To(beforeVersion)
 
-	fdbCluster = factory.CreateFdbHaCluster(config)
+	fdbCluster = factory.CreateFdbHaCluster(ctx, config)
 	if enableHealthCheck {
 		Expect(
-			fdbCluster.GetPrimary().InvariantClusterStatusAvailable(),
+			fdbCluster.GetPrimary().InvariantClusterStatusAvailable(ctx),
 		).ShouldNot(HaveOccurred())
 	}
 
 	if enableOperatorPodChaos && factory.ChaosTestsEnabled() {
 		for _, curCluster := range fdbCluster.GetAllClusters() {
 			factory.ScheduleInjectPodKill(
+				ctx,
 				fixtures.GetOperatorSelector(curCluster.Namespace()),
 				"*/5 * * * *",
 				chaosmesh.OneMode,
@@ -80,32 +83,32 @@ func clusterSetupWithHealthCheckOption(
 	}
 }
 
-func clusterSetup(beforeVersion string, enableOperatorPodChaos bool) {
-	clusterSetupWithHealthCheckOption(beforeVersion, enableOperatorPodChaos, true)
+func clusterSetup(ctx context.Context, beforeVersion string, enableOperatorPodChaos bool) {
+	clusterSetupWithHealthCheckOption(ctx, beforeVersion, enableOperatorPodChaos, true)
 }
 
 var _ = Describe("Operator HA Upgrades", Label("e2e"), func() {
-	BeforeEach(func() {
+	BeforeEach(func(_ SpecContext) {
 		factory = fixtures.CreateFactory(testOptions)
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		if CurrentSpecReport().Failed() {
-			fdbCluster.DumpState()
+			fdbCluster.DumpState(ctx)
 		}
-		factory.Shutdown()
+		factory.Shutdown(ctx)
 	})
 
 	// https://github.com/FoundationDB/fdb-kubernetes-operator/issues/172, debug why this test is flaky and how
 	// to make it stable.
 	DescribeTable(
 		"when no remote processes are restarted",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion, false)
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetup(ctx, beforeVersion, false)
 
 			// Select remote processes and use the buggify option to skip those
 			// processes during the restart command.
-			remoteProcessGroups := fdbCluster.GetRemote().GetCluster().Status.ProcessGroups
+			remoteProcessGroups := fdbCluster.GetRemote().GetCluster(ctx).Status.ProcessGroups
 			ignoreDuringRestart := make(
 				[]fdbv1beta2.ProcessGroupID,
 				0,
@@ -127,13 +130,13 @@ var _ = Describe("Operator HA Upgrades", Label("e2e"), func() {
 
 			// We have to set this to all clusters as any operator could be doing the cluster wide restart.
 			for _, cluster := range fdbCluster.GetAllClusters() {
-				cluster.SetIgnoreDuringRestart(ignoreDuringRestart)
+				cluster.SetIgnoreDuringRestart(ctx, ignoreDuringRestart)
 			}
 
 			// The cluster should still be able to upgrade.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 			// Verify that the upgrade proceeds
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 
 			// TODO add validation here processes are updated new version
 		},

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -27,6 +27,7 @@ Each test will create a new HA FoundationDB cluster which will be upgraded.
 */
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strconv"
@@ -67,7 +68,7 @@ type testConfig struct {
 	clusterConfig          *fixtures.ClusterConfig
 }
 
-func clusterSetupWithTestConfig(config testConfig) {
+func clusterSetupWithTestConfig(ctx context.Context, config testConfig) {
 	if config.clusterConfig == nil {
 		config.clusterConfig = fixtures.DefaultClusterConfigWithHaMode(
 			fixtures.HaFourZoneSingleSat,
@@ -76,22 +77,22 @@ func clusterSetupWithTestConfig(config testConfig) {
 	}
 
 	config.clusterConfig.Version = ptr.To(config.beforeVersion)
-	fdbCluster = factory.CreateFdbHaCluster(config.clusterConfig)
+	fdbCluster = factory.CreateFdbHaCluster(ctx, config.clusterConfig)
 
 	if config.enableHealthCheck {
 		Expect(
-			fdbCluster.GetPrimary().InvariantClusterStatusAvailable(),
+			fdbCluster.GetPrimary().InvariantClusterStatusAvailable(ctx),
 		).ShouldNot(HaveOccurred())
 	}
 
 	if config.loadData {
 		// Load some data async into the cluster. We will only block as long as the Job is created.
-		factory.CreateDataLoaderIfAbsent(fdbCluster.GetPrimary())
+		factory.CreateDataLoaderIfAbsent(ctx, fdbCluster.GetPrimary())
 	}
 
 	if config.enableOperatorPodChaos && factory.ChaosTestsEnabled() {
 		for _, curCluster := range fdbCluster.GetAllClusters() {
-			factory.ScheduleInjectPodKill(
+			factory.ScheduleInjectPodKill(ctx,
 				fixtures.GetOperatorSelector(curCluster.Namespace()),
 				"*/5 * * * *",
 				chaosmesh.OneMode,
@@ -100,8 +101,8 @@ func clusterSetupWithTestConfig(config testConfig) {
 	}
 }
 
-func clusterSetup(beforeVersion string, enableOperatorPodChaos bool) {
-	clusterSetupWithTestConfig(
+func clusterSetup(ctx context.Context, beforeVersion string, enableOperatorPodChaos bool) {
+	clusterSetupWithTestConfig(ctx,
 		testConfig{
 			beforeVersion:          beforeVersion,
 			enableOperatorPodChaos: enableOperatorPodChaos,
@@ -118,14 +119,14 @@ func clusterSetup(beforeVersion string, enableOperatorPodChaos bool) {
 //
 // Note: we tried doing this by polling for "UpgradeRequeued" event on primary/remote/primary-satellite data centers,
 // but we found that that approach is not very reliable.
-func verifyBouncingIsBlocked() {
+func verifyBouncingIsBlocked(ctx context.Context) {
 	Eventually(func(g Gomega) {
 		for _, cluster := range fdbCluster.GetAllClusters() {
 			if strings.HasSuffix(cluster.Name(), fixtures.RemoteSatelliteID) {
 				continue
 			}
 
-			g.Expect(cluster.AllProcessGroupsHaveCondition(fdbv1beta2.IncorrectCommandLine, true)).
+			g.Expect(cluster.AllProcessGroupsHaveCondition(ctx, fdbv1beta2.IncorrectCommandLine, true)).
 				To(BeTrue(), fmt.Sprintf("all process groups in cluster %s should have the incorrect command line condition", cluster.Name()))
 		}
 	}).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).MustPassRepeatedly(30).Should(Succeed())
@@ -138,15 +139,15 @@ var _ = AfterSuite(func() {
 })
 
 var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
-	BeforeEach(func() {
+	BeforeEach(func(_ SpecContext) {
 		factory = fixtures.CreateFactory(testOptions)
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		if CurrentSpecReport().Failed() {
-			fdbCluster.DumpState()
+			fdbCluster.DumpState(ctx)
 		}
-		factory.Shutdown()
+		factory.Shutdown(ctx)
 	})
 
 	// Ginkgo lacks the support for AfterEach and BeforeEach in tables, so we have to put everything inside the testing function
@@ -154,11 +155,11 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 	// for different versions without hard coding or having multiple flags.
 	PDescribeTable(
 		"without chaos",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion, false)
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetup(ctx, beforeVersion, false)
 
-			Expect(fdbCluster.UpgradeCluster(targetVersion, true)).NotTo(HaveOccurred())
-			fdbCluster.VerifyVersion(targetVersion)
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, true)).NotTo(HaveOccurred())
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 		},
 		EntryDescription("Upgrade from %s to %s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -166,19 +167,19 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"with operator pod chaos and without foundationdb pod chaos",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetupWithTestConfig(testConfig{
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetupWithTestConfig(ctx, testConfig{
 				beforeVersion:          beforeVersion,
 				enableOperatorPodChaos: true,
 				enableHealthCheck:      true,
 				loadData:               true,
 			})
-			initialGeneration := fdbCluster.GetPrimary().GetStatus().Cluster.Generation
+			initialGeneration := fdbCluster.GetPrimary().GetStatus(ctx).Cluster.Generation
 			// Make use of a sync.Map here as we have to modify it concurrently.
 			var transactionSystemProcessGroups sync.Map
 			// Fetch all initial process groups before starting the upgrade.
 			for _, cluster := range fdbCluster.GetAllClusters() {
-				processGroups := cluster.GetCluster().Status.ProcessGroups
+				processGroups := cluster.GetCluster(ctx).Status.ProcessGroups
 				for _, processGroup := range processGroups {
 					if processGroup.ProcessClass == fdbv1beta2.ProcessClassStorage {
 						continue
@@ -193,7 +194,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 			startTime := time.Now()
 			// Start the upgrade for the whole cluster
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			// Wait until all clusters are reconciled and collect the process groups during that time.
 			g := new(errgroup.Group)
@@ -201,7 +202,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 				targetCluster := fdbCluster // https://golang.org/doc/faq#closures_and_goroutines
 
 				g.Go(func() error {
-					err := targetCluster.WaitUntilWithForceReconcile(
+					err := targetCluster.WaitUntilWithForceReconcile(ctx,
 						2,
 						1200,
 						func(cluster *fdbv1beta2.FoundationDBCluster) bool {
@@ -267,7 +268,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			// Make sure we haven't replaced to many transaction processes.
 			Expect(processCounts).To(BeNumerically("<=", expectedProcessCounts))
 
-			finalGeneration := fdbCluster.GetPrimary().GetStatus().Cluster.Generation
+			finalGeneration := fdbCluster.GetPrimary().GetStatus(ctx).Cluster.Generation
 			log.Println(
 				"upgrade took:",
 				time.Since(startTime).String(),
@@ -289,8 +290,8 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			// change, which happens a number of times, during an upgrade).
 			Expect(finalGeneration).To(BeNumerically("<=", initialGeneration+80))
 			// Make sure the cluster has no data loss
-			fdbCluster.GetPrimary().EnsureTeamTrackersAreHealthy()
-			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.GetPrimary().EnsureTeamTrackersAreHealthy(ctx)
+			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -298,20 +299,20 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"one dc is upgraded before the other dcs started the upgrade",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				Skip("skipping test since those versions are protocol compatible")
 			}
 
-			clusterSetup(beforeVersion, true /* = enableOperatorPodChaos */)
+			clusterSetup(ctx, beforeVersion, true /* = enableOperatorPodChaos */)
 
 			// Upgrade the primary cluster before upgrading the rest.
 			primary := fdbCluster.GetPrimary()
-			Expect(primary.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(primary.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			// Should update all sidecars of the primary cluster.
 			Eventually(func() bool {
-				pods := primary.GetPods()
+				pods := primary.GetPods(ctx)
 				if pods == nil {
 					return false
 				}
@@ -333,12 +334,16 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 			// It should block the restart of the processes until the rest of the cluster is upgraded.
 			Eventually(func() bool {
-				return primary.AllProcessGroupsHaveCondition(fdbv1beta2.IncorrectCommandLine, true)
+				return primary.AllProcessGroupsHaveCondition(
+					ctx,
+					fdbv1beta2.IncorrectCommandLine,
+					true,
+				)
 			}).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).MustPassRepeatedly(30).Should(BeTrue())
 
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 			// Verify that the upgrade proceeds
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -346,29 +351,30 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"with a temporary partition",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion, false /* = enableOperatorPodChaos */)
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetup(ctx, beforeVersion, false /* = enableOperatorPodChaos */)
 
 			// Find the remote satellite operator pods.
-			operatorPods := factory.GetOperatorPods(
+			operatorPods := factory.GetOperatorPods(ctx,
 				fdbCluster.GetRemoteSatellite().Namespace(),
 			)
 
 			// Disable the auto replacement to prevent the operator te replace the partitioned processes, the default
 			// replace time in the operator is 2h and in our test suite 5 minutes.
 			Expect(
-				fdbCluster.GetRemoteSatellite().SetAutoReplacements(false, 20*time.Minute),
+				fdbCluster.GetRemoteSatellite().SetAutoReplacements(ctx, false, 20*time.Minute),
 			).NotTo(HaveOccurred())
 
 			// Partition them from the rest of the database.
 			log.Println("Partitioning the remote satellite operator pods")
 			partitionExperiment := factory.InjectPartitionBetween(
+				ctx,
 				fdbCluster.GetNamespaceSelector(),
 				fixtures.PodsSelector(operatorPods.Items),
 			)
 
 			// Start the upgrade, but do not wait for reconciliation to complete.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			if !fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				// Verify that bouncing is blocked because the Pods in the remote satellite
@@ -376,16 +382,16 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 				// process groups in all other data centers are at "IncorrectCommandLine"
 				// state.
 				log.Println("Ensure bouncing is blocked")
-				verifyBouncingIsBlocked()
+				verifyBouncingIsBlocked(ctx)
 				log.Println("Ensure cluster(s) are not upgraded")
-				fdbCluster.VerifyVersion(beforeVersion)
+				fdbCluster.VerifyVersion(ctx, beforeVersion)
 			} else {
 				// If we do a version compatible upgrade, ensure the partition is present for 30 seconds.
 				time.Sleep(30 * time.Second)
 			}
 
 			log.Println("Restoring connectivity")
-			factory.DeleteChaosMeshExperiment(partitionExperiment)
+			factory.DeleteChaosMeshExperiment(ctx, partitionExperiment)
 
 			// When using protocol compatible versions, the other operator instances are able to move forward. In some
 			// cases it can happen that new coordinators are selected and all the old coordinators are deleted. In this
@@ -394,25 +400,25 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				Eventually(func(g Gomega) {
 					currentConnectionString := fdbCluster.GetPrimary().
-						GetStatus().
+						GetStatus(ctx).
 						Cluster.ConnectionString
 					remoteSat := fdbCluster.GetRemoteSatellite()
-					remoteConnectionString := remoteSat.GetCluster().Status.ConnectionString
+					remoteConnectionString := remoteSat.GetCluster(ctx).Status.ConnectionString
 
 					// If the connection string is different we have to update it on the remote satellite side
 					// as the operator instances were partitioned.
 					if currentConnectionString != remoteConnectionString {
-						if !remoteSat.GetCluster().Spec.Skip {
-							remoteSat.SetSkipReconciliation(true)
+						if !remoteSat.GetCluster(ctx).Spec.Skip {
+							remoteSat.SetSkipReconciliation(ctx, true)
 							// Wait one minute, that should be enough time for the operator to end the reconciliation loop
 							// if started.
 							time.Sleep(1 * time.Minute)
 						}
 
-						remoteSatStatus := remoteSat.GetCluster().Status.DeepCopy()
+						remoteSatStatus := remoteSat.GetCluster(ctx).Status.DeepCopy()
 						remoteSatStatus.ConnectionString = currentConnectionString
 						fdbCluster.GetRemoteSatellite().
-							UpdateClusterStatusWithStatus(remoteSatStatus)
+							UpdateClusterStatusWithStatus(ctx, remoteSatStatus)
 					}
 
 					g.Expect(remoteConnectionString).To(Equal(currentConnectionString))
@@ -424,15 +430,15 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			// cluster it will be put into a queue again, at some time the queue will delay the next reconcile attempt
 			// for a long time and since the network partition is not emitting any events for the operator this won't trigger
 			// a reconciliation either. So this step is only to speed up the reconcile process.
-			factory.RecreateOperatorPods(fdbCluster.GetRemoteSatellite().Namespace())
+			factory.RecreateOperatorPods(ctx, fdbCluster.GetRemoteSatellite().Namespace())
 
 			// Ensure that the remote satellite is not set to skip.
-			fdbCluster.GetRemoteSatellite().SetSkipReconciliation(false)
+			fdbCluster.GetRemoteSatellite().SetSkipReconciliation(ctx, false)
 
 			// Upgrade should make progress now - wait until all processes have upgraded
 			// to "targetVersion".
-			fdbCluster.VerifyVersion(targetVersion)
-			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.VerifyVersion(ctx, targetVersion)
+			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %s to %s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -440,11 +446,11 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"with a random pod deleted during the staging phase",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion, false /* = enableOperatorPodChaos */)
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetup(ctx, beforeVersion, false /* = enableOperatorPodChaos */)
 
 			// Start the upgrade, but do not wait for reconciliation to complete.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			// Keep deleting pods until all clusters are running with the new version.
 			clusters := fdbCluster.GetAllClusters()
@@ -454,7 +460,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 				// Are all clusters running at "targetVersion"?
 				clustersAtTargetVersion := true
 				for _, cluster := range clusters {
-					coordinators := cluster.GetCoordinators()
+					coordinators := cluster.GetCoordinators(ctx)
 					for _, pod := range coordinators {
 						coordinatorMap[pod.UID] = pod
 					}
@@ -463,11 +469,11 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 						"Cluster",
 						cluster.Name(),
 						"is running at version",
-						cluster.GetCluster().GetRunningVersion(),
+						cluster.GetCluster(ctx).GetRunningVersion(),
 						"target version is",
 						targetVersion,
 					)
-					if cluster.GetCluster().GetRunningVersion() == targetVersion {
+					if cluster.GetCluster(ctx).GetRunningVersion() == targetVersion {
 						continue
 					}
 
@@ -483,7 +489,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 				var randomPod *corev1.Pod
 				g.Eventually(func() bool {
 					randomPod = factory.ChooseRandomPod(
-						factory.RandomPickOneCluster(clusters).GetPods(),
+						factory.RandomPickOneCluster(clusters).GetPods(ctx),
 					)
 					_, ok := coordinatorMap[randomPod.UID]
 					if ok {
@@ -494,12 +500,12 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 				}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(BeFalse())
 
 				log.Println("Deleting pod:", randomPod.Name)
-				factory.DeletePod(randomPod)
+				factory.DeletePod(ctx, randomPod)
 				return false
 			}).WithTimeout(30 * time.Minute).WithPolling(2 * time.Minute).Should(BeTrue())
 
 			// Make sure the cluster has no data loss
-			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription(
 			"Upgrade from %s to %s",
@@ -510,12 +516,12 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 	// TODO(johscheuer): Enable tests again, once they are stable.
 	PDescribeTable(
 		"with network link that drops some packets",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			if !factory.ChaosTestsEnabled() {
 				Skip("chaos mesh is disabled")
 			}
 
-			clusterSetupWithTestConfig(testConfig{
+			clusterSetupWithTestConfig(ctx, testConfig{
 				beforeVersion:          beforeVersion,
 				enableOperatorPodChaos: false,
 				enableHealthCheck:      false,
@@ -524,17 +530,17 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 			// 1. Introduce packet loss b/w pods.
 			log.Println("Injecting packet loss b/w pod")
-			primaryPods := fdbCluster.GetPrimary().GetAllPods()
-			primarySatellitePods := fdbCluster.GetPrimarySatellite().GetAllPods()
-			remoteSatellitePods := fdbCluster.GetRemoteSatellite().GetAllPods()
-			remotePods := fdbCluster.GetRemote().GetAllPods()
-			operatorPrimaryPods := factory.GetOperatorPods(fdbCluster.GetPrimary().Namespace())
-			operatorRemotePods := factory.GetOperatorPods(fdbCluster.GetRemote().Namespace())
-			operatorPrimarySatellitePods := factory.GetOperatorPods(
+			primaryPods := fdbCluster.GetPrimary().GetAllPods(ctx)
+			primarySatellitePods := fdbCluster.GetPrimarySatellite().GetAllPods(ctx)
+			remoteSatellitePods := fdbCluster.GetRemoteSatellite().GetAllPods(ctx)
+			remotePods := fdbCluster.GetRemote().GetAllPods(ctx)
+			operatorPrimaryPods := factory.GetOperatorPods(ctx, fdbCluster.GetPrimary().Namespace())
+			operatorRemotePods := factory.GetOperatorPods(ctx, fdbCluster.GetRemote().Namespace())
+			operatorPrimarySatellitePods := factory.GetOperatorPods(ctx,
 				fdbCluster.GetPrimarySatellite().Namespace(),
 			)
 
-			factory.InjectNetworkLossBetweenPods([]chaosmesh.PodSelectorSpec{
+			factory.InjectNetworkLossBetweenPods(ctx, []chaosmesh.PodSelectorSpec{
 				fixtures.PodsSelector(primaryPods.Items),
 				fixtures.PodsSelector(primarySatellitePods.Items),
 				fixtures.PodsSelector(remoteSatellitePods.Items),
@@ -544,10 +550,10 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 				fixtures.PodsSelector(operatorPrimarySatellitePods.Items),
 			}, "20")
 
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 			// Verify that the upgrade proceeds
-			fdbCluster.VerifyVersion(targetVersion)
-			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.VerifyVersion(ctx, targetVersion)
+			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -558,10 +564,10 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 	// See: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/2196
 	PDescribeTable(
 		"when no remote storage processes are restarted",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			// We disable the health check here, as the remote storage processes are not restarted and this can be
 			// disruptive to the cluster.
-			clusterSetupWithTestConfig(testConfig{
+			clusterSetupWithTestConfig(ctx, testConfig{
 				beforeVersion:          beforeVersion,
 				enableOperatorPodChaos: false,
 				enableHealthCheck:      false,
@@ -570,7 +576,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 			// Select remote storage processes and use the buggify option to skip those
 			// processes during the restart command.
-			remoteProcessGroups := fdbCluster.GetRemote().GetCluster().Status.ProcessGroups
+			remoteProcessGroups := fdbCluster.GetRemote().GetCluster(ctx).Status.ProcessGroups
 
 			ignoreDuringRestart := make(
 				[]fdbv1beta2.ProcessGroupID,
@@ -594,12 +600,12 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 				ignoreDuringRestart,
 				"to be skipped during the restart",
 			)
-			fdbCluster.GetRemote().SetIgnoreDuringRestart(ignoreDuringRestart)
+			fdbCluster.GetRemote().SetIgnoreDuringRestart(ctx, ignoreDuringRestart)
 
 			// The cluster should still be able to upgrade.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 			// Verify that the upgrade proceeds
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -607,7 +613,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"when locality based exclusions are used and the resources are limited in a satellite namespace",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			fdbVersion, err := fdbv1beta2.ParseFdbVersion(beforeVersion)
 			Expect(err).NotTo(HaveOccurred())
 			if !fdbVersion.SupportsLocalityBasedExclusions() {
@@ -630,6 +636,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			clusterConfig.UseLocalityBasedExclusions = ptr.To(true)
 
 			clusterSetupWithTestConfig(
+				ctx,
 				testConfig{
 					beforeVersion:          beforeVersion,
 					enableOperatorPodChaos: false,
@@ -640,20 +647,20 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			)
 
 			Expect(
-				fdbCluster.GetPrimarySatellite().GetCluster().UseLocalitiesForExclusion(),
+				fdbCluster.GetPrimarySatellite().GetCluster(ctx).UseLocalitiesForExclusion(),
 			).To(BeTrue())
 			processCounts, err := fdbCluster.GetPrimarySatellite().
-				GetCluster().
+				GetCluster(ctx).
 				GetProcessCountsWithDefaults()
 			Expect(err).NotTo(HaveOccurred())
 
-			currentPods := fdbCluster.GetPrimarySatellite().GetPods()
+			currentPods := fdbCluster.GetPrimarySatellite().GetPods(ctx)
 			podLimit := processCounts.Total() + 3
 			Expect(currentPods.Items).To(HaveLen(podLimit - 3))
 
 			// Create Quota to limit the additional Pods that can be created to 1, the actual value here is 3, because we run
 			// 2 Operator Pods.
-			Expect(factory.CreateIfAbsent(&corev1.ResourceQuota{
+			Expect(factory.CreateIfAbsent(ctx, &corev1.ResourceQuota{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testing-quota",
 					Namespace: fdbCluster.GetPrimarySatellite().Namespace(),
@@ -666,24 +673,24 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			})).NotTo(HaveOccurred())
 
 			// The cluster should still be able to upgrade.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 			// Wait for clusters to be updated.
 			time.Sleep(15 * time.Second)
 			// Wait here for the clusters to reconcile.
-			Expect(fdbCluster.WaitForReconciliation(
+			Expect(fdbCluster.WaitForReconciliation(ctx,
 				fixtures.SoftReconcileOption(true),
 			)).NotTo(HaveOccurred())
 			// Verify that the upgrade took place.
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 			// Make sure the cluster has no data loss
-			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
 
 	DescribeTable("when maintenance feature is enabled",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			clusterConfig := fixtures.DefaultClusterConfigWithHaMode(
 				fixtures.HaFourZoneSingleSat,
 				false,
@@ -691,6 +698,7 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			clusterConfig.UseMaintenanceMode = true
 
 			clusterSetupWithTestConfig(
+				ctx,
 				testConfig{
 					beforeVersion:          beforeVersion,
 					enableOperatorPodChaos: false,
@@ -700,27 +708,30 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 				},
 			)
 
-			Expect(fdbCluster.GetPrimary().GetCluster().UseMaintenaceMode()).To(BeTrue())
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.GetPrimary().GetCluster(ctx).UseMaintenaceMode()).To(BeTrue())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 			// Verify that the upgrade proceeds
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 			// Wait here for the primary satellite to reconcile, this means all Pods have been replaced
-			Expect(fdbCluster.GetPrimarySatellite().WaitForReconciliation()).NotTo(HaveOccurred())
+			Expect(
+				fdbCluster.GetPrimarySatellite().WaitForReconciliation(ctx),
+			).NotTo(HaveOccurred())
 			// Make sure the cluster has no data loss
-			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
 	)
 
 	DescribeTable("when tester processes are running in the primary and remote dc",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			clusterConfig := fixtures.DefaultClusterConfigWithHaMode(
 				fixtures.HaFourZoneSingleSat,
 				false,
 			)
 
 			clusterSetupWithTestConfig(
+				ctx,
 				testConfig{
 					beforeVersion:          beforeVersion,
 					enableOperatorPodChaos: false,
@@ -731,21 +742,23 @@ var _ = Describe("Operator HA Upgrades", Label("e2e", "pr"), func() {
 			)
 
 			// Start tester processes in the primary side
-			primaryTester := fdbCluster.GetPrimary().CreateTesterDeployment(4)
+			primaryTester := fdbCluster.GetPrimary().CreateTesterDeployment(ctx, 4)
 			// Start tester processes in the remote side
-			remoteTester := fdbCluster.GetRemote().CreateTesterDeployment(4)
+			remoteTester := fdbCluster.GetRemote().CreateTesterDeployment(ctx, 4)
 
 			// Start the upgrade with the tester processes present.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 			// Verify that the upgrade proceeds
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 			// Wait here for the primary satellite to reconcile, this means all Pods have been replaced
-			Expect(fdbCluster.GetPrimarySatellite().WaitForReconciliation()).NotTo(HaveOccurred())
+			Expect(
+				fdbCluster.GetPrimarySatellite().WaitForReconciliation(ctx),
+			).NotTo(HaveOccurred())
 			// Make sure the cluster has no data loss
-			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas(ctx)
 
-			factory.Delete(primaryTester)
-			factory.Delete(remoteTester)
+			factory.Delete(ctx, primaryTester)
+			factory.Delete(ctx, remoteTester)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),

--- a/e2e/test_operator_maintenance_mode/operator_maintenance_mode_test.go
+++ b/e2e/test_operator_maintenance_mode/operator_maintenance_mode_test.go
@@ -47,46 +47,46 @@ func init() {
 	testOptions = fixtures.InitFlags()
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	factory = fixtures.CreateFactory(testOptions)
-	fdbCluster = factory.CreateFdbCluster(fixtures.DefaultClusterConfig(false))
+	fdbCluster = factory.CreateFdbCluster(ctx, fixtures.DefaultClusterConfig(false))
 
 	// Make sure the unschedulable Pod is not removed
-	Expect(fdbCluster.SetAutoReplacements(false, 12*time.Hour)).NotTo(HaveOccurred())
+	Expect(fdbCluster.SetAutoReplacements(ctx, false, 12*time.Hour)).NotTo(HaveOccurred())
 
 	// Load some data into the cluster.
-	factory.CreateDataLoaderIfAbsent(fdbCluster)
+	factory.CreateDataLoaderIfAbsent(ctx, fdbCluster)
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx SpecContext) {
 	if CurrentSpecReport().Failed() {
 		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
 	}
-	factory.Shutdown()
+	factory.Shutdown(ctx)
 })
 
 var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
-	AfterEach(func() {
-		Expect(fdbCluster.ClearBuggifyNoSchedule(false)).NotTo(HaveOccurred())
+	AfterEach(func(ctx SpecContext) {
+		Expect(fdbCluster.ClearBuggifyNoSchedule(ctx, false)).NotTo(HaveOccurred())
 		if CurrentSpecReport().Failed() {
-			factory.DumpState(fdbCluster)
+			factory.DumpState(ctx, fdbCluster)
 		}
-		Expect(fdbCluster.WaitForReconciliation()).ToNot(HaveOccurred())
+		Expect(fdbCluster.WaitForReconciliation(ctx)).ToNot(HaveOccurred())
 		factory.StopInvariantCheck()
 		// Make sure all data is present in the cluster
-		fdbCluster.EnsureTeamTrackersAreHealthy()
-		fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+		fdbCluster.EnsureTeamTrackersAreHealthy(ctx)
+		fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 	})
 
 	When("the maintenance mode is set", func() {
 		var failingStoragePod corev1.Pod
 		var faultDomain fdbv1beta2.FaultDomain
 
-		BeforeEach(func() {
-			failingStoragePod = factory.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
+		BeforeEach(func(ctx SpecContext) {
+			failingStoragePod = factory.RandomPickOnePod(fdbCluster.GetStoragePods(ctx).Items)
 
 			// Set maintenance mode for this Pod
-			for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+			for _, processGroup := range fdbCluster.GetCluster(ctx).Status.ProcessGroups {
 				if processGroup.ProcessClass != fdbv1beta2.ProcessClassStorage {
 					continue
 				}
@@ -97,28 +97,28 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 			}
 
 			// Set the maintenance mode for 4 minutes.
-			fdbCluster.RunFdbCliCommandInOperator(
+			fdbCluster.RunFdbCliCommandInOperator(ctx,
 				fmt.Sprintf("maintenance on %s 240", faultDomain),
 				false,
 				60,
 			)
 
 			// Set this Pod as unschedulable to keep it pending.
-			fdbCluster.SetPodAsUnschedulable(failingStoragePod)
+			fdbCluster.SetPodAsUnschedulable(ctx, failingStoragePod)
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			// Make sure that the quota is deleted and new PVCs can be created.
-			Expect(fdbCluster.ClearBuggifyNoSchedule(true)).NotTo(HaveOccurred())
+			Expect(fdbCluster.ClearBuggifyNoSchedule(ctx, true)).NotTo(HaveOccurred())
 			// Reset the maintenance mode
-			fdbCluster.RunFdbCliCommandInOperator("maintenance off", false, 60)
+			fdbCluster.RunFdbCliCommandInOperator(ctx, "maintenance off", false, 60)
 		})
 
 		When("the Pod comes back before the maintenance mode times out", func() {
-			It("should not set the team tracker status to unhealthy", func() {
+			It("should not set the team tracker status to unhealthy", func(ctx SpecContext) {
 				// Make sure the team tracker status shows healthy for the failed Pod and the maintenance zone is set.
 				Consistently(func(g Gomega) fdbv1beta2.FaultDomain {
-					status := fdbCluster.GetStatus()
+					status := fdbCluster.GetStatus(ctx)
 
 					for _, tracker := range status.Cluster.Data.TeamTrackers {
 						log.Println(tracker.State.Name, ":", tracker.State.Healthy)
@@ -132,10 +132,10 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 		})
 
 		When("the maintenance mode times out", func() {
-			It("should update the team tracker status to unhealthy", func() {
+			It("should update the team tracker status to unhealthy", func(ctx SpecContext) {
 				// Make sure the team tracker status shows healthy for the failed Pod and the maintenance zone is set.
 				Consistently(func(g Gomega) fdbv1beta2.FaultDomain {
-					status := fdbCluster.GetStatus()
+					status := fdbCluster.GetStatus(ctx)
 
 					for _, tracker := range status.Cluster.Data.TeamTrackers {
 						g.Expect(tracker.State.Healthy).To(BeTrue())
@@ -147,14 +147,14 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 				log.Println("Wait until maintenance mode times out")
 				// Wait until the maintenance zone is reset
 				Eventually(func() fdbv1beta2.FaultDomain {
-					return fdbCluster.GetStatus().Cluster.MaintenanceZone
+					return fdbCluster.GetStatus(ctx).Cluster.MaintenanceZone
 				}).WithTimeout(10 * time.Minute).WithPolling(2 * time.Second).Should(Equal(fdbv1beta2.FaultDomain("")))
 
 				startTime := time.Now()
 				log.Println("Wait until failure is detected")
 				// We would expect that the team tracker gets unhealthy once the maintenance mode is timed out.
 				Eventually(func(g Gomega) fdbv1beta2.FaultDomain {
-					status := fdbCluster.GetStatus()
+					status := fdbCluster.GetStatus(ctx)
 					for _, tracker := range status.Cluster.Data.TeamTrackers {
 						g.Expect(tracker.State.Healthy).To(BeFalse())
 					}
@@ -167,24 +167,24 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 		})
 
 		When("there is a failure during maintenance mode", func() {
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				// Set the maintenance mode for a long duration, e.g. 2h hours to make sure the mode is not timing out
 				// but actually is being reset.
-				fdbCluster.RunFdbCliCommandInOperator(
+				fdbCluster.RunFdbCliCommandInOperator(ctx,
 					fmt.Sprintf("maintenance on %s 7200", faultDomain),
 					false,
 					60,
 				)
 			})
 
-			AfterEach(func() {
-				fdbCluster.SetCrashLoopContainers(nil, false)
+			AfterEach(func(ctx SpecContext) {
+				fdbCluster.SetCrashLoopContainers(ctx, nil, false)
 			})
 
-			It("should remove the maintenance mode", func() {
+			It("should remove the maintenance mode", func(ctx SpecContext) {
 				// Make sure the team tracker status shows healthy for the failed Pod and the maintenance zone is set.
 				Consistently(func(g Gomega) fdbv1beta2.FaultDomain {
-					status := fdbCluster.GetStatus()
+					status := fdbCluster.GetStatus(ctx)
 
 					for _, tracker := range status.Cluster.Data.TeamTrackers {
 						g.Expect(tracker.State.Healthy).To(BeTrue())
@@ -196,7 +196,7 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 				log.Println("When another storage Pod is failing")
 				var podToRecreate corev1.Pod
 
-				for _, pod := range fdbCluster.GetStoragePods().Items {
+				for _, pod := range fdbCluster.GetStoragePods(ctx).Items {
 					if pod.Name == failingStoragePod.Name {
 						continue
 					}
@@ -207,7 +207,7 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 
 				// We delete a Pod and make it crash-looping, to make sure the process is failed for more than 60 seconds.
 				log.Println("Delete Pod", podToRecreate.Name)
-				fdbCluster.SetCrashLoopContainers([]fdbv1beta2.CrashLoopContainerObject{
+				fdbCluster.SetCrashLoopContainers(ctx, []fdbv1beta2.CrashLoopContainerObject{
 					{
 						ContainerName: fdbv1beta2.MainContainerName,
 						Targets: []fdbv1beta2.ProcessGroupID{
@@ -215,13 +215,13 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 						},
 					},
 				}, false)
-				factory.DeletePod(&podToRecreate)
+				factory.DeletePod(ctx, &podToRecreate)
 
 				log.Println("Wait until maintenance mode is reset")
 				startTime := time.Now()
 				// We would expect that the team tracker gets unhealthy once the maintenance mode is timed out.
 				Eventually(func(g Gomega) fdbv1beta2.FaultDomain {
-					status := fdbCluster.GetStatus()
+					status := fdbCluster.GetStatus(ctx)
 					for _, tracker := range status.Cluster.Data.TeamTrackers {
 						g.Expect(tracker.State.Healthy).To(BeFalse())
 					}
@@ -234,19 +234,19 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 		})
 
 		When("there is additional load on the cluster", func() {
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				// Set the maintenance mode for a long duration, e.g. 2h hours to make sure the mode is not timing out
 				// but actually is being reset.
-				fdbCluster.RunFdbCliCommandInOperator(
+				fdbCluster.RunFdbCliCommandInOperator(ctx,
 					fmt.Sprintf("maintenance on %s 7200", faultDomain),
 					false,
 					60,
 				)
 			})
 
-			AfterEach(func() {
+			AfterEach(func(ctx SpecContext) {
 				Consistently(func(g Gomega) fdbv1beta2.FaultDomain {
-					status := fdbCluster.GetStatus()
+					status := fdbCluster.GetStatus(ctx)
 
 					for _, tracker := range status.Cluster.Data.TeamTrackers {
 						g.Expect(tracker.State.Healthy).To(BeTrue())
@@ -256,10 +256,10 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 				}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Equal(faultDomain))
 			})
 
-			It("should not remove the maintenance mode", func() {
+			It("should not remove the maintenance mode", func(ctx SpecContext) {
 				// Make sure the team tracker status shows healthy for the failed Pod and the maintenance zone is set.
 				Consistently(func(g Gomega) fdbv1beta2.FaultDomain {
-					status := fdbCluster.GetStatus()
+					status := fdbCluster.GetStatus(ctx)
 
 					for _, tracker := range status.Cluster.Data.TeamTrackers {
 						g.Expect(tracker.State.Healthy).To(BeTrue())
@@ -269,40 +269,40 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 				}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Equal(faultDomain))
 
 				log.Println("When loading additional data into the cluster")
-				factory.CreateDataLoaderIfAbsent(fdbCluster)
-				factory.CreateDataLoaderIfAbsent(fdbCluster)
+				factory.CreateDataLoaderIfAbsent(ctx, fdbCluster)
+				factory.CreateDataLoaderIfAbsent(ctx, fdbCluster)
 			})
 		})
 
 		When("the number of storage Pods is changed", func() {
 			var initialStoragePods int
 
-			BeforeEach(func() {
-				counts, err := fdbCluster.GetCluster().GetProcessCountsWithDefaults()
+			BeforeEach(func(ctx SpecContext) {
+				counts, err := fdbCluster.GetCluster(ctx).GetProcessCountsWithDefaults()
 				Expect(err).NotTo(HaveOccurred())
 
 				initialStoragePods = counts.Storage
 				// Set the maintenance mode for a long duration, e.g. 2h hours to make sure the mode is not timing out
 				// but actually is being reset.
-				fdbCluster.RunFdbCliCommandInOperator(
+				fdbCluster.RunFdbCliCommandInOperator(ctx,
 					fmt.Sprintf("maintenance on %s 7200", faultDomain),
 					false,
 					60,
 				)
 			})
 
-			AfterEach(func() {
-				Expect(fdbCluster.ClearBuggifyNoSchedule(false)).NotTo(HaveOccurred())
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			AfterEach(func(ctx SpecContext) {
+				Expect(fdbCluster.ClearBuggifyNoSchedule(ctx, false)).NotTo(HaveOccurred())
+				spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 				// Add 3 additional storage Pods.
 				spec.ProcessCounts.Storage = initialStoragePods
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 			})
 
-			It("should not remove the maintenance mode", func() {
+			It("should not remove the maintenance mode", func(ctx SpecContext) {
 				// Make sure the team tracker status shows healthy for the failed Pod and the maintenance zone is set.
 				Consistently(func(g Gomega) fdbv1beta2.FaultDomain {
-					status := fdbCluster.GetStatus()
+					status := fdbCluster.GetStatus(ctx)
 
 					for _, tracker := range status.Cluster.Data.TeamTrackers {
 						g.Expect(tracker.State.Healthy).To(BeTrue())
@@ -312,14 +312,14 @@ var _ = Describe("Operator maintenance mode tests", Label("e2e"), func() {
 				}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Equal(faultDomain))
 
 				log.Println("When adding additional storage processes to the cluster")
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 				// Add 3 additional storage Pods.
 				spec.ProcessCounts.Storage = initialStoragePods + 3
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 
 				// Make sure the maintenance mode is kept and the team tracker shows healthy.
 				Consistently(func(g Gomega) fdbv1beta2.FaultDomain {
-					status := fdbCluster.GetStatus()
+					status := fdbCluster.GetStatus(ctx)
 
 					for _, tracker := range status.Cluster.Data.TeamTrackers {
 						g.Expect(tracker.State.Healthy).To(BeTrue())

--- a/e2e/test_operator_migrate_image_type/operator_migate_image_type_test.go
+++ b/e2e/test_operator_migrate_image_type/operator_migate_image_type_test.go
@@ -50,48 +50,48 @@ var _ = BeforeSuite(func() {
 	factory = fixtures.CreateFactory(testOptions)
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx SpecContext) {
 	if CurrentSpecReport().Failed() {
 		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
 	}
-	factory.Shutdown()
+	factory.Shutdown(ctx)
 })
 
 var _ = PDescribe("Operator Migrate Image Type", Label("e2e"), func() {
 	When("migrating from split to unified", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			config := fixtures.DefaultClusterConfig(false)
 			config.UseUnifiedImage = ptr.To(false)
-			fdbCluster = factory.CreateFdbCluster(
+			fdbCluster = factory.CreateFdbCluster(ctx,
 				config,
 			)
 
 			// Load some data async into the cluster. We will only block as long as the Job is created.
-			factory.CreateDataLoaderIfAbsent(fdbCluster)
+			factory.CreateDataLoaderIfAbsent(ctx, fdbCluster)
 
 			// Update the cluster spec to run with the unified image.
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			imageType := fdbv1beta2.ImageTypeUnified
 			spec.ImageType = &imageType
 			// Generate the new config to make use of the unified images.
 			overrides := factory.GetMainContainerOverrides(config)
 			overrides.EnableTLS = spec.MainContainer.EnableTLS
 			spec.MainContainer = overrides
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+			Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.Destroy()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.Destroy(ctx)).NotTo(HaveOccurred())
 		})
 
-		It("should convert the cluster", func() {
+		It("should convert the cluster", func(ctx SpecContext) {
 			// Make sure we didn't lose data.
-			fdbCluster.EnsureTeamTrackersAreHealthy()
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersAreHealthy(ctx)
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 
 			unifiedImage := factory.GetUnifiedFoundationDBImage()
-			pods := fdbCluster.GetPods()
+			pods := fdbCluster.GetPods(ctx)
 			for _, pod := range pods.Items {
 				// Ignore Pods that are pending the deletion.
 				if !pod.DeletionTimestamp.IsZero() {
@@ -107,45 +107,45 @@ var _ = PDescribe("Operator Migrate Image Type", Label("e2e"), func() {
 	})
 
 	When("migrating from split to unified with Pod IP family set", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			config := fixtures.DefaultClusterConfig(false)
 			config.UseUnifiedImage = ptr.To(false)
-			fdbCluster = factory.CreateFdbCluster(
+			fdbCluster = factory.CreateFdbCluster(ctx,
 				config,
 			)
 
 			// Set the Pod IP Family
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.Routing.PodIPFamily = ptr.To(4)
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+			Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 
 			// Load some data async into the cluster. We will only block as long as the Job is created.
-			factory.CreateDataLoaderIfAbsent(fdbCluster)
+			factory.CreateDataLoaderIfAbsent(ctx, fdbCluster)
 
 			// Update the cluster spec to run with the unified image.
-			spec = fdbCluster.GetCluster().Spec.DeepCopy()
+			spec = fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			imageType := fdbv1beta2.ImageTypeUnified
 			spec.ImageType = &imageType
 			// Generate the new config to make use of the unified images.
 			overrides := factory.GetMainContainerOverrides(config)
 			overrides.EnableTLS = spec.MainContainer.EnableTLS
 			spec.MainContainer = overrides
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+			Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.Destroy()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.Destroy(ctx)).NotTo(HaveOccurred())
 		})
 
-		It("should convert the cluster", func() {
+		It("should convert the cluster", func(ctx SpecContext) {
 			// Make sure we didn't lose data.
-			fdbCluster.EnsureTeamTrackersAreHealthy()
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersAreHealthy(ctx)
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 
 			unifiedImage := factory.GetUnifiedFoundationDBImage()
-			pods := fdbCluster.GetPods()
+			pods := fdbCluster.GetPods(ctx)
 			for _, pod := range pods.Items {
 				// Ignore Pods that are pending the deletion.
 				if !pod.DeletionTimestamp.IsZero() {
@@ -161,40 +161,40 @@ var _ = PDescribe("Operator Migrate Image Type", Label("e2e"), func() {
 	})
 
 	When("migrating from unified to split", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			config := fixtures.DefaultClusterConfig(false)
 			config.UseUnifiedImage = ptr.To(true)
-			fdbCluster = factory.CreateFdbCluster(
+			fdbCluster = factory.CreateFdbCluster(ctx,
 				config,
 			)
 
 			// Load some data async into the cluster. We will only block as long as the Job is created.
-			factory.CreateDataLoaderIfAbsent(fdbCluster)
+			factory.CreateDataLoaderIfAbsent(ctx, fdbCluster)
 
 			// Update the cluster spec to run with the split image.
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			imageType := fdbv1beta2.ImageTypeSplit
 			spec.ImageType = &imageType
 			// Generate the new config to make use of the split images.
 			overrides := factory.GetMainContainerOverrides(config)
 			overrides.EnableTLS = spec.MainContainer.EnableTLS
 			spec.MainContainer = overrides
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+			Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.Destroy()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.Destroy(ctx)).NotTo(HaveOccurred())
 		})
 
-		It("should convert the cluster", func() {
+		It("should convert the cluster", func(ctx SpecContext) {
 			// Make sure we didn't lose data.
-			fdbCluster.EnsureTeamTrackersAreHealthy()
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersAreHealthy(ctx)
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 
 			fdbImage := factory.GetFoundationDBImage()
 			sidecarImage := factory.GetSidecarImage()
-			pods := fdbCluster.GetPods()
+			pods := fdbCluster.GetPods(ctx)
 			for _, pod := range pods.Items {
 				// Ignore Pods that are pending the deletion.
 				if !pod.DeletionTimestamp.IsZero() {

--- a/e2e/test_operator_migrations/operator_migration_test.go
+++ b/e2e/test_operator_migrations/operator_migration_test.go
@@ -26,6 +26,7 @@ expected under different scenarios.
 */
 
 import (
+	"context"
 	"log"
 	"strconv"
 	"time"
@@ -47,10 +48,14 @@ var (
 	testOptions *fixtures.FactoryOptions
 )
 
-func validateStorageClass(processClass fdbv1beta2.ProcessClass, targetStorageClass string) {
+func validateStorageClass(
+	ctx context.Context,
+	processClass fdbv1beta2.ProcessClass,
+	targetStorageClass string,
+) {
 	Eventually(func() map[string]fdbv1beta2.None {
 		storageClassNames := make(map[string]fdbv1beta2.None)
-		volumeClaims := fdbCluster.GetVolumeClaimsForProcesses(processClass)
+		volumeClaims := fdbCluster.GetVolumeClaimsForProcesses(ctx, processClass)
 		for _, volumeClaim := range volumeClaims.Items {
 			storageClassNames[*volumeClaim.Spec.StorageClassName] = fdbv1beta2.None{}
 		}
@@ -77,35 +82,35 @@ func init() {
 	testOptions = fixtures.InitFlags()
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	factory = fixtures.CreateFactory(testOptions)
-	fdbCluster = factory.CreateFdbCluster(
+	fdbCluster = factory.CreateFdbCluster(ctx,
 		fixtures.DefaultClusterConfig(false),
 	)
 	// Load some data into the cluster.
-	factory.CreateDataLoaderIfAbsent(fdbCluster)
+	factory.CreateDataLoaderIfAbsent(ctx, fdbCluster)
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx SpecContext) {
 	if CurrentSpecReport().Failed() {
 		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
 	}
-	factory.Shutdown()
+	factory.Shutdown(ctx)
 })
 
 var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		if CurrentSpecReport().Failed() {
-			factory.DumpState(fdbCluster)
+			factory.DumpState(ctx, fdbCluster)
 		}
-		Expect(fdbCluster.WaitForReconciliation()).ToNot(HaveOccurred())
+		Expect(fdbCluster.WaitForReconciliation(ctx)).ToNot(HaveOccurred())
 	})
 
 	When("a migration is triggered and the namespace quota is limited", func() {
 		var quota *corev1.ResourceQuota
 
-		BeforeEach(func() {
-			processCounts, err := fdbCluster.GetCluster().GetProcessCountsWithDefaults()
+		BeforeEach(func(ctx SpecContext) {
+			processCounts, err := fdbCluster.GetCluster(ctx).GetProcessCountsWithDefaults()
 			Expect(err).NotTo(HaveOccurred())
 			// Create Quota to limit the additional Pods that can be created to 5, the actual value here is 7, because we run
 			// 2 Operator Pods.
@@ -120,7 +125,7 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 					},
 				},
 			}
-			Expect(factory.CreateIfAbsent(quota)).NotTo(HaveOccurred())
+			Expect(factory.CreateIfAbsent(ctx, quota)).NotTo(HaveOccurred())
 
 			logSettings := fdbCluster.GetProcessSettings(fdbv1beta2.ProcessClassLog).DeepCopy()
 			for idx, container := range logSettings.PodTemplate.Spec.Containers {
@@ -136,30 +141,30 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 				logSettings.PodTemplate.Spec.Containers[idx] = container
 			}
 
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.Processes[fdbv1beta2.ProcessClassLog] = *logSettings
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 
-			Expect(fdbCluster.WaitForReconciliation()).To(Succeed())
+			Expect(fdbCluster.WaitForReconciliation(ctx)).To(Succeed())
 		})
 
-		AfterEach(func() {
-			factory.Delete(quota)
+		AfterEach(func(ctx SpecContext) {
+			factory.Delete(ctx, quota)
 		})
 
-		It("should add the new env variable to all log pods", func() {
+		It("should add the new env variable to all log pods", func(ctx SpecContext) {
 			lastForcedReconciliationTime := time.Now()
 			forceReconcileDuration := 4 * time.Minute
 
 			Eventually(func(g Gomega) {
 				// Force a reconcile if needed to make sure we speed up the reconciliation if needed.
 				if time.Since(lastForcedReconciliationTime) >= forceReconcileDuration {
-					fdbCluster.ForceReconcile()
+					fdbCluster.ForceReconcile(ctx)
 					lastForcedReconciliationTime = time.Now()
 				}
 
 				// Check if all log pods are migrated
-				for _, pod := range fdbCluster.GetLogPods().Items {
+				for _, pod := range fdbCluster.GetLogPods(ctx).Items {
 					for _, container := range pod.Spec.Containers {
 						if container.Name != fdbv1beta2.MainContainerName {
 							continue
@@ -176,21 +181,21 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 	})
 
 	When("changing the public IP source", func() {
-		BeforeEach(func() {
-			if fdbCluster.GetCluster().UseDNSInClusterFile() {
+		BeforeEach(func(ctx SpecContext) {
+			if fdbCluster.GetCluster(ctx).UseDNSInClusterFile() {
 				Skip("using DNS and public IP from service is not tested")
 			}
 
 			log.Printf("set public IP source to %s", fdbv1beta2.PublicIPSourceService)
 			Expect(
-				fdbCluster.SetPublicIPSource(fdbv1beta2.PublicIPSourceService),
+				fdbCluster.SetPublicIPSource(ctx, fdbv1beta2.PublicIPSourceService),
 			).ShouldNot(HaveOccurred())
 		})
 
-		It("should change the public IP source and create/delete services", func() {
+		It("should change the public IP source and create/delete services", func(ctx SpecContext) {
 			Eventually(func() bool {
-				pods := fdbCluster.GetPods()
-				svcList := fdbCluster.GetServices()
+				pods := fdbCluster.GetPods(ctx)
+				svcList := fdbCluster.GetServices(ctx)
 
 				svcMap := make(map[string]struct{}, len(svcList.Items))
 				for _, svc := range svcList.Items {
@@ -219,12 +224,12 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 			}).Should(BeTrue())
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			log.Printf("set public IP source to %s", fdbv1beta2.PublicIPSourcePod)
 			Expect(
-				fdbCluster.SetPublicIPSource(fdbv1beta2.PublicIPSourcePod),
+				fdbCluster.SetPublicIPSource(ctx, fdbv1beta2.PublicIPSourcePod),
 			).ShouldNot(HaveOccurred())
-			svcList := fdbCluster.GetServices()
+			svcList := fdbCluster.GetServices(ctx)
 
 			var expectedSvcCnt int
 			if fdbCluster.HasHeadlessService() {
@@ -238,10 +243,10 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 		var initialLogPods []string
 		var newSize resource.Quantity
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			var err error
 
-			pods := fdbCluster.GetLogPods()
+			pods := fdbCluster.GetLogPods(ctx)
 			for _, pod := range pods.Items {
 				initialLogPods = append(initialLogPods, pod.Name)
 			}
@@ -252,12 +257,12 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 			newSize = initialStorageSize.DeepCopy()
 			newSize.Add(resource.MustParse("10G"))
 			Expect(
-				fdbCluster.SetVolumeSize(fdbv1beta2.ProcessClassLog, newSize),
+				fdbCluster.SetVolumeSize(ctx, fdbv1beta2.ProcessClassLog, newSize),
 			).NotTo(HaveOccurred())
 		})
 
-		It("should replace all the log Pods and use the new volume size", func() {
-			pods := fdbCluster.GetLogPods()
+		It("should replace all the log Pods and use the new volume size", func(ctx SpecContext) {
+			pods := fdbCluster.GetLogPods(ctx)
 			newLogPods := make([]string, 0, len(pods.Items))
 			for _, pod := range pods.Items {
 				// Ignore pods that are marked for deletion.
@@ -270,6 +275,7 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 
 			Expect(newLogPods).NotTo(ContainElements(initialLogPods))
 			volumeClaims := fdbCluster.GetVolumeClaimsForProcesses(
+				ctx,
 				fdbv1beta2.ProcessClassLog,
 			)
 
@@ -286,33 +292,33 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 		var initialPods []string
 		var podIPFamily = fdbv1beta2.PodIPFamilyIPv4
 
-		BeforeEach(func() {
-			pods := fdbCluster.GetPods()
+		BeforeEach(func(ctx SpecContext) {
+			pods := fdbCluster.GetPods(ctx)
 			for _, pod := range pods.Items {
 				initialPods = append(initialPods, pod.Name)
 			}
 
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.Routing.PodIPFamily = ptr.To(podIPFamily)
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
-			Expect(fdbCluster.WaitForReconciliation()).To(Succeed())
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+			Expect(fdbCluster.WaitForReconciliation(ctx)).To(Succeed())
 		})
 
-		AfterEach(func() {
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+		AfterEach(func(ctx SpecContext) {
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.Routing.PodIPFamily = nil
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 			Expect(
-				fdbCluster.WaitForReconciliation(fixtures.SoftReconcileOption(true)),
+				fdbCluster.WaitForReconciliation(ctx, fixtures.SoftReconcileOption(true)),
 			).To(Succeed())
 		})
 
-		It("should replace all pods and configure them properly", func() {
-			pods := fdbCluster.GetPods()
+		It("should replace all pods and configure them properly", func(ctx SpecContext) {
+			pods := fdbCluster.GetPods(ctx)
 			podIPFamilyString := strconv.Itoa(podIPFamily)
 			var expectedContainerWithEnv string
 			// In the case of the split image the sidecar will have that env variable.
-			if fdbCluster.GetCluster().UseUnifiedImage() {
+			if fdbCluster.GetCluster(ctx).UseUnifiedImage() {
 				expectedContainerWithEnv = fdbv1beta2.MainContainerName
 			} else {
 				expectedContainerWithEnv = fdbv1beta2.SidecarContainerName
@@ -371,102 +377,108 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 		var initialPodUpdateStrategy fdbv1beta2.PodUpdateStrategy
 		var initialReplaceInstancesWhenResourcesChange *bool
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// Remember the current settings before updating the spec
-			initialConcurrentReplacements = fdbCluster.GetCluster().Spec.AutomationOptions.MaxConcurrentReplacements
-			initialPodUpdateStrategy = fdbCluster.GetClusterSpec().AutomationOptions.PodUpdateStrategy
-			initialReplaceInstancesWhenResourcesChange = fdbCluster.GetCluster().Spec.ReplaceInstancesWhenResourcesChange
+			initialConcurrentReplacements = fdbCluster.GetCluster(
+				ctx,
+			).Spec.AutomationOptions.MaxConcurrentReplacements
+			initialPodUpdateStrategy = fdbCluster.GetClusterSpec(
+				ctx,
+			).AutomationOptions.PodUpdateStrategy
+			initialReplaceInstancesWhenResourcesChange = fdbCluster.GetCluster(
+				ctx,
+			).Spec.ReplaceInstancesWhenResourcesChange
 			// Allow to replacement of 3 pods concurrently, as there are 5 storage servers, there need to be at least 2 rounds of replacements to replace all.
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.AutomationOptions.MaxConcurrentReplacements = ptr.To(3)
 			spec.AutomationOptions.PodUpdateStrategy = fdbv1beta2.PodUpdateStrategyDelete
 			spec.ReplaceInstancesWhenResourcesChange = ptr.To(true)
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			// Reset to the initial settings
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.AutomationOptions.MaxConcurrentReplacements = initialConcurrentReplacements
 			spec.AutomationOptions.PodUpdateStrategy = initialPodUpdateStrategy
 			spec.ReplaceInstancesWhenResourcesChange = initialReplaceInstancesWhenResourcesChange
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 		})
 
 		When("a change that requires a replacement of all storage pods", func() {
 			var initialVolumeClaims []types.UID
 			var newCPURequest, initialCPURequest resource.Quantity
 
-			BeforeEach(func() {
-				initialVolumeClaims = fdbCluster.GetListOfUIDsFromVolumeClaims(
+			BeforeEach(func(ctx SpecContext) {
+				initialVolumeClaims = fdbCluster.GetListOfUIDsFromVolumeClaims(ctx,
 					fdbv1beta2.ProcessClassStorage,
 				)
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 				initialCPURequest = spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
 				newCPURequest = initialCPURequest.DeepCopy()
 
 				// An increase in request requires a replacement when ReplaceInstancesWhenResourcesChange is set to true
 				newCPURequest.Add(resource.MustParse("1m"))
 				spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = newCPURequest
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 
 				// Wait for the reconciliation to finish
-				Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+				Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 			})
 
-			AfterEach(func() {
+			AfterEach(func(ctx SpecContext) {
 				// Undo the change to cpu requests
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+				spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 				spec.Processes[fdbv1beta2.ProcessClassStorage].PodTemplate.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = initialCPURequest
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 
 				// Wait for the reconciliation to finish
-				Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+				Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 			})
 
-			It("should replace all storage pods", func() {
+			It("should replace all storage pods", func(ctx SpecContext) {
 				// A replacement of a storage pod will create a new PVC. After reconciliation the set of PVCs should be completely changed.
 				Expect(
 					initialVolumeClaims,
-				).NotTo(ContainElements(fdbCluster.GetListOfUIDsFromVolumeClaims(fdbv1beta2.ProcessClassStorage)), "PVC should not be present in the new set of PVCs")
+				).NotTo(ContainElements(fdbCluster.GetListOfUIDsFromVolumeClaims(ctx, fdbv1beta2.ProcessClassStorage)), "PVC should not be present in the new set of PVCs")
 			})
 		})
 	})
 
 	When("migrating a cluster to make use of DNS in the cluster file", func() {
-		BeforeEach(func() {
-			if fdbCluster.GetCluster().UseDNSInClusterFile() {
+		BeforeEach(func(ctx SpecContext) {
+			if fdbCluster.GetCluster(ctx).UseDNSInClusterFile() {
 				Skip("cluster already uses DNS")
 			}
 
-			Expect(fdbCluster.SetUseDNSInClusterFile(true)).ToNot(HaveOccurred())
+			Expect(fdbCluster.SetUseDNSInClusterFile(ctx, true)).ToNot(HaveOccurred())
 		})
 
-		It("should migrate the cluster", func() {
-			cluster := fdbCluster.GetCluster()
+		It("should migrate the cluster", func(ctx SpecContext) {
+			cluster := fdbCluster.GetCluster(ctx)
 			Eventually(func() string {
-				return fdbCluster.GetStatus().Cluster.ConnectionString
+				return fdbCluster.GetStatus(ctx).Cluster.ConnectionString
 			}).Should(ContainSubstring(cluster.GetDNSDomain()))
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.SetUseDNSInClusterFile(false)).ToNot(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.SetUseDNSInClusterFile(ctx, false)).ToNot(HaveOccurred())
 		})
 	})
 
 	When("Migrating a cluster to a different storage class", func() {
 		var defaultStorageClass, targetStorageClass string
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// This will only return StorageClasses that have a label foundationdb.org/operator-testing=true defined.
-			storageClasses := factory.GetStorageClasses(map[string]string{
+			storageClasses := factory.GetStorageClasses(ctx, map[string]string{
 				"foundationdb.org/operator-testing": "true",
 			})
 			if len(storageClasses.Items) < 2 {
 				Skip("This test requires at least two available StorageClasses")
 			}
 
-			defaultStorageClass = factory.GetDefaultStorageClass()
+			defaultStorageClass = factory.GetDefaultStorageClass(ctx)
 			// Select all StorageClasses that are not the default one as candidate.
 			candidates := make([]string, 0, len(storageClasses.Items))
 			for _, storageClass := range storageClasses.Items {
@@ -479,19 +491,19 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 
 			targetStorageClass = candidates[factory.Intn(len(candidates))]
 
-			Expect(fdbCluster.UpdateStorageClass(
+			Expect(fdbCluster.UpdateStorageClass(ctx,
 				targetStorageClass,
 				fdbv1beta2.ProcessClassLog,
 			)).NotTo(HaveOccurred())
 		})
 
-		It("should migrate the cluster", func() {
-			validateStorageClass(fdbv1beta2.ProcessClassLog, targetStorageClass)
+		It("should migrate the cluster", func(ctx SpecContext) {
+			validateStorageClass(ctx, fdbv1beta2.ProcessClassLog, targetStorageClass)
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			if defaultStorageClass != "" {
-				Expect(fdbCluster.UpdateStorageClass(
+				Expect(fdbCluster.UpdateStorageClass(ctx,
 					defaultStorageClass,
 					fdbv1beta2.ProcessClassLog,
 				)).NotTo(HaveOccurred())
@@ -502,64 +514,70 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 	When("Changing the TLS setting", func() {
 		var initialTLSSetting bool
 
-		BeforeEach(func() {
-			initialTLSSetting = fdbCluster.GetCluster().Spec.MainContainer.EnableTLS
+		BeforeEach(func(ctx SpecContext) {
+			initialTLSSetting = fdbCluster.GetCluster(ctx).Spec.MainContainer.EnableTLS
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			Expect(
-				fdbCluster.SetTLS(
+				fdbCluster.SetTLS(ctx,
 					initialTLSSetting,
-					fdbCluster.GetCluster().Spec.SidecarContainer.EnableTLS,
+					fdbCluster.GetCluster(ctx).Spec.SidecarContainer.EnableTLS,
 				),
 			).NotTo(HaveOccurred())
-			Expect(fdbCluster.HasTLSEnabled()).To(Equal(initialTLSSetting))
-			checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), initialTLSSetting)
+			Expect(fdbCluster.HasTLSEnabled(ctx)).To(Equal(initialTLSSetting))
+			checkCoordinatorsTLSFlag(fdbCluster.GetCluster(ctx), initialTLSSetting)
 		})
 
 		When("the pod spec stays the same", func() {
-			It("should update the TLS setting  and keep the cluster available", func() {
-				// Only change the TLS setting for the cluster and not for the sidecar otherwise we have to recreate
-				// all Pods which takes a long time since we recreate the Pods one by one.
-				Expect(
-					fdbCluster.SetTLS(
-						!initialTLSSetting,
-						fdbCluster.GetCluster().Spec.SidecarContainer.EnableTLS,
-					),
-				).NotTo(HaveOccurred())
-				Expect(fdbCluster.HasTLSEnabled()).To(Equal(!initialTLSSetting))
-				checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), !initialTLSSetting)
-			})
+			It(
+				"should update the TLS setting  and keep the cluster available",
+				func(ctx SpecContext) {
+					// Only change the TLS setting for the cluster and not for the sidecar otherwise we have to recreate
+					// all Pods which takes a long time since we recreate the Pods one by one.
+					Expect(
+						fdbCluster.SetTLS(ctx,
+							!initialTLSSetting,
+							fdbCluster.GetCluster(ctx).Spec.SidecarContainer.EnableTLS,
+						),
+					).NotTo(HaveOccurred())
+					Expect(fdbCluster.HasTLSEnabled(ctx)).To(Equal(!initialTLSSetting))
+					checkCoordinatorsTLSFlag(fdbCluster.GetCluster(ctx), !initialTLSSetting)
+				},
+			)
 		})
 
 		When("the pod spec is changed", func() {
-			It("should update the TLS setting  and keep the cluster available", func() {
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
-				spec.MainContainer.EnableTLS = !initialTLSSetting
+			It(
+				"should update the TLS setting  and keep the cluster available",
+				func(ctx SpecContext) {
+					spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
+					spec.MainContainer.EnableTLS = !initialTLSSetting
 
-				// Add a new env variable to ensure this will cause some additional replacements.
-				processSettings := fdbCluster.GetProcessSettings(fdbv1beta2.ProcessClassLog)
-				for i, container := range processSettings.PodTemplate.Spec.Containers {
-					if container.Name != fdbv1beta2.MainContainerName {
-						continue
+					// Add a new env variable to ensure this will cause some additional replacements.
+					processSettings := fdbCluster.GetProcessSettings(fdbv1beta2.ProcessClassLog)
+					for i, container := range processSettings.PodTemplate.Spec.Containers {
+						if container.Name != fdbv1beta2.MainContainerName {
+							continue
+						}
+
+						container.Env = append(container.Env, corev1.EnvVar{
+							Name:  "TESTING_TLS_CHANGE",
+							Value: "EMPTY",
+						})
+
+						processSettings.PodTemplate.Spec.Containers[i] = container
+						break
 					}
 
-					container.Env = append(container.Env, corev1.EnvVar{
-						Name:  "TESTING_TLS_CHANGE",
-						Value: "EMPTY",
-					})
+					spec.Processes[fdbv1beta2.ProcessClassLog] = *processSettings
 
-					processSettings.PodTemplate.Spec.Containers[i] = container
-					break
-				}
-
-				spec.Processes[fdbv1beta2.ProcessClassLog] = *processSettings
-
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
-				Expect(fdbCluster.WaitForReconciliation()).To(Succeed())
-				Expect(fdbCluster.HasTLSEnabled()).To(Equal(!initialTLSSetting))
-				checkCoordinatorsTLSFlag(fdbCluster.GetCluster(), !initialTLSSetting)
-			})
+					fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+					Expect(fdbCluster.WaitForReconciliation(ctx)).To(Succeed())
+					Expect(fdbCluster.HasTLSEnabled(ctx)).To(Equal(!initialTLSSetting))
+					checkCoordinatorsTLSFlag(fdbCluster.GetCluster(ctx), !initialTLSSetting)
+				},
+			)
 		})
 	})
 
@@ -567,10 +585,10 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 	PWhen("migrating the storage engine", func() {
 		var newStorageEngine fdbv1beta2.StorageEngine
 
-		BeforeEach(func() {
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+		BeforeEach(func(ctx SpecContext) {
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			initialEngine := spec.DatabaseConfiguration.NormalizeConfiguration(
-				fdbCluster.GetCluster(),
+				fdbCluster.GetCluster(ctx),
 			).StorageEngine
 			log.Println("initialEngine", initialEngine)
 			if initialEngine == fdbv1beta2.StorageEngineSSD2 {
@@ -584,23 +602,23 @@ var _ = Describe("Operator Migrations", Label("e2e", "pr"), func() {
 			spec.DatabaseConfiguration.StorageMigrationType = &migrationType
 			spec.DatabaseConfiguration.PerpetualStorageWiggle = ptr.To(1)
 			spec.DatabaseConfiguration.StorageEngine = newStorageEngine
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 		})
 
-		It("should add the prefix to all instances", func() {
+		It("should add the prefix to all instances", func(ctx SpecContext) {
 			lastForcedReconciliationTime := time.Now()
 			forceReconcileDuration := 4 * time.Minute
 
 			Eventually(func() fdbv1beta2.StorageEngine {
 				// Force a reconcile if needed to make sure we speed up the reconciliation if needed.
 				if time.Since(lastForcedReconciliationTime) >= forceReconcileDuration {
-					fdbCluster.ForceReconcile()
+					fdbCluster.ForceReconcile(ctx)
 					lastForcedReconciliationTime = time.Now()
 				}
 
-				return fdbCluster.GetStatus().Cluster.DatabaseConfiguration.StorageEngine
+				return fdbCluster.GetStatus(ctx).Cluster.DatabaseConfiguration.StorageEngine
 			}).WithTimeout(40 * time.Minute).WithPolling(5 * time.Second).Should(Equal(newStorageEngine))
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/e2e/test_operator_plugin/operator_plugin_test.go
+++ b/e2e/test_operator_plugin/operator_plugin_test.go
@@ -25,7 +25,6 @@ This test suite includes functional tests for the kubectl-fdb plugin.
 */
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -52,31 +51,31 @@ func init() {
 	testOptions = fixtures.InitFlags()
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	factory = fixtures.CreateFactory(testOptions)
 	clusterConfig = fixtures.DefaultClusterConfigWithHaMode(fixtures.HaFourZoneSingleSat, false)
-	fdbCluster = factory.CreateFdbHaCluster(clusterConfig)
+	fdbCluster = factory.CreateFdbHaCluster(ctx, clusterConfig)
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx SpecContext) {
 	if CurrentSpecReport().Failed() {
 		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
 	}
-	factory.Shutdown()
+	factory.Shutdown(ctx)
 })
 
 var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 	When("getting the plugin version from the operator pod", func() {
-		It("should print the version", func() {
+		It("should print the version", func(ctx SpecContext) {
 			// Pick one operator pod and execute the kubectl version command to ensure that kubectl-fdb is present
 			// and can be executed.
 			operatorPod := factory.RandomPickOnePod(
-				factory.GetOperatorPods(fdbCluster.GetPrimary().Namespace()).Items,
+				factory.GetOperatorPods(ctx, fdbCluster.GetPrimary().Namespace()).Items,
 			)
 			log.Println("operatorPod:", operatorPod.Name)
 			Eventually(func(g Gomega) string {
 				stdout, stderr, err := factory.ExecuteCmdOnPod(
-					context.Background(),
+					ctx,
 					&operatorPod,
 					"manager",
 					fmt.Sprintf(
@@ -94,51 +93,51 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 	When("all Pods in the primary and satellites are down", func() {
 		var useDNS bool
 
-		JustBeforeEach(func() {
+		JustBeforeEach(func(ctx SpecContext) {
 			var errGroup errgroup.Group
 			// Enable DNS names in the cluster file for the whole cluster.
 			for _, cluster := range fdbCluster.GetAllClusters() {
 				target := cluster
 				errGroup.Go(func() error {
-					return target.SetUseDNSInClusterFile(useDNS)
+					return target.SetUseDNSInClusterFile(ctx, useDNS)
 				})
 			}
 			Expect(errGroup.Wait()).NotTo(HaveOccurred())
 
 			for _, cluster := range fdbCluster.GetAllClusters() {
-				Expect(cluster.GetCluster().UseDNSInClusterFile()).To(Equal(useDNS))
+				Expect(cluster.GetCluster(ctx).UseDNSInClusterFile()).To(Equal(useDNS))
 			}
 
 			// This tests is a destructive test where the cluster will stop working for some period.
 			primary := fdbCluster.GetPrimary()
-			primary.SetSkipReconciliation(true)
+			primary.SetSkipReconciliation(ctx, true)
 
 			primarySatellite := fdbCluster.GetPrimarySatellite()
-			primarySatellite.SetSkipReconciliation(true)
+			primarySatellite.SetSkipReconciliation(ctx, true)
 
 			remoteSatellite := fdbCluster.GetRemoteSatellite()
-			remoteSatellite.SetSkipReconciliation(true)
+			remoteSatellite.SetSkipReconciliation(ctx, true)
 
 			remote := fdbCluster.GetRemote()
-			remote.SetSkipReconciliation(true)
+			remote.SetSkipReconciliation(ctx, true)
 
 			var wg errgroup.Group
 			log.Println("Delete Pods in primary")
 			wg.Go(func() error {
 				return factory.GetControllerRuntimeClient().
-					DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.MatchingLabels(primary.GetResourceLabels()), ctrlClient.InNamespace(primary.Namespace()))
+					DeleteAllOf(ctx, &corev1.Pod{}, ctrlClient.MatchingLabels(primary.GetResourceLabels()), ctrlClient.InNamespace(primary.Namespace()))
 			})
 
 			log.Println("Delete Pods in primary satellite")
 			wg.Go(func() error {
 				return factory.GetControllerRuntimeClient().
-					DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.MatchingLabels(primarySatellite.GetResourceLabels()), ctrlClient.InNamespace(primarySatellite.Namespace()))
+					DeleteAllOf(ctx, &corev1.Pod{}, ctrlClient.MatchingLabels(primarySatellite.GetResourceLabels()), ctrlClient.InNamespace(primarySatellite.Namespace()))
 			})
 
 			log.Println("Delete Pods in remote satellite")
 			wg.Go(func() error {
 				return factory.GetControllerRuntimeClient().
-					DeleteAllOf(context.Background(), &corev1.Pod{}, ctrlClient.MatchingLabels(remoteSatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))
+					DeleteAllOf(ctx, &corev1.Pod{}, ctrlClient.MatchingLabels(remoteSatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))
 			})
 
 			Expect(wg.Wait()).NotTo(HaveOccurred())
@@ -148,7 +147,7 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 			// Ensure that all the pods are deleted.
 			Eventually(func(g Gomega) []corev1.Pod {
 				pods := &corev1.PodList{}
-				g.Expect(factory.GetControllerRuntimeClient().List(context.Background(), pods, ctrlClient.MatchingLabels(primary.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).
+				g.Expect(factory.GetControllerRuntimeClient().List(ctx, pods, ctrlClient.MatchingLabels(primary.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).
 					To(Succeed())
 
 				return pods.Items
@@ -156,7 +155,7 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 
 			Eventually(func(g Gomega) []corev1.Pod {
 				pods := &corev1.PodList{}
-				g.Expect(factory.GetControllerRuntimeClient().List(context.Background(), pods, ctrlClient.MatchingLabels(primarySatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).
+				g.Expect(factory.GetControllerRuntimeClient().List(ctx, pods, ctrlClient.MatchingLabels(primarySatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).
 					To(Succeed())
 
 				return pods.Items
@@ -164,7 +163,7 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 
 			Eventually(func(g Gomega) []corev1.Pod {
 				pods := &corev1.PodList{}
-				g.Expect(factory.GetControllerRuntimeClient().List(context.Background(), pods, ctrlClient.MatchingLabels(remoteSatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).
+				g.Expect(factory.GetControllerRuntimeClient().List(ctx, pods, ctrlClient.MatchingLabels(remoteSatellite.GetResourceLabels()), ctrlClient.InNamespace(remoteSatellite.Namespace()))).
 					To(Succeed())
 
 				return pods.Items
@@ -176,19 +175,19 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 		// Because of the above issues the test case is currently disabled (marked as pending) and can be used
 		// to run the test manually if needed.
 		PWhen("DNS is disabled", func() {
-			BeforeEach(func() {
+			BeforeEach(func(_ SpecContext) {
 				useDNS = false
 			})
 
-			It("should recover the coordinators", func() {
+			It("should recover the coordinators", func(ctx SpecContext) {
 				remote := fdbCluster.GetRemote()
 				// Pick one operator pod and execute the recovery command
 				operatorPod := factory.RandomPickOnePod(
-					factory.GetOperatorPods(remote.Namespace()).Items,
+					factory.GetOperatorPods(ctx, remote.Namespace()).Items,
 				)
 				log.Println("operatorPod:", operatorPod.Name)
 				stdout, stderr, err := factory.ExecuteCmdOnPod(
-					context.Background(),
+					ctx,
 					&operatorPod,
 					"manager",
 					fmt.Sprintf(
@@ -203,18 +202,21 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 
 				// Ensure the cluster is available again.
 				Eventually(func() bool {
-					return remote.GetStatus().Client.DatabaseStatus.Available
+					return remote.GetStatus(ctx).Client.DatabaseStatus.Available
 				}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(BeTrue())
 
-				remote.SetSkipReconciliation(false)
+				remote.SetSkipReconciliation(ctx, false)
 				// Recreate the operator pods to ensure they get the new connection string.
-				factory.RecreateOperatorPods(remote.Namespace())
+				factory.RecreateOperatorPods(ctx, remote.Namespace())
 				// Ensure that the cluster is able to reconcile
-				Expect(remote.WaitForReconciliation()).To(Succeed())
+				Expect(remote.WaitForReconciliation(ctx)).To(Succeed())
 
-				log.Println("new connection string:", remote.GetCluster().Status.ConnectionString)
+				log.Println(
+					"new connection string:",
+					remote.GetCluster(ctx).Status.ConnectionString,
+				)
 				connectionString, err := fdbv1beta2.ParseConnectionString(
-					remote.GetCluster().Status.ConnectionString,
+					remote.GetCluster(ctx).Status.ConnectionString,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -227,19 +229,19 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 		})
 
 		When("DNS names in the cluster file are used", func() {
-			BeforeEach(func() {
+			BeforeEach(func(_ SpecContext) {
 				useDNS = true
 			})
 
-			It("should recover the coordinators", func() {
+			It("should recover the coordinators", func(ctx SpecContext) {
 				remote := fdbCluster.GetRemote()
 				// Pick one operator pod and execute the recovery command
 				operatorPod := factory.RandomPickOnePod(
-					factory.GetOperatorPods(remote.Namespace()).Items,
+					factory.GetOperatorPods(ctx, remote.Namespace()).Items,
 				)
 				log.Println("operatorPod:", operatorPod.Name)
 				stdout, stderr, err := factory.ExecuteCmdOnPod(
-					context.Background(),
+					ctx,
 					&operatorPod,
 					"manager",
 					fmt.Sprintf(
@@ -259,10 +261,10 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 
 				// Ensure the cluster is available again.
 				Eventually(func() bool {
-					return remote.GetStatus().Client.DatabaseStatus.Available
+					return remote.GetStatus(ctx).Client.DatabaseStatus.Available
 				}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(BeTrue())
 
-				currentConnectionString := remote.GetStatus().Cluster.ConnectionString
+				currentConnectionString := remote.GetStatus(ctx).Cluster.ConnectionString
 				log.Println("new connection string:", currentConnectionString)
 				connectionString, err := fdbv1beta2.ParseConnectionString(currentConnectionString)
 				Expect(err).NotTo(HaveOccurred())
@@ -276,13 +278,13 @@ var _ = Describe("Operator Plugin", Label("e2e", "pr"), func() {
 			})
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			log.Println("Recreate cluster")
 			// Delete the broken cluster.
-			factory.Shutdown()
+			factory.Shutdown(ctx)
 			// Recreate the cluster to make sure  the next tests can proceed
 			factory = fixtures.CreateFactory(testOptions)
-			fdbCluster = factory.CreateFdbHaCluster(clusterConfig)
+			fdbCluster = factory.CreateFdbHaCluster(ctx, clusterConfig)
 		})
 	})
 })

--- a/e2e/test_operator_stress/operator_stress_test.go
+++ b/e2e/test_operator_stress/operator_stress_test.go
@@ -44,21 +44,21 @@ var _ = BeforeSuite(func() {
 	factory = fixtures.CreateFactory(testOptions)
 })
 
-var _ = AfterSuite(func() {
-	factory.Shutdown()
+var _ = AfterSuite(func(ctx SpecContext) {
+	factory.Shutdown(ctx)
 })
 
 var _ = Describe("Operator Stress", Label("e2e"), func() {
 	When("creating and deleting a cluster multiple times", func() {
-		It("should create a healthy and available cluster", func() {
+		It("should create a healthy and available cluster", func(ctx SpecContext) {
 			// Since Ginkgo doesn't support what we want, we run this multiple times.
 			// We create and delete a cluster 10 times to ensure we don't have any flaky behaviour in the operator.
 			for range 10 {
-				fdbCluster := factory.CreateFdbCluster(
+				fdbCluster := factory.CreateFdbCluster(ctx,
 					fixtures.DefaultClusterConfig(false),
 				)
-				Expect(fdbCluster.IsAvailable()).To(BeTrue())
-				Expect(fdbCluster.Destroy()).NotTo(HaveOccurred())
+				Expect(fdbCluster.IsAvailable(ctx)).To(BeTrue())
+				Expect(fdbCluster.Destroy(ctx)).NotTo(HaveOccurred())
 			}
 		})
 	})
@@ -66,23 +66,23 @@ var _ = Describe("Operator Stress", Label("e2e"), func() {
 	When("replacing processes in a continuously manner", func() {
 		var fdbCluster *fixtures.FdbCluster
 
-		BeforeEach(func() {
-			fdbCluster = factory.CreateFdbCluster(
+		BeforeEach(func(ctx SpecContext) {
+			fdbCluster = factory.CreateFdbCluster(ctx,
 				fixtures.DefaultClusterConfig(false),
 			)
-			Expect(fdbCluster.InvariantClusterStatusAvailable()).NotTo(HaveOccurred())
+			Expect(fdbCluster.InvariantClusterStatusAvailable(ctx)).NotTo(HaveOccurred())
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.Destroy()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.Destroy(ctx)).NotTo(HaveOccurred())
 		})
 
-		It("should replace the targeted Pod", func() {
+		It("should replace the targeted Pod", func(ctx SpecContext) {
 			// Since Ginkgo doesn't support what we want, we run this multiple times.
 			for range 10 {
-				Expect(fdbCluster.ClearProcessGroupsToRemove()).ShouldNot(HaveOccurred())
-				pod := factory.ChooseRandomPod(fdbCluster.GetPods())
-				fdbCluster.ReplacePod(*pod, true)
+				Expect(fdbCluster.ClearProcessGroupsToRemove(ctx)).ShouldNot(HaveOccurred())
+				pod := factory.ChooseRandomPod(fdbCluster.GetPods(ctx))
+				fdbCluster.ReplacePod(ctx, *pod, true)
 			}
 		})
 	})

--- a/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
+++ b/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
@@ -50,26 +50,30 @@ func init() {
 	testOptions = fixtures.InitFlags()
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	factory = fixtures.CreateFactory(testOptions)
 	config := fixtures.DefaultClusterConfig(false)
 	config.RedundancyMode = fdbv1beta2.RedundancyModeThreeDataHall
 	config.UseUnifiedImage = ptr.To(true)
 
-	fdbCluster = factory.CreateFdbCluster(
+	fdbCluster = factory.CreateFdbCluster(ctx,
 		config,
 	)
 
 	// Make sure that the test suite is able to fetch logs from Pods.
-	operatorPod := factory.RandomPickOnePod(factory.GetOperatorPods(fdbCluster.Namespace()).Items)
-	Expect(factory.GetLogsForPod(&operatorPod, "manager", nil)).NotTo(BeEmpty())
+	operatorPod := factory.RandomPickOnePod(
+		factory.GetOperatorPods(ctx, fdbCluster.Namespace()).Items,
+	)
+	Expect(
+		factory.GetLogsForPod(ctx, &operatorPod, "manager", nil),
+	).NotTo(BeEmpty())
 
 	// Load some data async into the cluster. We will only block as long as the Job is created.
-	factory.CreateDataLoaderIfAbsent(fdbCluster)
+	factory.CreateDataLoaderIfAbsent(ctx, fdbCluster)
 
 	// In order to test the robustness of the operator we try to kill the operator Pods every minute.
 	if factory.ChaosTestsEnabled() {
-		scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(
+		scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(ctx,
 			fixtures.GetOperatorSelector(fdbCluster.Namespace()),
 			"*/2 * * * *",
 			chaosmesh.OneMode,
@@ -78,39 +82,39 @@ var _ = BeforeSuite(func() {
 	}
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx SpecContext) {
 	if CurrentSpecReport().Failed() {
 		log.Printf("failed due to %s", CurrentSpecReport().FailureMessage())
 	}
-	factory.Shutdown()
+	factory.Shutdown(ctx)
 })
 
 // TODO (johscheuer): Add those tests later again to the e2e pipeline.
 var _ = Describe("Operator with three data hall", Label("e2e"), func() {
 	var availabilityCheck bool
 
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		// Reset availabilityCheck if a test case removes this check.
 		availabilityCheck = true
 		if CurrentSpecReport().Failed() {
-			factory.DumpState(fdbCluster)
+			factory.DumpState(ctx, fdbCluster)
 		}
-		Expect(fdbCluster.WaitForReconciliation()).ToNot(HaveOccurred())
+		Expect(fdbCluster.WaitForReconciliation(ctx)).ToNot(HaveOccurred())
 		factory.StopInvariantCheck()
 		// Make sure all data is present in the cluster
-		fdbCluster.EnsureTeamTrackersAreHealthy()
-		fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+		fdbCluster.EnsureTeamTrackersAreHealthy(ctx)
+		fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		if availabilityCheck {
-			err := fdbCluster.InvariantClusterStatusAvailable()
+			err := fdbCluster.InvariantClusterStatusAvailable(ctx)
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
 
-	It("should bring up the cluster with three data hall redundancy", func() {
-		status := fdbCluster.GetStatus()
+	It("should bring up the cluster with three data hall redundancy", func(ctx SpecContext) {
+		status := fdbCluster.GetStatus(ctx)
 		Expect(
 			status.Cluster.DatabaseConfiguration.RedundancyMode,
 		).To(Equal(fdbv1beta2.RedundancyModeThreeDataHall))
@@ -123,9 +127,9 @@ var _ = Describe("Operator with three data hall", Label("e2e"), func() {
 		var replacedPod corev1.Pod
 		var useLocalitiesForExclusion bool
 
-		JustBeforeEach(func() {
-			initialPods := fdbCluster.GetLogPods()
-			coordinators := fdbstatus.GetCoordinatorsFromStatus(fdbCluster.GetStatus())
+		JustBeforeEach(func(ctx SpecContext) {
+			initialPods := fdbCluster.GetLogPods(ctx)
+			coordinators := fdbstatus.GetCoordinatorsFromStatus(fdbCluster.GetStatus(ctx))
 
 			for _, pod := range initialPods.Items {
 				_, isCoordinator := coordinators[string(fixtures.GetProcessGroupID(pod))]
@@ -141,36 +145,36 @@ var _ = Describe("Operator with three data hall", Label("e2e"), func() {
 			}
 
 			log.Println("coordinators:", coordinators, "replacedPod", replacedPod.Name)
-			fdbCluster.ReplacePod(replacedPod, true)
+			fdbCluster.ReplacePod(ctx, replacedPod, true)
 		})
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// Until the race condition is resolved in the FDB go bindings make sure the operator is not restarted.
 			// See: https://github.com/apple/foundationdb/issues/11222
 			// We can remove this once 7.1 is the default version.
-			factory.DeleteChaosMeshExperiment(scheduleInjectPodKill)
-			useLocalitiesForExclusion = fdbCluster.GetCluster().UseLocalitiesForExclusion()
+			factory.DeleteChaosMeshExperiment(ctx, scheduleInjectPodKill)
+			useLocalitiesForExclusion = fdbCluster.GetCluster(ctx).UseLocalitiesForExclusion()
 		})
 
-		AfterEach(func() {
-			Expect(fdbCluster.ClearProcessGroupsToRemove()).NotTo(HaveOccurred())
+		AfterEach(func(ctx SpecContext) {
+			Expect(fdbCluster.ClearProcessGroupsToRemove(ctx)).NotTo(HaveOccurred())
 			// Make sure we reset the previous behaviour.
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 			spec.AutomationOptions.UseLocalitiesForExclusion = ptr.To(
 				useLocalitiesForExclusion,
 			)
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 			Expect(
-				fdbCluster.GetCluster().UseLocalitiesForExclusion(),
+				fdbCluster.GetCluster(ctx).UseLocalitiesForExclusion(),
 			).To(Equal(useLocalitiesForExclusion))
 
 			// Making sure we included back all the process groups after exclusion is complete.
 			Expect(
-				fdbCluster.GetStatus().Cluster.DatabaseConfiguration.ExcludedServers,
+				fdbCluster.GetStatus(ctx).Cluster.DatabaseConfiguration.ExcludedServers,
 			).To(BeEmpty())
 
 			if factory.ChaosTestsEnabled() {
-				scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(
+				scheduleInjectPodKill = factory.ScheduleInjectPodKillWithName(ctx,
 					fixtures.GetOperatorSelector(fdbCluster.Namespace()),
 					"*/2 * * * *",
 					chaosmesh.OneMode,
@@ -180,21 +184,21 @@ var _ = Describe("Operator with three data hall", Label("e2e"), func() {
 		})
 
 		When("IP addresses are used for exclusion", func() {
-			BeforeEach(func() {
-				spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			BeforeEach(func(ctx SpecContext) {
+				spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 				spec.AutomationOptions.UseLocalitiesForExclusion = ptr.To(false)
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
-				Expect(fdbCluster.GetCluster().UseLocalitiesForExclusion()).To(BeFalse())
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+				Expect(fdbCluster.GetCluster(ctx).UseLocalitiesForExclusion()).To(BeFalse())
 			})
 
-			It("should remove the targeted Pod", func() {
-				fdbCluster.EnsurePodIsDeleted(replacedPod.Name)
+			It("should remove the targeted Pod", func(ctx SpecContext) {
+				fdbCluster.EnsurePodIsDeleted(ctx, replacedPod.Name)
 			})
 		})
 
 		When("localities are used for exclusion", func() {
-			BeforeEach(func() {
-				cluster := fdbCluster.GetCluster()
+			BeforeEach(func(ctx SpecContext) {
+				cluster := fdbCluster.GetCluster(ctx)
 
 				fdbVersion, err := fdbv1beta2.ParseFdbVersion(cluster.GetRunningVersion())
 				Expect(err).NotTo(HaveOccurred())
@@ -207,18 +211,18 @@ var _ = Describe("Operator with three data hall", Label("e2e"), func() {
 
 				spec := cluster.Spec.DeepCopy()
 				spec.AutomationOptions.UseLocalitiesForExclusion = ptr.To(true)
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
-				Expect(fdbCluster.GetCluster().UseLocalitiesForExclusion()).To(BeTrue())
+				fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+				Expect(fdbCluster.GetCluster(ctx).UseLocalitiesForExclusion()).To(BeTrue())
 			})
 
-			It("should remove the targeted Pod", func() {
+			It("should remove the targeted Pod", func(ctx SpecContext) {
 				Expect(
 					ptr.Deref(
-						fdbCluster.GetCluster().Spec.AutomationOptions.UseLocalitiesForExclusion,
+						fdbCluster.GetCluster(ctx).Spec.AutomationOptions.UseLocalitiesForExclusion,
 						false,
 					),
 				).To(BeTrue())
-				fdbCluster.EnsurePodIsDeleted(replacedPod.Name)
+				fdbCluster.EnsurePodIsDeleted(ctx, replacedPod.Name)
 			})
 		})
 	})

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -61,12 +61,13 @@ var _ = AfterSuite(func() {
 })
 
 func clusterSetupWithConfig(
+	ctx context.Context,
 	beforeVersion string,
 	availabilityCheck bool,
 	config *fixtures.ClusterConfig,
 ) {
 	config.Version = ptr.To(beforeVersion)
-	fdbCluster = factory.CreateFdbCluster(
+	fdbCluster = factory.CreateFdbCluster(ctx,
 		config,
 	)
 
@@ -77,26 +78,26 @@ func clusterSetupWithConfig(
 	}
 
 	Expect(
-		fdbCluster.InvariantClusterStatusAvailable(),
+		fdbCluster.InvariantClusterStatusAvailable(ctx),
 	).ShouldNot(HaveOccurred())
 }
 
-func clusterSetup(beforeVersion string, availabilityCheck bool) {
-	clusterSetupWithConfig(beforeVersion, availabilityCheck, &fixtures.ClusterConfig{
+func clusterSetup(ctx context.Context, beforeVersion string, availabilityCheck bool) {
+	clusterSetupWithConfig(ctx, beforeVersion, availabilityCheck, &fixtures.ClusterConfig{
 		DebugSymbols: false,
 	})
 }
 
 var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
-	BeforeEach(func() {
+	BeforeEach(func(_ SpecContext) {
 		factory = fixtures.CreateFactory(testOptions)
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		if CurrentSpecReport().Failed() {
-			factory.DumpState(fdbCluster)
+			factory.DumpState(ctx, fdbCluster)
 		}
-		factory.Shutdown()
+		factory.Shutdown(ctx)
 	})
 
 	// Ginkgo lacks the support for AfterEach and BeforeEach in tables, so we have to put everything inside the testing function
@@ -104,15 +105,15 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 	// for different versions without hard coding or having multiple flags.
 	DescribeTable(
 		"upgrading a cluster with a random Pod deleted during rolling bounce phase",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			// We disable the availability check here as there could be some race conditions between the operator and
 			// the test suite where two pods are taken down at the same time which would affect the availability of the
 			// cluster.
-			clusterSetup(beforeVersion, false)
-			prevImage := fdbCluster.GetFDBImage()
+			clusterSetup(ctx, beforeVersion, false)
+			prevImage := fdbCluster.GetFDBImage(ctx)
 
 			// 1. Start upgrade.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			// If the versions are protocol compatible we only have a rolling bounce phase. The check below is only
 			// required if the versions are not compatible and the operator is using the staging phase.
@@ -120,7 +121,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				// 2. Wait until we get to rolling bounce phase.
 				log.Println("wait for rolling bounce phase.")
 				Eventually(func() bool {
-					return fdbCluster.GetCluster().Status.RunningVersion == targetVersion
+					return fdbCluster.GetCluster(ctx).Status.RunningVersion == targetVersion
 				}).Should(BeTrue())
 				log.Println("cluster in rolling bounce phase.")
 			}
@@ -132,7 +133,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			// the running image.
 			Eventually(func() bool {
 				pods := make([]corev1.Pod, 0)
-				for _, pod := range fdbCluster.GetPods().Items {
+				for _, pod := range fdbCluster.GetPods(ctx).Items {
 					// Ignore pods that are in the deletion process.
 					if !pod.DeletionTimestamp.IsZero() {
 						continue
@@ -165,16 +166,16 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 				selectedPod := factory.RandomPickOnePod(pods)
 				log.Println("deleting pod: ", selectedPod.Name)
-				factory.DeletePod(&selectedPod)
-				fdbCluster.WaitForPodRemoval(&selectedPod)
+				factory.DeletePod(ctx, &selectedPod)
+				fdbCluster.WaitForPodRemoval(ctx, &selectedPod)
 				return false
 			}).WithTimeout(20 * time.Minute).WithPolling(3 * time.Minute).Should(BeTrue())
 
 			// 5. Verify a final time that the cluster is reconciled, this should be quick.
-			Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
+			Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
 
 			// Make sure the cluster has no data loss.
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 
 		EntryDescription("Upgrade from %[1]s to %[2]s with pods deleted during rolling bounce"),
@@ -183,19 +184,19 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"upgrading a cluster where one coordinator gets restarted during the staging phase",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				Skip("this test case only affects version incompatible upgrades")
 			}
 
-			clusterSetup(beforeVersion, false)
+			clusterSetup(ctx, beforeVersion, false)
 
 			// Select one coordinator that will be restarted during the staging phase. We prefer to pick a coordinator
 			// that is running on a log process, if we don't find one we fall back to a coordinator running on
 			// a storage process.
-			coordinators := fdbCluster.GetCoordinatorsOnLogProcesses()
+			coordinators := fdbCluster.GetCoordinatorsOnLogProcesses(ctx)
 			if len(coordinators) == 0 {
-				coordinators = fdbCluster.GetCoordinators()
+				coordinators = fdbCluster.GetCoordinators(ctx)
 			}
 			Expect(coordinators).NotTo(BeEmpty())
 
@@ -210,21 +211,21 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 			// Disable the feature that the operator restarts processes. This allows us to restart the coordinator
 			// once all new binaries are present.
-			fdbCluster.SetKillProcesses(false, true)
+			fdbCluster.SetKillProcesses(ctx, false, true)
 
 			// Start the upgrade.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			// Wait until all process groups are in the staging phase and the new binaries are available.
 			Eventually(func() bool {
-				return fdbCluster.AllProcessGroupsHaveCondition(
+				return fdbCluster.AllProcessGroupsHaveCondition(ctx,
 					fdbv1beta2.IncorrectCommandLine,
 					true,
 				)
 			}).WithTimeout(10 * time.Minute).WithPolling(2 * time.Second).Should(BeTrue())
 
 			// Restart the fdbserver process to pickup the new configuration and run with the newer version.
-			_, _, err := fdbCluster.ExecuteCmdOnPod(
+			_, _, err := fdbCluster.ExecuteCmdOnPod(ctx,
 				selectedCoordinator,
 				fdbv1beta2.MainContainerName,
 				"pkill fdbserver",
@@ -234,7 +235,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 			// Check if the restarted process is showing up in IncompatibleConnections list in status output.
 			Eventually(func(g Gomega) map[string]fdbv1beta2.None {
-				status := fdbCluster.GetStatus()
+				status := fdbCluster.GetStatus(ctx)
 				if len(status.Cluster.IncompatibleConnections) == 0 {
 					return nil
 				}
@@ -252,13 +253,13 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			}).WithTimeout(180 * time.Second).WithPolling(4 * time.Second).Should(And(HaveLen(1), HaveKey(selectedCoordinator.Status.PodIP)))
 
 			// Allow the operator to restart processes and the upgrade should continue and finish.
-			fdbCluster.SetKillProcesses(true, false)
+			fdbCluster.SetKillProcesses(ctx, true, false)
 
 			// Ensure that the cluster was upgraded.
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 
 			// Make sure the cluster has no data loss.
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 
 		EntryDescription(
@@ -269,16 +270,16 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"upgrading a cluster with a crash looping sidecar process",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion, true)
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetup(ctx, beforeVersion, true)
 
-			Expect(fdbCluster.SetAutoReplacements(false, 20*time.Minute)).ToNot(HaveOccurred())
+			Expect(fdbCluster.SetAutoReplacements(ctx, false, 20*time.Minute)).ToNot(HaveOccurred())
 
 			// 1. Introduce crash-loop into sidecar container to artificially create a partition.
-			pickedPod := factory.ChooseRandomPod(fdbCluster.GetStoragePods())
+			pickedPod := factory.ChooseRandomPod(fdbCluster.GetStoragePods(ctx))
 			log.Println("Injecting container fault to crash-loop sidecar process:", pickedPod.Name)
 
-			fdbCluster.SetCrashLoopContainers([]fdbv1beta2.CrashLoopContainerObject{
+			fdbCluster.SetCrashLoopContainers(ctx, []fdbv1beta2.CrashLoopContainerObject{
 				{
 					ContainerName: fdbv1beta2.SidecarContainerName,
 					Targets: []fdbv1beta2.ProcessGroupID{
@@ -292,7 +293,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 			// Wait until the Pod is running again and the sidecar is crash-looping.
 			Eventually(func(g Gomega) corev1.PodPhase {
-				pod := fdbCluster.GetPod(pickedPod.Name)
+				pod := fdbCluster.GetPod(ctx, pickedPod.Name)
 				for _, container := range pod.Spec.Containers {
 					if container.Name == fdbv1beta2.SidecarContainerName {
 						log.Println(
@@ -312,10 +313,10 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 			// Make sure we trigger a new reconciliation to make sure the process is up and running and only the sidecar
 			// is crash looping.
-			fdbCluster.ForceReconcile()
+			fdbCluster.ForceReconcile(ctx)
 
 			Eventually(func(g Gomega) bool {
-				for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+				for _, processGroup := range fdbCluster.GetCluster(ctx).Status.ProcessGroups {
 					g.Expect(processGroup.GetConditionTime(fdbv1beta2.MissingProcesses)).To(BeNil())
 				}
 
@@ -324,7 +325,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 			// 2. Start cluster upgrade.
 			log.Printf("Crash injected in sidecar container %s. Starting upgrade.", pickedPod.Name)
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			if !fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				// 3. Until we remove the crash loop setup, cluster should not be upgraded.
@@ -332,30 +333,30 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				//    but cluster is not restarted to new version.
 				log.Println("upgrade should not finish while sidecar process is unavailable")
 				Consistently(func() bool {
-					return fdbCluster.GetCluster().Status.RunningVersion == beforeVersion
+					return fdbCluster.GetCluster(ctx).Status.RunningVersion == beforeVersion
 				}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(BeTrue())
 			} else {
 				// It should upgrade the cluster if the version is protocol compatible.
-				fdbCluster.VerifyVersion(targetVersion)
+				fdbCluster.VerifyVersion(ctx, targetVersion)
 			}
 
 			// 4. Remove the crash-loop.
 			log.Println("Removing crash-loop from", pickedPod.Name)
-			fdbCluster.SetCrashLoopContainers(nil, false)
+			fdbCluster.SetCrashLoopContainers(ctx, nil, false)
 
 			// Wait for the Pod to come back again.
 			Eventually(func() corev1.PodPhase {
-				pod := fdbCluster.GetPod(pickedPod.Name)
+				pod := fdbCluster.GetPod(ctx, pickedPod.Name)
 
 				return pod.Status.Phase
 			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).MustPassRepeatedly(5).Should(Equal(corev1.PodRunning))
 
-			fdbCluster.ForceReconcile()
+			fdbCluster.ForceReconcile(ctx)
 
 			// 5. Upgrade should proceed after we stop killing the sidecar.
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 			// Make sure the cluster has no data loss.
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s with crash-looping sidecar"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -363,11 +364,11 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"upgrading a cluster and one coordinator is not restarted",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion, true)
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetup(ctx, beforeVersion, true)
 
 			// 1. Select one coordinator and use the buggify option to skip it during the restart command.
-			coordinators := fdbCluster.GetCoordinators()
+			coordinators := fdbCluster.GetCoordinators(ctx)
 			Expect(coordinators).NotTo(BeEmpty())
 
 			selectedCoordinator := coordinators[0]
@@ -378,7 +379,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				selectedCoordinator.Status.PodIP,
 				") to be skipped during the restart",
 			)
-			fdbCluster.SetIgnoreDuringRestart(
+			fdbCluster.SetIgnoreDuringRestart(ctx,
 				[]fdbv1beta2.ProcessGroupID{
 					fdbv1beta2.ProcessGroupID(
 						selectedCoordinator.Labels[fdbCluster.GetCachedCluster().GetProcessGroupIDLabel()],
@@ -387,15 +388,15 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			)
 
 			// The cluster should still be able to upgrade.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, true)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, true)).NotTo(HaveOccurred())
 
 			// Make sure that the incompatible connections are cleaned up after some time.
 			Eventually(func() []string {
-				return fdbCluster.GetStatus().Cluster.IncompatibleConnections
+				return fdbCluster.GetStatus(ctx).Cluster.IncompatibleConnections
 			}).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).MustPassRepeatedly(5).Should(BeEmpty())
 
 			// Make sure the cluster has no data loss.
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s with one coordinator not being restarted"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -403,20 +404,20 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"upgrading a cluster and multiple processes are not restarted",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			// We ignore the availability check here since this check is sometimes flaky if not all coordinators are running.
-			clusterSetup(beforeVersion, false)
+			clusterSetup(ctx, beforeVersion, false)
 
 			// 1. Select half of the stateless and half of the log processes and use the buggify option to skip those
 			// processes during the restart command.
-			statelessPods := fdbCluster.GetStatelessPods()
+			statelessPods := fdbCluster.GetStatelessPods(ctx)
 			Expect(statelessPods.Items).NotTo(BeEmpty())
 			selectedStatelessPods := factory.RandomPickPod(
 				statelessPods.Items,
 				len(statelessPods.Items)/2,
 			)
 
-			logPods := fdbCluster.GetLogPods()
+			logPods := fdbCluster.GetLogPods(ctx)
 			Expect(logPods.Items).NotTo(BeEmpty())
 			selectedLogPods := factory.RandomPickPod(logPods.Items, len(logPods.Items)/2)
 
@@ -449,13 +450,13 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				ignoreDuringRestart,
 				" to be skipped during the restart",
 			)
-			fdbCluster.SetIgnoreDuringRestart(ignoreDuringRestart)
+			fdbCluster.SetIgnoreDuringRestart(ctx, ignoreDuringRestart)
 
 			// The cluster should still be able to upgrade.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, true)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, true)).NotTo(HaveOccurred())
 
 			// Make sure the cluster has no data loss.
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s and multiple processes are not restarted"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -463,12 +464,12 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"upgrading a cluster and no coordinator is restarted",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			// We ignore the availability check here since this check is sometimes flaky if not all coordinators are running.
-			clusterSetup(beforeVersion, false)
+			clusterSetup(ctx, beforeVersion, false)
 
 			// 1. Select one coordinator and use the buggify option to skip it during the restart command.
-			coordinators := fdbCluster.GetCoordinators()
+			coordinators := fdbCluster.GetCoordinators(ctx)
 			Expect(coordinators).NotTo(BeEmpty())
 
 			ignoreDuringRestart := make([]fdbv1beta2.ProcessGroupID, 0, len(coordinators))
@@ -481,21 +482,21 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				)
 			}
 
-			fdbCluster.SetIgnoreDuringRestart(ignoreDuringRestart)
+			fdbCluster.SetIgnoreDuringRestart(ctx, ignoreDuringRestart)
 
 			// The cluster will be stuck in this state until the coordinators are upgraded
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			if !fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				// The upgrade will be stuck until the coordinators are restarted
 				Consistently(func() bool {
-					return fdbCluster.GetCluster().IsBeingUpgraded()
+					return fdbCluster.GetCluster(ctx).IsBeingUpgraded()
 				}).WithTimeout(5 * time.Minute).WithPolling(2 * time.Second).Should(BeTrue())
 
 				// Restart the fdbserver processes
 				for _, coordinator := range coordinators {
 					Eventually(func() error {
-						_, _, err := fdbCluster.ExecuteCmdOnPod(
+						_, _, err := fdbCluster.ExecuteCmdOnPod(ctx,
 							coordinator,
 							fdbv1beta2.MainContainerName,
 							"pkill fdbserver",
@@ -512,7 +513,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				}
 			}
 
-			fdbCluster.SetIgnoreDuringRestart(nil)
+			fdbCluster.SetIgnoreDuringRestart(ctx, nil)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s and no coordinator is restarted"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -520,27 +521,27 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"one process is marked for removal and is stuck in removal",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				Skip("this test only affects version incompatible upgrades")
 			}
 
-			clusterSetup(beforeVersion, true)
+			clusterSetup(ctx, beforeVersion, true)
 
 			// Select one Pod, this Pod will be marked to be removed but the actual removal will be blocked. The intention
 			// is to simulate a Pods that should be removed but the removal is not completed yet and an upgrade will be started.
-			podMarkedForRemoval := factory.RandomPickOnePod(fdbCluster.GetPods().Items)
+			podMarkedForRemoval := factory.RandomPickOnePod(fdbCluster.GetPods(ctx).Items)
 			processGroupMarkedForRemoval := fixtures.GetProcessGroupID(podMarkedForRemoval)
 			log.Println("picked Pod", podMarkedForRemoval.Name, "to be marked for removal")
 			// Use the buggify option to block the actual removal.
-			fdbCluster.SetBuggifyBlockRemoval(
+			fdbCluster.SetBuggifyBlockRemoval(ctx,
 				[]fdbv1beta2.ProcessGroupID{processGroupMarkedForRemoval},
 			)
 			// Don't wait for reconciliation as the cluster will never reconcile.
-			fdbCluster.ReplacePod(podMarkedForRemoval, false)
+			fdbCluster.ReplacePod(ctx, podMarkedForRemoval, false)
 			// Make sure the process group is marked for removal
 			Eventually(func() *metav1.Time {
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					if processGroup.ProcessGroupID != processGroupMarkedForRemoval {
@@ -554,16 +555,16 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).MustPassRepeatedly(5).ShouldNot(BeNil())
 
 			// Update the cluster version.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			// Make sure the cluster is upgraded
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 
 			// Make sure the other processes are updated to the new image and the operator is able to proceed with the upgrade.
 			Eventually(func() int {
 				var processesToUpdate int
 
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					if processGroup.ProcessGroupID == processGroupMarkedForRemoval {
 						continue
@@ -598,9 +599,9 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			}).WithTimeout(30 * time.Minute).WithPolling(5 * time.Second).MustPassRepeatedly(5).Should(BeNumerically("==", 0))
 
 			// Remove the buggify option and make sure that the terminating processes are removed.
-			fdbCluster.SetBuggifyBlockRemoval(nil)
+			fdbCluster.SetBuggifyBlockRemoval(ctx, nil)
 			Eventually(func(g Gomega) {
-				processGroups := fdbCluster.GetCluster().Status.ProcessGroups
+				processGroups := fdbCluster.GetCluster(ctx).Status.ProcessGroups
 
 				for _, processGroup := range processGroups {
 					g.Expect(processGroup.GetConditionTime(fdbv1beta2.ResourcesTerminating)).
@@ -609,7 +610,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 
 			// Make sure the cluster has no data loss.
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -617,32 +618,32 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"one process is marked for removal and is stuck in terminating state",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				Skip("this test only affects version incompatible upgrades")
 			}
 
-			clusterSetup(beforeVersion, true)
+			clusterSetup(ctx, beforeVersion, true)
 
 			// Select one Pod, this Pod will be marked to be removed but the actual removal will be blocked. The intention
 			// is to simulate a Pods that should be removed but the removal is not completed yet and an upgrade will be started.
-			podMarkedForRemoval := factory.RandomPickOnePod(fdbCluster.GetPods().Items)
+			podMarkedForRemoval := factory.RandomPickOnePod(fdbCluster.GetPods(ctx).Items)
 			processGroupMarkedForRemoval := fixtures.GetProcessGroupID(podMarkedForRemoval)
 			log.Println("picked Pod", podMarkedForRemoval.Name, "to be marked for removal")
 			// Set a finalizer for this Pod to make sure the Pod object cannot be garbage collected
-			factory.SetFinalizerForPod(&podMarkedForRemoval, []string{"foundationdb.org/test"})
+			factory.SetFinalizerForPod(ctx, &podMarkedForRemoval, []string{"foundationdb.org/test"})
 			// Don't wait for reconciliation as the cluster will never reconcile.
-			fdbCluster.ReplacePod(podMarkedForRemoval, false)
+			fdbCluster.ReplacePod(ctx, podMarkedForRemoval, false)
 
 			timeSinceLastForceReconcile := time.Now()
 			// Make sure the process group is marked for removal
 			Eventually(func() *int64 {
 				if time.Since(timeSinceLastForceReconcile) > 1*time.Minute {
-					fdbCluster.ForceReconcile()
+					fdbCluster.ForceReconcile(ctx)
 					timeSinceLastForceReconcile = time.Now()
 				}
 
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					if processGroup.ProcessGroupID != processGroupMarkedForRemoval {
@@ -656,22 +657,22 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			}).WithTimeout(5 * time.Minute).WithPolling(2 * time.Second).MustPassRepeatedly(5).ShouldNot(BeNil())
 
 			// Update the cluster version.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			// Make sure the cluster is upgraded
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 
 			// Make sure the other processes are updated to the new image and the operator is able to proceed with the upgrade.
 			// We allow soft reconciliation here since the terminating Pod will block the "full" reconciliation
 			Expect(
-				fdbCluster.WaitForReconciliation(fixtures.SoftReconcileOption(true)),
+				fdbCluster.WaitForReconciliation(ctx, fixtures.SoftReconcileOption(true)),
 			).NotTo(HaveOccurred())
 
 			// Make sure we remove the finalizer to not block the clean up.
-			factory.SetFinalizerForPod(&podMarkedForRemoval, []string{})
+			factory.SetFinalizerForPod(ctx, &podMarkedForRemoval, []string{})
 
 			// Make sure the cluster has no data loss.
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -679,12 +680,12 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"upgrading a cluster with a pending pod",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion, true)
-			pendingPod := factory.RandomPickOnePod(fdbCluster.GetPods().Items)
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetup(ctx, beforeVersion, true)
+			pendingPod := factory.RandomPickOnePod(fdbCluster.GetPods(ctx).Items)
 			// Set the pod in pending state.
-			fdbCluster.SetPodAsUnschedulable(pendingPod)
-			fdbCluster.UpgradeAndVerify(targetVersion)
+			fdbCluster.SetPodAsUnschedulable(ctx, pendingPod)
+			fdbCluster.UpgradeAndVerify(ctx, targetVersion)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s with a pending pod"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -692,16 +693,16 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"one process is under maintenance",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				Skip("this test only affects version incompatible upgrades")
 			}
 
-			clusterSetup(beforeVersion, true)
+			clusterSetup(ctx, beforeVersion, true)
 
 			// Pick a storage process and set it under maintenance
 			var storageProcessGroupUnderMaintenance *fdbv1beta2.ProcessGroupStatus
-			for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+			for _, processGroup := range fdbCluster.GetCluster(ctx).Status.ProcessGroups {
 				if processGroup.ProcessClass != fdbv1beta2.ProcessClassStorage {
 					continue
 				}
@@ -718,7 +719,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				"to be under maintenance with fault domain:",
 				storageProcessGroupUnderMaintenance.FaultDomain,
 			)
-			_, _ = fdbCluster.RunFdbCliCommandInOperator(
+			_, _ = fdbCluster.RunFdbCliCommandInOperator(ctx,
 				fmt.Sprintf(
 					"maintenance on %s 3600",
 					storageProcessGroupUnderMaintenance.FaultDomain,
@@ -729,24 +730,24 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 			// Make sure the machine-readable status reflects the maintenance mode
 			Eventually(func() fdbv1beta2.FaultDomain {
-				return fdbCluster.GetStatus().Cluster.MaintenanceZone
+				return fdbCluster.GetStatus(ctx).Cluster.MaintenanceZone
 			}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).MustPassRepeatedly(5).Should(Equal(storageProcessGroupUnderMaintenance.FaultDomain))
 
 			// Update the cluster version.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			// Make sure the cluster is not upgraded until the maintenance is removed.
 			Consistently(func() string {
-				return fdbCluster.GetCluster().GetRunningVersion()
+				return fdbCluster.GetCluster(ctx).GetRunningVersion()
 			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Equal(beforeVersion))
 			// Turn maintenance off.
-			_, _ = fdbCluster.RunFdbCliCommandInOperator("maintenance off", false, 30)
+			_, _ = fdbCluster.RunFdbCliCommandInOperator(ctx, "maintenance off", false, 30)
 
 			// Make sure the cluster is upgraded
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 
 			// Make sure the cluster has no data loss.
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -754,7 +755,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"one process cannot connect to the Kubernetes API",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			if !factory.ChaosTestsEnabled() {
 				Skip("Chaos tests are skipped for the operator")
 			}
@@ -764,14 +765,13 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				Skip("The sidecar image doesn't require connectivity to the Kubernetes API")
 			}
 
-			clusterSetup(beforeVersion, true)
+			clusterSetup(ctx, beforeVersion, true)
 
-			selectedPod := factory.RandomPickOnePod(fdbCluster.GetStoragePods().Items)
+			selectedPod := factory.RandomPickOnePod(fdbCluster.GetStoragePods(ctx).Items)
 
 			var kubernetesServiceHost string
 			Eventually(func(g Gomega) error {
-				std, _, err := factory.ExecuteCmdOnPod(
-					context.Background(),
+				std, _, err := factory.ExecuteCmdOnPod(ctx,
 					&selectedPod,
 					fdbv1beta2.MainContainerName,
 					"printenv KUBERNETES_SERVICE_HOST",
@@ -784,14 +784,13 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 				return err
 			}, 5*time.Minute).ShouldNot(HaveOccurred())
 
-			exp := factory.InjectPartitionWithExternalTargets(
+			exp := factory.InjectPartitionWithExternalTargets(ctx,
 				fixtures.PodSelector(&selectedPod),
 				[]string{kubernetesServiceHost},
 			)
 			// Make sure that the partition takes effect.
 			Eventually(func() error {
-				_, _, err := factory.ExecuteCmdOnPod(
-					context.Background(),
+				_, _, err := factory.ExecuteCmdOnPod(ctx,
 					&selectedPod,
 					fdbv1beta2.MainContainerName,
 					fmt.Sprintf("nc -vz -w 2 %s 443", kubernetesServiceHost),
@@ -802,23 +801,23 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			}).WithTimeout(2 * time.Minute).WithPolling(1 * time.Second).Should(HaveOccurred())
 
 			// Update the cluster version.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			if !fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				// If the upgrade is version incompatible it will block the upgrade process.
 				// Otherwise, the operator will recreate the Pods.
 				Consistently(func() bool {
-					return fdbCluster.GetCluster().Status.RunningVersion == beforeVersion
+					return fdbCluster.GetCluster(ctx).Status.RunningVersion == beforeVersion
 				}).WithTimeout(3 * time.Minute).WithPolling(2 * time.Second).Should(BeTrue())
 
-				factory.DeleteChaosMeshExperiment(exp)
+				factory.DeleteChaosMeshExperiment(ctx, exp)
 			}
 
 			// Make sure the cluster is upgraded
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 
 			// Make sure the cluster has no data loss.
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -826,10 +825,10 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"upgrading a cluster with changes to the Pod spec.",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion, false)
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetup(ctx, beforeVersion, false)
 			// Ensure we have pulled that latest state of the cluster.
-			spec := fdbCluster.GetCluster().Spec.DeepCopy()
+			spec := fdbCluster.GetCluster(ctx).Spec.DeepCopy()
 
 			log.Printf(
 				"Upgrading cluster from version %s to version %s",
@@ -856,15 +855,15 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 			}
 
 			spec.Processes[fdbv1beta2.ProcessClassGeneral] = processSettings
-			fdbCluster.UpdateClusterSpecWithSpec(spec)
+			fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
 			// Ensure the version is actually upgraded.
-			Expect(fdbCluster.GetCluster().Spec.Version).To(Equal(targetVersion))
+			Expect(fdbCluster.GetCluster(ctx).Spec.Version).To(Equal(targetVersion))
 
 			// Make sure the cluster is upgraded
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 
 			// Make sure the cluster has no data loss.
-			fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+			fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 		},
 
 		EntryDescription("Upgrade from %[1]s to %[2]s with changes to the Pod spec"),

--- a/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
+++ b/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
@@ -64,29 +64,33 @@ type testConfig struct {
 	loadData      bool
 }
 
-func clusterSetupWithConfig(config testConfig) *fixtures.FdbCluster {
+func clusterSetupWithConfig(ctx context.Context, config testConfig) *fixtures.FdbCluster {
 	config.clusterConfig.Version = ptr.To(config.beforeVersion)
 
-	cluster := factory.CreateFdbCluster(config.clusterConfig)
+	cluster := factory.CreateFdbCluster(ctx, config.clusterConfig)
 
 	if config.loadData {
 		// Load some data into the cluster.
-		factory.CreateDataLoaderIfAbsent(cluster)
+		factory.CreateDataLoaderIfAbsent(ctx, cluster)
 	}
 
 	Expect(
-		cluster.InvariantClusterStatusAvailable(),
+		cluster.InvariantClusterStatusAvailable(ctx),
 	).ShouldNot(HaveOccurred())
 
 	return cluster
 }
 
-func performUpgrade(config testConfig, preUpgradeFunction func(cluster *fixtures.FdbCluster)) {
-	fdbCluster = clusterSetupWithConfig(config)
+func performUpgrade(
+	ctx context.Context,
+	config testConfig,
+	preUpgradeFunction func(cluster *fixtures.FdbCluster),
+) {
+	fdbCluster = clusterSetupWithConfig(ctx, config)
 	startTime := time.Now()
 	loggingTime := time.Now()
 	preUpgradeFunction(fdbCluster)
-	Expect(fdbCluster.UpgradeCluster(config.targetVersion, false)).NotTo(HaveOccurred())
+	Expect(fdbCluster.UpgradeCluster(ctx, config.targetVersion, false)).NotTo(HaveOccurred())
 
 	if !fixtures.VersionsAreProtocolCompatible(config.beforeVersion, config.targetVersion) {
 		// Ensure that the operator is setting the IncorrectConfigMap and IncorrectCommandLine conditions during the upgrade
@@ -99,11 +103,11 @@ func performUpgrade(config testConfig, preUpgradeFunction func(cluster *fixtures
 		Eventually(func() bool {
 			// If the status is not updated after 5 minutes try a force reconciliation.
 			if time.Since(loggingTime) > 5*time.Minute {
-				fdbCluster.ForceReconcile()
+				fdbCluster.ForceReconcile(ctx)
 				loggingTime = time.Now()
 			}
 
-			for _, processGroup := range fdbCluster.GetCluster().Status.ProcessGroups {
+			for _, processGroup := range fdbCluster.GetCluster(ctx).Status.ProcessGroups {
 				if processGroup.MatchesConditions(expectedConditions) {
 					return true
 				}
@@ -117,7 +121,7 @@ func performUpgrade(config testConfig, preUpgradeFunction func(cluster *fixtures
 	transactionSystemProcessGroups := make(map[fdbv1beta2.ProcessGroupID]fdbv1beta2.None)
 	// Wait until the cluster is upgraded and fully reconciled.
 	Expect(
-		fdbCluster.WaitUntilWithForceReconcile(
+		fdbCluster.WaitUntilWithForceReconcile(ctx,
 			2,
 			1500,
 			func(cluster *fdbv1beta2.FoundationDBCluster) bool {
@@ -130,7 +134,7 @@ func performUpgrade(config testConfig, preUpgradeFunction func(cluster *fixtures
 						!processGroup.IsExcluded() {
 						log.Println("Missing process for:", processGroup.ProcessGroupID)
 						stdout, stderr, err := factory.ExecuteCmd(
-							context.Background(),
+							ctx,
 							cluster.Namespace,
 							processGroup.GetPodName(cluster),
 							fdbv1beta2.MainContainerName,
@@ -139,7 +143,7 @@ func performUpgrade(config testConfig, preUpgradeFunction func(cluster *fixtures
 						)
 						log.Println("stdout:", stdout, "stderr", stderr, "err", err)
 
-						pod, err := factory.GetPod(
+						pod, err := factory.GetPod(ctx,
 							cluster.Namespace,
 							processGroup.GetPodName(cluster),
 						)
@@ -149,6 +153,7 @@ func performUpgrade(config testConfig, preUpgradeFunction func(cluster *fixtures
 								processGroup.ProcessGroupID,
 								":",
 								factory.GetLogsForPod(
+									ctx,
 									pod,
 									fdbv1beta2.MainContainerName,
 									missingTime,
@@ -193,22 +198,22 @@ func performUpgrade(config testConfig, preUpgradeFunction func(cluster *fixtures
 	expectedProcessCounts := (processCounts.Total()-processCounts.Storage)*2 + 5
 	Expect(len(transactionSystemProcessGroups)).To(BeNumerically("<=", expectedProcessCounts))
 	// Ensure we have no data loss.
-	fdbCluster.EnsureTeamTrackersAreHealthy()
-	fdbCluster.EnsureTeamTrackersHaveMinReplicas()
+	fdbCluster.EnsureTeamTrackersAreHealthy(ctx)
+	fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 }
 
 var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
-	BeforeEach(func() {
+	BeforeEach(func(_ SpecContext) {
 		factory = fixtures.CreateFactory(testOptions)
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		if CurrentSpecReport().Failed() {
 			if fdbCluster != nil {
-				factory.DumpState(fdbCluster)
+				factory.DumpState(ctx, fdbCluster)
 			}
 		}
-		factory.Shutdown()
+		factory.Shutdown(ctx)
 		fdbCluster = nil
 	})
 
@@ -217,15 +222,16 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 	// for different versions without hard coding or having multiple flags.
 	DescribeTable(
 		"upgrading a cluster without chaos", Label("foundationdb-pr"),
-		func(beforeVersion string, targetVersion string) {
-			performUpgrade(testConfig{
-				beforeVersion: beforeVersion,
-				targetVersion: targetVersion,
-				clusterConfig: &fixtures.ClusterConfig{
-					DebugSymbols: false,
-				},
-				loadData: true,
-			}, func(_ *fixtures.FdbCluster) {})
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			performUpgrade(ctx,
+				testConfig{
+					beforeVersion: beforeVersion,
+					targetVersion: targetVersion,
+					clusterConfig: &fixtures.ClusterConfig{
+						DebugSymbols: false,
+					},
+					loadData: true,
+				}, func(_ *fixtures.FdbCluster) {})
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -233,18 +239,19 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"with 2 storage servers per Pod",
-		func(beforeVersion string, targetVersion string) {
-			performUpgrade(testConfig{
-				beforeVersion: beforeVersion,
-				targetVersion: targetVersion,
-				clusterConfig: &fixtures.ClusterConfig{
-					DebugSymbols:        false,
-					StorageServerPerPod: 2,
-				},
-				loadData: false,
-			}, func(cluster *fixtures.FdbCluster) {
-				Expect(cluster.GetCluster().Spec.StorageServersPerPod).To(Equal(2))
-			})
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			performUpgrade(ctx,
+				testConfig{
+					beforeVersion: beforeVersion,
+					targetVersion: targetVersion,
+					clusterConfig: &fixtures.ClusterConfig{
+						DebugSymbols:        false,
+						StorageServerPerPod: 2,
+					},
+					loadData: false,
+				}, func(cluster *fixtures.FdbCluster) {
+					Expect(cluster.GetCluster(ctx).Spec.StorageServersPerPod).To(Equal(2))
+				})
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -252,18 +259,19 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"with 2 log servers per Pod",
-		func(beforeVersion string, targetVersion string) {
-			performUpgrade(testConfig{
-				beforeVersion: beforeVersion,
-				targetVersion: targetVersion,
-				clusterConfig: &fixtures.ClusterConfig{
-					DebugSymbols:     false,
-					LogServersPerPod: 2,
-				},
-				loadData: false,
-			}, func(cluster *fixtures.FdbCluster) {
-				Expect(cluster.GetCluster().Spec.LogServersPerPod).To(Equal(2))
-			})
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			performUpgrade(ctx,
+				testConfig{
+					beforeVersion: beforeVersion,
+					targetVersion: targetVersion,
+					clusterConfig: &fixtures.ClusterConfig{
+						DebugSymbols:     false,
+						LogServersPerPod: 2,
+					},
+					loadData: false,
+				}, func(cluster *fixtures.FdbCluster) {
+					Expect(cluster.GetCluster(ctx).Spec.LogServersPerPod).To(Equal(2))
+				})
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -271,18 +279,19 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"with maintenance mode enabled",
-		func(beforeVersion string, targetVersion string) {
-			performUpgrade(testConfig{
-				beforeVersion: beforeVersion,
-				targetVersion: targetVersion,
-				clusterConfig: &fixtures.ClusterConfig{
-					DebugSymbols:       false,
-					UseMaintenanceMode: true,
-				},
-				loadData: false,
-			}, func(cluster *fixtures.FdbCluster) {
-				Expect(cluster.GetCluster().UseMaintenaceMode()).To(BeTrue())
-			})
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			performUpgrade(ctx,
+				testConfig{
+					beforeVersion: beforeVersion,
+					targetVersion: targetVersion,
+					clusterConfig: &fixtures.ClusterConfig{
+						DebugSymbols:       false,
+						UseMaintenanceMode: true,
+					},
+					loadData: false,
+				}, func(cluster *fixtures.FdbCluster) {
+					Expect(cluster.GetCluster(ctx).UseMaintenaceMode()).To(BeTrue())
+				})
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -290,18 +299,19 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"with locality based exclusions disabled",
-		func(beforeVersion string, targetVersion string) {
-			performUpgrade(testConfig{
-				beforeVersion: beforeVersion,
-				targetVersion: targetVersion,
-				clusterConfig: &fixtures.ClusterConfig{
-					DebugSymbols:               false,
-					UseLocalityBasedExclusions: ptr.To(false),
-				},
-				loadData: false,
-			}, func(cluster *fixtures.FdbCluster) {
-				Expect(cluster.GetCluster().UseLocalitiesForExclusion()).To(BeFalse())
-			})
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			performUpgrade(ctx,
+				testConfig{
+					beforeVersion: beforeVersion,
+					targetVersion: targetVersion,
+					clusterConfig: &fixtures.ClusterConfig{
+						DebugSymbols:               false,
+						UseLocalityBasedExclusions: ptr.To(false),
+					},
+					loadData: false,
+				}, func(cluster *fixtures.FdbCluster) {
+					Expect(cluster.GetCluster(ctx).UseLocalitiesForExclusion()).To(BeFalse())
+				})
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -309,18 +319,19 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"with DNS in cluster file disabled",
-		func(beforeVersion string, targetVersion string) {
-			performUpgrade(testConfig{
-				beforeVersion: beforeVersion,
-				targetVersion: targetVersion,
-				clusterConfig: &fixtures.ClusterConfig{
-					DebugSymbols: false,
-					UseDNS:       ptr.To(false),
-				},
-				loadData: false,
-			}, func(cluster *fixtures.FdbCluster) {
-				Expect(cluster.GetCluster().UseDNSInClusterFile()).To(BeFalse())
-			})
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			performUpgrade(ctx,
+				testConfig{
+					beforeVersion: beforeVersion,
+					targetVersion: targetVersion,
+					clusterConfig: &fixtures.ClusterConfig{
+						DebugSymbols: false,
+						UseDNS:       ptr.To(false),
+					},
+					loadData: false,
+				}, func(cluster *fixtures.FdbCluster) {
+					Expect(cluster.GetCluster(ctx).UseDNSInClusterFile()).To(BeFalse())
+				})
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -328,30 +339,31 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"upgrading a cluster with coordinator Pods",
-		func(beforeVersion string, targetVersion string) {
-			performUpgrade(testConfig{
-				beforeVersion: beforeVersion,
-				targetVersion: targetVersion,
-				clusterConfig: &fixtures.ClusterConfig{
-					DebugSymbols: false,
-				},
-				loadData: false,
-			}, func(cluster *fixtures.FdbCluster) {
-				// Update the cluster spec to create dedicated coordinator Pods and make use DNS in the cluster file.
-				spec := cluster.GetCluster().Spec.DeepCopy()
-				spec.CoordinatorSelection = []fdbv1beta2.CoordinatorSelectionSetting{
-					{
-						Priority:     100,
-						ProcessClass: fdbv1beta2.ProcessClassCoordinator,
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			performUpgrade(ctx,
+				testConfig{
+					beforeVersion: beforeVersion,
+					targetVersion: targetVersion,
+					clusterConfig: &fixtures.ClusterConfig{
+						DebugSymbols: false,
 					},
-				}
-				spec.ProcessCounts.Coordinator = fdbCluster.GetCachedCluster().
-					DesiredCoordinatorCount() +
-					fdbCluster.GetCachedCluster().
-						DesiredFaultTolerance()
-				fdbCluster.UpdateClusterSpecWithSpec(spec)
-				Expect(fdbCluster.WaitForReconciliation()).NotTo(HaveOccurred())
-			})
+					loadData: false,
+				}, func(cluster *fixtures.FdbCluster) {
+					// Update the cluster spec to create dedicated coordinator Pods and make use DNS in the cluster file.
+					spec := cluster.GetCluster(ctx).Spec.DeepCopy()
+					spec.CoordinatorSelection = []fdbv1beta2.CoordinatorSelectionSetting{
+						{
+							Priority:     100,
+							ProcessClass: fdbv1beta2.ProcessClassCoordinator,
+						},
+					}
+					spec.ProcessCounts.Coordinator = fdbCluster.GetCachedCluster().
+						DesiredCoordinatorCount() +
+						fdbCluster.GetCachedCluster().
+							DesiredFaultTolerance()
+					fdbCluster.UpdateClusterSpecWithSpec(ctx, spec)
+					Expect(fdbCluster.WaitForReconciliation(ctx)).NotTo(HaveOccurred())
+				})
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -359,21 +371,22 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 
 	DescribeTable(
 		"upgrading a cluster with zone ID from a custom environment variable",
-		func(beforeVersion string, targetVersion string) {
-			performUpgrade(testConfig{
-				beforeVersion: beforeVersion,
-				targetVersion: targetVersion,
-				clusterConfig: &fixtures.ClusterConfig{
-					DebugSymbols:                 false,
-					SimulateCustomFaultDomainEnv: true,
-				},
-				loadData: false,
-			}, func(cluster *fixtures.FdbCluster) {
-				spec := cluster.GetCluster().Spec.DeepCopy()
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			performUpgrade(ctx,
+				testConfig{
+					beforeVersion: beforeVersion,
+					targetVersion: targetVersion,
+					clusterConfig: &fixtures.ClusterConfig{
+						DebugSymbols:                 false,
+						SimulateCustomFaultDomainEnv: true,
+					},
+					loadData: false,
+				}, func(cluster *fixtures.FdbCluster) {
+					spec := cluster.GetCluster(ctx).Spec.DeepCopy()
 
-				Expect(spec.FaultDomain.Key).To(Equal(corev1.LabelHostname))
-				Expect(spec.FaultDomain.ValueFrom).To(HaveSuffix(fdbv1beta2.EnvNameInstanceID))
-			})
+					Expect(spec.FaultDomain.Key).To(Equal(corev1.LabelHostname))
+					Expect(spec.FaultDomain.ValueFrom).To(HaveSuffix(fdbv1beta2.EnvNameInstanceID))
+				})
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),

--- a/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
@@ -28,6 +28,7 @@ Since FoundationDB is version incompatible for major and minor versions and the 
 */
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -58,8 +59,8 @@ var _ = AfterSuite(func() {
 	}
 })
 
-func clusterSetup(beforeVersion string) {
-	fdbCluster = factory.CreateFdbCluster(
+func clusterSetup(ctx context.Context, beforeVersion string) {
+	fdbCluster = factory.CreateFdbCluster(ctx,
 		&fixtures.ClusterConfig{
 			DebugSymbols: false,
 			Version:      ptr.To(beforeVersion),
@@ -67,23 +68,23 @@ func clusterSetup(beforeVersion string) {
 	)
 
 	Expect(
-		fdbCluster.InvariantClusterStatusAvailable(),
+		fdbCluster.InvariantClusterStatusAvailable(ctx),
 	).ShouldNot(HaveOccurred())
 }
 
 var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func() {
-	BeforeEach(func() {
+	BeforeEach(func(_ SpecContext) {
 		factory = fixtures.CreateFactory(testOptions)
 		if !factory.ChaosTestsEnabled() {
 			Skip("chaos mesh is disabled")
 		}
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		if CurrentSpecReport().Failed() {
-			factory.DumpState(fdbCluster)
+			factory.DumpState(ctx, fdbCluster)
 		}
-		factory.Shutdown()
+		factory.Shutdown(ctx)
 	})
 
 	// Ginkgo lacks the support for AfterEach and BeforeEach in tables, so we have to put everything inside the testing function
@@ -91,19 +92,20 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 	// for different versions without hard coding or having multiple flags.
 	DescribeTable(
 		"upgrading a cluster with a partitioned pod",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion)
-			Expect(fdbCluster.SetAutoReplacements(false, 20*time.Minute)).ToNot(HaveOccurred())
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetup(ctx, beforeVersion)
+			Expect(fdbCluster.SetAutoReplacements(ctx, false, 20*time.Minute)).ToNot(HaveOccurred())
 			// Ensure the operator is not skipping the process because it's missing for to long
-			fdbCluster.SetIgnoreMissingProcessesSeconds(5 * time.Minute)
+			fdbCluster.SetIgnoreMissingProcessesSeconds(ctx, 5*time.Minute)
 
 			// 1. Introduce network partition b/w Pod and cluster.
 			// Inject chaos only to storage Pods to reduce the risk of a long recovery because a transaction
 			// system Pod was partitioned. The test still has the same checks that will be performed.
 			// Once we have a better availability check for upgrades we can target all pods again.
-			partitionedPod := factory.ChooseRandomPod(fdbCluster.GetStoragePods())
+			partitionedPod := factory.ChooseRandomPod(fdbCluster.GetStoragePods(ctx))
 			log.Println("Injecting network partition to pod: ", partitionedPod.Name)
 			exp := factory.InjectPartitionBetween(
+				ctx,
 				fixtures.PodSelector(partitionedPod),
 				chaosmesh.PodSelectorSpec{
 					GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
@@ -113,7 +115,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 				},
 			)
 
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			if !fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				// 2. Until we remove the partition, cluster should not have
@@ -121,14 +123,14 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 				//
 				// This is only true for version incompatible upgrades.
 				Consistently(func() bool {
-					return fdbCluster.GetCluster().Status.RunningVersion == beforeVersion
+					return fdbCluster.GetCluster(ctx).Status.RunningVersion == beforeVersion
 				}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(BeTrue())
 			}
 
 			// 3. Delete the partition, and the upgrade should proceed.
 			log.Println("deleting chaos experiment and cluster should upgrade")
-			factory.DeleteChaosMeshExperiment(exp)
-			fdbCluster.VerifyVersion(targetVersion)
+			factory.DeleteChaosMeshExperiment(ctx, exp)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 		},
 
 		EntryDescription("Upgrade from %[1]s to %[2]s with partitioned Pod"),
@@ -137,16 +139,17 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 
 	DescribeTable(
 		"with a partitioned pod which eventually gets replaced",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion)
-			Expect(fdbCluster.SetAutoReplacements(false, 5*time.Minute)).ToNot(HaveOccurred())
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetup(ctx, beforeVersion)
+			Expect(fdbCluster.SetAutoReplacements(ctx, false, 5*time.Minute)).ToNot(HaveOccurred())
 			// Ensure the operator is not skipping the process because it's missing for too long
-			fdbCluster.SetIgnoreMissingProcessesSeconds(30 * time.Minute)
+			fdbCluster.SetIgnoreMissingProcessesSeconds(ctx, 30*time.Minute)
 
 			// 1. Introduce network partition b/w Pod and cluster.
-			partitionedPod := factory.ChooseRandomPod(fdbCluster.GetStoragePods())
+			partitionedPod := factory.ChooseRandomPod(fdbCluster.GetStoragePods(ctx))
 			log.Println("Injecting network partition to pod: ", partitionedPod.Name)
 			_ = factory.InjectPartitionBetween(
+				ctx,
 				fixtures.PodSelector(partitionedPod),
 				chaosmesh.PodSelectorSpec{
 					GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
@@ -156,25 +159,25 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 				},
 			)
 
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			if !fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				// 2. Until we remove the partition, cluster should not have upgraded. Keep checking for 2m.
 				//
 				// This is only true for version incompatible upgrades.
 				Consistently(func() bool {
-					return fdbCluster.GetCluster().Status.RunningVersion == beforeVersion
+					return fdbCluster.GetCluster(ctx).Status.RunningVersion == beforeVersion
 				}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(BeTrue())
 			}
 
 			// Enable the auto replacement feature again, but don't wait for reconciliation, otherwise we wait
 			// until the whole cluster is upgraded.
 			Expect(
-				fdbCluster.SetAutoReplacementsWithWait(true, 3*time.Minute, false),
+				fdbCluster.SetAutoReplacementsWithWait(ctx, true, 3*time.Minute, false),
 			).ToNot(HaveOccurred())
 
 			// Make sure to allow missing processes again to be ignored.
-			fdbCluster.SetIgnoreMissingProcessesSeconds(10 * time.Second)
+			fdbCluster.SetIgnoreMissingProcessesSeconds(ctx, 10*time.Second)
 
 			// In the case of a version compatible upgrade the operator will proceed with recreating the storage Pods
 			// to make sure they use the new version. At the same time all transaction processes are marked for removal
@@ -183,12 +186,12 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			// the injected partition from chaos-mesh is lost and therefore the process is reporting to the cluster again.
 			if !fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				log.Println("waiting for pod removal:", partitionedPod.Name)
-				fdbCluster.WaitForPodRemoval(partitionedPod)
+				fdbCluster.WaitForPodRemoval(ctx, partitionedPod)
 				log.Println("pod removed:", partitionedPod.Name)
 			}
 
 			// 3. Upgrade should proceed without removing the partition, as Pod will be replaced.
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 		},
 
 		EntryDescription(
@@ -199,12 +202,12 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 
 	DescribeTable(
 		"upgrading a cluster with link that drops some packets",
-		func(beforeVersion string, targetVersion string) {
-			clusterSetup(beforeVersion)
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
+			clusterSetup(ctx, beforeVersion)
 
 			// 1. Introduce packet loss b/w pods.
 			log.Println("Injecting packet loss b/w pod")
-			allPods := fdbCluster.GetAllPods()
+			allPods := fdbCluster.GetAllPods(ctx)
 
 			pickedPods := factory.RandomPickPod(allPods.Items, len(allPods.Items)/5)
 			Expect(pickedPods).ToNot(BeEmpty())
@@ -212,7 +215,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 				log.Println("Picked Pod", pod.Name)
 			}
 
-			factory.InjectNetworkLoss("20", fixtures.PodsSelector(pickedPods),
+			factory.InjectNetworkLoss(ctx, "20", fixtures.PodsSelector(pickedPods),
 				chaosmesh.PodSelectorSpec{
 					GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
 						Namespaces:     []string{fdbCluster.Namespace()},
@@ -221,8 +224,9 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 				}, chaosmesh.Both)
 
 			// Also inject network loss b/w operator pods and cluster pods.
-			operatorPods := factory.GetOperatorPods(fdbCluster.Namespace())
+			operatorPods := factory.GetOperatorPods(ctx, fdbCluster.Namespace())
 			factory.InjectNetworkLoss(
+				ctx,
 				"20",
 				fixtures.PodsSelector(allPods.Items),
 				fixtures.PodsSelector(operatorPods.Items),
@@ -230,10 +234,10 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 
 			// 2. Start cluster upgrade.
 			log.Println("Starting cluster upgrade.")
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 
 			// 3. Upgrade should finish.
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s with network link that drops some packets"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),
@@ -241,7 +245,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 
 	DescribeTable(
 		"upgrading a cluster and one process has the fdbmonitor.conf file not ready",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				Skip("this test only affects version incompatible upgrades")
 			}
@@ -252,29 +256,29 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 				Skip("this test only affects the split image setup")
 			}
 
-			clusterSetup(beforeVersion)
+			clusterSetup(ctx, beforeVersion)
 
 			// Update the cluster version.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 			// Skip the reconciliation here to have time to stage everything.
-			fdbCluster.SetSkipReconciliation(true)
+			fdbCluster.SetSkipReconciliation(ctx, true)
 
 			// Select one Pod, this Pod will mount the fdbmonitor config file as read-only.
 			// This should block the upgrade.
-			faultyPod := factory.RandomPickOnePod(fdbCluster.GetPods().Items)
+			faultyPod := factory.RandomPickOnePod(fdbCluster.GetPods(ctx).Items)
 
 			// We have to update the sidecar before the operator is doing it. If we don't do this here the operator
 			// will update the sidecar and then the I/O chaos will be gone. So we prepare the faulty Pod to already
 			// be using the new sidecar image and then we inject IO chaos.
-			sidecarImage := fdbCluster.GetSidecarImageForVersion(targetVersion)
-			fdbCluster.UpdateContainerImage(
+			sidecarImage := fdbCluster.GetSidecarImageForVersion(ctx, targetVersion)
+			fdbCluster.UpdateContainerImage(ctx,
 				&faultyPod,
 				fdbv1beta2.SidecarContainerName,
 				sidecarImage,
 			)
 
 			Eventually(func() bool {
-				pod := fdbCluster.GetPod(faultyPod.Name)
+				pod := fdbCluster.GetPod(ctx, faultyPod.Name)
 
 				for _, status := range pod.Status.ContainerStatuses {
 					if status.Name != fdbv1beta2.SidecarContainerName {
@@ -290,7 +294,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 
 			log.Println("Inject IO chaos to", faultyPod.Name)
 			// Ensure that the fdbmonitor config file is not writeable for the sidecar.
-			exp := factory.InjectDiskFailureWithPath(
+			exp := factory.InjectDiskFailureWithPath(ctx,
 				fixtures.PodSelector(&faultyPod),
 				"/var/output-files",
 				"/var/output-files/fdbmonitor.conf",
@@ -308,6 +312,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			// Make sure the sidecar is not able to write the fdbmonitor config.
 			Eventually(func() error {
 				stdout, stderr, err := fdbCluster.ExecuteCmdOnPod(
+					ctx,
 					faultyPod,
 					fdbv1beta2.SidecarContainerName,
 					"cat /var/output-files/fdbmonitor.conf && echo '\n' >> /var/output-files/fdbmonitor.conf",
@@ -320,7 +325,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(HaveOccurred())
 
 			// Now we have the faulty Pod prepared with I/O chaos injected, so we can continue with the upgrade.
-			fdbCluster.SetSkipReconciliation(false)
+			fdbCluster.SetSkipReconciliation(ctx, false)
 
 			// The cluster will be stuck in this state until the I/O chaos is resolved.
 			expectedConditions := map[fdbv1beta2.ProcessGroupConditionType]bool{
@@ -332,7 +337,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			// The upgrade will be stuck until the I/O chaos is removed and the sidecar is able to provide the latest
 			// fdbmonitor conf file.
 			Eventually(func() bool {
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					if processGroup.ProcessGroupID != faultyProcessGroupID {
 						continue
@@ -354,14 +359,14 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			}).WithTimeout(5 * time.Minute).WithPolling(2 * time.Second).MustPassRepeatedly(30).Should(BeTrue())
 
 			// Make sure the cluster was not upgraded yet.
-			cluster := fdbCluster.GetCluster()
+			cluster := fdbCluster.GetCluster(ctx)
 			Expect(cluster.Spec.Version).NotTo(Equal(cluster.Status.RunningVersion))
 
 			// Remove the IO chaos, the cluster should proceed.
-			factory.DeleteChaosMeshExperiment(exp)
+			factory.DeleteChaosMeshExperiment(ctx, exp)
 
 			// Ensure the upgrade proceeds and is able to finish.
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 		},
 		EntryDescription(
 			"Upgrade from %[1]s to %[2]s and one process has the fdbmonitor.conf file not ready",
@@ -371,7 +376,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 
 	DescribeTable(
 		"upgrading a cluster and one process is missing the new binary",
-		func(beforeVersion string, targetVersion string) {
+		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			if fixtures.VersionsAreProtocolCompatible(beforeVersion, targetVersion) {
 				Skip("this test only affects version incompatible upgrades")
 			}
@@ -384,29 +389,29 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 				Skip("in the unified image setup the operator doesn't validate the binary")
 			}
 
-			clusterSetup(beforeVersion)
+			clusterSetup(ctx, beforeVersion)
 
 			// Update the cluster version.
-			Expect(fdbCluster.UpgradeCluster(targetVersion, false)).NotTo(HaveOccurred())
+			Expect(fdbCluster.UpgradeCluster(ctx, targetVersion, false)).NotTo(HaveOccurred())
 			// Skip the reconciliation here to have time to stage everything.
-			fdbCluster.SetSkipReconciliation(true)
+			fdbCluster.SetSkipReconciliation(ctx, true)
 
 			// Select one Pod, this Pod will miss the new fdbserver binary.
 			// This should block the upgrade.
-			faultyPod := factory.RandomPickOnePod(fdbCluster.GetPods().Items)
+			faultyPod := factory.RandomPickOnePod(fdbCluster.GetPods(ctx).Items)
 
 			// We have to update the sidecar before the operator is doing it. If we don't do this here the operator
 			// will update the sidecar and then the sidecar will copy the binaries at start-up. So we prepare the faulty Pod to already
 			// be using the new sidecar image and then we delete the new fdbserver binary.
-			sidecarImage := fdbCluster.GetSidecarImageForVersion(targetVersion)
-			fdbCluster.UpdateContainerImage(
+			sidecarImage := fdbCluster.GetSidecarImageForVersion(ctx, targetVersion)
+			fdbCluster.UpdateContainerImage(ctx,
 				&faultyPod,
 				fdbv1beta2.SidecarContainerName,
 				sidecarImage,
 			)
 
 			Eventually(func() bool {
-				pod := fdbCluster.GetPod(faultyPod.Name)
+				pod := fdbCluster.GetPod(ctx, faultyPod.Name)
 
 				for _, status := range pod.Status.ContainerStatuses {
 					if status.Name != fdbv1beta2.SidecarContainerName {
@@ -437,7 +442,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 
 			// Make sure the sidecar is missing the fdbserver binary.
 			Eventually(func() error {
-				_, _, err := fdbCluster.ExecuteCmdOnPod(
+				_, _, err := fdbCluster.ExecuteCmdOnPod(ctx,
 					faultyPod,
 					fdbv1beta2.SidecarContainerName,
 					fmt.Sprintf("rm -f %s", fdbserverBinary),
@@ -447,7 +452,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).ShouldNot(HaveOccurred())
 
 			// Now we have the faulty Pod prepared, so we can continue with the upgrade.
-			fdbCluster.SetSkipReconciliation(false)
+			fdbCluster.SetSkipReconciliation(ctx, false)
 
 			// The cluster will be stuck in this state until the Pod is restarted and the new binary is present.
 			expectedConditions := map[fdbv1beta2.ProcessGroupConditionType]bool{
@@ -459,12 +464,12 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			creationTimestamp := faultyPod.CreationTimestamp
 			// The upgrade will be stuck until the new fdbserver binary is copied to the shared directory again.
 			Eventually(func() bool {
-				currentPod := fdbCluster.GetPod(faultyPod.Name)
+				currentPod := fdbCluster.GetPod(ctx, faultyPod.Name)
 				if creationTimestamp.Compare(currentPod.CreationTimestamp.Time) != 0 {
 					Skip("Faulty Pod was deleted, skipping test as the test setup failed.")
 				}
 
-				cluster := fdbCluster.GetCluster()
+				cluster := fdbCluster.GetCluster(ctx)
 				for _, processGroup := range cluster.Status.ProcessGroups {
 					if processGroup.ProcessGroupID != faultyProcessGroupID {
 						continue
@@ -486,12 +491,12 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			}).WithTimeout(5 * time.Minute).WithPolling(2 * time.Second).MustPassRepeatedly(30).Should(BeTrue())
 
 			// Make sure the cluster was not upgraded yet.
-			cluster := fdbCluster.GetCluster()
+			cluster := fdbCluster.GetCluster(ctx)
 			Expect(cluster.Spec.Version).NotTo(Equal(cluster.Status.RunningVersion))
 
 			// Ensure the binary is present in the shared folder.
 			Eventually(func() error {
-				_, _, err := fdbCluster.ExecuteCmdOnPod(
+				_, _, err := fdbCluster.ExecuteCmdOnPod(ctx,
 					faultyPod,
 					fdbv1beta2.SidecarContainerName,
 					fmt.Sprintf("cp -f /usr/bin/fdbserver %s", fdbserverBinary),
@@ -501,7 +506,7 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).ShouldNot(HaveOccurred())
 
 			// Ensure the upgrade proceeds and is able to finish.
-			fdbCluster.VerifyVersion(targetVersion)
+			fdbCluster.VerifyVersion(ctx, targetVersion)
 		},
 		EntryDescription("Upgrade from %[1]s to %[2]s and one process is missing the new binary"),
 		fixtures.GenerateUpgradeTableEntries(testOptions),

--- a/e2e/test_operator_velocity/operator_velocity_test.go
+++ b/e2e/test_operator_velocity/operator_velocity_test.go
@@ -25,6 +25,7 @@ This test suite includes tests to validate the rollout time of new knobs under d
 */
 
 import (
+	"context"
 	"log"
 	"strings"
 	"time"
@@ -52,6 +53,7 @@ var (
 )
 
 func CheckKnobRollout(
+	ctx context.Context,
 	fdbCluster *fixtures.HaFdbCluster,
 	expectedGeneralCustomParameters fdbv1beta2.FoundationDBCustomParameters,
 	expectedStorageCustomParameters fdbv1beta2.FoundationDBCustomParameters,
@@ -60,7 +62,7 @@ func CheckKnobRollout(
 	totalStorageProcessCount int,
 ) {
 	primary := fdbCluster.GetPrimary()
-	initialGeneration := primary.GetStatus().Cluster.Generation
+	initialGeneration := primary.GetStatus(ctx).Cluster.Generation
 
 	startTime := time.Now()
 	timeoutTime := startTime.Add(time.Duration(knobRolloutTimeoutSeconds) * time.Second)
@@ -70,6 +72,7 @@ func CheckKnobRollout(
 		durationSinceLastStateDump := time.Since(lastStateDump)
 		if durationSinceLastStateDump > 2*time.Minute {
 			factory.DumpStateHaClusterWithLogsSince(
+				ctx,
 				fdbCluster,
 				ptr.To[int64](int64(durationSinceLastStateDump.Seconds())+5),
 			)
@@ -77,7 +80,7 @@ func CheckKnobRollout(
 			lastStateDump = time.Now()
 		}
 
-		status := primary.GetStatus()
+		status := primary.GetStatus(ctx)
 		commandLines := primary.GetCommandlineForProcessesPerClassWithStatus(status)
 		var generalProcessCounts, storageProcessCounts int
 
@@ -112,7 +115,7 @@ func CheckKnobRollout(
 		)
 
 		for _, cluster := range fdbCluster.GetAllClusters() {
-			currentCluster := cluster.GetCluster()
+			currentCluster := cluster.GetCluster(ctx)
 			log.Println(
 				"cluster state:",
 				currentCluster.Name,
@@ -128,7 +131,7 @@ func CheckKnobRollout(
 	}).WithTimeout(time.Until(timeoutTime)).WithPolling(15 * time.Second).Should(Succeed())
 
 	rolloutDuration := time.Since(startTime)
-	finalGeneration := primary.GetStatus().Cluster.Generation
+	finalGeneration := primary.GetStatus(ctx).Cluster.Generation
 
 	log.Println(
 		"Knob rollout took",
@@ -143,7 +146,7 @@ func CheckKnobRollout(
 	// If the synchronization mode is global, we expect to see only a single recovery. Since those tests are running on
 	// a real cluster we add some additional buffer of two additional recoveries. We check for an increase of 6 generations
 	// because FDB increase the current generation by 2 if a recovery is triggered.
-	if primary.GetCluster().GetSynchronizationMode() == fdbv1beta2.SynchronizationModeGlobal {
+	if primary.GetCluster(ctx).GetSynchronizationMode() == fdbv1beta2.SynchronizationModeGlobal {
 		Expect(finalGeneration - initialGeneration).To(BeNumerically("<=", 6))
 	}
 }
@@ -172,9 +175,9 @@ func parametersExists(cmdLine string, params fdbv1beta2.FoundationDBCustomParame
 	return true
 }
 
-var _ = BeforeSuite(func() {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	factory = fixtures.CreateFactory(testOptions)
-	fdbCluster = factory.CreateFdbHaCluster(
+	fdbCluster = factory.CreateFdbHaCluster(ctx,
 		fixtures.DefaultClusterConfigWithHaMode(fixtures.HaFourZoneDoubleSat, false),
 	)
 
@@ -205,36 +208,36 @@ var _ = BeforeSuite(func() {
 	}
 })
 
-var _ = AfterSuite(func() {
-	factory.Shutdown()
+var _ = AfterSuite(func(ctx SpecContext) {
+	factory.Shutdown(ctx)
 })
 
 var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 	var totalGeneralProcessCount, totalStorageProcessCount int
 
-	BeforeEach(func() {
-		Expect(fdbCluster.WaitForReconciliation()).ToNot(HaveOccurred())
+	BeforeEach(func(ctx SpecContext) {
+		Expect(fdbCluster.WaitForReconciliation(ctx)).ToNot(HaveOccurred())
 
 		totalGeneralProcessCount = 0
 		totalStorageProcessCount = 0
 
 		for _, cluster := range fdbCluster.GetAllClusters() {
-			processCnt, err := cluster.GetCluster().GetProcessCountsWithDefaults()
+			processCnt, err := cluster.GetCluster(ctx).GetProcessCountsWithDefaults()
 			Expect(err).NotTo(HaveOccurred())
 			totalStorageProcessCount += processCnt.Storage * cluster.GetStorageServerPerPod()
 			totalGeneralProcessCount += processCnt.Total() - processCnt.Storage
 		}
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		if CurrentSpecReport().Failed() {
-			factory.DumpStateHaCluster(fdbCluster)
+			factory.DumpStateHaCluster(ctx, fdbCluster)
 		}
-		Expect(factory.CleanupChaosMeshExperiments()).ToNot(HaveOccurred())
+		Expect(factory.CleanupChaosMeshExperiments(ctx)).ToNot(HaveOccurred())
 		log.Println("Reverting knobs back to initial settings")
 		start := time.Now()
 		Expect(
-			fdbCluster.SetCustomParameters(
+			fdbCluster.SetCustomParameters(ctx,
 				map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 					fdbv1beta2.ProcessClassGeneral: initialGeneralCustomParameters,
 					fdbv1beta2.ProcessClassStorage: initialStorageCustomParameters,
@@ -247,9 +250,9 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 	})
 
 	When("a knob is changed", func() {
-		It("should roll out knob changes within expected time", func() {
+		It("should roll out knob changes within expected time", func(ctx SpecContext) {
 			Expect(
-				fdbCluster.SetCustomParameters(
+				fdbCluster.SetCustomParameters(ctx,
 					map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 						fdbv1beta2.ProcessClassGeneral: newGeneralCustomParameters,
 						fdbv1beta2.ProcessClassStorage: newStorageCustomParameters,
@@ -259,6 +262,7 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 			).To(Succeed())
 
 			CheckKnobRollout(
+				ctx,
 				fdbCluster,
 				newGeneralCustomParameters,
 				newStorageCustomParameters,
@@ -269,10 +273,10 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 	})
 
 	When("a knob is changed and the cluster is bounced", func() {
-		It("should roll out knob changes within expected time", func() {
-			Expect(fdbCluster.GetPrimary().BounceClusterWithoutWait()).ToNot(HaveOccurred())
+		It("should roll out knob changes within expected time", func(ctx SpecContext) {
+			Expect(fdbCluster.GetPrimary().BounceClusterWithoutWait(ctx)).ToNot(HaveOccurred())
 			Expect(
-				fdbCluster.SetCustomParameters(
+				fdbCluster.SetCustomParameters(ctx,
 					map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 						fdbv1beta2.ProcessClassGeneral: newGeneralCustomParameters,
 						fdbv1beta2.ProcessClassStorage: newStorageCustomParameters,
@@ -283,11 +287,12 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 
 			// Make sure to wait for the cluster to become available again.
 			Eventually(func() bool {
-				return fdbCluster.GetPrimary().IsAvailable()
+				return fdbCluster.GetPrimary().IsAvailable(ctx)
 			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(BeTrue())
 
-			cluster := fdbCluster.GetPrimary().GetCluster()
+			cluster := fdbCluster.GetPrimary().GetCluster(ctx)
 			CheckKnobRollout(
+				ctx,
 				fdbCluster,
 				newGeneralCustomParameters,
 				newStorageCustomParameters,
@@ -302,32 +307,32 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 		var initialReplaceTime time.Duration
 		var exp *fixtures.ChaosMeshExperiment
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			initialReplaceTime = time.Duration(ptr.Deref(
 				fdbCluster.GetPrimary().
-					GetClusterSpec().
+					GetClusterSpec(ctx).
 					AutomationOptions.Replacements.FailureDetectionTimeSeconds,
 				90,
 			)) * time.Second
 			Expect(
-				fdbCluster.GetPrimary().SetAutoReplacements(false, 1*time.Hour),
+				fdbCluster.GetPrimary().SetAutoReplacements(ctx, false, 1*time.Hour),
 			).NotTo(HaveOccurred())
 			// Partition a storage Pod from the rest of the cluster
-			pod := factory.ChooseRandomPod(fdbCluster.GetPrimary().GetStoragePods())
+			pod := factory.ChooseRandomPod(fdbCluster.GetPrimary().GetStoragePods(ctx))
 			log.Printf("partition Pod: %s", pod.Name)
-			exp = factory.InjectPartition(fixtures.PodSelector(pod))
+			exp = factory.InjectPartition(ctx, fixtures.PodSelector(pod))
 		})
 
-		AfterEach(func() {
-			factory.DeleteChaosMeshExperiment(exp)
+		AfterEach(func(ctx SpecContext) {
+			factory.DeleteChaosMeshExperiment(ctx, exp)
 			Expect(
-				fdbCluster.GetPrimary().SetAutoReplacements(true, initialReplaceTime),
+				fdbCluster.GetPrimary().SetAutoReplacements(ctx, true, initialReplaceTime),
 			).NotTo(HaveOccurred())
 		})
 
-		It("should roll out knob changes within expected time", func() {
+		It("should roll out knob changes within expected time", func(ctx SpecContext) {
 			Expect(
-				fdbCluster.SetCustomParameters(
+				fdbCluster.SetCustomParameters(ctx,
 					map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 						fdbv1beta2.ProcessClassGeneral: newGeneralCustomParameters,
 						fdbv1beta2.ProcessClassStorage: newStorageCustomParameters,
@@ -342,11 +347,12 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 			// as the partitioned Pod will block the release of the lock and the next operator has to wait until the
 			// lock is expired.
 			CheckKnobRollout(
+				ctx,
 				fdbCluster,
 				newGeneralCustomParameters,
 				newStorageCustomParameters,
 				normalKnobRolloutTimeoutSeconds+int(
-					fdbCluster.GetPrimary().GetCluster().GetLockDuration().Seconds(),
+					fdbCluster.GetPrimary().GetCluster(ctx).GetLockDuration().Seconds(),
 				),
 				totalGeneralProcessCount,
 				totalStorageProcessCount-(1*fdbCluster.GetPrimary().GetStorageServerPerPod()),
@@ -355,21 +361,21 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 	})
 
 	When("a knob is changed and a single pod in the primary region is replaced", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			// Start replacement of a random storage Pod.
-			pod := factory.ChooseRandomPod(fdbCluster.GetPrimary().GetStoragePods())
+			pod := factory.ChooseRandomPod(fdbCluster.GetPrimary().GetStoragePods(ctx))
 			log.Println("Start replacing", pod.Name)
-			fdbCluster.GetPrimary().ReplacePod(*pod, false)
+			fdbCluster.GetPrimary().ReplacePod(ctx, *pod, false)
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			// Wait until the replaced process group is removed.
-			Expect(fdbCluster.WaitForReconciliation()).To(Succeed())
+			Expect(fdbCluster.WaitForReconciliation(ctx)).To(Succeed())
 		})
 
-		It("should roll out knob changes within expected time", func() {
+		It("should roll out knob changes within expected time", func(ctx SpecContext) {
 			Expect(
-				fdbCluster.SetCustomParameters(
+				fdbCluster.SetCustomParameters(ctx,
 					map[fdbv1beta2.ProcessClass]fdbv1beta2.FoundationDBCustomParameters{
 						fdbv1beta2.ProcessClassGeneral: newGeneralCustomParameters,
 						fdbv1beta2.ProcessClassStorage: newStorageCustomParameters,
@@ -382,15 +388,16 @@ var _ = Describe("Test Operator Velocity", Label("e2e", "nightly"), func() {
 			// In our testing pipeline we see failures due to the fact that the replacement takes a long time, e.g.
 			// when a new node must be created for the replaced pod.
 			if fdbCluster.GetPrimary().
-				GetCluster().
+				GetCluster(ctx).
 				GetSynchronizationMode() ==
 				fdbv1beta2.SynchronizationModeLocal {
 				knobRolloutTimeout += int(
-					fdbCluster.GetPrimary().GetCluster().GetLockDuration().Seconds() * 2,
+					fdbCluster.GetPrimary().GetCluster(ctx).GetLockDuration().Seconds() * 2,
 				)
 			}
 
 			CheckKnobRollout(
+				ctx,
 				fdbCluster,
 				newGeneralCustomParameters,
 				newStorageCustomParameters,


### PR DESCRIPTION
# Description

Add context.Context to all e2e test specs and remove the context.Background and context.TODO

## Type of change

- Other

## Discussion

I only changed the signatures and passed down the `ctx` variable. Passing down the context is a better practice and should allow better handling of sigterm, when stopping the test cases.

## Testing

Ran `make fmt lint test` and CI will run the e2e test suite.

## Documentation

-

## Follow-up

We should update out unit tests too.
