### PR TITLE
Fix context handling in go routine in e2e test suite

### DIFF
--- a/e2e/fixtures/fixtures.go
+++ b/e2e/fixtures/fixtures.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
 
@@ -79,6 +80,8 @@ func CheckInvariant(
 	var failureStartTime time.Time
 	var currentFailureDuration time.Duration
 	var longestFailureDuration time.Duration
+	// Handle failures in this call since we are calling a go routine. https://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure
+	defer ginkgo.GinkgoRecover()
 
 	go func() {
 		defer waitGroup.Done()

--- a/e2e/fixtures/status.go
+++ b/e2e/fixtures/status.go
@@ -280,12 +280,14 @@ func (fdbCluster *FdbCluster) WaitUntilAvailable(ctx context.Context) {
 // StatusInvariantChecker provides a way to check an invariant for the cluster status.
 // nolint:nilerr
 func (fdbCluster *FdbCluster) StatusInvariantChecker(
-	ctx context.Context,
 	name string,
 	threshold time.Duration,
 	f func(status *fdbv1beta2.FoundationDBStatus) error,
 ) error {
 	first := true
+	// We use a dedicated context here to prevent using a canceled context if the test case completed.
+	ctx := context.Background()
+
 	return CheckInvariant(
 		name,
 		&fdbCluster.factory.invariantShutdownHooks,
@@ -354,11 +356,9 @@ func checkAvailability(status *fdbv1beta2.FoundationDBStatus) error {
 
 // InvariantClusterStatusAvailableWithThreshold checks if the database is at a maximum unavailable for the provided threshold.
 func (fdbCluster *FdbCluster) InvariantClusterStatusAvailableWithThreshold(
-	ctx context.Context,
 	availabilityThreshold time.Duration,
 ) error {
 	return fdbCluster.StatusInvariantChecker(
-		ctx,
 		"InvariantClusterStatusAvailable",
 		availabilityThreshold,
 		checkAvailability,
@@ -366,9 +366,8 @@ func (fdbCluster *FdbCluster) InvariantClusterStatusAvailableWithThreshold(
 }
 
 // InvariantClusterStatusAvailable checks if the cluster is available the whole test with the default unavailable threshold.
-func (fdbCluster *FdbCluster) InvariantClusterStatusAvailable(ctx context.Context) error {
+func (fdbCluster *FdbCluster) InvariantClusterStatusAvailable() error {
 	return fdbCluster.InvariantClusterStatusAvailableWithThreshold(
-		ctx,
 		fdbCluster.factory.GetDefaultUnavailableThreshold(),
 	)
 }

--- a/e2e/test_operator/operator_test.go
+++ b/e2e/test_operator/operator_test.go
@@ -117,9 +117,9 @@ var _ = Describe("Operator", Label("e2e", "pr"), func() {
 		fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 	})
 
-	JustBeforeEach(func(ctx SpecContext) {
+	JustBeforeEach(func() {
 		if availabilityCheck {
-			Expect(fdbCluster.InvariantClusterStatusAvailable(ctx)).To(Succeed())
+			Expect(fdbCluster.InvariantClusterStatusAvailable()).To(Succeed())
 		}
 	})
 

--- a/e2e/test_operator_ha/operator_ha_test.go
+++ b/e2e/test_operator_ha/operator_ha_test.go
@@ -106,10 +106,10 @@ var _ = Describe("Operator HA tests", Label("e2e", "pr"), func() {
 		fdbCluster.GetPrimary().EnsureTeamTrackersHaveMinReplicas(ctx)
 	})
 
-	JustBeforeEach(func(ctx SpecContext) {
+	JustBeforeEach(func() {
 		if availabilityCheck {
 			Expect(
-				fdbCluster.GetPrimary().InvariantClusterStatusAvailable(ctx),
+				fdbCluster.GetPrimary().InvariantClusterStatusAvailable(),
 			).NotTo(HaveOccurred())
 		}
 	})

--- a/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
+++ b/e2e/test_operator_ha_flaky_upgrades/operator_ha_flaky_upgrade_test.go
@@ -67,7 +67,7 @@ func clusterSetupWithHealthCheckOption(
 	fdbCluster = factory.CreateFdbHaCluster(ctx, config)
 	if enableHealthCheck {
 		Expect(
-			fdbCluster.GetPrimary().InvariantClusterStatusAvailable(ctx),
+			fdbCluster.GetPrimary().InvariantClusterStatusAvailable(),
 		).ShouldNot(HaveOccurred())
 	}
 

--- a/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
+++ b/e2e/test_operator_ha_upgrades/operator_ha_upgrade_test.go
@@ -81,7 +81,7 @@ func clusterSetupWithTestConfig(ctx context.Context, config testConfig) {
 
 	if config.enableHealthCheck {
 		Expect(
-			fdbCluster.GetPrimary().InvariantClusterStatusAvailable(ctx),
+			fdbCluster.GetPrimary().InvariantClusterStatusAvailable(),
 		).ShouldNot(HaveOccurred())
 	}
 

--- a/e2e/test_operator_stress/operator_stress_test.go
+++ b/e2e/test_operator_stress/operator_stress_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Operator Stress", Label("e2e"), func() {
 			fdbCluster = factory.CreateFdbCluster(ctx,
 				fixtures.DefaultClusterConfig(false),
 			)
-			Expect(fdbCluster.InvariantClusterStatusAvailable(ctx)).NotTo(HaveOccurred())
+			Expect(fdbCluster.InvariantClusterStatusAvailable()).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func(ctx SpecContext) {

--- a/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
+++ b/e2e/test_operator_three_data_hall/operator_three_data_hall_test.go
@@ -106,9 +106,9 @@ var _ = Describe("Operator with three data hall", Label("e2e"), func() {
 		fdbCluster.EnsureTeamTrackersHaveMinReplicas(ctx)
 	})
 
-	JustBeforeEach(func(ctx SpecContext) {
+	JustBeforeEach(func() {
 		if availabilityCheck {
-			err := fdbCluster.InvariantClusterStatusAvailable(ctx)
+			err := fdbCluster.InvariantClusterStatusAvailable()
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})

--- a/e2e/test_operator_upgrades/operator_upgrades_test.go
+++ b/e2e/test_operator_upgrades/operator_upgrades_test.go
@@ -78,7 +78,7 @@ func clusterSetupWithConfig(
 	}
 
 	Expect(
-		fdbCluster.InvariantClusterStatusAvailable(ctx),
+		fdbCluster.InvariantClusterStatusAvailable(),
 	).ShouldNot(HaveOccurred())
 }
 

--- a/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
+++ b/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
@@ -75,7 +75,7 @@ func clusterSetupWithConfig(ctx context.Context, config testConfig) *fixtures.Fd
 	}
 
 	Expect(
-		cluster.InvariantClusterStatusAvailable(ctx),
+		cluster.InvariantClusterStatusAvailable(),
 	).ShouldNot(HaveOccurred())
 
 	return cluster
@@ -220,7 +220,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 	// Ginkgo lacks the support for AfterEach and BeforeEach in tables, so we have to put everything inside the testing function
 	// this setup allows to dynamically generate the table entries that will be executed e.g. to test different upgrades
 	// for different versions without hard coding or having multiple flags.
-	DescribeTable(
+	FDescribeTable(
 		"upgrading a cluster without chaos", Label("foundationdb-pr"),
 		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			performUpgrade(ctx,

--- a/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
+++ b/e2e/test_operator_upgrades_variations/operator_upgrades_variations_test.go
@@ -220,7 +220,7 @@ var _ = Describe("Operator Upgrades", Label("e2e", "pr"), func() {
 	// Ginkgo lacks the support for AfterEach and BeforeEach in tables, so we have to put everything inside the testing function
 	// this setup allows to dynamically generate the table entries that will be executed e.g. to test different upgrades
 	// for different versions without hard coding or having multiple flags.
-	FDescribeTable(
+	DescribeTable(
 		"upgrading a cluster without chaos", Label("foundationdb-pr"),
 		func(ctx SpecContext, beforeVersion string, targetVersion string) {
 			performUpgrade(ctx,

--- a/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
@@ -68,7 +68,7 @@ func clusterSetup(ctx context.Context, beforeVersion string) {
 	)
 
 	Expect(
-		fdbCluster.InvariantClusterStatusAvailable(ctx),
+		fdbCluster.InvariantClusterStatusAvailable(),
 	).ShouldNot(HaveOccurred())
 }
 


### PR DESCRIPTION
# Description

Fix context handling in go routine in e2e test suite, otherwise if could happen that the invariant checker uses the canceled context which then would cause a Ginkgo panic (fixed both issue).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Tried to reproduce the issue and ran the e2e tests manually.

## Documentation

-

## Follow-up

-
