### PR TITLE
Release the lock after each full reconcile run instead of releasing it only after full reconciliation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG FDB_VERSION=7.1.67
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM golang:1.26.4-bookworm AS builder
+FROM golang:1.26.5-bookworm AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -350,7 +350,11 @@ func (r *FoundationDBClusterReconciler) Reconcile(
 		if cluster.ShouldUseLocks() {
 			lockErr := r.releaseLock(clusterLog, cluster)
 			if lockErr != nil {
-				clusterLog.Info("could not release lock after sub-reconcilers have run")
+				clusterLog.Info(
+					"could not release lock after sub-reconcilers have run",
+					"err",
+					lockErr,
+				)
 			}
 		}
 	}()

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -344,6 +344,17 @@ func (r *FoundationDBClusterReconciler) Reconcile(
 	var delayedRequeueDuration time.Duration
 	var delayedRequeue bool
 
+	defer func() {
+		// After each full run of all sub-reconcilers release the lock if this operator instance was holding a lock.
+		// This gives other operator instances the chance to perform operations without stalling them.
+		if cluster.ShouldUseLocks() {
+			lockErr := r.releaseLock(clusterLog, cluster)
+			if lockErr != nil {
+				clusterLog.Info("could not release lock after sub-reconcilers have run")
+			}
+		}
+	}()
+
 	for _, subReconciler := range subReconcilers {
 		// We have to set the normalized spec here again otherwise any call to Update() for the status of the cluster
 		// will reset all normalized fields...

--- a/controllers/update_lock_configuration.go
+++ b/controllers/update_lock_configuration.go
@@ -45,7 +45,7 @@ func (updateLockConfiguration) reconcile(
 	}
 
 	// If no lock entries must be set or removed we can skip all the work.
-	if len(cluster.Status.Locks.DenyList) == 0 && len(cluster.Spec.LockOptions.DenyList) == 0 {
+	if len(cluster.Spec.LockOptions.DenyList) == 0 {
 		return nil
 	}
 

--- a/controllers/update_lock_configuration.go
+++ b/controllers/update_lock_configuration.go
@@ -40,8 +40,12 @@ func (updateLockConfiguration) reconcile(
 	_ *fdbv1beta2.FoundationDBStatus,
 	logger logr.Logger,
 ) *requeue {
-	if len(cluster.Spec.LockOptions.DenyList) == 0 || !cluster.ShouldUseLocks() ||
-		!cluster.Status.Configured {
+	if !cluster.ShouldUseLocks() || !cluster.Status.Configured {
+		return nil
+	}
+
+	// If no lock entries must be set or removed we can skip all the work.
+	if len(cluster.Status.Locks.DenyList) == 0 && len(cluster.Spec.LockOptions.DenyList) == 0 {
 		return nil
 	}
 

--- a/controllers/update_status.go
+++ b/controllers/update_status.go
@@ -285,20 +285,24 @@ func (c updateStatus) reconcile(
 		clusterStatus.NeedsNewCoordinators = !coordinatorsValid
 	}
 
-	if len(cluster.Spec.LockOptions.DenyList) > 0 && cluster.ShouldUseLocks() &&
-		clusterStatus.Configured {
-		lockClient, err := r.getLockClient(logger, cluster)
-		if err != nil {
-			return &requeue{curError: err}
+	if cluster.ShouldUseLocks() && clusterStatus.Configured {
+		// If the original status had an entry for the deny list we have to query the FDB cluster until that entry was
+		// removed. Same for the case a user added at least one entry to the deny list.
+		if len(cluster.Spec.LockOptions.DenyList) > 0 || len(originalStatus.Locks.DenyList) > 0 {
+			lockClient, err := r.getLockClient(logger, cluster)
+			if err != nil {
+				return &requeue{curError: err}
+			}
+			denyList, err := lockClient.GetDenyList()
+			if err != nil {
+				return &requeue{curError: err}
+			}
+			if len(denyList) == 0 {
+				denyList = nil
+			}
+
+			clusterStatus.Locks.DenyList = denyList
 		}
-		denyList, err := lockClient.GetDenyList()
-		if err != nil {
-			return &requeue{curError: err}
-		}
-		if len(denyList) == 0 {
-			denyList = nil
-		}
-		clusterStatus.Locks.DenyList = denyList
 	}
 
 	// Sort slices that are assembled based on pods to prevent a reordering from
@@ -331,14 +335,6 @@ func (c updateStatus) reconcile(
 		err = coordination.UpdateGlobalCoordinationState(logger, cluster, adminClient, processMap)
 		if err != nil {
 			return &requeue{curError: err}
-		}
-	}
-
-	if reconciled && cluster.ShouldUseLocks() {
-		// Once the cluster is reconciled the operator will release any pending locks for this cluster.
-		lockErr := r.releaseLock(logger, cluster)
-		if lockErr != nil {
-			return &requeue{curError: lockErr}
 		}
 	}
 

--- a/fdbclient/lock_client.go
+++ b/fdbclient/lock_client.go
@@ -332,6 +332,7 @@ func (client *realLockClient) ReleaseLock() error {
 
 		return nil, nil
 	})
+
 	return err
 }
 

--- a/sample-apps/data-loader/Dockerfile
+++ b/sample-apps/data-loader/Dockerfile
@@ -2,7 +2,7 @@ ARG FDB_VERSION=7.1.67
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 # Build the manager binary
-FROM golang:1.26.4-bookworm AS builder
+FROM golang:1.26.5-bookworm AS builder
 
 ARG FDB_VERSION
 ARG FDB_WEBSITE


### PR DESCRIPTION
# Description

Otherwise it could happen that one operator instance is keeping the lock for a long time, which can cause lock stalls for those other instances.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

-

## Testing

Will perform additional e2e tests.

## Documentation

Will be updated.

## Follow-up

-
