### PR TITLE
Remove team tracker health check in DoStorageServerFaultDomainCheckOnStatus

### DIFF
--- a/controllers/remove_process_groups_test.go
+++ b/controllers/remove_process_groups_test.go
@@ -208,8 +208,9 @@ var _ = Describe("remove_process_groups", func() {
 							{
 								Primary: true,
 								State: fdbv1beta2.FoundationDBStatusDataState{
-									Healthy:              false,
-									MinReplicasRemaining: 2,
+									Healthy: false,
+									// The cluster uses double replication and one shard is down.
+									MinReplicasRemaining: 1,
 								},
 							},
 						}
@@ -334,42 +335,6 @@ var _ = Describe("remove_process_groups", func() {
 						Expect(err).To(BeNil())
 						Expect(include).To(BeTrue())
 					})
-				})
-
-				When("storage have 2 replicas", func() {
-					BeforeEach(func() {
-						adminClient, err := mock.NewMockAdminClientUncast(cluster, k8sClient)
-						Expect(err).NotTo(HaveOccurred())
-						adminClient.TeamTracker = []fdbv1beta2.FoundationDBStatusTeamTracker{
-							{
-								Primary: true,
-								State: fdbv1beta2.FoundationDBStatusDataState{
-									Healthy:              true,
-									MinReplicasRemaining: 2,
-								},
-							},
-						}
-					})
-					It(
-						"should not remove the process group and should not exclude processes",
-						func() {
-							Expect(result).NotTo(BeNil())
-							Expect(
-								result.message,
-							).To(Equal("Removals cannot proceed because cluster has degraded fault tolerance"))
-							// Ensure resources are not deleted
-							include, err := confirmRemoval(
-								context.Background(),
-								globalControllerLogger,
-								clusterReconciler,
-								cluster,
-								removedProcessGroup,
-							)
-							Expect(err).NotTo(BeNil())
-							Expect(internal.IsResourceNotDeleted(err)).To(BeTrue())
-							Expect(include).To(BeFalse())
-						},
-					)
 				})
 			})
 

