### PR TITLE
Select operator pods by label selector instead of providing the pod names

### DIFF
--- a/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
+++ b/e2e/test_operator_upgrades_with_chaos/operator_upgrades_with_chaos_test.go
@@ -224,12 +224,18 @@ var _ = Describe("Operator Upgrades with chaos-mesh", Label("e2e", "pr"), func()
 				}, chaosmesh.Both)
 
 			// Also inject network loss b/w operator pods and cluster pods.
-			operatorPods := factory.GetOperatorPods(ctx, fdbCluster.Namespace())
 			factory.InjectNetworkLoss(
 				ctx,
 				"20",
 				fixtures.PodsSelector(allPods.Items),
-				fixtures.PodsSelector(operatorPods.Items),
+				chaosmesh.PodSelectorSpec{
+					GenericSelectorSpec: chaosmesh.GenericSelectorSpec{
+						Namespaces: []string{fdbCluster.Namespace()},
+						LabelSelectors: map[string]string{
+							"app": "fdb-kubernetes-operator-controller-manager",
+						},
+					},
+				},
 				chaosmesh.Both)
 
 			// 2. Start cluster upgrade.


### PR DESCRIPTION
# Description

Select operator pods by label selector instead of providing the pod names.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Discussion

We observed one case where a single operator pod was deleted and this blocked the reconciliation of the network loss.

## Testing

CI will run e2e tests. Ran `make fmt lint test`.

## Documentation

Nothing to update.

## Follow-up

-
