### PR TITLE
Backup reconciler will delete terminal pods

### DIFF
--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -54,6 +54,8 @@ type FoundationDBBackupReconciler struct {
 	// is unset in AllowedPodModifications, we allow everything to not break the current setups. In a new major release we could
 	// change this and enforce that fields are only allowed to change if the according AllowedPodModifications is set.
 	AllowedPodModifications *fdbv1beta2.AllowedPodModifications
+	// MinimumAgeForTerminalPodDeletion defines the minimum age of a terminal pod before it will be deleted.
+	MinimumAgeForTerminalPodDeletion time.Duration
 }
 
 // +kubebuilder:rbac:groups=apps.foundationdb.org,resources=foundationdbbackups,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -125,18 +125,48 @@ func (r *FoundationDBBackupReconciler) Reconcile(
 		return ctrl.Result{}, fmt.Errorf("FoundationDBBackup is not valid: %w", err)
 	}
 
+	var delayedRequeueDuration time.Duration
+	var delayedRequeue bool
+
 	for _, subReconciler := range backupSubReconcilers {
 		req := subReconciler.reconcile(ctx, r, backup)
 		if req == nil {
 			continue
 		}
 
+		if req.delayedRequeue {
+			backupLog.Info("Delaying requeue for sub-reconciler",
+				"reconciler", fmt.Sprintf("%T", subReconciler),
+				"message", req.message,
+				"delayedRequeueDuration", delayedRequeueDuration.String(),
+				"error", req.curError)
+			if delayedRequeueDuration < req.delay {
+				delayedRequeueDuration = req.delay
+			}
+
+			delayedRequeue = true
+			continue
+		}
+
 		return processRequeue(req, subReconciler, backup, r.Recorder, backupLog)
 	}
 
-	if backup.Status.Generations.Reconciled < originalGeneration {
-		backupLog.Info("Backup was not fully reconciled by reconciliation process")
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	if backup.Status.Generations.Reconciled < originalGeneration || delayedRequeue {
+		backupLog.Info("Backup was not fully reconciled by reconciliation process",
+			"status",
+			backup.Status.Generations,
+			"CurrentGeneration",
+			backup.Status.Generations.Reconciled,
+			"OriginalGeneration",
+			originalGeneration,
+			"DelayedRequeue",
+			delayedRequeueDuration.String())
+
+		if delayedRequeueDuration == time.Duration(0) {
+			delayedRequeueDuration = 5 * time.Second
+		}
+
+		return ctrl.Result{RequeueAfter: delayedRequeueDuration}, nil
 	}
 
 	backupLog.Info("Reconciliation complete")

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -21,6 +21,7 @@
 package controllers
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/utils/ptr"
@@ -32,12 +33,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"context"
-
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func reloadBackup(backup *fdbv1beta2.FoundationDBBackup) (int64, error) {
@@ -338,6 +339,36 @@ var _ = Describe("backup_controller", func() {
 			})
 		})
 
+		When("a backup agent pod is stuck in a Failed state", func() {
+			BeforeEach(func(ctx SpecContext) {
+				generationGap = 0
+				setupUnreadyDeploymentWithTerminalPod(
+					ctx,
+					backup,
+					corev1.PodFailed,
+				)
+			})
+
+			It("should delete the terminal pod", func() {
+				expectNoTerminalBackupAgentPods(backup)
+			})
+		})
+
+		When("a backup agent pod completed but was not cleaned up", func() {
+			BeforeEach(func(ctx SpecContext) {
+				generationGap = 0
+				setupUnreadyDeploymentWithTerminalPod(
+					ctx,
+					backup,
+					corev1.PodSucceeded,
+				)
+			})
+
+			It("should delete the terminal pod", func() {
+				expectNoTerminalBackupAgentPods(backup)
+			})
+		})
+
 		When("providing custom parameters", func() {
 			BeforeEach(func() {
 				backup.Spec.CustomParameters = fdbv1beta2.FoundationDBCustomParameters{
@@ -459,3 +490,18 @@ var _ = Describe("backup_controller", func() {
 		})
 	})
 })
+
+// expectNoTerminalBackupAgentPods asserts that no Pod with the backup's deployment selector labels
+// remains in the namespace after reconciliation.
+func expectNoTerminalBackupAgentPods(backup *fdbv1beta2.FoundationDBBackup) {
+	podList := &corev1.PodList{}
+	Expect(k8sClient.List(
+		context.TODO(),
+		podList,
+		client.InNamespace(backup.Namespace),
+		client.MatchingLabels(map[string]string{
+			fdbv1beta2.BackupDeploymentPodLabel: internal.GetBackupDeploymentName(backup),
+		}),
+	)).To(Succeed())
+	Expect(podList.Items).To(BeEmpty())
+}

--- a/controllers/update_backup_agents.go
+++ b/controllers/update_backup_agents.go
@@ -24,8 +24,10 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
+	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -94,6 +96,7 @@ func (u updateBackupAgents) reconcile(
 			return &requeue{curError: err}
 		}
 	}