--- a/controllers/replace_failed_process_groups_test.go
+++ b/controllers/replace_failed_process_groups_test.go
@@ -603,8 +603,9 @@ var _ = Describe("replace_failed_process_groups", func() {
 									{
 										Primary: true,
 										State: fdbv1beta2.FoundationDBStatusDataState{
-											Healthy:              false,
-											MinReplicasRemaining: 2,
+											Healthy: false,
+											// The cluster uses double replication and one shard is down.
+											MinReplicasRemaining: 1,
 										},
 									},
 								}
@@ -1214,8 +1215,9 @@ var _ = Describe("replace_failed_process_groups", func() {
 									{
 										Primary: true,
 										State: fdbv1beta2.FoundationDBStatusDataState{
-											Healthy:              false,
-											MinReplicasRemaining: 2,
+											Healthy: false,
+											// The cluster uses double replication and one shard is down.
+											MinReplicasRemaining: 1,
 										},
 									},
 								}

--- a/pkg/fdbstatus/status_checks.go
+++ b/pkg/fdbstatus/status_checks.go
@@ -396,8 +396,8 @@ func DoStorageServerFaultDomainCheckOnStatus(status *fdbv1beta2.FoundationDBStat
 			region = "remote"
 		}
 
-		// We are not checking the health state here because any data-movement, except for rebalancing will mean this
-		// flag is set to false. This means the operator would always wait until all storage servers are fully excluded.
+		// We are not checking the health state here because any data-movement, except for rebalancing will mean that
+		// tracker.State.Healthy is set to false. This means the operator would always wait until all storage servers are fully excluded.
 		// This behaviour is too restrictive for the operator, especially in large scale deployments. The operator
 		// performs the exclusion check before trying to remove a pod, so this is an additional safety guard but the
 		// tracker.State.MinReplicasRemaining is a better check for this.

--- a/pkg/fdbstatus/status_checks.go
+++ b/pkg/fdbstatus/status_checks.go
@@ -355,7 +355,7 @@ func GetMinimumUptimeAndAddressMap(
 		}
 
 		addressMap[fdbv1beta2.ProcessGroupID(processGroupID)] = append(
-			addressMap[fdbv1beta2.ProcessGroupID(process.Locality[fdbv1beta2.FDBLocalityInstanceIDKey])],
+			addressMap[fdbv1beta2.ProcessGroupID(processGroupID)],
 			process.Address,
 		)
 
@@ -373,7 +373,7 @@ func GetMinimumUptimeAndAddressMap(
 		// cases where only storage processes are restarted.
 		if process.UptimeSeconds < minimumUptime {
 			logger.V(1).
-				Info("Process uptime is less than the last recovery", "processGroupID", process.Address, "minimumUptime", minimumUptime, "process.UptimeSeconds", process.UptimeSeconds)
+				Info("Process uptime is less than the last recovery", "processGroupID", processGroupID, "minimumUptime", minimumUptime, "process.UptimeSeconds", process.UptimeSeconds, "process.Address", process.Address)
 			minimumUptime = process.UptimeSeconds
 		}
 	}
@@ -396,13 +396,26 @@ func DoStorageServerFaultDomainCheckOnStatus(status *fdbv1beta2.FoundationDBStat
 			region = "remote"
 		}
 
-		if !tracker.State.Healthy {
-			return fmt.Errorf("team tracker in %s is in unhealthy state", region)
-		}
-
+		// We are not checking the health state here because any data-movement, except for rebalancing will mean this
+		// flag is set to false. This means the operator would always wait until all storage servers are fully excluded.
+		// This behaviour is too restrictive for the operator, especially in large scale deployments. The operator
+		// performs the exclusion check before trying to remove a pod, so this is an additional safety guard but the
+		// tracker.State.MinReplicasRemaining is a better check for this.
+		//
+		// The data distributor (DD) has those states in the team tracker:
+		//
+		//  healthy=false, name=missing_data       → min_replicas_remaining = 0
+		//  healthy=false, name=healing (1 left)   → min_replicas_remaining = 1
+		//  healthy=false, name=healing (2 left)   → min_replicas_remaining = 2
+		//  healthy=false, name=healing            → min_replicas_remaining = storageTeamSize  ← PRIORITY_TEAM_UNHEALTHY
+		//  healthy=true,  all other states        → min_replicas_remaining = storageTeamSize
+		//
+		// In the case of a triple replicated cluster, minimumRequiredReplicas would be 3 and during a planned exclusions
+		// min_replicas_remaining would be 3, so the deletion would be allowed. If another process is absent min_replicas_remaining
+		// would be 2 and the deletion would be blocked as expected.
 		if tracker.State.MinReplicasRemaining < minimumRequiredReplicas {
 			return fmt.Errorf(
-				"team tracker in %s has %d replicas left but we require more than %d",
+				"team tracker in %s has %d replicas left but we require at least %d",
 				region,
 				tracker.State.MinReplicasRemaining,
 				minimumRequiredReplicas,
@@ -525,7 +538,7 @@ func HasDesiredFaultToleranceFromStatus(
 		return false
 	}
 
-	// Should we also add a method to check the different process classes? Currently the degraded log fault tolerance
+	// Should we also add a method to check the different process classes? Currently, the degraded log fault tolerance
 	// will block the removal of a storage process.
 	err := DoStorageServerFaultDomainCheckOnStatus(status)
 	if err != nil {

--- a/pkg/fdbstatus/status_checks_test.go
+++ b/pkg/fdbstatus/status_checks_test.go
@@ -1025,14 +1025,14 @@ var _ = Describe("status_checks", func() {
 										Description:          "",
 										Healthy:              true,
 										Name:                 "healthy",
-										MinReplicasRemaining: 4,
+										MinReplicasRemaining: 3,
 									},
 								},
 							},
 						},
 					},
 				}
-				Expect(DoStorageServerFaultDomainCheckOnStatus(status)).NotTo(HaveOccurred())
+				Expect(DoStorageServerFaultDomainCheckOnStatus(status)).To(Succeed())
 			})
 
 			It("primary storage server team unhealthy", func() {
@@ -1046,7 +1046,7 @@ var _ = Describe("status_checks", func() {
 										Description:          "",
 										Healthy:              false,
 										Name:                 "healthy",
-										MinReplicasRemaining: 4,
+										MinReplicasRemaining: 3,
 									},
 								},
 								{
@@ -1055,16 +1055,14 @@ var _ = Describe("status_checks", func() {
 										Description:          "",
 										Healthy:              true,
 										Name:                 "healthy",
-										MinReplicasRemaining: 0,
+										MinReplicasRemaining: 3,
 									},
 								},
 							},
 						},
 					},
 				}
