### PR TITLE
Fix restore for newer FDB clusters

### DIFF
--- a/api/v1beta2/foundationdb_errors.go
+++ b/api/v1beta2/foundationdb_errors.go
@@ -41,6 +41,12 @@ type BackupNotRunning struct {
 	Err error
 }
 
+// RestoreDoesNotExist represents an error for the restore command when the targeted restore does not exist.
+// +k8s:deepcopy-gen=false
+type RestoreDoesNotExist struct {
+	Err error
+}
+
 // SpecialKeysAPIFailureError represents the error when an Api call through special keys failed.
 // For more information, call get on special key 0xff0xff/error_message to get a json string of the error message.
 // See: https://github.com/apple/foundationdb/blob/main/flow/include/flow/error_definitions.h
@@ -67,4 +73,9 @@ func (err BackupNotRunning) Error() string {
 // Error returns the error message from a failed Api call through special keys.
 func (err SpecialKeysAPIFailureError) Error() string {
 	return fmt.Sprintf("fdb special_keys_api_failure: %s", err.Err.Error())
+}
+
+// Error returns the error message of the fdbrestore command if no restore is present.
+func (err RestoreDoesNotExist) Error() string {
+	return fmt.Sprintf("fdb restore does not exist: %s", err.Err.Error())
 }

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -78,13 +78,13 @@ func (r *FoundationDBRestoreReconciler) Reconcile(
 		uuid.NewUUID(),
 	)
 
-	subReconcilers := []restoreSubReconciler{
+	restoreSubReconcilers := []restoreSubReconciler{
 		updateRestoreStatus{},
 		startRestore{},
 		updateRestoreStatus{},
 	}
 
-	for _, subReconciler := range subReconcilers {
+	for _, subReconciler := range restoreSubReconcilers {
 		req := subReconciler.reconcile(ctx, r, restore)
 		if req == nil {
 			continue

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -129,4 +129,27 @@ var _ = Describe("restore_controller", func() {
 			})
 		})
 	})
+
+	Describe("reconciling a new restore when the CLI reports no restore found", func() {
+		BeforeEach(func() {
+			Expect(k8sClient.Create(context.TODO(), cluster)).To(Succeed())
+
+			result, err := reconcileCluster(cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			adminClient.MockRestoreDoesNotExist(true)
+
+			Expect(k8sClient.Create(context.TODO(), restore)).To(Succeed())
+		})
+
+		It("should start the restore", func() {
+			result, err := reconcileRestore(restore)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			Expect(reloadRestore(restore)).To(Succeed())
+			Expect(restore.Status.Running).To(BeTrue())
+		})
+	})
 })

--- a/controllers/start_restore.go
+++ b/controllers/start_restore.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
 )
 
 // startRestore provides a reconciliation step for starting a new restore.
@@ -46,7 +47,7 @@ func (s startRestore) reconcile(
 	}()
 
 	status, err := adminClient.GetRestoreStatus()
-	if err != nil {
+	if err != nil && !internal.IsRestoreDoesNotExist(err) {
 		return &requeue{curError: err}
 	}
 

--- a/controllers/update_restore_status.go
+++ b/controllers/update_restore_status.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
 )
 
 // updateRestoreStatus provides a reconciliation step for updating the restore status.
@@ -48,6 +49,10 @@ func (updateRestoreStatus) reconcile(
 
 	status, err := adminClient.GetRestoreStatus()
 	if err != nil {
+		if internal.IsRestoreDoesNotExist(err) {
+			return nil
+		}
+
 		return &requeue{curError: err}
 	}
 

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -1062,12 +1062,22 @@ func (client *cliAdminClient) StartRestore(
 
 // GetRestoreStatus gets the status of the current restore.
 func (client *cliAdminClient) GetRestoreStatus() (string, error) {
-	return client.runCommand(cliCommand{
+	output, err := client.runCommand(cliCommand{
 		binary: fdbrestoreStr,
 		args: []string{
 			"status",
 		},
 	})
+
+	if strings.Contains(output, "No restores found") {
+		if err == nil {
+			err = fmt.Errorf("no restores found")
+		}
+
+		return "", fdbv1beta2.RestoreDoesNotExist{Err: err}
+	}
+
+	return output, err
 }
 
 // Close cleans up any pending resources.

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -23,12 +23,14 @@ package fdbclient
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path"
 	"time"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/v2/api/v1beta2"
+	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal"
 	"github.com/FoundationDB/fdb-kubernetes-operator/v2/internal/metrics"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -1431,6 +1433,64 @@ protocol fdb00b071010000`,
 			})
 		})
 
+	})
+
+	Describe("getting the restore status", func() {
+		var mockRunner *mockCommandRunner
+		var status string
+		var err error
+
+		JustBeforeEach(func() {
+			cliClient := &cliAdminClient{
+				Cluster:   &fdbv1beta2.FoundationDBCluster{},
+				log:       logr.Discard(),
+				cmdRunner: mockRunner,
+			}
+
+			status, err = cliClient.GetRestoreStatus()
+		})
+
+		When("no restore has ever been started", func() {
+			BeforeEach(func() {
+				mockRunner = &mockCommandRunner{
+					mockedOutput: []string{"No restores found for tag `default'\n"},
+				}
+			})
+
+			It("should return a RestoreDoesNotExist error and an empty status", func() {
+				Expect(status).To(BeEmpty())
+				Expect(err).To(HaveOccurred())
+				Expect(internal.IsRestoreDoesNotExist(err)).To(BeTrue())
+			})
+		})
+
+		When("a restore is currently running", func() {
+			BeforeEach(func() {
+				mockRunner = &mockCommandRunner{
+					mockedOutput: []string{"UID: ABCD, State: running\n"},
+				}
+			})
+
+			It("should return the raw status and no error", func() {
+				Expect(status).To(ContainSubstring("State: running"))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		When("the command fails for an unrelated reason", func() {
+			BeforeEach(func() {
+				mockRunner = &mockCommandRunner{
+					mockedOutput: []string{""},
+					mockedError:  []error{fmt.Errorf("connection failed")},
+				}
+			})
+
+			It("should propagate the raw error and not report RestoreDoesNotExist", func() {
+				Expect(status).To(BeEmpty())
+				Expect(err).To(HaveOccurred())
+				Expect(internal.IsRestoreDoesNotExist(err)).To(BeFalse())
+			})
+		})
 	})
 })
 

