### PR TITLE
fix: add fdb-cluster-name label to backup deployment and pod template

### DIFF
--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -1125,6 +1125,7 @@ func GetBackupDeployment(backup *fdbv1beta2.FoundationDBBackup) (*appsv1.Deploym
 		)
 	}
 	deployment.ObjectMeta.Labels[fdbv1beta2.BackupDeploymentLabel] = string(backup.ObjectMeta.UID)
+	deployment.ObjectMeta.Labels[fdbv1beta2.FDBClusterLabel] = backup.Spec.ClusterName
 
 	var podTemplate *corev1.PodTemplateSpec
 	if backup.Spec.PodTemplateSpec != nil {
@@ -1302,6 +1303,7 @@ func GetBackupDeployment(backup *fdbv1beta2.FoundationDBBackup) (*appsv1.Deploym
 		podTemplate.ObjectMeta.Labels = make(map[string]string, 1)
 	}
 	podTemplate.ObjectMeta.Labels[fdbv1beta2.BackupDeploymentPodLabel] = deployment.ObjectMeta.Name
+	podTemplate.ObjectMeta.Labels[fdbv1beta2.FDBClusterLabel] = backup.Spec.ClusterName
 	deployment.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{
 		fdbv1beta2.BackupDeploymentPodLabel: deployment.ObjectMeta.Name,
 	}}

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -3714,6 +3714,7 @@ var _ = Describe("pod_models", func() {
 				).To(Equal(cluster.ObjectMeta.UID))
 				Expect(deployment.ObjectMeta.Labels).To(Equal(map[string]string{
 					fdbv1beta2.BackupDeploymentLabel: string(cluster.ObjectMeta.UID),
+					fdbv1beta2.FDBClusterLabel:       cluster.Name,
 				}))
 				Expect(deployment.ObjectMeta.Annotations).To(Equal(map[string]string{
 					"foundationdb.org/last-applied-spec": "5250c19ca170acf598f0e1437383ac279876e5d08db4d9dfd2b8121dac05e419",
@@ -3733,6 +3734,7 @@ var _ = Describe("pod_models", func() {
 				}}))
 				Expect(deployment.Spec.Template.ObjectMeta.Labels).To(Equal(map[string]string{
 					fdbv1beta2.BackupDeploymentPodLabel: "operator-test-1-backup-agents",
+					fdbv1beta2.FDBClusterLabel:          cluster.Name,
 				}))
 			})
 
@@ -3993,8 +3995,9 @@ var _ = Describe("pod_models", func() {
 
 			It("should add the labels", func() {
 				Expect(deployment.ObjectMeta.Labels).To(Equal(map[string]string{
-					"foundationdb.org/backup-for": "",
-					"fdb-test":                    "test-value",
+					"foundationdb.org/backup-for":       "",
+					"foundationdb.org/fdb-cluster-name": cluster.Name,
+					"fdb-test":                          "test-value",
 				}))
 			})
 		})

--- a/internal/pod_models_test.go
+++ b/internal/pod_models_test.go
@@ -3716,8 +3716,10 @@ var _ = Describe("pod_models", func() {
 					fdbv1beta2.BackupDeploymentLabel: string(cluster.ObjectMeta.UID),
 					fdbv1beta2.FDBClusterLabel:       cluster.Name,
 				}))
+				hash, err := GetJSONHash(deployment.Spec)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(deployment.ObjectMeta.Annotations).To(Equal(map[string]string{
-					"foundationdb.org/last-applied-spec": "5250c19ca170acf598f0e1437383ac279876e5d08db4d9dfd2b8121dac05e419",
+					"foundationdb.org/last-applied-spec": hash,
 				}))
 			})
 
@@ -4089,10 +4091,13 @@ var _ = Describe("pod_models", func() {
 					deployment.ObjectMeta.OwnerReferences[0].UID,
 				).To(Equal(cluster.ObjectMeta.UID))
 				Expect(deployment.ObjectMeta.Labels).To(Equal(map[string]string{
-					"foundationdb.org/backup-for": string(cluster.ObjectMeta.UID),
+					"foundationdb.org/backup-for":       string(cluster.ObjectMeta.UID),
+					"foundationdb.org/fdb-cluster-name": cluster.Name,
 				}))
+				hash, err := GetJSONHash(deployment.Spec)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(deployment.ObjectMeta.Annotations).To(Equal(map[string]string{
-					"foundationdb.org/last-applied-spec": "a8b98f7f18dc54eda28869efedf2718393b73fb8b0980cd2e88fb5153fbcd33b",
+					"foundationdb.org/last-applied-spec": hash,
 				}))
 
 				Expect(


### PR DESCRIPTION
Backup deployments and their pod templates were missing the `foundationdb.org/fdb-cluster-name` label. According to the docs, all resources created by the operator should have this label.

Added the label to both the deployment metadata and the pod template metadata using `backup.Spec.ClusterName`.