### PR TITLE
Add support for backup related changes in 7.4.7 and newer

### DIFF
--- a/api/v1beta2/foundationdb_version.go
+++ b/api/v1beta2/foundationdb_version.go
@@ -115,6 +115,11 @@ func (version Version) IsProtocolCompatible(other Version) bool {
 	return version.Version.IsProtocolCompatible(other.Version)
 }
 
+// UsesMutationLogType determines whether this FDB version uses the --mutation-log-type flag instead of --partitioned-log.
+func (version Version) UsesMutationLogType() bool {
+	return version.Version.IsAtLeast(Versions.UsesMutationLogType.Version)
+}
+
 // Equal checks if two Version are the same.
 func (version Version) Equal(other Version) bool {
 	return version.Version.Equal(other.Version)
@@ -156,6 +161,7 @@ var Versions = struct {
 	SupportsRecoveryState,
 	SupportsLocalityBasedExclusions71,
 	SupportsLocalityBasedExclusions,
+	UsesMutationLogType,
 	Default Version
 }{
 	Default:                           Version{api.Version{Major: 7, Minor: 1, Patch: 57}},
@@ -172,4 +178,5 @@ var Versions = struct {
 	SupportsLocalityBasedExclusions:   Version{api.Version{Major: 7, Minor: 3, Patch: 26}},
 	SupportsBackupEncryption:          Version{api.Version{Major: 7, Minor: 4, Patch: 6}},
 	SupportsBackupEncryption73:        Version{api.Version{Major: 7, Minor: 3, Patch: 73}},
+	UsesMutationLogType:               Version{api.Version{Major: 7, Minor: 4, Patch: 7}},
 }

--- a/api/v1beta2/foundationdbbackup_types.go
+++ b/api/v1beta2/foundationdbbackup_types.go
@@ -381,8 +381,12 @@ type FDBBackupDescribe struct {
 	// and can be used to restore a database.
 	Restorable *bool `json:"Restorable,omitempty"`
 
-	// Partitioned indicates if the partitioned_log backup system is used.
+	// Partitioned indicates if the partitioned_log backup system is used. Removed in 7.4.7.
+	// Deprecated: use MutationLogType instead.
 	Partitioned *bool `json:"Partitioned,omitempty"`
+
+	// MutationLogType indicates the MutationLogType that was used for the backup.
+	MutationLogType *string `json:"MutationLogType,omitempty"`
 
 	// FileLevelEncryption indicates whether file-level encryption
 	// is enabled for the backup data.

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -432,6 +432,11 @@ func (in *FDBBackupDescribe) DeepCopyInto(out *FDBBackupDescribe) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MutationLogType != nil {
+		in, out := &in.MutationLogType, &out.MutationLogType
+		*out = new(string)
+		**out = **in
+	}
 	if in.FileLevelEncryption != nil {
 		in, out := &in.FileLevelEncryption, &out.FileLevelEncryption
 		*out = new(bool)

--- a/docs/backup_spec.md
+++ b/docs/backup_spec.md
@@ -85,7 +85,8 @@ FDBBackupDescribe represents the JSON output of the `fdbbackup describe` command
 | SchemaVersion | SchemaVersion is the version of the backup metadata schema. | *string | false |
 | URL | URL is the backup destination being described. | *string | false |
 | Restorable | Restorable indicates whether the backup is in a valid state and can be used to restore a database. | *bool | false |
-| Partitioned | Partitioned indicates if the partitioned_log backup system is used. | *bool | false |
+| Partitioned | Partitioned indicates if the partitioned_log backup system is used. Removed in 7.4.7. **Deprecated: use MutationLogType instead.** | *bool | false |
+| MutationLogType | MutationLogType indicates the MutationLogType that was used for the backup. | *string | false |
 | FileLevelEncryption | FileLevelEncryption indicates whether file-level encryption is enabled for the backup data. | *bool | false |
 | TotalSnapshotBytes | TotalSnapshotBytes is the total size in bytes of all snapshot files in the backup destination. Drops to zero once every snapshot covering the live restorable range has been expired. | *int64 | false |
 

--- a/e2e/fixtures/fdb_backup.go
+++ b/e2e/fixtures/fdb_backup.go
@@ -120,6 +120,8 @@ func (factory *Factory) GenerateBackupSpecForCluster(
 			SidecarContainer: fdbCluster.cluster.Spec.SidecarContainer,
 			PodTemplateSpec: &corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					// The backup_agent is directly started and doesn't listen to the SIGTERM signal.
+					TerminationGracePeriodSeconds: ptr.To[int64](2),
 					Containers: []corev1.Container{
 						{
 							Name: fdbv1beta2.MainContainerName,
@@ -307,6 +309,7 @@ func (fdbBackup *FdbBackup) RunCommandOnBackupPod(ctx context.Context, command s
 		fdbv1beta2.MainContainerName,
 		command,
 		false)
+	log.Println("command:", command, "output:", out, "stderr", stderr)
 	gomega.Expect(err).
 		To(gomega.Succeed(), fmt.Sprintf("could not execute command: %s, got error; %s", command, stderr))
 	return out
@@ -425,8 +428,7 @@ func (fdbBackup *FdbBackup) GetBackupPods(ctx context.Context) *corev1.PodList {
 		client.InNamespace(fdbBackup.fdbCluster.Namespace()),
 		client.MatchingLabels(map[string]string{fdbv1beta2.BackupDeploymentPodLabel: fdbBackup.fdbCluster.Name() + "-backup-agents"}),
 	),
-	).
-		NotTo(gomega.HaveOccurred())
+	).NotTo(gomega.HaveOccurred())
 
 	return podList
 }

--- a/e2e/fixtures/fdb_restore.go
+++ b/e2e/fixtures/fdb_restore.go
@@ -50,6 +50,16 @@ func (factory *Factory) CreateRestoreForCluster(
 	backupVersion *uint64,
 ) *FdbRestore {
 	gomega.Expect(backup).NotTo(gomega.BeNil())
+	// If a backup is still running or paused on this cluster the restore will be stuck in queued. The stop will
+	// discontinue the backup, which allows the restore to get started.
+	if backup.backup.Spec.BackupState != fdbv1beta2.BackupStateStopped {
+		log.Println(
+			"backup was not stopped, will stop backup before restore. Current desired state:",
+			backup.backup.Spec.BackupState,
+		)
+		backup.Stop(ctx)
+	}
+
 	restore := &FdbRestore{
 		restore: &fdbv1beta2.FoundationDBRestore{
 			ObjectMeta: metav1.ObjectMeta{
@@ -121,7 +131,7 @@ func (restore *FdbRestore) waitForRestoreToComplete(ctx context.Context, backup 
 		}
 
 		return currentRestore.Status.State
-	}).WithTimeout(20 * time.Minute).WithPolling(1 * time.Second).Should(gomega.Equal(fdbv1beta2.CompletedFoundationDBRestoreState))
+	}).WithTimeout(30 * time.Minute).WithPolling(1 * time.Second).Should(gomega.Equal(fdbv1beta2.CompletedFoundationDBRestoreState))
 }
 
 // Destroy will delete the FoundationDBRestore for the associated FdbBackup if it exists.

--- a/e2e/test_operator_backups/operator_backup_test.go
+++ b/e2e/test_operator_backups/operator_backup_test.go
@@ -120,11 +120,17 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 			var backupConfiguration *fixtures.FdbBackupConfiguration
 			var currentRestorableVersion *uint64
 
+			BeforeEach(func(_ SpecContext) {
+				skipRestore = false
+				shouldPauseBackup = false
+			})
+
 			JustBeforeEach(func(ctx SpecContext) {
 				log.Printf(
-					"creating backup for cluster, skipRestore: %t, useRestorableVersion: %t\n",
+					"creating backup for cluster, skipRestore: %t, useRestorableVersion: %t, shouldPauseBackup: %t\n",
 					skipRestore,
 					useRestorableVersion,
+					shouldPauseBackup,
 				)
 				var restorableVersion uint64
 				keyValues = fdbCluster.GenerateRandomValues(10, prefix)
@@ -205,11 +211,24 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 					JustBeforeEach(func(ctx SpecContext) {
 						// running describe command
 						describeCommandOutput := backup.RunDescribeCommand(ctx)
+						Expect(describeCommandOutput).NotTo(BeNil())
 						if factory.GetFDBVersion().SupportsBackupEncryption() {
+							Expect(describeCommandOutput.FileLevelEncryption).NotTo(BeNil())
 							Expect(*describeCommandOutput.FileLevelEncryption).To(BeFalse())
 						}
+
+						Expect(describeCommandOutput.Restorable).NotTo(BeNil())
 						Expect(*describeCommandOutput.Restorable).To(BeTrue())
-						Expect(*describeCommandOutput.Partitioned).To(BeFalse())
+
+						if factory.GetFDBVersion().UsesMutationLogType() {
+							Expect(describeCommandOutput.MutationLogType).NotTo(BeNil())
+							Expect(*describeCommandOutput.MutationLogType).To(Equal("default"))
+							Expect(describeCommandOutput.Partitioned).To(BeNil())
+						} else {
+							Expect(describeCommandOutput.Partitioned).NotTo(BeNil())
+							Expect(*describeCommandOutput.Partitioned).To(BeFalse())
+							Expect(describeCommandOutput.MutationLogType).To(BeNil())
+						}
 					})
 
 					It(
@@ -292,11 +311,12 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 						JustBeforeEach(func(ctx SpecContext) {
 							// running status command
 							statusCommandOutput := backup.RunStatusCommand(ctx)
+							Expect(statusCommandOutput).NotTo(BeNil())
 							Expect(statusCommandOutput.SnapshotIntervalSeconds).To(Equal(864000))
 							Expect(statusCommandOutput.UID).NotTo(BeNil())
 							backupUID := *statusCommandOutput.UID
 
-							// running list command
+							// Running list command
 							listCommandOutput := backup.RunListCommand(ctx)
 							Expect(listCommandOutput).To(HaveLen(1))
 
@@ -307,6 +327,7 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 							backup.SetSnapshotInterval(ctx, modifiedSnapshotPeriod)
 							// validating snapshot interval changed and the backup UID is same
 							statusCommandOutput = backup.RunStatusCommand(ctx)
+							Expect(statusCommandOutput).NotTo(BeNil())
 							Expect(
 								statusCommandOutput.SnapshotIntervalSeconds,
 							).To(Equal(modifiedSnapshotPeriod))
@@ -314,11 +335,23 @@ var _ = Describe("Operator Backup", Label("e2e", "pr", "foundationdb-pr"), func(
 							Expect(*statusCommandOutput.UID).To(Equal(backupUID))
 							backup.Stop(ctx)
 
-							// running describe command
+							// Running describe command
 							describeCommandOutput := backup.RunDescribeCommand(ctx)
+							Expect(describeCommandOutput.FileLevelEncryption).NotTo(BeNil())
 							Expect(*describeCommandOutput.FileLevelEncryption).To(BeTrue())
+
+							Expect(describeCommandOutput.Restorable).NotTo(BeNil())
 							Expect(*describeCommandOutput.Restorable).To(BeTrue())
-							Expect(*describeCommandOutput.Partitioned).To(BeFalse())
+
+							if factory.GetFDBVersion().UsesMutationLogType() {
+								Expect(describeCommandOutput.MutationLogType).NotTo(BeNil())
+								Expect(*describeCommandOutput.MutationLogType).To(Equal("default"))
+								Expect(describeCommandOutput.Partitioned).To(BeNil())
+							} else {
+								Expect(describeCommandOutput.Partitioned).NotTo(BeNil())
+								Expect(*describeCommandOutput.Partitioned).To(BeFalse())
+								Expect(describeCommandOutput.MutationLogType).To(BeNil())
+							}
 						})
 
 						It(

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -868,7 +868,16 @@ func (client *cliAdminClient) StartBackup(backup *fdbv1beta2.FoundationDBBackup)
 	}
 
 	if backup.GetBackupType() == fdbv1beta2.BackupTypePartitionedLog {
-		args = append(args, "--partitioned-log-experimental")
+		fdbVersion, err := fdbv1beta2.ParseFdbVersion(backup.Spec.Version)
+		if err != nil {
+			return err
+		}
+
+		if fdbVersion.UsesMutationLogType() {
+			args = append(args, "--mutation-log-type", "partitioned-log-experimental")
+		} else {
+			args = append(args, "--partitioned-log-experimental")
+		}
 	}
 
 	_, err = client.runCommand(cliCommand{

--- a/fdbclient/admin_client_test.go
+++ b/fdbclient/admin_client_test.go
@@ -1097,6 +1097,26 @@ protocol fdb00b071010000`,
 				"-z",
 				"--partitioned-log-experimental",
 			}),
+		Entry("with partitioned log backup type with mutation log type argument",
+			&fdbv1beta2.FoundationDBBackup{
+				Spec: fdbv1beta2.FoundationDBBackupSpec{
+					Version: fdbv1beta2.Versions.UsesMutationLogType.String(),
+					BlobStoreConfiguration: &fdbv1beta2.BlobStoreConfiguration{
+						AccountName: "@test",
+						BackupName:  "test-backup",
+					},
+					SnapshotPeriodSeconds: ptr.To(60),
+					BackupType:            ptr.To(fdbv1beta2.BackupTypePartitionedLog),
+				},
+			}, []string{
+				"start",
+				"-d", "blobstore://@test:443/test-backup?bucket=fdb-backups",
+				"-t", "default",
+				"-s", "60",
+				"-z",
+				"--mutation-log-type",
+				"partitioned-log-experimental",
+			}),
 		Entry("with backup agent (default) backup type",
 			&fdbv1beta2.FoundationDBBackup{
 				Spec: fdbv1beta2.FoundationDBBackupSpec{


### PR DESCRIPTION
# Description

Add support for backup related changes in 7.4.7 and newer, see https://github.com/apple/foundationdb/pull/13127 for the affected changes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

I implemented things in a way to support the previous versions and 7.4.7+.

## Testing

Added unit tests and ran e2e tests.

## Documentation

Nothing to update.

## Follow-up

-