--- a/internal/error_helper.go
+++ b/internal/error_helper.go
@@ -77,3 +77,9 @@ func IsBackupNotfound(err error) bool {
 	var backupError fdbv1beta2.BackupDoesNotExist
 	return errors.As(err, &backupError)
 }
+
+// IsRestoreDoesNotExist returns true if the provided error is a restore not found error from fdbrestore.
+func IsRestoreDoesNotExist(err error) bool {
+	var restoreErr fdbv1beta2.RestoreDoesNotExist
+	return errors.As(err, &restoreErr)
+}

--- a/internal/error_helper_test.go
+++ b/internal/error_helper_test.go
@@ -136,4 +136,40 @@ var _ = Describe("Internal error helper", func() {
 				}),
 		)
 	})
+
+	When("checking if an error is a restore does not exist error", func() {
+		type testCase struct {
+			err      error
+			expected bool
+		}
+
+		DescribeTable("it should detect the restore does not exist error",
+			func(tc testCase) {
+				Expect(IsRestoreDoesNotExist(tc.err)).To(Equal(tc.expected))
+			},
+			Entry("simple error",
+				testCase{
+					err:      fmt.Errorf("test"),
+					expected: false,
+				}),
+			Entry("nil error",
+				testCase{
+					err:      nil,
+					expected: false,
+				}),
+			Entry("simple restore does not exist error",
+				testCase{
+					err:      fdbv1beta2.RestoreDoesNotExist{Err: fmt.Errorf("no restores found")},
+					expected: true,
+				}),
+			Entry("wrapped restore does not exist error",
+				testCase{
+					err: fmt.Errorf(
+						"test : %w",
+						fdbv1beta2.RestoreDoesNotExist{Err: fmt.Errorf("no restores found")},
+					),
+					expected: true,
+				}),
+		)
+	})
 })

--- a/pkg/fdbadminclient/mock/admin_client_mock.go
+++ b/pkg/fdbadminclient/mock/admin_client_mock.go
@@ -76,6 +76,7 @@ type AdminClient struct {
 	ActiveGenerations                        *int
 	MaintenanceZone                          fdbv1beta2.FaultDomain
 	restoreURL                               string
+	restoreDoesNotExist                      bool
 	maintenanceZoneStartTimestamp            time.Time
 	MockAdditionTimeForGlobalCoordination    time.Time
 	uptimeSecondsForMaintenanceZone          float64
@@ -1027,6 +1028,7 @@ func (client *AdminClient) StartRestore(
 		return client.mockError
 	}
 
+	client.restoreDoesNotExist = false
 	client.restoreURL = url
 	return nil
 }
@@ -1038,6 +1040,10 @@ func (client *AdminClient) GetRestoreStatus() (string, error) {
 
 	if client.mockError != nil {
 		return "", client.mockError
+	}
+
+	if client.restoreDoesNotExist {
+		return "", fdbv1beta2.RestoreDoesNotExist{Err: fmt.Errorf("no restores found")}
 	}
 
 	if client.restoreURL == "" {
@@ -1188,6 +1194,15 @@ func (client *AdminClient) MockUptimeSecondsForMaintenanceZone(seconds float64) 
 // a nil value to this method.
 func (client *AdminClient) MockError(err error) {
 	client.mockError = err
+}
+
+// MockRestoreDoesNotExist makes GetRestoreStatus return a RestoreDoesNotExist error, mimicking the fdbrestore CLI
+// when no restore has ever been started for the cluster.
+func (client *AdminClient) MockRestoreDoesNotExist(doesNotExist bool) {
+	adminClientMutex.Lock()
+	defer adminClientMutex.Unlock()
+
+	client.restoreDoesNotExist = doesNotExist
 }
 
 // SetLimitingDurabilityLag sets/mocks the limiting durability lag of any storage server in the cluster.


### PR DESCRIPTION
# Description

Changes from FDB main: https://github.com/apple/foundationdb/pull/12729

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

Without those changes the restore is never started because the status output is not empty.T he new changes work with the existing setup (returning an empty string) and the new change with the error message.

## Testing

Added units tests and CI will run e2e tests.

## Documentation

Nothing to update.

## Follow-up

-
