### PR TITLE
Document `PodDisruptionBudget` (PDB) restrictions

### DIFF
--- a/docs/manual/fault_domains.md
+++ b/docs/manual/fault_domains.md
@@ -400,6 +400,12 @@ there are not enough storage pods, or the storage pods are not spread across
 enough fault domains it also considers log pods, and finally transaction pods as
 well.
 
+Note that `FoundationDBCluster` resources do not implement the `scale` subresource, and so pod disruption budgets have [some restrictions](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#arbitrary-controllers-and-selectors).
+In particular (to quote the Kubernetes documentation):
+
+> - only `.spec.minAvailable` can be used, not `.spec.maxUnavailable`.
+> - only an integer value can be used with `.spec.minAvailable`, not a percentage.
+
 ## Coordinators
 
 Per default the FDB operator will try to select the best fitting processes to be coordinators.


### PR DESCRIPTION
The `FoundationDBCluster` resource doesn't implement the `scale` subresource, and as a consequence, pod disruption budgets have some [restrictions](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#arbitrary-controllers-and-selectors) that may not be obvious to end users.

The ["managing disruption"](https://github.com/FoundationDB/fdb-kubernetes-operator/blob/main/docs/manual/fault_domains.md#managing-disruption) section of the manual encourages pod disruption budgets, but doesn't mention the limitations. That can lead users to a place where (speaking from experience) they write pod disruption budgets that violate one of the restrictions, don't work as expected, and can prevent other operations (in our case, a node pool update) from succeeding for reasons that can be tricky to identify.

This change just notes the restrictions in the "managing disruption" docs so users will be less likely to run into one of the pitfalls.