-				err := DoStorageServerFaultDomainCheckOnStatus(status)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("team tracker in primary is in unhealthy state"))
+				Expect(DoStorageServerFaultDomainCheckOnStatus(status)).To(Succeed())
 			})
 
 			It("remote storage server team unhealthy", func() {
@@ -1078,7 +1076,7 @@ var _ = Describe("status_checks", func() {
 										Description:          "",
 										Healthy:              true,
 										Name:                 "healthy",
-										MinReplicasRemaining: 4,
+										MinReplicasRemaining: 3,
 									},
 								},
 								{
@@ -1087,16 +1085,14 @@ var _ = Describe("status_checks", func() {
 										Description:          "",
 										Healthy:              false,
 										Name:                 "healthy",
-										MinReplicasRemaining: 0,
+										MinReplicasRemaining: 3,
 									},
 								},
 							},
 						},
 					},
 				}
-				err := DoStorageServerFaultDomainCheckOnStatus(status)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("team tracker in remote is in unhealthy state"))
+				Expect(DoStorageServerFaultDomainCheckOnStatus(status)).To(Succeed())
 			})
 		})
 
@@ -1429,7 +1425,7 @@ var _ = Describe("status_checks", func() {
 			It("do storage server fault domain check", func() {
 				err := DoFaultDomainChecksOnStatus(status, true, false, false)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("team tracker in remote is in unhealthy state"))
+				Expect(err.Error()).To(Equal("team tracker in remote has 0 replicas left but we require at least 2"))
 			})
 
 			It("do log server fault domain check", func() {
@@ -1447,13 +1443,13 @@ var _ = Describe("status_checks", func() {
 			It("do storage server and log server fault domain checks", func() {
 				err := DoFaultDomainChecksOnStatus(status, true, true, false)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("team tracker in remote is in unhealthy state"))
+				Expect(err.Error()).To(Equal("team tracker in remote has 0 replicas left but we require at least 2"))
 			})
 
 			It("do all fault domain checks", func() {
 				err := DoFaultDomainChecksOnStatus(status, true, true, true)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("team tracker in remote is in unhealthy state"))
+				Expect(err.Error()).To(Equal("team tracker in remote has 0 replicas left but we require at least 2"))
 			})
 		})
 	})

--- a/pkg/fdbstatus/status_checks_test.go
+++ b/pkg/fdbstatus/status_checks_test.go
@@ -1425,7 +1425,9 @@ var _ = Describe("status_checks", func() {
 			It("do storage server fault domain check", func() {
 				err := DoFaultDomainChecksOnStatus(status, true, false, false)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("team tracker in remote has 0 replicas left but we require at least 2"))
+				Expect(
+					err.Error(),
+				).To(Equal("team tracker in remote has 0 replicas left but we require at least 2"))
 			})
 
 			It("do log server fault domain check", func() {
@@ -1443,13 +1445,17 @@ var _ = Describe("status_checks", func() {
 			It("do storage server and log server fault domain checks", func() {
 				err := DoFaultDomainChecksOnStatus(status, true, true, false)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("team tracker in remote has 0 replicas left but we require at least 2"))
+				Expect(
+					err.Error(),
+				).To(Equal("team tracker in remote has 0 replicas left but we require at least 2"))
 			})
 
 			It("do all fault domain checks", func() {
 				err := DoFaultDomainChecksOnStatus(status, true, true, true)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("team tracker in remote has 0 replicas left but we require at least 2"))
+				Expect(
+					err.Error(),
+				).To(Equal("team tracker in remote has 0 replicas left but we require at least 2"))
 			})
 		})
 	})


### PR DESCRIPTION
# Description

Remove team tracker health check in DoStorageServerFaultDomainCheckOnStatus to prevent long exclusions to block the removal of fully excluded processes

## Type of change

- Other

## Discussion

-

## Testing

Updated unit tests.

## Documentation

Updated the documentation for this decision in the code.

## Follow-up

-