+
 	if !needCreation && deployment != nil {
 		annotationChange := internal.MergeAnnotations(
 			&existingDeployment.ObjectMeta,
@@ -106,6 +109,62 @@ func (u updateBackupAgents) reconcile(
 			err = r.Update(ctx, deployment)
 			if err != nil {
 				return &requeue{curError: err}
+			}
+		}
+
+		if existingDeployment.Status.ReadyReplicas < existingDeployment.Status.Replicas {
+			backupAgentPods := &corev1.PodList{}
+			err = r.List(
+				ctx,
+				backupAgentPods,
+				client.InNamespace(backup.Namespace),
+				client.MatchingLabels(existingDeployment.Spec.Selector.MatchLabels),
+			)
+			if err != nil {
+				return &requeue{curError: err}
+			}
+
+			// minRemaining keeps track of the minimum time the operator has to wait before it can delete a new pod that
+			// is stuck in a terminal state.
+			var minRemaining time.Duration
+			for _, pod := range backupAgentPods.Items {
+				phase := pod.Status.Phase
+				reason := pod.Status.Reason
+				if phase != corev1.PodFailed && phase != corev1.PodSucceeded {
+					continue
+				}
+
+				remaining := time.Until(
+					pod.CreationTimestamp.Add(r.MinimumAgeForTerminalPodDeletion),
+				)
+				if remaining > 0 {
+					logger.Info("Pod in terminal state is too young to be deleted",
+						"pod", pod.Name,
+						"phase", phase,
+						"reason", reason,
+						"minimumAge", r.MinimumAgeForTerminalPodDeletion)
+					if minRemaining == 0 || remaining < minRemaining {
+						minRemaining = remaining
+					}
+					continue
+				}
+
+				logger.Info("Deleting pod that is stuck in a terminal state",
+					"pod", pod.Name,
+					"phase", phase,
+					"reason", reason)
+				err = r.Delete(ctx, ptr.To(pod))
+				if err != nil {
+					return &requeue{curError: err}
+				}
+			}
+
+			if minRemaining > 0 {
+				return &requeue{
+					message:        "pod in terminal state is too young to be deleted",
+					delay:          minRemaining,
+					delayedRequeue: true,
+				}
 			}
 		}
 	}

--- a/controllers/update_backup_agents.go
+++ b/controllers/update_backup_agents.go
@@ -124,9 +124,9 @@ func (u updateBackupAgents) reconcile(
 				return &requeue{curError: err}
 			}
 
-			// minRemaining keeps track of the minimum time the operator has to wait before it can delete a new pod that
+			// minTimeTillNextDeletion keeps track of the minimum time the operator has to wait before it can delete a new pod that
 			// is stuck in a terminal state.
-			var minRemaining time.Duration
+			var minTimeTillNextDeletion time.Duration
 			for _, pod := range backupAgentPods.Items {
 				phase := pod.Status.Phase
 				reason := pod.Status.Reason
@@ -143,8 +143,8 @@ func (u updateBackupAgents) reconcile(
 						"phase", phase,
 						"reason", reason,
 						"minimumAge", r.MinimumAgeForTerminalPodDeletion)
-					if minRemaining == 0 || remaining < minRemaining {
-						minRemaining = remaining
+					if minTimeTillNextDeletion == 0 || remaining < minTimeTillNextDeletion {
+						minTimeTillNextDeletion = remaining
 					}
 					continue
 				}
@@ -159,10 +159,10 @@ func (u updateBackupAgents) reconcile(
 				}
 			}
 
-			if minRemaining > 0 {
+			if minTimeTillNextDeletion > 0 {
 				return &requeue{
 					message:        "pod in terminal state is too young to be deleted",
-					delay:          minRemaining,
+					delay:          minTimeTillNextDeletion,
 					delayedRequeue: true,
 				}
 			}

--- a/controllers/update_backup_agents_test.go
+++ b/controllers/update_backup_agents_test.go
@@ -1,0 +1,118 @@
+/*
+ * update_backup_agents_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2018-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("updateBackupAgents", func() {
+	var cluster *fdbv1beta2.FoundationDBCluster
+	var backup *fdbv1beta2.FoundationDBBackup
+
+	BeforeEach(func(ctx SpecContext) {
+		cluster = internal.CreateDefaultCluster()
+		backup = internal.CreateDefaultBackup(cluster)
+
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		_, err := reconcileCluster(cluster)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Create(ctx, backup)).To(Succeed())
+		_, err = reconcileBackup(backup)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	When("a backup agent pod is in a terminal state but too young to be deleted", func() {
+		BeforeEach(func(ctx SpecContext) {
+			backupReconciler.MinimumAgeForTerminalPodDeletion = 1 * time.Hour
+			setupUnreadyDeploymentWithTerminalPod(ctx, backup, corev1.PodFailed)
+		})
+
+		It("should not delete the pod and should return a delayed requeue", func(ctx SpecContext) {
+			result := updateBackupAgents{}.reconcile(ctx, backupReconciler, backup)
+			Expect(result).NotTo(BeNil())
+			Expect(result.delayedRequeue).To(BeTrue())
+			Expect(result.delay).To(BeNumerically(">", 0))
+			Expect(result.delay).To(BeNumerically("<=", 1*time.Hour))
+
+			podList := &corev1.PodList{}
+			Expect(k8sClient.List(ctx, podList,
+				client.InNamespace(backup.Namespace),
+				client.MatchingLabels(map[string]string{
+					fdbv1beta2.BackupDeploymentPodLabel: internal.GetBackupDeploymentName(backup),
+				}),
+			)).To(Succeed())
+			// We have one pod in this list because our test setup only generates one pod.
+			Expect(podList.Items).To(HaveLen(1))
+		})
+	})
+})
+
+// setupUnreadyDeploymentWithTerminalPod marks the named deployment as having one unready replica
+// and creates a single Pod in the given terminal phase with the deployment's selector labels.
+func setupUnreadyDeploymentWithTerminalPod(
+	ctx context.Context,
+	backup *fdbv1beta2.FoundationDBBackup,
+	phase corev1.PodPhase,
+) {
+	deploymentName := internal.GetBackupDeploymentName(backup)
+
+	deployment := &appsv1.Deployment{}
+	Expect(k8sClient.Get(
+		ctx,
+		types.NamespacedName{Namespace: backup.Namespace, Name: deploymentName},
+		deployment,
+	)).To(Succeed())
+
+	deployment.Status.Replicas = 3
+	deployment.Status.ReadyReplicas = 2
+	Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "terminal-backup-agent",
+			Namespace: backup.Namespace,
+			Labels:    deployment.Spec.Selector.MatchLabels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "backup-agent", Image: fdbv1beta2.FoundationDBKubernetesBaseImage},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+	pod.Status.Phase = phase
+	Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+}

--- a/e2e/fixtures/fdb_backup.go
+++ b/e2e/fixtures/fdb_backup.go
@@ -474,7 +474,7 @@ func (fdbBackup *FdbBackup) UpdateBackupSpecWithSpec(
 	fetchedBackup := &fdbv1beta2.FoundationDBBackup{}
 
 	// This is flaky. It sometimes responds with an error saying that the object has been updated.
-	// Try a few times before giving up.
+	// Try every second for 10 minutes  before giving up.
 	gomega.Eventually(func(g gomega.Gomega) bool {
 		err := fdbBackup.fdbCluster.getClient().
 			Get(context.Background(), client.ObjectKeyFromObject(fdbBackup.backup), fetchedBackup)

--- a/e2e/fixtures/fdb_backup.go
+++ b/e2e/fixtures/fdb_backup.go
@@ -32,6 +32,7 @@ import (
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -450,4 +451,47 @@ func (fdbBackup *FdbBackup) ForceReconcile(ctx context.Context) {
 	if err != nil {
 		log.Println("error patching annotation to force reconcile, error:", err.Error())
 	}
+}
+
+// UpdateBackupSpec ensures that the FoundationDBBackup will be updated in Kubernetes. This method has a retry mechanism
+// implemented and ensures that the provided (local) Spec matches the Spec in Kubernetes.
+func (fdbBackup *FdbBackup) UpdateBackupSpec() {
+	fdbBackup.UpdateBackupSpecWithSpec(fdbBackup.backup.Spec.DeepCopy())
+}
+
+// UpdateBackupSpecWithSpec ensures that the FoundationDBBackup will be updated in Kubernetes. This method has a retry mechanism
+// implemented and ensures that the provided (local) Spec matches the Spec in Kubernetes. You must make sure that you call
+// backup.GetBackup() before updating the spec, to make sure you are not overwriting the current state with an outdated state.
+// An example on how to update a field with this method:
+//
+//	spec := backup.GetBackup().Spec.DeepCopy() // Fetch the current Spec.
+//	spec.AgentCount = "42" // Make your changes.
+//
+//	backup.UpdateBackupSpecWithSpec(backupSpec) // Update the spec.
+func (fdbBackup *FdbBackup) UpdateBackupSpecWithSpec(
+	desiredSpec *fdbv1beta2.FoundationDBBackupSpec,
+) {
+	fetchedBackup := &fdbv1beta2.FoundationDBBackup{}
+
+	// This is flaky. It sometimes responds with an error saying that the object has been updated.
+	// Try a few times before giving up.
+	gomega.Eventually(func(g gomega.Gomega) bool {
+		err := fdbBackup.fdbCluster.getClient().
+			Get(context.Background(), client.ObjectKeyFromObject(fdbBackup.backup), fetchedBackup)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "error fetching backup")
+
+		specUpdated := equality.Semantic.DeepEqual(fetchedBackup.Spec, *desiredSpec)
+		log.Println("UpdateBackupSpec: specUpdated:", specUpdated)
+		if specUpdated {
+			return true
+		}
+
+		desiredSpec.DeepCopyInto(&fetchedBackup.Spec)
+		err = fdbBackup.fdbCluster.getClient().Update(context.Background(), fetchedBackup)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "error updating backup spec")
+		// Retry here and let the method fetch the latest version of the backup again until the spec is updated.
+		return false
+	}).WithTimeout(10 * time.Minute).WithPolling(1 * time.Second).Should(gomega.BeTrue())
+
+	fdbBackup.backup = fetchedBackup
 }

--- a/e2e/test_operator_backups/operator_backup_test.go
+++ b/e2e/test_operator_backups/operator_backup_test.go
@@ -30,10 +30,14 @@ import (
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/e2e/fixtures"
+	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -323,6 +327,87 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 							).Should(Equal(keyValues))
 						},
 					)
+				})
+
+				When("the replica count is changed", func() {
+					JustBeforeEach(func() {
+						currentBackup := backup.GetBackup()
+						backupSpec := currentBackup.Spec.DeepCopy()
+						backupSpec.AgentCount = ptr.To(currentBackup.GetDesiredAgentCount() * 2)
+						backup.UpdateBackupSpecWithSpec(backupSpec)
+					})
+
+					It("should update the running backup agent pods", func() {
+						desiredAgentCount := backup.GetBackup().GetDesiredAgentCount()
+						Eventually(func() int {
+							return len(backup.GetBackupPods().Items)
+						}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(BeNumerically("==", desiredAgentCount))
+					})
+				})
+
+				When("a pod is stuck in a terminal state", func() {
+					terminalPodName := "terminal-pod"
+
+					JustBeforeEach(func(ctx SpecContext) {
+						currentBackup := backup.GetBackup()
+
+						deployment := &appsv1.Deployment{}
+						Expect(factory.GetControllerRuntimeClient().Get(ctx, ctrlClient.ObjectKey{
+							Name:      internal.GetBackupDeploymentName(currentBackup),
+							Namespace: currentBackup.Namespace,
+						}, deployment)).To(Succeed())
+
+						// Create a pod that is assigned to a node that doesn't exist.
+						spec := deployment.Spec.Template.Spec
+						spec.NodeName = "doesnotexist"
+						terminalPod := &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      terminalPodName,
+								Namespace: currentBackup.Namespace,
+								Labels:    deployment.Spec.Template.Labels,
+							},
+							Spec: spec,
+						}
+
+						Expect(factory.GetControllerRuntimeClient().DeleteAllOf(ctx, &corev1.Pod{},
+							ctrlClient.InNamespace(currentBackup.Namespace),
+							ctrlClient.MatchingLabels(map[string]string{fdbv1beta2.BackupDeploymentPodLabel: currentBackup.Name + "-backup-agents"}),
+						),
+						).To(Succeed())
+
+						Expect(
+							factory.GetControllerRuntimeClient().Create(ctx, terminalPod),
+						).To(Succeed())
+
+						for _, backupAgentPod := range backup.GetBackupPods().Items {
+							if backupAgentPod.Name == terminalPodName {
+								continue
+							}
+
+							if !backupAgentPod.DeletionTimestamp.IsZero() {
+								continue
+							}
+
+							Expect(
+								factory.GetControllerRuntimeClient().
+									Delete(ctx, ptr.To(backupAgentPod)),
+							).To(Succeed())
+						}
+					})
+
+					It("should delete the pod in terminal state", func() {
+						backup.ForceReconcile()
+						Eventually(func(g Gomega) {
+							for _, backupAgentPod := range backup.GetBackupPods().Items {
+								log.Println(
+									backupAgentPod.Name,
+									"state:",
+									backupAgentPod.Status.Phase,
+								)
+								g.Expect(backupAgentPod.Name).NotTo(Equal(terminalPodName))
+							}
+						}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+					})
 				})
 			})
 

--- a/e2e/test_operator_backups/operator_backup_test.go
+++ b/e2e/test_operator_backups/operator_backup_test.go
@@ -330,17 +330,17 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 				})
 
 				When("the replica count is changed", func() {
-					JustBeforeEach(func() {
-						currentBackup := backup.GetBackup()
+					JustBeforeEach(func(ctx SpecContext) {
+						currentBackup := backup.GetBackup(ctx)
 						backupSpec := currentBackup.Spec.DeepCopy()
 						backupSpec.AgentCount = ptr.To(currentBackup.GetDesiredAgentCount() * 2)
 						backup.UpdateBackupSpecWithSpec(backupSpec)
 					})
 
-					It("should update the running backup agent pods", func() {
-						desiredAgentCount := backup.GetBackup().GetDesiredAgentCount()
+					It("should update the running backup agent pods", func(ctx SpecContext) {
+						desiredAgentCount := backup.GetBackup(ctx).GetDesiredAgentCount()
 						Eventually(func() int {
-							return len(backup.GetBackupPods().Items)
+							return len(backup.GetBackupPods(ctx).Items)
 						}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(BeNumerically("==", desiredAgentCount))
 					})
 				})
@@ -349,7 +349,7 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 					terminalPodName := "terminal-pod"
 
 					JustBeforeEach(func(ctx SpecContext) {
-						currentBackup := backup.GetBackup()
+						currentBackup := backup.GetBackup(ctx)
 
 						deployment := &appsv1.Deployment{}
 						Expect(factory.GetControllerRuntimeClient().Get(ctx, ctrlClient.ObjectKey{
@@ -379,7 +379,7 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 							factory.GetControllerRuntimeClient().Create(ctx, terminalPod),
 						).To(Succeed())
 
-						for _, backupAgentPod := range backup.GetBackupPods().Items {
+						for _, backupAgentPod := range backup.GetBackupPods(ctx).Items {
 							if backupAgentPod.Name == terminalPodName {
 								continue
 							}
@@ -395,10 +395,10 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 						}
 					})
 
-					It("should delete the pod in terminal state", func() {
-						backup.ForceReconcile()
+					It("should delete the pod in terminal state", func(ctx SpecContext) {
+						backup.ForceReconcile(ctx)
 						Eventually(func(g Gomega) {
-							for _, backupAgentPod := range backup.GetBackupPods().Items {
+							for _, backupAgentPod := range backup.GetBackupPods(ctx).Items {
 								log.Println(
 									backupAgentPod.Name,
 									"state:",

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -603,6 +603,7 @@ func StartManager(
 		backupReconciler.Log = logr.WithName("controllers").WithName("FoundationDBBackup")
 		backupReconciler.ServerSideApply = operatorOpts.ServerSideApply
 		backupReconciler.AllowedPodModifications = allowedPodModifications
+		backupReconciler.MinimumAgeForTerminalPodDeletion = operatorOpts.MinimumAgeForTerminalPodDeletion
 
 		if err := backupReconciler.SetupWithManager(
 			mgr,


### PR DESCRIPTION
# Description

Delete backup_agent pods that are in a terminal state, e.g. they are stuck in pending or they terminated.

## Type of change

- New feature (non-breaking change which adds functionality)

## Discussion

We have the same functionality in the cluster reconciler, adding the functionality in the operator will improve the backup agent management.

## Testing

Added new e2e tests and new unit tests.

## Documentation

Nothing to update.

## Follow-up

-
