### PR TITLE
fix comparison in checkError

### DIFF
--- a/fdbclient/fdb_client.go
+++ b/fdbclient/fdb_client.go
@@ -295,7 +295,7 @@ func (fdbClient *realFdbLibClient) getProcessAddresses(
 
 func checkError(err error) error {
 	if err != nil {
-		var fdbError *fdb.Error
+		var fdbError fdb.Error
 		if errors.As(err, &fdbError) {
 			// See: https://apple.github.io/foundationdb/api-error-codes.html
 			// 1031: Operation aborted because the transaction timed out.


### PR DESCRIPTION
# Description

CheckError compares pointer-to-error against error and in my (non-operator) tests that will result in the error never matching

## Type of change

 Bug fix (non-breaking change which fixes an issue)

## Discussion

Nope

## Testing

Manual tests with the code transplanted onto other codebases

I don't think so, if tests pass I think it's fine, but I could be wrong.

## Documentation

N/a

## Follow-up

I don't think this should cause any issues, only potentially cause errors to get correctly classified now (which could theoretically change behaviours, but I'm not aware of any it would)
