### PR TITLE
Add more logging for restores that are stuck

### DIFF
--- a/e2e/fixtures/factory.go
+++ b/e2e/fixtures/factory.go
@@ -776,20 +776,44 @@ func (factory *Factory) DumpStateWithLogsSince(
 		w,
 		"Name\tReady\tSTATUS\tUnschedulable\tRestarts\tMain Image\tSidecar Image\tIPs\tNode\tAge",
 	)
-	var operatorPods []corev1.Pod
-	for _, pod := range pods.Items {
-		if pod.Labels["app"] == "fdb-kubernetes-operator-controller-manager" {
-			operatorPods = append(operatorPods, pod)
-		}
 
-		_, _ = fmt.Fprintln(w, writePodInformation(pod))
-	}
 	_ = w.Flush()
 
 	log.Println(buffer.String())
 
+	factory.DumpOperatorLogs(ctx, fdbCluster, logsSinceSeconds)
+}
+
+// DumpOperatorLogs will write the operator logs for the specified time.
+func (factory *Factory) DumpOperatorLogs(
+	ctx context.Context,
+	cluster *FdbCluster,
+	logsSinceSeconds *int64,
+) {
+	operatorPods := &corev1.PodList{}
+	err := factory.controllerRuntimeClient.List(
+		ctx,
+		operatorPods,
+		client.InNamespace(cluster.Namespace()),
+		client.MatchingLabels(
+			map[string]string{"app": "fdb-kubernetes-operator-controller-manager"},
+		),
+	)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	// Make use of a tabwriter for better output.
+	w := tabwriter.NewWriter(log.Writer(), 0, 0, 1, ' ', tabwriter.Debug)
+
+	for _, pod := range operatorPods.Items {
+		_, _ = fmt.Fprintln(w, writePodInformation(pod))
+	}
+	_ = w.Flush()
+
 	// Printout the logs of the operator Pods for the last 300 seconds.
-	for _, pod := range operatorPods {
+	for _, pod := range operatorPods.Items {
 		targetPod := pod
 		log.Println(factory.GetLogsForPod(ctx, &targetPod, "manager", logsSinceSeconds))
 	}

--- a/e2e/fixtures/fdb_restore.go
+++ b/e2e/fixtures/fdb_restore.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -128,6 +129,9 @@ func (restore *FdbRestore) waitForRestoreToComplete(ctx context.Context, backup 
 
 			log.Println(out)
 			g.Expect(err).To(gomega.Succeed())
+
+			// Dump the operator state and logs.
+			restore.fdbCluster.factory.DumpOperatorLogs(ctx, restore.fdbCluster, ptr.To[int64](300))
 		}
 
 		return currentRestore.Status.State


### PR DESCRIPTION
# Description

Add more logging for restores that are stuck. This should help to identify the reason why a restore might be stuck.

## Type of change

- Other

## Discussion

-

## Testing

Ran the e2e test manually.

## Documentation

Nothing to update.

## Follow-up

-
